### PR TITLE
Fixing the gitlab master ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ variables:
   PROJECT_ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
   ACCOUNT: -p pdebug -A eng
+  MIRROR: "/usr/workspace/smithdev/mirror"
 
 # There are no tests for now
 stages:

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -67,16 +67,19 @@ clang_9_0_0 (Master build_with_deps_on_quartz):
   variables:
     COMPILER: "clang@9.0.0"
     SPEC: "@develop%${COMPILER}"
+    MIRROR: "/usr/workspace/smithdev/mirror"
   extends: .master_build_with_deps_on_quartz
 
 gcc_8_1_0 (Master build_with_deps_on_quartz):
   variables:
     COMPILER: "gcc@8.1.0"
     SPEC: "@develop%${COMPILER}"
+    MIRROR: "/usr/workspace/smithdev/mirror"
   extends: .master_build_with_deps_on_quartz
 
 intel_19_0_4 (Master build_with_deps_on_quartz):
   variables:
     COMPILER: "intel@19.0.4"
     SPEC: "@develop%${COMPILER}"
+    MIRROR: "/usr/workspace/smithdev/mirror"
   extends: .master_build_with_deps_on_quartz

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -67,19 +67,16 @@ clang_9_0_0 (Master build_with_deps_on_quartz):
   variables:
     COMPILER: "clang@9.0.0"
     SPEC: "@develop%${COMPILER}"
-    MIRROR: "/usr/workspace/smithdev/mirror"
   extends: .master_build_with_deps_on_quartz
 
 gcc_8_1_0 (Master build_with_deps_on_quartz):
   variables:
     COMPILER: "gcc@8.1.0"
     SPEC: "@develop%${COMPILER}"
-    MIRROR: "/usr/workspace/smithdev/mirror"
   extends: .master_build_with_deps_on_quartz
 
 intel_19_0_4 (Master build_with_deps_on_quartz):
   variables:
     COMPILER: "intel@19.0.4"
     SPEC: "@develop%${COMPILER}"
-    MIRROR: "/usr/workspace/smithdev/mirror"
   extends: .master_build_with_deps_on_quartz

--- a/scripts/gitlab/build_and_test.sh
+++ b/scripts/gitlab/build_and_test.sh
@@ -18,6 +18,7 @@ sys_type=${SYS_TYPE:-""}
 compiler=${COMPILER:-""}
 hostconfig=${HOST_CONFIG:-""}
 spec=${SPEC:-""}
+mirror=${MIRROR:-""}
 
 # Dependencies
 if [[ "${option}" != "--build-only" && "${option}" != "--test-only" ]]
@@ -32,7 +33,7 @@ then
         exit 1
     fi
 
-    python scripts/uberenv/uberenv.py --spec=${spec}
+    python scripts/uberenv/uberenv.py --spec=${spec} --mirror=${mirror}
 
 fi
 


### PR DESCRIPTION
This adds a mirror option to the gitlab master CI in case TPL repos are inaccessible. 