### PR TITLE
Fixing serac CI on Gitlab: back to the basics [fix/ci]

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,9 +6,8 @@
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
   SLURM_ALLOC_NAME: serac_$CI_COMMIT_SHORT_SHA
-  BUILD_ROOT: $CI_BUILDS_DIR/serac_$CI_COMMIT_REF_SLUG
-  LIBS_ROOT: $CI_BUILDS_DIR/serac_libs_$CI_COMMIT_REF_SLUG
-  INSTALL_ROOT: $CI_BUILDS_DIR/spack_uberenv
+  BUILD_ROOT: $CI_BUILDS_DIR/serac/${CI_COMMIT_REF_SLUG}_${CI_PIPELIN_ID}
+  LIBS_ROOT: $CI_BUILDS_DIR/serac/${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}/libs
   SPACK_MIRROR: /usr/workspace/radiuss/mirrors/packages
 
 before_script:
@@ -69,9 +68,9 @@ setup_env:
 .build_blueos_3_ppc64le_ib_p9_script:
   extends: .build_blueos_3_ppc64le_ib_script
 
-.clean_toss_3_x86_64_ib_script:
-  script:
-    - rm -rf ${INSTALL_ROOT}_{COMPILER}
+  #.clean_toss_3_x86_64_ib_script:
+  #  script:
+  #    - rm -rf ${BUILD_ROOT}
 
 # This is where jobs are included
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,72 +5,14 @@
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
-  SLURM_ALLOC_NAME: serac_$CI_COMMIT_SHORT_SHA
-  BUILD_ROOT: $CI_BUILDS_DIR/serac/${CI_COMMIT_REF_SLUG}_${CI_PIPELIN_ID}
-  LIBS_ROOT: $CI_BUILDS_DIR/serac/${CI_COMMIT_REF_SLUG}_${CI_PIPELINE_ID}/libs
-  SPACK_MIRROR: /usr/workspace/radiuss/mirrors/packages
-
-before_script:
-  - date
-
-after_script:
-  - date
+  SLURM_ALLOC_NAME: serac_${CI_PIPELINE_ID}
+  BUILD_ROOT: ${CI_PROJECT_DIR}
 
 # There are no tests for now
 stages:
-  - setup
   - allocate_resources
-  - dependencies
   - build
-  - test
   - release_resources
-  - clean
-
-setup_env:
-  stage: setup
-  tags:
-    - shell
-    - quartz
-  script:
-    - mkdir -p ${BUILD_ROOT}
-
-.dependencies_toss_3_x86_64_ib_script:
-  script:
-    - echo ${SLURM_ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${SLURM_ALLOC_NAME} --format=%A)
-    - echo ${JOBID}
-    - rm -rf ${LIBS_ROOT}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 20 -N 1 -n 1 -c 4 python scripts/uberenv/uberenv.py --prefix=${LIBS_ROOT}_${COMPILER} --spec=${SPEC}
-    - mv ${LIBS_ROOT}/${COMPILER}.cmake ${BUILD_ROOT}/${SYS_TYPE}_${COMPILER}.cmake
-
-# This is not a job, but contains project specific build commands
-# If an allocation exist with the name defined in this pipeline, the job will use it
-.build_toss_3_x86_64_ib_script:
-  script:
-    - echo ${SLURM_ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${SLURM_ALLOC_NAME} --format=%A)
-    - echo ${JOBID}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 5 -N 1 -n 1 -c 4 scripts/gitlab/build_and_test.sh --build-only
-
-# This is not a job, but contains project specific build commands
-.test_toss_3_x86_64_ib_script:
-  script:
-    - echo ${SLURM_ALLOC_NAME}
-    - export JOBID=$(squeue -h --name=${SLURM_ALLOC_NAME} --format=%A)
-    - echo ${JOBID}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 5 -N 1 -n 1 -c 4 scripts/gitlab/build_and_test.sh --test-only
-
-# Butte uses a very different job allocation system, building on login nodes is recommended
-.build_blueos_3_ppc64le_ib_script:
-  script:
-    - lalloc 1 scripts/gitlab/build_and_test.sh
-
-.build_blueos_3_ppc64le_ib_p9_script:
-  extends: .build_blueos_3_ppc64le_ib_script
-
-  #.clean_toss_3_x86_64_ib_script:
-  #  script:
-  #    - rm -rf ${BUILD_ROOT}
 
 # This is where jobs are included
 include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ setup_env:
     - export JOBID=$(squeue -h --name=${SLURM_ALLOC_NAME} --format=%A)
     - echo ${JOBID}
     - rm -rf ${LIBS_ROOT}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 20 -N 1 -n 1 -c 4 python scripts/uberenv/uberenv.py --mirror=${SPACK_MIRROR} --prefix=${LIBS_ROOT} --spec=${SPEC}
+    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 20 -N 1 -n 1 -c 4 python scripts/uberenv/uberenv.py --mirror=${SPACK_MIRROR} --prefix=${LIBS_ROOT}_${COMPILER} --spec=${SPEC}
     - mv ${LIBS_ROOT}/${COMPILER}.cmake ${BUILD_ROOT}/${SYS_TYPE}_${COMPILER}.cmake
 
 # This is not a job, but contains project specific build commands

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,7 +41,7 @@ setup_env:
     - export JOBID=$(squeue -h --name=${SLURM_ALLOC_NAME} --format=%A)
     - echo ${JOBID}
     - rm -rf ${LIBS_ROOT}
-    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 20 -N 1 -n 1 -c 4 python scripts/uberenv/uberenv.py --mirror=${SPACK_MIRROR} --prefix=${LIBS_ROOT}_${COMPILER} --spec=${SPEC}
+    - srun $( [[ -n "${JOBID}" ]] && echo "--jobid=${JOBID}" ) -t 20 -N 1 -n 1 -c 4 python scripts/uberenv/uberenv.py --prefix=${LIBS_ROOT}_${COMPILER} --spec=${SPEC}
     - mv ${LIBS_ROOT}/${COMPILER}.cmake ${BUILD_ROOT}/${SYS_TYPE}_${COMPILER}.cmake
 
 # This is not a job, but contains project specific build commands

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -1,6 +1,6 @@
 ####
 # This is the share configuration of jobs for quartz
-.quartz_common:
+.on_quartz:
   tags:
     - shell
     - quartz
@@ -13,7 +13,7 @@
 ####
 # In pre-build phase, allocate a node for builds
 allocate_resources_build_quartz:
-  extends: .quartz_common
+  extends: .on_quartz
   stage: allocate_resources
   script:
     - salloc -N 1 -c 36 -p pdebug -t 30 --no-shell --job-name=${SLURM_ALLOC_NAME}
@@ -22,7 +22,7 @@ allocate_resources_build_quartz:
 # In post-build phase, deallocate resources
 # Note : make sure this is run even on build phase failure
 release_resources_build_quartz:
-  extends: .quartz_common
+  extends: .on_quartz
   stage: release_resources
   script:
     - export JOBID=$(squeue -h --name=${SLURM_ALLOC_NAME} --format=%A)
@@ -30,93 +30,33 @@ release_resources_build_quartz:
   when: always
 
 ####
-# Generic quartz jobs
-.dependencies_quartz:
-  extends:
-    - .quartz_common
-    - .dependencies_toss_3_x86_64_ib_script
-  stage: dependencies
-
+# Template
 .build_quartz:
-  extends:
-    - .quartz_common
-    - .build_toss_3_x86_64_ib_script
+  extends: .on_quartz
   stage: build
-
-.test_quartz:
-  extends:
-    - .quartz_common
-    - .test_toss_3_x86_64_ib_script
-  stage: test
-
-  #.clean_quartz:
-  #  extends:
-  #    - .quartz_common
-  #    - .clean_toss_3_x86_64_ib_script
-  #  stage: clean
+  script:
+    - JOBID="$(squeue -h --name=${SLURM_ALLOC_NAME} --format=%A)"
+    - JOBID="$( [[ -n ${JOBID} ]] && echo --jobid=${JOBID} )"
+    - EXEC_PREFIX="srun ${JOBID} -t 20 -N 1 -n 1 -c 4"
+    - ${EXEC_PREFIX} python scripts/uberenv/uberenv.py --spec=${SPEC}
+    - ${EXEC_PREFIX} scripts/gitlab/build_and_test.sh
 
 ####
-# Here are all quartz dependencies jobs
-
-dependencies_quartz_clang_4_0_0:
-  variables:
-    COMPILER: "clang@4.0.0"
-    SPEC: "@develop%${COMPILER}"
-  extends: .dependencies_quartz
-
-dependencies_quartz_gcc_8_1_0:
-  variables:
-    COMPILER: "gcc@8.1.0"
-    SPEC: "@develop%${COMPILER}"
-  extends: .dependencies_quartz
-
-dependencies_quartz_intel_19_0_4:
-  variables:
-    COMPILER: "intel@19.0.4"
-    SPEC: "@develop%${COMPILER}"
-  extends: .dependencies_quartz
-
-####
-# Here are all quartz build jobs
-
+# Build jobs
 build_quartz_clang_4_0_0:
-  needs: ["dependencies_quartz_clang_4_0_0"]
   variables:
     COMPILER: "clang@4.0.0"
     SPEC: "@develop%${COMPILER}"
   extends: .build_quartz
 
 build_quartz_gcc_8_1_0:
-  needs: ["dependencies_quartz_gcc_8_1_0"]
   variables:
     COMPILER: "gcc@8.1.0"
     SPEC: "@develop%${COMPILER}"
   extends: .build_quartz
 
 build_quartz_intel_18_0_2:
-  needs: ["dependencies_quartz_intel_19_0_4"]
   variables:
     COMPILER: "intel@19.0.4"
     SPEC: "@develop%${COMPILER}"
   extends: .build_quartz
-
-  #####
-  ## Here are all quartz tests jobs
-  #
-  #clean_quartz_clang_4_0_0:
-  #  variables:
-  #    COMPILER: "clang@4.0.0"
-  #    SPEC: "@develop%${COMPILER}"
-  #  extends: .clean_quartz
-  #
-  #clean_quartz_gcc_8_1_0:
-  #  variables:
-  #    COMPILER: "gcc@8.1.0"
-  #    SPEC: "@develop%${COMPILER}"
-  #  extends: .clean_quartz
-  #
-  #clean_quartz_intel_19_0_4:
-  #  variables:
-  #    COMPILER: "intel@19.0.4"
-  #    SPEC: "@develop%${COMPILER}"
-  #  extends: .clean_quartz

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -55,7 +55,7 @@ build_quartz_gcc_8_1_0:
     SPEC: "@develop%${COMPILER}"
   extends: .build_quartz
 
-build_quartz_intel_18_0_2:
+build_quartz_intel_19_0_4:
   variables:
     COMPILER: "intel@19.0.4"
     SPEC: "@develop%${COMPILER}"

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -49,11 +49,11 @@ release_resources_build_quartz:
     - .test_toss_3_x86_64_ib_script
   stage: test
 
-.clean_quartz:
-  extends:
-    - .quartz_common
-    - .clean_toss_3_x86_64_ib_script
-  stage: clean
+  #.clean_quartz:
+  #  extends:
+  #    - .quartz_common
+  #    - .clean_toss_3_x86_64_ib_script
+  #  stage: clean
 
 ####
 # Here are all quartz dependencies jobs
@@ -100,23 +100,23 @@ build_quartz_intel_18_0_2:
     SPEC: "@develop%${COMPILER}"
   extends: .build_quartz
 
-####
-# Here are all quartz tests jobs
-
-clean_quartz_clang_4_0_0:
-  variables:
-    COMPILER: "clang@4.0.0"
-    SPEC: "@develop%${COMPILER}"
-  extends: .clean_quartz
-
-clean_quartz_gcc_8_1_0:
-  variables:
-    COMPILER: "gcc@8.1.0"
-    SPEC: "@develop%${COMPILER}"
-  extends: .clean_quartz
-
-clean_quartz_intel_19_0_4:
-  variables:
-    COMPILER: "intel@19.0.4"
-    SPEC: "@develop%${COMPILER}"
-  extends: .clean_quartz
+  #####
+  ## Here are all quartz tests jobs
+  #
+  #clean_quartz_clang_4_0_0:
+  #  variables:
+  #    COMPILER: "clang@4.0.0"
+  #    SPEC: "@develop%${COMPILER}"
+  #  extends: .clean_quartz
+  #
+  #clean_quartz_gcc_8_1_0:
+  #  variables:
+  #    COMPILER: "gcc@8.1.0"
+  #    SPEC: "@develop%${COMPILER}"
+  #  extends: .clean_quartz
+  #
+  #clean_quartz_intel_19_0_4:
+  #  variables:
+  #    COMPILER: "intel@19.0.4"
+  #    SPEC: "@develop%${COMPILER}"
+  #  extends: .clean_quartz

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -8,39 +8,36 @@
 
 set -e
 
-PROJECT_DIRECTORY="$(pwd)"
-BUILD_DIRECTORY="${BUILD_ROOT}/build_${SYS_TYPE}_${COMPILER}"
-CCONF="${BUILD_ROOT}/${SYS_TYPE}_${COMPILER}.cmake"
-
-# If building, then delete everything first
-if [[ "${1}" != "--test-only" ]]
-then
-    rm -rf ${BUILD_DIRECTORY}
-    mkdir -p ${BUILD_DIRECTORY}
-fi
-
-# Assert that build directory exist (mainly for --test-only mode)
-if [[ ! -d ${BUILD_DIRECTORY} ]]
-then
-    echo "Build directory not found : $(pwd)/${BUILD_DIRECTORY}"
-    exit 1
-fi
-
-# Always go to build directory
-echo "moving to ${BUILD_DIRECTORY}"
-cd ${BUILD_DIRECTORY}
+project_dir="$(pwd)"
+build_dir="${BUILD_ROOT}/build_${SYS_TYPE}_${COMPILER}"
+hostconfig="${BUILD_ROOT}/uberenv_libs/${COMPILER}.cmake"
 
 # Build
 if [[ "${1}" != "--test-only" ]]
 then
+    rm -rf ${build_dir}
+    mkdir -p ${build_dir}
+
+    echo "moving to ${build_dir}"
+    cd ${build_dir}
+
     cmake \
-      -C ${CCONF} \
-      ${PROJECT_DIRECTORY}
+      -C ${hostconfig} \
+      ${project_dir}
     cmake --build . -j 4
 fi
 
 # Test
-if [[ "${1}" != "--build-only" ]] 
+if [[ "${1}" != "--build-only" ]]
 then
+    if [[ ! -d ${build_dir} ]]
+    then
+        echo "Build directory not found : $(pwd)/${build_dir}"
+        exit 1
+    fi
+
+    echo "moving to ${build_dir}"
+    cd ${build_dir}
+
     ctest -T test
 fi


### PR DESCRIPTION
### Intro
I have fixed Serac CI on LC Gitlab.

My mistake was to try to use the same pipeline template I use for other projects, while I could have kept things simple.

I simplified the pipeline, which means less optimization (produces more data, is longer to run), but better robustness.

### What
The result is a 3-stage pipeline, allocation/run/release. (I kept the "single allocation" optimization)

The run phase consists in three streps (in one job) aiming at reproducing the development workflow:
- install dependencies and generate the host-config file (uberenv)
- build with classic cmake commands (not using uberenv)
- test

This is done for 3 compilers (clang@4.0.0, gcc@8.1.0, intel@19.0.4) on quartz only and could (should?) be extended to lassen (just tell be what you want).

### Comments
The pipeline still fails, because some tests fails when built with gcc@8.1.0
Someone more into the project should give a look at this...

### TODO
- I found a way to control the collapse of logs by sections in GitLab, I will test it. It would make the all-in-one job log easier to read.
- I want to update Uberenv. (not necessarily in this PR)
- Add other targets (more recent clang? lassen?)