### PR TITLE
Bugfix/bramwell/updatedocs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   PROJECT_ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
-  ACCOUNT: -p pdebug -A radiuss
+  ACCOUNT: -p pdebug -A eng
 
 # There are no tests for now
 stages:

--- a/src/docs/sphinx/index.rst
+++ b/src/docs/sphinx/index.rst
@@ -43,7 +43,7 @@ using the following commands:
 
    $ sudo apt-get update
    $ sudo apt-get upgrade
-   $ sudo apt-get install cmake libopenblas-dev libopenblas-base mpich mesa-common-dev libglu1-mesa-dev freeglut3-dev cppcheck doxygen
+   $ sudo apt-get install cmake libopenblas-dev libopenblas-base mpich mesa-common-dev libglu1-mesa-dev freeglut3-dev cppcheck doxygen libreadline-dev
    $ sudo ln -s /usr/lib/x86_64-linux-gnu/* /usr/lib
 
 Note that the last line is required since Spack expects the system libraries to exist in a directory named `lib`. The call to `uberenv` should 


### PR DESCRIPTION
This adds an update to the wsl build documentation and changes the default gitlab bank to `eng`. This should work in the new smith-owned gitlab repo.