### PR TITLE
bump spack version

### DIFF
--- a/host-configs/quartz-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -33,7 +33,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-4.0.0/bin/mp
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_03_25_23_14_51/clang-4.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_17_07_45/clang-4.0.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 
@@ -50,7 +50,7 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.15/bin/doxygen" CACHE PATH 
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/sphinx-build" CACHE PATH "")
 
-set(ASTYLE_EXECUTABLE "${DEVTOOLS_ROOT}/astyle-3.1/bin/astyle" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-9.0.0/bin/clang-format" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -33,7 +33,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-gcc-8.1.0/bin/mpic
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_03_25_23_14_51/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_17_07_45/gcc-8.1.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 
@@ -50,7 +50,7 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.15/bin/doxygen" CACHE PATH 
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/sphinx-build" CACHE PATH "")
 
-set(ASTYLE_EXECUTABLE "${DEVTOOLS_ROOT}/astyle-3.1/bin/astyle" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-9.0.0/bin/clang-format" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -33,7 +33,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-intel-19.0.4/bin/m
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_03_25_23_14_51/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_17_07_45/intel-19.0.4" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 
@@ -50,7 +50,7 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.15/bin/doxygen" CACHE PATH 
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/sphinx-build" CACHE PATH "")
 
-set(ASTYLE_EXECUTABLE "${DEVTOOLS_ROOT}/astyle-3.1/bin/astyle" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-9.0.0/bin/clang-format" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -33,7 +33,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-4.0.0/bin/mp
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_03_20_22_45_04/clang-4.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_16_32_41/clang-4.0.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 
@@ -50,7 +50,7 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.15/bin/doxygen" CACHE PATH 
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/sphinx-build" CACHE PATH "")
 
-set(ASTYLE_EXECUTABLE "${DEVTOOLS_ROOT}/astyle-3.1/bin/astyle" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-9.0.0/bin/clang-format" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -33,7 +33,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-gcc-8.1.0/bin/mpic
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_03_20_22_45_04/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_16_32_41/gcc-8.1.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 
@@ -50,7 +50,7 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.15/bin/doxygen" CACHE PATH 
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/sphinx-build" CACHE PATH "")
 
-set(ASTYLE_EXECUTABLE "${DEVTOOLS_ROOT}/astyle-3.1/bin/astyle" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-9.0.0/bin/clang-format" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -33,7 +33,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-intel-19.0.4/bin/m
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_03_20_22_45_04/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_16_32_41/intel-19.0.4" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 
@@ -50,7 +50,7 @@ set(DOXYGEN_EXECUTABLE "${DEVTOOLS_ROOT}/doxygen-1.8.15/bin/doxygen" CACHE PATH 
 
 set(SPHINX_EXECUTABLE "${DEVTOOLS_ROOT}/python-3.7.4/bin/sphinx-build" CACHE PATH "")
 
-set(ASTYLE_EXECUTABLE "${DEVTOOLS_ROOT}/astyle-3.1/bin/astyle" CACHE PATH "")
+set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-9.0.0/bin/clang-format" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
 

--- a/scripts/uberenv/packages/serac/package.py
+++ b/scripts/uberenv/packages/serac/package.py
@@ -89,7 +89,6 @@ class Serac(Package):
     depends_on("mpi")
 
     # Devtool dependencies these need to match serac_devtools/package.py
-    depends_on('astyle', when="+devtools")
     depends_on('cmake', when="+devtools")
     depends_on('cppcheck', when="+devtools")
     depends_on('doxygen', when="+devtools")
@@ -268,7 +267,7 @@ class Serac(Package):
         # Add common prefix to path replacement list
         if "+devtools" in spec:
             # Grab common devtools root and strip the trailing slash
-            path1 = os.path.realpath(spec["astyle"].prefix)
+            path1 = os.path.realpath(spec["python"].prefix)
             path2 = os.path.realpath(spec["doxygen"].prefix)
             devtools_root = os.path.commonprefix([path1, path2])[:-1]
             path_replacements[devtools_root] = "${DEVTOOLS_ROOT}"
@@ -288,9 +287,9 @@ class Serac(Package):
         else:
             cfg.write(cmake_cache_option("ENABLE_DOCS", False))
 
-        if "astyle" in spec:
-            astyle_bin_dir = get_spec_path(spec, "astyle", path_replacements, use_bin=True)
-            cfg.write(cmake_cache_entry("ASTYLE_EXECUTABLE", pjoin(astyle_bin_dir, "astyle")))
+        clangformatpath = "/usr/tce/packages/clang/clang-9.0.0/bin/clang-format"
+        if os.path.exists(clangformatpath):
+            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", clangformatpath))
 
         if "cppcheck" in spec:
             cppcheck_bin_dir = get_spec_path(spec, "cppcheck", path_replacements, use_bin=True)

--- a/scripts/uberenv/packages/serac_devtools/package.py
+++ b/scripts/uberenv/packages/serac_devtools/package.py
@@ -10,7 +10,6 @@ class SeracDevtools(BundlePackage):
 
     version('fakeversion')
 
-    depends_on('astyle')
     depends_on('cmake')
     depends_on('cppcheck')
     depends_on('doxygen')

--- a/scripts/uberenv/project.json
+++ b/scripts/uberenv/project.json
@@ -4,6 +4,6 @@
 "package_final_phase" : "hostconfig",
 "package_source_dir" : "../..",
 "spack_url": "https://github.com/spack/spack",
-"spack_commit": "d98b433a3c14af5aaba03fd439f6e47cb970bac6",
+"spack_commit": "0c7fff60651ce3c129551e1c1657ccc80ee816f8",
 "spack_activate" : {}
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,10 +74,10 @@ if (ENABLE_GTEST)
         NAME       serac_dtor
         SOURCES    serac_dtor.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-        DEPENDS_ON solvers mpi mfem gtest )
+        DEPENDS_ON solvers mpi mfem )
     blt_add_test(
         NAME              serac_dtor
-        COMMAND           serac_dtor
+        COMMAND           serac_dtor -m ${PROJECT_SOURCE_DIR}/data/beam-hex.mesh
         NUM_MPI_TASKS     4
         WORKING_DIRECTORY ${TEST_OUTPUT_DIRECTORY} )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -74,7 +74,7 @@ if (ENABLE_GTEST)
         NAME       serac_dtor
         SOURCES    serac_dtor.cpp
         OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-        DEPENDS_ON solvers mpi mfem )
+        DEPENDS_ON solvers mpi mfem gtest )
     blt_add_test(
         NAME              serac_dtor
         COMMAND           serac_dtor -m ${PROJECT_SOURCE_DIR}/data/beam-hex.mesh

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -85,8 +85,6 @@ TEST(serac_dtor, test1)
   do_nothing(therm_solver);
   do_nothing(therm_solver);
   do_nothing(therm_solver);
-
-  MPI_Finalize();
 }
 
 int main(int argc, char *argv[])

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -31,6 +31,7 @@ int main(int argc, char **argv)
   MPI_Barrier(MPI_COMM_WORLD);
 
   const char *mesh_file = "NO_MESH_GIVEN";
+
   // Parse command line options
   mfem::OptionsParser args(argc, argv);
   args.AddOption(&mesh_file, "-m", "--mesh", "Mesh file to use.", true);
@@ -46,7 +47,9 @@ int main(int argc, char **argv)
     args.PrintOptions(std::cout);
   }
 
-  std::ifstream imesh("../../data/beam-hex.mesh");
+  // Open the mesh
+  ASSERT_TRUE(file_exists(mesh_file));
+  std::ifstream imesh(mesh_file);
   mfem::Mesh *  mesh = new mfem::Mesh(imesh, 1, 1, true);
   imesh.close();
 

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include <gtest/gtest.h>
+
 #include <fstream>
 #include <sys/stat.h>
 

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -5,7 +5,9 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <fstream>
+#include <sys/stat.h>
 
+#include "mfem.hpp"
 #include "solvers/thermal_solver.hpp"
 
 template <typename T>


### PR DESCRIPTION
Some of the [build_issues](https://github.com/spack/spack/issues/12238) we have on Ubuntu/WSL are related to using an older version of spack.

Other potential fixes:
-target the master branch and do to not specify a specific commit
-add spack as a submodule, rather than use uberenv to download it