### PR TITLE
Initial cut at Axom and TRIBOL integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /build*/
 *.swp
-cmake/defaults.cmake
 /uberenv_libs*
 spack-build*
 /src/docs/doxygen/html/

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -42,7 +42,6 @@ release_resources_build_quartz:
     - JOBID=$(squeue -h --name=${PROJECT_ALLOC_NAME} --format=%A)
     - JOBID=$(if [[ -n "${JOBID}" ]]; then echo "--jobid=${JOBID}"; fi)
     - EXEC_PREFIX="srun ${JOBID} -t 20 -N 1 -n 1 -c 4"
-    - ${EXEC_PREFIX} python scripts/uberenv/uberenv.py --spec=${SPEC}
     - ${EXEC_PREFIX} scripts/gitlab/build_and_test.sh
 
 ####
@@ -50,17 +49,17 @@ release_resources_build_quartz:
 build_quartz_clang_4_0_0:
   variables:
     COMPILER: "clang@4.0.0"
-    SPEC: "@develop%${COMPILER}"
+    HOST_CONFIG: "quartz-toss_3_x86_64_ib-clang@4.0.0.cmake"
   extends: .build_quartz
 
 build_quartz_gcc_8_1_0:
   variables:
     COMPILER: "gcc@8.1.0"
-    SPEC: "@develop%${COMPILER}"
+    HOST_CONFIG: "quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake"
   extends: .build_quartz
 
 build_quartz_intel_19_0_4:
   variables:
     COMPILER: "intel@19.0.4"
-    SPEC: "@develop%${COMPILER}"
+    HOST_CONFIG: "quartz-toss_3_x86_64_ib-intel@19.0.4.cmake"
   extends: .build_quartz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 #------------------------------------------------------------------------------
 
 include(${PROJECT_SOURCE_DIR}/cmake/SeracMacros.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/SeracBasics.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/thirdparty/SetupSeracThirdParty.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/SeracConfigHeader.cmake)
 
 #------------------------------------------------------------------------------
 # Build src
@@ -66,17 +68,6 @@ add_subdirectory(src)
 if(ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
-
-#------------------------------------------------------------------------------
-# Copy utility TPL executables
-#------------------------------------------------------------------------------
-
-if(GLVIS_EXECUTABLE)
-    ADD_CUSTOM_TARGET(glvis_symlink ALL
-                      COMMAND ${CMAKE_COMMAND} 
-                      -E create_symlink ${GLVIS_EXECUTABLE} ${CMAKE_INSTALL_BINDIR}/glvis)
-endif()
-
 
 #------------------------------------------------------------------------------
 # Add Code Checks

--- a/cmake/SeracBasics.cmake
+++ b/cmake/SeracBasics.cmake
@@ -1,0 +1,20 @@
+# Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+# other Serac Project Developers. See the top-level LICENSE file for
+# details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+
+#------------------------------------------------------------------------------
+# Create symlink in installed bin
+#------------------------------------------------------------------------------
+if(GLVIS_EXECUTABLE)
+    add_custom_target(glvis_symlink ALL
+                      COMMAND ${CMAKE_COMMAND} 
+                      -E create_symlink ${GLVIS_EXECUTABLE} ${CMAKE_INSTALL_BINDIR}/glvis)
+endif()
+
+#------------------------------------------------------------------------------
+# Global includes (restrict these as much as possible)
+#------------------------------------------------------------------------------
+include_directories(${CMAKE_BINARY_DIR}/include)
+include_directories(${PROJECT_SOURCE_DIR})

--- a/cmake/SeracConfigHeader.cmake
+++ b/cmake/SeracConfigHeader.cmake
@@ -1,0 +1,71 @@
+# Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+# other Serac Project Developers. See the top-level LICENSE file for
+# details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+
+#------------------------------------------------------------------------------
+# Version information that go into the generated config header
+#------------------------------------------------------------------------------
+set(SERAC_VERSION_MAJOR 0)
+set(SERAC_VERSION_MINOR 0)
+set(SERAC_VERSION_PATCH 1)
+string(CONCAT SERAC_VERSION_FULL
+    "v${SERAC_VERSION_MAJOR}"
+    ".${SERAC_VERSION_MINOR}"
+    ".${SERAC_VERSION_PATCH}" )
+
+if (Git_FOUND)
+  ## check to see if we are building from a Git repo or an exported tarball
+  blt_is_git_repo( OUTPUT_STATE is_git_repo )
+
+  if(${is_git_repo})
+    blt_git_hashcode(HASHCODE sha1 RETURN_CODE rc)
+    if(NOT ${rc} EQUAL 0)
+      message(FATAL_ERROR "blt_git_hashcode failed!")
+    endif()
+
+    set(SERAC_GIT_SHA ${sha1})
+  endif()
+
+endif()
+
+message(STATUS "Configuring Serac version ${SERAC_VERSION_FULL}")
+
+
+#------------------------------------------------------------------------------
+# Create variable for every TPL
+#------------------------------------------------------------------------------
+set(TPL_DEPS AXOM CONDUIT FMT HDF5 MFEM MPI TRIBOL )
+foreach(dep ${TPL_DEPS})
+    if( ${dep}_FOUND OR ENABLE_${dep} )
+        set(SERAC_USE_${dep} TRUE)
+    endif()
+endforeach()
+
+
+#--------------------------------------------------------------------------
+# Add define we can use when debug builds are enabled
+#--------------------------------------------------------------------------
+set(SERAC_DEBUG FALSE)
+if(CMAKE_BUILD_TYPE MATCHES "(Debug|RelWithDebInfo)")
+    set(SERAC_DEBUG TRUE)
+endif()
+
+
+#------------------------------------------------------------------------------
+# General Build Info
+#------------------------------------------------------------------------------
+convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} SERAC_SRC_DIR)
+convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   SERAC_BIN_DIR)
+
+
+#------------------------------------------------------------------------------
+# Create Config Header
+#------------------------------------------------------------------------------
+configure_file(
+    ${PROJECT_SOURCE_DIR}/src/serac_config.hpp.in
+    ${CMAKE_BINARY_DIR}/include/serac_config.hpp
+)
+
+install(FILES ${CMAKE_BINARY_DIR}/include/serac_config.hpp DESTINATION include)

--- a/cmake/SeracConfigHeader.cmake
+++ b/cmake/SeracConfigHeader.cmake
@@ -56,8 +56,8 @@ endif()
 #------------------------------------------------------------------------------
 # General Build Info
 #------------------------------------------------------------------------------
-convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} SERAC_SRC_DIR)
-convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   SERAC_BIN_DIR)
+serac_convert_to_native_escaped_file_path(${PROJECT_SOURCE_DIR} SERAC_SRC_DIR)
+serac_convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   SERAC_BIN_DIR)
 
 
 #------------------------------------------------------------------------------

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -4,6 +4,19 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
+
+#------------------------------------------------------------------------------
+# Adds code checks for all cpp/hpp files recursively under the current directory
+# that regex match INCLUDES and excludes any files that regex match EXCLUDES
+# 
+# This creates the following parent build targets:
+#  check - Runs a non file changing style check and CppCheck
+#  style - In-place code formatting
+#
+# Creates various child build targets that follow this pattern:
+#  serac_<check|style>
+#  serac_<cppcheck|clangformat>_<check|style>
+#------------------------------------------------------------------------------
 macro(serac_add_code_checks)
 
     set(options)
@@ -51,3 +64,27 @@ macro(serac_add_code_checks)
                         CPPCHECK_FLAGS  --enable=all --inconclusive)
 
 endmacro(serac_add_code_checks)
+
+#------------------------------------------------------------------------------
+# Asserts that the given VARIABLE_NAME's value is a directory and exists.
+# Fails with a helpful message when it doesn't.
+#------------------------------------------------------------------------------
+macro(serac_assert_is_directory)
+
+    set(options)
+    set(singleValueArgs VARIABLE_NAME)
+    set(multiValueArgs)
+
+    # Parse the arguments to the macro
+    cmake_parse_arguments(arg
+         "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if (NOT EXISTS "${${arg_VARIABLE_NAME}}")
+        message(FATAL_ERROR "Given ${arg_VARIABLE_NAME} does not exist: ${${arg_VARIABLE_NAME}}")
+    endif()
+
+    if (NOT IS_DIRECTORY "${${arg_VARIABLE_NAME}}")
+        message(FATAL_ERROR "Given ${arg_VARIABLE_NAME} is not a directory: ${${arg_VARIABLE_NAME}}")
+    endif()
+
+endmacro(serac_assert_is_directory)

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -88,3 +88,16 @@ macro(serac_assert_is_directory)
     endif()
 
 endmacro(serac_assert_is_directory)
+
+
+##------------------------------------------------------------------------------
+## serac_convert_to_native_escaped_file_path( path output )
+##
+## This macro converts a cmake path to a platform specific string literal
+## usable in C++.  (For example, on windows C:/Path will be come C:\\Path)
+##------------------------------------------------------------------------------
+
+macro(serac_convert_to_native_escaped_file_path path output)
+    file(TO_NATIVE_PATH ${path} ${output})
+    string(REPLACE "\\" "\\\\"  ${output} "${${output}}")
+endmacro(serac_convert_to_native_escaped_file_path)

--- a/cmake/thirdparty/FindMFEM.cmake
+++ b/cmake/thirdparty/FindMFEM.cmake
@@ -9,15 +9,14 @@
 #
 # This file defines:
 #  MFEM_FOUND        - If MFEM was found
-#  MFEM_INCLUDE_DIRS - The MFEM include directories
-#  MFEM_LIBRARY      - The MFEM library
+#  mfem              - BLT Registered Library 
 #------------------------------------------------------------------------------
 
 if(NOT MFEM_DIR)
     message(FATAL_ERROR "MFEM support needs explicit MFEM_DIR")
 endif()
-
 message(STATUS "Looking for MFEM using MFEM_DIR = ${MFEM_DIR}")
+serac_assert_is_directory(VARIABLE_NAME MFEM_DIR)
 
 set(_mfem_cmake_config "${MFEM_DIR}/MFEMConfig.cmake")
 
@@ -114,7 +113,7 @@ find_package_handle_standard_args(MFEM DEFAULT_MSG
                                   MFEM_INCLUDE_DIRS )
 
 if(NOT MFEM_FOUND)
-    message(FATAL_ERROR "MFEM_FOUND is not a path to a valid MFEM install")
+    message(FATAL_ERROR "MFEM_DIR is not a path to a valid MFEM install")
 endif()
 
 message(STATUS "MFEM Includes: ${MFEM_INCLUDE_DIRS}")

--- a/cmake/thirdparty/FindMFEM.cmake
+++ b/cmake/thirdparty/FindMFEM.cmake
@@ -74,7 +74,9 @@ else()
 
     # parse include flags
     string(REGEX MATCHALL "MFEM_TPLFLAGS [^\n]+\n" mfem_tpl_inc_flags ${mfem_cfg_file_txt})
-    message(VERBOSE "Content of variable mfem_tpl_inc_flags: ${mfem_tpl_inc_flags}")
+    if(${CMAKE_VERSION} VERSION_GREATER 3.15.0)
+        message(VERBOSE "Content of variable mfem_tpl_inc_flags: ${mfem_tpl_inc_flags}")
+    endif()
     string(REGEX REPLACE  "MFEM_TPLFLAGS +=" "" mfem_tpl_inc_flags ${mfem_tpl_inc_flags})
     string(FIND  ${mfem_tpl_inc_flags} "\n" mfem_tpl_inc_flags_end_pos)
     string(SUBSTRING ${mfem_tpl_inc_flags} 0 ${mfem_tpl_inc_flags_end_pos} mfem_tpl_inc_flags)
@@ -92,7 +94,9 @@ else()
 
     # parse link flags
     string(REGEX MATCHALL "MFEM_EXT_LIBS [^\n]+\n" mfem_tpl_lnk_flags ${mfem_cfg_file_txt})
-    message(VERBOSE "Content of variable mfem_tpl_lnk_flags: ${mfem_tpl_lnk_flags}")
+    if(${CMAKE_VERSION} VERSION_GREATER 3.15.0)
+        message(VERBOSE "Content of variable mfem_tpl_lnk_flags: ${mfem_tpl_lnk_flags}")
+    endif()
     if(NOT mfem_tpl_lnk_flags EQUAL "")
         string(REGEX REPLACE  "MFEM_EXT_LIBS +=" "" mfem_tpl_lnk_flags ${mfem_tpl_lnk_flags})
         string(FIND  ${mfem_tpl_lnk_flags} "\n" mfem_tpl_lnl_flags_end_pos )

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -91,29 +91,42 @@ include(cmake/thirdparty/FindMFEM.cmake)
 
 
 #------------------------------------------------------------------------------
-# TRIBOL
+# Tribol
 #------------------------------------------------------------------------------
-if (TRIBOL_DIR)
+if(TRIBOL_DIR)
     serac_assert_is_directory(VARIABLE_NAME TRIBOL_DIR)
 
-    find_package(tribol REQUIRED PATHS ${TRIBOL_DIR})
+    set(TRIBOL_INCLUDE_DIR ${TRIBOL_DIR}/include)
 
-    message(STATUS "Checking for expected TRIBOL target 'tribol'")
-    if (NOT TARGET tribol)
-        message(FATAL_ERROR "TRIBOL failed to load: ${TRIBOL_DIR}")
-    else()
-        message(STATUS "TRIBOL loaded: ${TRIBOL_DIR}")
-        set_property(TARGET tribol 
-                     APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                     ${TRIBOL_INCLUDE_DIRS})
-        set(TRIBOL_FOUND TRUE CACHE BOOL "")
+    set(_target_file ${TRIBOL_DIR}/lib/cmake/tribol-targets.cmake)
+
+    if(NOT EXISTS ${_target_file})
+        message(FATAL_ERROR "Could not find Tribol CMake exported target file (${_target_file})")
     endif()
+
+    include(${_target_file})
+
+    if(TARGET tribol)
+        message(STATUS "Tribol CMake exported library loaded: tribol")
+    else()
+        message(FATAL_ERROR "Could not load Tribol CMake exported library: tribol")
+    endif()
+
+    # Set include dir to system
+    set_property(TARGET tribol
+                 APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                 ${TRIBOL_INCLUDE_DIR})
+
+    set(TRIBOL_FOUND TRUE CACHE BOOL "")
 else()
-    message(STATUS "TRIBOL support is OFF")
+    message(STATUS "Tribol support is OFF")
     set(TRIBOL_FOUND FALSE CACHE BOOL "")
 endif()
 
+
+#------------------------------------------------------------------------------
 # Remove exported OpenMP flags because they are not language agnostic
+#------------------------------------------------------------------------------
 set(_props)
 if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0" )
     list(APPEND _props INTERFACE_LINK_OPTIONS)

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -4,12 +4,67 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-####################################
-# 3rd Party Dependencies
-####################################
 
-################################
+#------------------------------------------------------------------------------
+# Axom
+#------------------------------------------------------------------------------
+if(AXOM_DIR)
+    serac_assert_is_directory(VARIABLE_NAME AXOM_DIR)
+
+    set(AXOM_INCLUDE_DIR ${AXOM_DIR}/include)
+
+    set(AXOM_LIBRARIES fmt axom )
+    foreach(_library ${AXOM_LIBRARIES})
+        set(_target_file ${AXOM_DIR}/lib/cmake/${_library}-targets.cmake)
+
+        if(NOT EXISTS ${_target_file})
+            MESSAGE(FATAL_ERROR "Could not find Axom CMake exported target file (${_target_file})")
+        endif()
+
+        include(${_target_file})
+
+        # Set include dir to system
+        set_property(TARGET ${_library}
+                    APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                    ${AXOM_INCLUDE_DIR})
+    endforeach()
+
+    # Sets AXOM_FOUND if AXOM_INCLUDE_DIRS and AXOM_LIBRARIES are not empty
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(AXOM  DEFAULT_MSG
+                                      AXOM_INCLUDE_DIRS
+                                      AXOM_LIBRARIES )
+else()
+    message(STATUS "Axom support is OFF")
+    set(AXOM_FOUND FALSE CACHE BOOL "")
+endif()
+
+
+#------------------------------------------------------------------------------
 # MFEM
-################################
+#------------------------------------------------------------------------------
 include(cmake/thirdparty/FindMFEM.cmake)
 
+
+#------------------------------------------------------------------------------
+# TRIBOL
+#------------------------------------------------------------------------------
+if (TRIBOL_DIR)
+    serac_assert_is_directory(VARIABLE_NAME TRIBOL_DIR)
+
+    find_package(tribol REQUIRED PATHS ${TRIBOL_DIR})
+
+    message(STATUS "Checking for expected TRIBOL target 'tribol'")
+    if (NOT TARGET tribol)
+        message(FATAL_ERROR "TRIBOL failed to load: ${TRIBOL_DIR}")
+    else()
+        message(STATUS "TRIBOL loaded: ${TRIBOL_DIR}")
+        set_property(TARGET tribol 
+                     APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                     ${TRIBOL_INCLUDE_DIRS})
+        set(TRIBOL_FOUND TRUE CACHE BOOL "")
+    endif()
+else()
+    message(STATUS "TRIBOL support is OFF")
+    set(TRIBOL_FOUND FALSE CACHE BOOL "")
+endif()

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -13,7 +13,7 @@ if(AXOM_DIR)
 
     set(AXOM_INCLUDE_DIR ${AXOM_DIR}/include)
 
-    set(AXOM_LIBRARIES fmt axom )
+    set(AXOM_LIBRARIES fmt sparsehash axom )
     foreach(_library ${AXOM_LIBRARIES})
         set(_target_file ${AXOM_DIR}/lib/cmake/${_library}-targets.cmake)
 

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -44,6 +44,47 @@ endif()
 
 
 #------------------------------------------------------------------------------
+# Conduit (required by Axom)
+#------------------------------------------------------------------------------
+if (AXOM_FOUND)
+    if(NOT CONDUIT_DIR)
+        MESSAGE(FATAL_ERROR "Could not find Conduit. Conduit requires explicit CONDUIT_DIR.")
+    endif()
+
+    if(NOT WIN32)
+        set(_conduit_config "${CONDUIT_DIR}/lib/cmake/ConduitConfig.cmake")
+        if(NOT EXISTS ${_conduit_config})
+            MESSAGE(FATAL_ERROR "Could not find Conduit cmake include file ${_conduit_config}")
+        endif()
+
+        find_package(Conduit REQUIRED
+                    NO_DEFAULT_PATH
+                    PATHS ${CONDUIT_DIR}/lib/cmake)
+    else()
+        # Allow for several different configurations of Conduit
+        find_package(Conduit CONFIG 
+            REQUIRED
+            HINTS ${CONDUIT_DIR}/cmake/conduit 
+                  ${CONDUIT_DIR}/lib/cmake/conduit
+                  ${CONDUIT_DIR}/share/cmake/conduit
+                  ${CONDUIT_DIR}/share/conduit
+                  ${CONDUIT_DIR}/cmake)
+    endif()
+
+    # Manually set includes as system includes
+    set_property(TARGET conduit::conduit 
+                 APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                 "${CONDUIT_INSTALL_PREFIX}/include/")
+
+    set_property(TARGET conduit::conduit 
+                 APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                 "${CONDUIT_INSTALL_PREFIX}/include/conduit/")
+else()
+    set(CONDUIT_FOUND FALSE CACHE BOOL "")
+endif()
+
+
+#------------------------------------------------------------------------------
 # MFEM
 #------------------------------------------------------------------------------
 include(cmake/thirdparty/FindMFEM.cmake)
@@ -71,3 +112,35 @@ else()
     message(STATUS "TRIBOL support is OFF")
     set(TRIBOL_FOUND FALSE CACHE BOOL "")
 endif()
+
+# Remove exported OpenMP flags because they are not language agnostic
+set(_props)
+if( ${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.13.0" )
+    list(APPEND _props INTERFACE_LINK_OPTIONS)
+endif()
+list(APPEND _props INTERFACE_COMPILE_OPTIONS)
+
+# This flag is empty due to us not enabling fortran but we need to strip it so it doesnt propagate
+# in our project
+if("${OpenMP_Fortran_FLAGS}" STREQUAL "")
+    set(OpenMP_Fortran_FLAGS "$<$<NOT:$<COMPILE_LANGUAGE:Fortran>>:-fopenmp=libomp>;$<$<COMPILE_LANGUAGE:Fortran>:-fopenmp>")
+endif()
+
+foreach(_target axom)
+    if(TARGET ${_target})
+        message(STATUS "Removing OpenMP Flags from target[${_target}]")
+
+        foreach(_prop ${_props})
+            get_target_property(_flags ${_target} ${_prop})
+            if ( _flags )
+                string( REPLACE "${OpenMP_CXX_FLAGS}" ""
+                        correct_flags "${_flags}" )
+                string( REPLACE "${OpenMP_Fortran_FLAGS}" ""
+                        correct_flags "${correct_flags}" )
+
+                set_target_properties( ${_target} PROPERTIES ${_prop} "${correct_flags}" )
+            endif()
+        endforeach()
+    endif()
+endforeach()
+

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -18,22 +18,25 @@ if(AXOM_DIR)
         set(_target_file ${AXOM_DIR}/lib/cmake/${_library}-targets.cmake)
 
         if(NOT EXISTS ${_target_file})
-            MESSAGE(FATAL_ERROR "Could not find Axom CMake exported target file (${_target_file})")
+            message(FATAL_ERROR "Could not find Axom CMake exported target file (${_target_file})")
         endif()
 
         include(${_target_file})
+
+        if(TARGET ${_library})
+            message(STATUS "Axom CMake exported library loaded: ${_library}")
+        else()
+            message(FATAL_ERROR "Could not load Axom CMake exported library: ${_library}")
+        endif()
 
         # Set include dir to system
         set_property(TARGET ${_library}
                     APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                     ${AXOM_INCLUDE_DIR})
-    endforeach()
 
-    # Sets AXOM_FOUND if AXOM_INCLUDE_DIRS and AXOM_LIBRARIES are not empty
-    include(FindPackageHandleStandardArgs)
-    find_package_handle_standard_args(AXOM  DEFAULT_MSG
-                                      AXOM_INCLUDE_DIRS
-                                      AXOM_LIBRARIES )
+        string(TOUPPER ${_library} _ucname)
+        set(${_ucname}_FOUND TRUE CACHE BOOL "")
+    endforeach()
 else()
     message(STATUS "Axom support is OFF")
     set(AXOM_FOUND FALSE CACHE BOOL "")

--- a/host-configs/quartz-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -33,7 +33,21 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-4.0.0/bin/mp
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_17_07_45/clang-4.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_16_21_23_26/clang-4.0.0" CACHE PATH "")
+
+set(AXOM_DIR "${TPL_ROOT}/axom-develop" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(HYPRE_DIR "${TPL_ROOT}/hypre-2.11.1" CACHE PATH "")
+
+set(METIS_DIR "${TPL_ROOT}/metis-5.1.0" CACHE PATH "")
+
+set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
+
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -33,7 +33,21 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-gcc-8.1.0/bin/mpic
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_17_07_45/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_16_21_23_26/gcc-8.1.0" CACHE PATH "")
+
+set(AXOM_DIR "${TPL_ROOT}/axom-develop" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(HYPRE_DIR "${TPL_ROOT}/hypre-2.11.1" CACHE PATH "")
+
+set(METIS_DIR "${TPL_ROOT}/metis-5.1.0" CACHE PATH "")
+
+set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
+
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 

--- a/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -33,7 +33,21 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-intel-19.0.4/bin/m
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_17_07_45/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_16_21_23_26/intel-19.0.4" CACHE PATH "")
+
+set(AXOM_DIR "${TPL_ROOT}/axom-develop" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(HYPRE_DIR "${TPL_ROOT}/hypre-2.11.1" CACHE PATH "")
+
+set(METIS_DIR "${TPL_ROOT}/metis-5.1.0" CACHE PATH "")
+
+set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
+
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -33,7 +33,21 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-clang-4.0.0/bin/mp
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_16_32_41/clang-4.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_16_21_15_41/clang-4.0.0" CACHE PATH "")
+
+set(AXOM_DIR "${TPL_ROOT}/axom-develop" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(HYPRE_DIR "${TPL_ROOT}/hypre-2.11.1" CACHE PATH "")
+
+set(METIS_DIR "${TPL_ROOT}/metis-5.1.0" CACHE PATH "")
+
+set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
+
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -33,7 +33,21 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-gcc-8.1.0/bin/mpic
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_16_32_41/gcc-8.1.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_16_21_15_41/gcc-8.1.0" CACHE PATH "")
+
+set(AXOM_DIR "${TPL_ROOT}/axom-develop" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(HYPRE_DIR "${TPL_ROOT}/hypre-2.11.1" CACHE PATH "")
+
+set(METIS_DIR "${TPL_ROOT}/metis-5.1.0" CACHE PATH "")
+
+set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
+
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -33,7 +33,21 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.2-intel-19.0.4/bin/m
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_06_16_32_41/intel-19.0.4" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_04_16_21_15_41/intel-19.0.4" CACHE PATH "")
+
+set(AXOM_DIR "${TPL_ROOT}/axom-develop" CACHE PATH "")
+
+set(CONDUIT_DIR "${TPL_ROOT}/conduit-master" CACHE PATH "")
+
+set(HDF5_DIR "${TPL_ROOT}/hdf5-1.8.21" CACHE PATH "")
+
+set(HYPRE_DIR "${TPL_ROOT}/hypre-2.11.1" CACHE PATH "")
+
+set(METIS_DIR "${TPL_ROOT}/metis-5.1.0" CACHE PATH "")
+
+set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
+
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.0.0" CACHE PATH "")
 

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -11,15 +11,26 @@ set -e
 hostname="$(hostname)"
 project_dir="$(pwd)"
 build_dir="${BUILD_ROOT}/build_${SYS_TYPE}_${COMPILER}"
-hostconfig="${BUILD_ROOT}/${hostname//[0-9]/}-${SYS_TYPE}-${COMPILER}.cmake"
+hostconfig="${project_dir}/host-configs/${HOST_CONFIG}"
+
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo "~~~~~ Host-config: ${hostconfig}"
+echo "~~~~~ Build Dir:   ${build_dir}"
+echo "~~~~~ Project Dir: ${project_dir}"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
 
 # Build
 if [[ "${1}" != "--test-only" ]]
 then
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~ Building Serac"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
     rm -rf ${build_dir}
     mkdir -p ${build_dir}
 
-    echo "moving to ${build_dir}"
+    echo "~~~~~ Moving to ${build_dir}"
     cd ${build_dir}
 
     cmake \
@@ -31,13 +42,17 @@ fi
 # Test
 if [[ "${1}" != "--build-only" ]]
 then
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+    echo "~~~~~ Testing Serac"
+    echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
     if [[ ! -d ${build_dir} ]]
     then
-        echo "Build directory not found : $(pwd)/${build_dir}"
+        echo "~~~~~ Build directory not found : $(pwd)/${build_dir}"
         exit 1
     fi
 
-    echo "moving to ${build_dir}"
+    echo "~~~~~ Moving to ${build_dir}"
     cd ${build_dir}
 
     ctest -T test

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -431,7 +431,10 @@ class Axom(Package):
 
             cmake_args = []
             cmake_args.extend(std_cmake_args)
-            cmake_args.extend(["-C", host_config_path, "../src"])
+            cmake_args.extend(["-C", host_config_path])
+            if self.run_tests == False:
+                cmake_args.extend(["-DENABLE_TESTS=OFF"])
+            cmake_args.extend(["../src"])
             print("Configuring Axom...")
             cmake(*cmake_args)
 

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -1,0 +1,459 @@
+# Copyright 2013-2020 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack import *
+
+import glob
+import os
+import platform
+import socket
+from os.path import join as pjoin
+
+import llnl.util.tty as tty
+
+def cmake_cache_entry(name, value, comment=""):
+    """Generate a string for a cmake cache variable"""
+    return 'set(%s "%s" CACHE PATH "%s")\n\n' % (name,value,comment)
+
+
+def cmake_cache_option(name, boolean_value, comment=""):
+    """Generate a string for a cmake configuration option"""
+
+    value = "ON" if boolean_value else "OFF"
+    return 'set(%s %s CACHE BOOL "%s")\n\n' % (name,value,comment)
+
+
+def get_spec_path(spec, package_name, path_replacements = {}, use_bin = False) :
+    """Extracts the prefix path for the given spack package
+       path_replacements is a dictionary with string replacements for the path.
+    """
+
+    if not use_bin:
+        path = spec[package_name].prefix
+    else:
+        path = spec[package_name].prefix.bin
+
+    path = os.path.realpath(path)
+
+    for key in path_replacements:
+        path = path.replace(key, path_replacements[key])
+
+    return path
+
+
+class Axom(Package):
+    """Axom provides a robust, flexible software infrastructure for the development
+       of multi-physics applications and computational tools."""
+
+    maintainers = ['white238']
+
+    homepage = "https://github.com/LLNL/axom"
+    url      = "https://github.com/LLNL/axom/releases/download/v0.3.2/Axom-v0.3.2.tar.gz"
+    git      = "https://github.com/LLNL/axom.git"
+
+    version('develop', branch='develop', submodules=True, preferred=True)
+
+    version('0.3.2', sha256='0acbbf0de7154cbd3a204f91ce40f4b756b17cd5a92e75664afac996364503bd')
+    version('0.3.1', sha256='fad9964c32d7f843aa6dd144c32a8de0a135febd82a79827b3f24d7665749ac5')
+
+    phases = ["hostconfig", "configure", "build", "install"]
+
+    #-----------------------------------------------------------------------
+    # Variants
+    #-----------------------------------------------------------------------
+    variant('debug', default=False,
+            description='Build debug instead of optimized version')
+
+    variant('fortran', default=True, description="Build with Fortran support")
+
+    variant("python",   default=False, description="Build python support")
+
+    variant("mpi",      default=True, description="Build MPI support")
+    variant("cuda",     default=False, description="Turn on CUDA support.")
+    variant('openmp',   default=True, description='Turn on OpenMP support.')
+
+    variant("mfem",     default=False, description="Build with mfem")
+    variant("hdf5",     default=True, description="Build with hdf5")
+    variant("scr",      default=False, description="Build with SCR")
+    variant("raja",     default=True, description="Build with raja")
+    variant("umpire",   default=True, description="Build with umpire")
+
+    variant("devtools",  default=False,
+            description="Build development tools (such as Sphinx, Uncrustify, etc...)")
+
+    #-----------------------------------------------------------------------
+    # Dependencies
+    #-----------------------------------------------------------------------
+    # Basics
+    depends_on("cmake@3.8.2:", type='build')
+    depends_on("cuda", when="+cuda")
+    depends_on("mpi", when="+mpi")
+
+    # Libraries
+    depends_on("conduit~shared+python", when="+python")
+    depends_on("conduit~shared~python", when="~python")
+    depends_on("conduit~shared+python+hdf5", when="+hdf5+python")
+    depends_on("conduit~shared+python~hdf5", when="~hdf5+python")
+    depends_on("conduit~shared~python+hdf5", when="+hdf5~python")
+    depends_on("conduit~shared~python~hdf5", when="~hdf5~python")
+
+    # HDF5 needs to be the same as Conduit's
+    depends_on("hdf5@1.8.19:1.8.999~mpi~cxx~shared~fortran", when="+hdf5")
+
+    depends_on("scr", when="+scr")
+
+    depends_on("raja~openmp", when="+raja~openmp")
+    depends_on("raja+openmp", when="+raja+openmp")
+    depends_on("raja~openmp+cuda", when="+raja~openmp+cuda")
+    depends_on("raja+openmp+cuda", when="+raja+openmp+cuda")
+
+    depends_on("umpire~openmp", when="+umpire~openmp")
+    depends_on("umpire+openmp", when="+umpire+openmp")
+    depends_on("umpire~openmp+cuda", when="+umpire~openmp+cuda")
+    depends_on("umpire+openmp+cuda", when="+umpire+openmp+cuda")
+
+    #depends_on("mfem~mpi", when="+mfem")
+    depends_on("mfem~mpi~hypre~metis~gzstream", when="+mfem")
+
+    depends_on("python", when="+python")
+
+    # Devtools
+    depends_on("cppcheck", when="+devtools")
+    depends_on("doxygen", when="+devtools")
+    depends_on("graphviz", when="+devtools")
+    depends_on("python", when="+devtools")
+    depends_on("py-sphinx", when="+devtools")
+    depends_on("py-shroud", when="+devtools")
+    depends_on("uncrustify@0.61", when="+devtools")
+
+    def _get_sys_type(self, spec):
+        sys_type = spec.architecture
+        # if on llnl systems, we can use the SYS_TYPE
+        if "SYS_TYPE" in env:
+            sys_type = env["SYS_TYPE"]
+        return sys_type
+
+
+    def _get_host_config_path(self, spec):
+        host_config_path = "%s-%s-%s.cmake" % (socket.gethostname().rstrip('1234567890'),
+                                               self._get_sys_type(spec),
+                                               spec.compiler)
+        #dest_dir     = env["SPACK_DEBUG_LOG_DIR"]
+        dest_dir     = self.stage.source_path
+        host_config_path = os.path.abspath(pjoin(dest_dir, host_config_path))
+        return host_config_path
+
+    def hostconfig(self, spec, prefix):
+        """
+        This method creates a 'host-config' file that specifies
+        all of the options used to configure and build Axom.
+        """
+
+        c_compiler   = env["SPACK_CC"]
+        cpp_compiler = env["SPACK_CXX"]
+        f_compiler   = None
+
+        # see if we should enable fortran support
+        if "SPACK_FC" in env.keys():
+            # even if this is set, it may not exist
+            # do one more sanity check
+            if os.path.isfile(env["SPACK_FC"]):
+                f_compiler  = env["SPACK_FC"]
+
+
+        # are we on a specific machine
+        sys_type = self._get_sys_type(spec)
+        on_blueos = 'blueos' in sys_type
+        on_blueos_p9 = on_blueos and 'p9' in sys_type
+        on_toss =  'toss_3' in sys_type
+
+        # cmake
+        if "+cmake" in spec:
+            cmake_exe = pjoin(spec['cmake'].prefix.bin,"cmake")
+        else:
+            cmake_exe = which("cmake")
+            if cmake_exe is None:
+                #error could not find cmake!
+                crash()
+            cmake_exe = cmake_exe.command
+
+        host_config_path = self._get_host_config_path(spec)
+        cfg = open(host_config_path,"w")
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# !!!! This is a generated file, edit at own risk !!!!\n")
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# Copyright (c) 2017-2020, Lawrence Livermore National Security, LLC and\n")
+        cfg.write("# other Axom Project Developers. See the top-level COPYRIGHT file for details.\n")
+        cfg.write("#\n")
+        cfg.write("# SPDX-License-Identifier: (BSD-3-Clause)\n")
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# SYS_TYPE: {}\n".format(sys_type))
+        cfg.write("# Compiler Spec: {}\n".format(spec.compiler))
+        cfg.write("#------------------{}\n".format("-"*60))
+        # show path to cmake for reference and to be used by config-build.py
+        cfg.write("# CMake executable path: {}\n".format(cmake_exe))
+        cfg.write("#------------------{}\n\n".format("-"*60))
+
+        # compiler settings
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# Compilers\n")
+        cfg.write("#------------------{}\n\n".format("-"*60))
+
+        cfg.write(cmake_cache_entry("CMAKE_C_COMPILER",c_compiler))
+        cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER",cpp_compiler))
+
+        if "+fortran" in spec or not f_compiler is None:
+            cfg.write(cmake_cache_option("ENABLE_FORTRAN",True))
+            cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER",f_compiler))
+        else:
+            cfg.write(cmake_cache_option("ENABLE_FORTRAN",False))
+
+        # TPL locations
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# TPLs\n")
+        cfg.write("#------------------{}\n\n".format("-"*60))
+
+        # Try to find the common prefix of the TPL directory, including the compiler
+        # If found, we will use this in the TPL paths
+        compiler_str = str(spec.compiler).replace('@','-')
+        prefix_paths = prefix.split( compiler_str )
+        path_replacements = {}
+
+        if len(prefix_paths) == 2:
+            tpl_root = os.path.realpath(pjoin(prefix_paths[0], compiler_str))
+            path_replacements[tpl_root] = "${TPL_ROOT}"
+            cfg.write("# Root directory for generated TPLs\n")
+            cfg.write(cmake_cache_entry("TPL_ROOT",tpl_root))
+
+        conduit_dir = get_spec_path(spec, "conduit", path_replacements)
+        cfg.write(cmake_cache_entry("CONDUIT_DIR",conduit_dir))
+
+        # optional tpls
+
+        if "+mfem" in spec:
+            mfem_dir = get_spec_path(spec, "mfem", path_replacements)
+            cfg.write(cmake_cache_entry("MFEM_DIR",mfem_dir))
+        else:
+            cfg.write("# MFEM not built\n\n")
+
+        if "+hdf5" in spec:
+            hdf5_dir = get_spec_path(spec, "hdf5", path_replacements)
+            cfg.write(cmake_cache_entry("HDF5_DIR",hdf5_dir))
+        else:
+            cfg.write("# HDF5 not built\n\n")
+
+        if "+scr" in spec:
+            scr_dir = get_spec_path(spec, "scr", path_replacements)
+            cfg.write(cmake_cache_entry("SCR_DIR",scr_dir))
+        else:
+            cfg.write("# SCR not built\n\n")
+
+        if "+raja" in spec:
+            raja_dir = get_spec_path(spec, "raja", path_replacements)
+            cfg.write(cmake_cache_entry("RAJA_DIR", raja_dir))
+        else:
+            cfg.write("# RAJA not built\n\n")
+
+        if "+umpire" in spec:
+            umpire_dir = get_spec_path(spec, "umpire", path_replacements)
+            cfg.write(cmake_cache_entry("UMPIRE_DIR", umpire_dir))
+        else:
+            cfg.write("# Umpire not built\n\n")
+
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# MPI\n")
+        cfg.write("#------------------{}\n\n".format("-"*60))
+
+        if "+mpi" in spec:
+            cfg.write(cmake_cache_option("ENABLE_MPI", True))
+            cfg.write(cmake_cache_entry("MPI_C_COMPILER", spec['mpi'].mpicc))
+            cfg.write(cmake_cache_entry("MPI_CXX_COMPILER", spec['mpi'].mpicxx))
+            if "+fortran" in spec or not f_compiler is None:
+                cfg.write(cmake_cache_entry("MPI_Fortran_COMPILER", spec['mpi'].mpifc))
+
+            # Determine MPIEXEC
+            if on_blueos:
+                mpiexec = join_path(spec['mpi'].prefix.bin, 'mpirun')
+            else:
+                mpiexec = join_path(spec['mpi'].prefix.bin, 'mpiexec')
+                if not os.path.isfile(mpiexec):
+                    mpiexec = "/usr/bin/srun"
+            # starting with cmake 3.10, FindMPI expects MPIEXEC_EXECUTABLE
+            # vs the older versions which expect MPIEXEC
+            if self.spec["cmake"].satisfies('@3.10:'):
+                cfg.write(cmake_cache_entry("MPIEXEC_EXECUTABLE", mpiexec))
+            else:
+                cfg.write(cmake_cache_entry("MPIEXEC", mpiexec))
+
+            # Determine MPIEXEC_NUMPROC_FLAG
+            if on_blueos:
+                cfg.write(cmake_cache_entry("MPIEXEC_NUMPROC_FLAG", "-np"))
+                cfg.write(cmake_cache_entry("BLT_MPI_COMMAND_APPEND", "mpibind"))
+            else:
+                cfg.write(cmake_cache_entry("MPIEXEC_NUMPROC_FLAG", "-n"))
+        else:
+            cfg.write(cmake_cache_option("ENABLE_MPI", False))
+
+
+        ##################################
+        # Devtools
+        ##################################
+
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# Devtools\n")
+        cfg.write("#------------------{}\n\n".format("-"*60))
+
+        # Add common prefix to path replacement list
+        if "+devtools" in spec:
+            # Grab common devtools root and strip the trailing slash
+            path1 = os.path.realpath(spec["uncrustify"].prefix)
+            path2 = os.path.realpath(spec["doxygen"].prefix)
+            devtools_root = os.path.commonprefix([path1, path2])[:-1]
+            path_replacements[devtools_root] = "${DEVTOOLS_ROOT}"
+            cfg.write("# Root directory for generated developer tools\n")
+            cfg.write(cmake_cache_entry("DEVTOOLS_ROOT",devtools_root))
+
+
+        if "python" in spec or "devtools" in spec:
+            python_bin_dir = get_spec_path(spec, "python", path_replacements, use_bin=True)
+            cfg.write(cmake_cache_entry("PYTHON_EXECUTABLE",pjoin(python_bin_dir, "python")))
+            
+        if "doxygen" in spec or "py-sphinx" in spec:
+            cfg.write(cmake_cache_option("ENABLE_DOCS", True))
+
+            if "doxygen" in spec:
+                doxygen_bin_dir = get_spec_path(spec, "doxygen", path_replacements, use_bin=True)
+                cfg.write(cmake_cache_entry("DOXYGEN_EXECUTABLE", pjoin(doxygen_bin_dir, "doxygen")))
+
+            if "py-sphinx" in spec:
+                python_bin_dir = get_spec_path(spec, "python", path_replacements, use_bin=True)
+                cfg.write(cmake_cache_entry("SPHINX_EXECUTABLE", pjoin(python_bin_dir, "sphinx-build")))
+        else:
+            cfg.write(cmake_cache_option("ENABLE_DOCS", False))
+
+        if "py-shroud" in spec:
+            python_bin_dir = get_spec_path(spec, "python", path_replacements, use_bin=True)
+            cfg.write(cmake_cache_entry("SHROUD_EXECUTABLE", pjoin(python_bin_dir, "shroud")))
+
+        if "uncrustify" in spec:
+            uncrustify_bin_dir = get_spec_path(spec, "uncrustify", path_replacements, use_bin=True)
+            cfg.write(cmake_cache_entry("UNCRUSTIFY_EXECUTABLE", pjoin(uncrustify_bin_dir, "uncrustify")))
+
+        if "cppcheck" in spec:
+            cppcheck_bin_dir = get_spec_path(spec, "cppcheck", path_replacements, use_bin=True)
+            cfg.write(cmake_cache_entry("CPPCHECK_EXECUTABLE", pjoin(cppcheck_bin_dir, "cppcheck")))
+
+
+        ##################################
+        # Other machine specifics
+        ##################################
+
+        cfg.write("#------------------{}\n".format("-"*60))
+        cfg.write("# Other machine specifics\n")
+        cfg.write("#------------------{}\n\n".format("-"*60))
+
+        # OpenMP
+        if "+openmp" in spec:
+            cfg.write(cmake_cache_option("ENABLE_OPENMP", True))
+
+        # Enable death tests
+        if on_blueos and "+cuda" in spec:
+            cfg.write(cmake_cache_option("ENABLE_GTEST_DEATH_TESTS", False))
+        else:
+            cfg.write(cmake_cache_option("ENABLE_GTEST_DEATH_TESTS", True))
+
+        # BlueOS
+        if on_blueos or on_blueos_p9:
+            if "xlf" in f_compiler:
+                cfg.write(cmake_cache_entry("CMAKE_Fortran_COMPILER_ID", "XL",
+                    "All of BlueOS compilers report clang due to nvcc, override to proper compiler family"))
+            if "xlc" in c_compiler:
+                cfg.write(cmake_cache_entry("CMAKE_C_COMPILER_ID", "XL",
+                    "All of BlueOS compilers report clang due to nvcc, override to proper compiler family"))
+            if "xlC" in cpp_compiler:
+                cfg.write(cmake_cache_entry("CMAKE_CXX_COMPILER_ID", "XL",
+                    "All of BlueOS compilers report clang due to nvcc, override to proper compiler family"))
+
+            if "xlf" in f_compiler:
+                cfg.write(cmake_cache_entry("BLT_FORTRAN_FLAGS", "-WF,-C!  -qxlf2003=polymorphic",
+                    "Converts C-style comments to Fortran style in preprocessed files"))
+                # Grab lib directory for the current fortran compiler
+                libdir = os.path.join(os.path.dirname(os.path.dirname(f_compiler)), "lib")
+                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
+                    "-Wl,-rpath," + libdir,
+                    "Adds a missing rpath for libraries associated with the fortran compiler"))
+
+
+            if "+cuda" in spec:
+                cfg.write("#------------------{}\n".format("-"*60))
+                cfg.write("# Cuda\n")
+                cfg.write("#------------------{}\n\n".format("-"*60))
+
+                cfg.write(cmake_cache_option("ENABLE_CUDA", True))
+                cfg.write(cmake_cache_entry("CUDA_TOOLKIT_ROOT_DIR", "/usr/tce/packages/cuda/cuda-10.1.168"))
+                cfg.write(cmake_cache_entry("CMAKE_CUDA_COMPILER", "${CUDA_TOOLKIT_ROOT_DIR}/bin/nvcc"))
+
+                cfg.write(cmake_cache_option("CUDA_SEPARABLE_COMPILATION", True))
+
+                if on_blueos_p9:
+                    cfg.write(cmake_cache_entry("AXOM_CUDA_ARCH", "sm_70"))
+                else:
+                    cfg.write(cmake_cache_entry("AXOM_CUDA_ARCH", "sm_60"))
+
+                cfg.write(cmake_cache_entry("CMAKE_CUDA_FLAGS" ,"-restrict -arch ${AXOM_CUDA_ARCH} -std=c++11 --expt-extended-lambda -G"))
+
+                if "+mpi" in spec:
+                    cfg.write(cmake_cache_entry("CMAKE_CUDA_HOST_COMPILER", "${MPI_CXX_COMPILER}"))
+                else:
+                    cfg.write(cmake_cache_entry("CMAKE_CUDA_HOST_COMPILER", "${CMAKE_CXX_COMPILER}"))
+
+                cfg.write("# nvcc does not like gtest's 'pthreads' flag\n")
+                cfg.write(cmake_cache_option("gtest_disable_pthreads", True))
+
+        # TOSS3
+        elif on_toss:
+            if ("gfortran" in f_compiler) and ("clang" in cpp_compiler):
+                clanglibdir = pjoin(os.path.dirname(os.path.dirname(cpp_compiler)), "lib")
+                cfg.write(cmake_cache_entry("BLT_EXE_LINKER_FLAGS",
+                    "-Wl,-rpath,{0}".format(clanglibdir),
+                    "Adds a missing rpath for libraries associated with the fortran compiler"))
+
+        cfg.write("\n")
+        cfg.close()
+        tty.info("Spack generated Axom host-config file: " + host_config_path)
+
+
+    def configure(self, spec, prefix):
+        with working_dir('spack-build', create=True):
+            host_config_path = self._get_host_config_path(spec)
+
+            cmake_args = []
+            cmake_args.extend(std_cmake_args)
+            cmake_args.extend(["-C", host_config_path, "../src"])
+            print("Configuring Axom...")
+            cmake(*cmake_args)
+
+
+    def build(self, spec, prefix):
+        with working_dir('spack-build'):
+            print("Building Axom...")
+            make()
+
+
+    @run_after('build')
+    @on_package_attributes(run_tests=True)
+    def test(self):
+        with working_dir('spack-build'):
+            print("Running Axom's Unit Tests...")
+            make("test")
+
+
+    def install(self, spec, prefix):
+        with working_dir('spack-build'):
+            make("install")
+            # install copy of host config for provenance
+            print("Installing Axom's CMake Host Config File...")
+            host_config_path = self._get_host_config_path(spec)
+            install(host_config_path, prefix)

--- a/scripts/uberenv/packages/serac/package.py
+++ b/scripts/uberenv/packages/serac/package.py
@@ -88,6 +88,8 @@ class Serac(Package):
     # Basic dependencies
     depends_on("mpi")
 
+    depends_on("axom~fortran~raja~umpire")
+
     # Devtool dependencies these need to match serac_devtools/package.py
     depends_on('cmake', when="+devtools")
     depends_on('cppcheck', when="+devtools")
@@ -248,6 +250,9 @@ class Serac(Package):
             tpl_root = os.path.join( prefix_paths[0], compiler_str )
             path_replacements[tpl_root] = "${TPL_ROOT}"
             cfg.write(cmake_cache_entry("TPL_ROOT", tpl_root))
+
+        axom_dir = get_spec_path(spec, "axom", path_replacements)
+        cfg.write(cmake_cache_entry("AXOM_DIR", axom_dir))
 
         hypre_dir = get_spec_path(spec, "hypre", path_replacements)
         cfg.write(cmake_cache_entry("HYPRE_DIR", hypre_dir))

--- a/scripts/uberenv/packages/serac/package.py
+++ b/scripts/uberenv/packages/serac/package.py
@@ -96,8 +96,8 @@ class Serac(Package):
     depends_on('py-sphinx', when="+devtools")
 
     # Libraries that support +debug
-    depends_on("mfem~shared+hypre+metis+superlu-dist+lapack+mpi")
-    depends_on("mfem~shared+hypre+metis+superlu-dist+lapack+mpi+debug", when="+debug")
+    depends_on("mfem~shared~gzstream+hypre+metis+superlu-dist+lapack+mpi")
+    depends_on("mfem~shared~gzstream+hypre+metis+superlu-dist+lapack+mpi+debug", when="+debug")
     depends_on("hypre~shared~superlu-dist+mpi")
     depends_on("hypre~shared~superlu-dist+mpi+debug", when="+debug")
 
@@ -248,6 +248,18 @@ class Serac(Package):
             tpl_root = os.path.join( prefix_paths[0], compiler_str )
             path_replacements[tpl_root] = "${TPL_ROOT}"
             cfg.write(cmake_cache_entry("TPL_ROOT", tpl_root))
+
+        hypre_dir = get_spec_path(spec, "hypre", path_replacements)
+        cfg.write(cmake_cache_entry("HYPRE_DIR", hypre_dir))
+
+        metis_dir = get_spec_path(spec, "metis", path_replacements)
+        cfg.write(cmake_cache_entry("METIS_DIR", metis_dir))
+
+        parmetis_dir = get_spec_path(spec, "parmetis", path_replacements)
+        cfg.write(cmake_cache_entry("PARMETIS_DIR", parmetis_dir))
+
+        superludist_dir = get_spec_path(spec, "superlu-dist", path_replacements)
+        cfg.write(cmake_cache_entry("SUPERLUDIST_DIR", superludist_dir))
 
         mfem_dir = get_spec_path(spec, "mfem", path_replacements)
         cfg.write(cmake_cache_entry("MFEM_DIR", mfem_dir))

--- a/scripts/uberenv/packages/serac/package.py
+++ b/scripts/uberenv/packages/serac/package.py
@@ -254,6 +254,12 @@ class Serac(Package):
         axom_dir = get_spec_path(spec, "axom", path_replacements)
         cfg.write(cmake_cache_entry("AXOM_DIR", axom_dir))
 
+        conduit_dir = get_spec_path(spec, "conduit", path_replacements)
+        cfg.write(cmake_cache_entry("CONDUIT_DIR", conduit_dir))
+
+        hdf5_dir = get_spec_path(spec, "hdf5", path_replacements)
+        cfg.write(cmake_cache_entry("HDF5_DIR", hdf5_dir))
+
         hypre_dir = get_spec_path(spec, "hypre", path_replacements)
         cfg.write(cmake_cache_entry("HYPRE_DIR", hypre_dir))
 

--- a/src/serac_config.hpp.in
+++ b/src/serac_config.hpp.in
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef SERAC_CONFIG_HPP
+#define SERAC_CONFIG_HPP
+
+// Serac Version Information
+#define SERAC_VERSION_MAJOR @SERAC_VERSION_MAJOR@
+#define SERAC_VERSION_MINOR @SERAC_VERSION_MINOR@
+#define SERAC_VERSION_PATCH @SERAC_VERSION_PATCH@
+#define SERAC_VERSION_FULL  "@SERAC_VERSION_FULL@"
+#cmakedefine SERAC_GIT_SHA "@SERAC_GIT_SHA@"
+
+
+// Serac Locations
+#define SERAC_SRC_DIR "@SERAC_SRC_DIR@"
+#define SERAC_BIN_DIR "@SERAC_BIN_DIR@"
+
+// General defines
+#cmakedefine SERAC_DEBUG
+
+
+// Compiler defines for TPLs
+#cmakedefine SERAC_USE_AXOM
+#cmakedefine SERAC_USE_CONDUIT
+#cmakedefine SERAC_USE_FMT
+#cmakedefine SERAC_USE_HDF5
+#cmakedefine SERAC_USE_MFEM
+#cmakedefine SERAC_USE_MPI
+#cmakedefine SERAC_USE_TRIBOL
+
+
+#endif  /* SERAC_CONFIG_CPP */


### PR DESCRIPTION
This enables all libraries needed for Tribol in our Uberenv/Spack build.  I have built them shared on the network on rzgenie and quartz.

This also creates a config header that has the necessary preprocessor guards (like SERAC_USE_TRIBOL) needed in Serac.

Instructions:

1) Build Tribol with shared libraries:

```
cd <Tribol/repo>
./bootstrap -hc ../../serac/repo/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake --with-cmake-args -DENABLE_DOCS=OFF
cd Debug-build
make -j
make install
```

3) Build Serac with Tribol:

```
cd <Serac/repo>
./config-build.py -hc host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake -DTRIBOL_DIR=<Tribol/repo>/Debug-install
cd build-rzgenie-toss_3_x86_64_ib-clang@4.0.0-debug
make -j
make test
```