### PR TITLE
Adapting to new naming of hostconfig file

### DIFF
--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -8,9 +8,10 @@
 
 set -e
 
+hostname="$(hostname)"
 project_dir="$(pwd)"
 build_dir="${BUILD_ROOT}/build_${SYS_TYPE}_${COMPILER}"
-hostconfig="${BUILD_ROOT}/uberenv_libs/${COMPILER}.cmake"
+hostconfig="${BUILD_ROOT}/${hostname//[0-9]/}-${SYS_TYPE}-${COMPILER}.cmake"
 
 # Build
 if [[ "${1}" != "--test-only" ]]


### PR DESCRIPTION
Quick fix for CI.
Now fails in tests with the 3 toolchains (others branches opened to fix these).