### PR TITLE
don't use the symlink for cmake

### DIFF
--- a/host-configs/quartz-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: toss_3_x86_64_ib
 # Compiler Spec: clang@4.0.0
-# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/2020_03_20_17_10_57/gcc-8.1.0/cmake-3.9.6/bin/cmake
 #---------------------------------------
 
 #---------------------------------------

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: toss_3_x86_64_ib
 # Compiler Spec: gcc@8.1.0
-# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/2020_03_20_17_10_57/gcc-8.1.0/cmake-3.9.6/bin/cmake
 #---------------------------------------
 
 #---------------------------------------

--- a/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: toss_3_x86_64_ib
 # Compiler Spec: intel@19.0.4
-# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/2020_03_20_17_10_57/gcc-8.1.0/cmake-3.9.6/bin/cmake
 #---------------------------------------
 
 #---------------------------------------

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@4.0.0.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: toss_3_x86_64_ib
 # Compiler Spec: clang@4.0.0
-# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/2020_03_20_17_10_57/gcc-8.1.0/cmake-3.9.6/bin/cmake
 #---------------------------------------
 
 #---------------------------------------

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.1.0.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: toss_3_x86_64_ib
 # Compiler Spec: gcc@8.1.0
-# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/2020_03_20_17_10_57/gcc-8.1.0/cmake-3.9.6/bin/cmake
 #---------------------------------------
 
 #---------------------------------------

--- a/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-intel@19.0.4.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: toss_3_x86_64_ib
 # Compiler Spec: intel@19.0.4
-# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/cmake-3.9.6/bin/cmake
+# CMake executable path: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/2020_03_20_17_10_57/gcc-8.1.0/cmake-3.9.6/bin/cmake
 #---------------------------------------
 
 #---------------------------------------


### PR DESCRIPTION
I am moving us to use the system CMake but there is a small window that master will be broken during that time.  This will make that not happen.