### PR TITLE
Use std::set instead of std::vector to indicate boundary attributes for BCs

### DIFF
--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -161,20 +161,14 @@ int main(int argc, char *argv[])
   solid_solver.SetDisplacement(defo_coef);
   solid_solver.SetVelocity(velo_coef);
 
-  // define a boundary attribute array and initialize to 0
-  std::vector<int> ess_bdr(pmesh->bdr_attributes.Max(), 0);
-
-  // boundary attribute 1 (index 0) is fixed (Dirichlet)
-  ess_bdr[0] = 1;
+  std::set<int> ess_bdr = {1};
 
   // define the displacement vector
   mfem::Vector disp(dim);
   disp           = 0.0;
   auto disp_coef = std::make_shared<mfem::VectorConstantCoefficient>(disp);
 
-  std::vector<int> trac_bdr(pmesh->bdr_attributes.Max(), 0);
-
-  trac_bdr[1] = 1;
+  std::set<int> trac_bdr = {2};
 
   // define the traction vector
   mfem::Vector traction(dim);

--- a/src/solvers/base_solver.cpp
+++ b/src/solvers/base_solver.cpp
@@ -29,26 +29,24 @@ BaseSolver::BaseSolver(MPI_Comm comm, int n) : BaseSolver(comm)
   m_gf_initialized.assign(n, false);
 }
 
-void BaseSolver::SetEssentialBCs(const std::vector<int> &                 ess_bdr,
+void BaseSolver::SetEssentialBCs(const std::set<int> &                 ess_bdr,
                                  std::shared_ptr<mfem::VectorCoefficient> ess_bdr_vec_coef,
                                  mfem::ParFiniteElementSpace &fes, int component)
 {
   auto bc = std::make_shared<BoundaryCondition>();
 
-  bc->markers.SetSize(ess_bdr.size());
+  bc->markers.SetSize(m_state.front()->mesh->bdr_attributes.Max());
+  bc->markers = 0;
 
-  for (unsigned int i = 0; i < ess_bdr.size(); ++i) {
-    bc->markers[i] = ess_bdr[i];
-
-    if (bc->markers[i] == 1) {
-      for (auto &existing_bc : m_ess_bdr) {
-        if (existing_bc->markers[i] == 1) {
-          mfem::mfem_warning("Multiple definition of essential boundary! Using first definition given.");
-          bc->markers[i] = 0;
-          break;
-        }
+  for (int attr : ess_bdr) {
+    bc->markers[attr-1] = 1;
+    for (auto &existing_bc : m_ess_bdr) {
+      if (existing_bc->markers[attr-1] == 1) {
+        mfem::mfem_warning("Multiple definition of essential boundary! Using first definition given.");
+        bc->markers[attr-1] = 0;
+        break;
       }
-    }
+    }    
   }
 
   bc->vec_coef  = ess_bdr_vec_coef;
@@ -73,15 +71,16 @@ void BaseSolver::SetTrueDofs(const mfem::Array<int> &                 true_dofs,
   m_ess_bdr.push_back(bc);
 }
 
-void BaseSolver::SetNaturalBCs(const std::vector<int> &                 nat_bdr,
+void BaseSolver::SetNaturalBCs(const std::set<int> &                 nat_bdr,
                                std::shared_ptr<mfem::VectorCoefficient> nat_bdr_vec_coef, int component)
 {
   auto bc = std::make_shared<BoundaryCondition>();
 
-  bc->markers.SetSize(nat_bdr.size());
+  bc->markers.SetSize(m_state.front()->mesh->bdr_attributes.Max());
+  bc->markers = 0;
 
-  for (unsigned int i = 0; i < nat_bdr.size(); ++i) {
-    bc->markers[i] = nat_bdr[i];
+  for (int attr : nat_bdr) {  
+    bc->markers[attr-1] = 1;
   }
 
   bc->vec_coef  = nat_bdr_vec_coef;
@@ -90,25 +89,23 @@ void BaseSolver::SetNaturalBCs(const std::vector<int> &                 nat_bdr,
   m_nat_bdr.push_back(bc);
 }
 
-void BaseSolver::SetEssentialBCs(const std::vector<int> &ess_bdr, std::shared_ptr<mfem::Coefficient> ess_bdr_coef,
+void BaseSolver::SetEssentialBCs(const std::set<int> &ess_bdr, std::shared_ptr<mfem::Coefficient> ess_bdr_coef,
                                  mfem::ParFiniteElementSpace &fes, int component)
 {
   auto bc = std::make_shared<BoundaryCondition>();
 
-  bc->markers.SetSize(ess_bdr.size());
+  bc->markers.SetSize(m_state.front()->mesh->bdr_attributes.Max());
+  bc->markers = 0;
 
-  for (unsigned int i = 0; i < ess_bdr.size(); ++i) {
-    bc->markers[i] = ess_bdr[i];
-
-    if (bc->markers[i] == 1) {
-      for (auto &existing_bc : m_ess_bdr) {
-        if (existing_bc->markers[i] == 1) {
-          mfem::mfem_warning("Multiple definition of essential boundary! Using first definition given.");
-          bc->markers[i] = 0;
-          break;
-        }
+  for (int attr : ess_bdr) {
+    bc->markers[attr-1] = 1;
+    for (auto &existing_bc : m_ess_bdr) {
+      if (existing_bc->markers[attr-1] == 1) {
+        mfem::mfem_warning("Multiple definition of essential boundary! Using first definition given.");
+        bc->markers[attr-1] = 0;
+        break;
       }
-    }
+    }    
   }
 
   bc->scalar_coef = ess_bdr_coef;
@@ -132,15 +129,16 @@ void BaseSolver::SetTrueDofs(const mfem::Array<int> &true_dofs, std::shared_ptr<
   m_ess_bdr.push_back(bc);
 }
 
-void BaseSolver::SetNaturalBCs(const std::vector<int> &nat_bdr, std::shared_ptr<mfem::Coefficient> nat_bdr_coef,
+void BaseSolver::SetNaturalBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfem::Coefficient> nat_bdr_coef,
                                int component)
 {
   auto bc = std::make_shared<BoundaryCondition>();
 
-  bc->markers.SetSize(nat_bdr.size());
+  bc->markers.SetSize(m_state.front()->mesh->bdr_attributes.Max());
+  bc->markers = 0;
 
-  for (unsigned int i = 0; i < nat_bdr.size(); ++i) {
-    bc->markers[i] = nat_bdr[i];
+  for (int attr : nat_bdr) {  
+    bc->markers[attr-1] = 1;
   }
 
   bc->scalar_coef = nat_bdr_coef;

--- a/src/solvers/base_solver.cpp
+++ b/src/solvers/base_solver.cpp
@@ -39,6 +39,7 @@ void BaseSolver::SetEssentialBCs(const std::set<int> &                 ess_bdr,
   bc->markers = 0;
 
   for (int attr : ess_bdr) {
+    MFEM_ASSERT(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
     bc->markers[attr-1] = 1;
     for (auto &existing_bc : m_ess_bdr) {
       if (existing_bc->markers[attr-1] == 1) {
@@ -80,6 +81,7 @@ void BaseSolver::SetNaturalBCs(const std::set<int> &                 nat_bdr,
   bc->markers = 0;
 
   for (int attr : nat_bdr) {  
+    MFEM_ASSERT(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
     bc->markers[attr-1] = 1;
   }
 
@@ -98,6 +100,7 @@ void BaseSolver::SetEssentialBCs(const std::set<int> &ess_bdr, std::shared_ptr<m
   bc->markers = 0;
 
   for (int attr : ess_bdr) {
+    MFEM_ASSERT(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
     bc->markers[attr-1] = 1;
     for (auto &existing_bc : m_ess_bdr) {
       if (existing_bc->markers[attr-1] == 1) {
@@ -138,6 +141,7 @@ void BaseSolver::SetNaturalBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfe
   bc->markers = 0;
 
   for (int attr : nat_bdr) {  
+    MFEM_ASSERT(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
     bc->markers[attr-1] = 1;
   }
 

--- a/src/solvers/base_solver.hpp
+++ b/src/solvers/base_solver.hpp
@@ -67,12 +67,12 @@ class BaseSolver {
 
   /// Set the essential boundary conditions from a list of boundary markers and
   /// a coefficient
-  virtual void SetEssentialBCs(const std::vector<int> &ess_bdr, std::shared_ptr<mfem::Coefficient> ess_bdr_coef,
+  virtual void SetEssentialBCs(const std::set<int> &ess_bdr, std::shared_ptr<mfem::Coefficient> ess_bdr_coef,
                                mfem::ParFiniteElementSpace &fes, int component = -1);
 
   /// Set the vector-valued essential boundary conditions from a list of
   /// boundary markers and a coefficient
-  virtual void SetEssentialBCs(const std::vector<int> &                 ess_bdr,
+  virtual void SetEssentialBCs(const std::set<int> &                 ess_bdr,
                                std::shared_ptr<mfem::VectorCoefficient> ess_bdr_vec_coef,
                                mfem::ParFiniteElementSpace &fes, int component = -1);
 
@@ -85,12 +85,12 @@ class BaseSolver {
 
   /// Set the natural boundary conditions from a list of boundary markers and a
   /// coefficient
-  virtual void SetNaturalBCs(const std::vector<int> &nat_bdr, std::shared_ptr<mfem::Coefficient> nat_bdr_coef,
+  virtual void SetNaturalBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfem::Coefficient> nat_bdr_coef,
                              int component = -1);
 
   /// Set the vector-valued natural boundary conditions from a list of boundary
   /// markers and a coefficient
-  virtual void SetNaturalBCs(const std::vector<int> &nat_bdr, std::shared_ptr<mfem::VectorCoefficient> nat_bdr_vec_coef,
+  virtual void SetNaturalBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfem::VectorCoefficient> nat_bdr_vec_coef,
                              int component = -1);
 
   /// Set the state variables from a coefficient

--- a/src/solvers/elasticity_solver.cpp
+++ b/src/solvers/elasticity_solver.cpp
@@ -37,13 +37,13 @@ ElasticitySolver::ElasticitySolver(int order, std::shared_ptr<mfem::ParMesh> pme
   displacement->name = "displacement";
 }
 
-void ElasticitySolver::SetDisplacementBCs(std::vector<int> &                       disp_bdr,
+void ElasticitySolver::SetDisplacementBCs(std::set<int> &                       disp_bdr,
                                           std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef, int component)
 {
   SetEssentialBCs(disp_bdr, disp_bdr_coef, *displacement->space, component);
 }
 
-void ElasticitySolver::SetTractionBCs(std::vector<int> &                       trac_bdr,
+void ElasticitySolver::SetTractionBCs(std::set<int> &                       trac_bdr,
                                       std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef, int component)
 {
   SetNaturalBCs(trac_bdr, trac_bdr_coef, component);

--- a/src/solvers/elasticity_solver.hpp
+++ b/src/solvers/elasticity_solver.hpp
@@ -65,11 +65,11 @@ class ElasticitySolver : public BaseSolver {
   ElasticitySolver(int order, std::shared_ptr<mfem::ParMesh> pmesh);
 
   /// Set the vector-valued essential displacement boundary conditions
-  void SetDisplacementBCs(std::vector<int> &disp_bdr, std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef,
+  void SetDisplacementBCs(std::set<int> &disp_bdr, std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef,
                           int component = -1);
 
   /// Set the vector-valued natural traction boundary conditions
-  void SetTractionBCs(std::vector<int> &trac_bdr, std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef,
+  void SetTractionBCs(std::set<int> &trac_bdr, std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef,
                       int component = -1);
 
   /// Driver for advancing the timestep

--- a/src/solvers/nonlinear_solid_solver.cpp
+++ b/src/solvers/nonlinear_solid_solver.cpp
@@ -59,19 +59,19 @@ NonlinearSolidSolver::NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParM
   *m_velocity->true_vec = 0.0;
 }
 
-void NonlinearSolidSolver::SetDisplacementBCs(const std::vector<int> &                 disp_bdr,
+void NonlinearSolidSolver::SetDisplacementBCs(const std::set<int> &                 disp_bdr,
                                               std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef)
 {
   SetEssentialBCs(disp_bdr, disp_bdr_coef, *m_displacement->space, -1);
 }
 
-void NonlinearSolidSolver::SetDisplacementBCs(const std::vector<int> &           disp_bdr,
+void NonlinearSolidSolver::SetDisplacementBCs(const std::set<int> &           disp_bdr,
                                               std::shared_ptr<mfem::Coefficient> disp_bdr_coef, int component)
 {
   SetEssentialBCs(disp_bdr, disp_bdr_coef, *m_displacement->space, component);
 }
 
-void NonlinearSolidSolver::SetTractionBCs(const std::vector<int> &                 trac_bdr,
+void NonlinearSolidSolver::SetTractionBCs(const std::set<int> &                 trac_bdr,
                                           std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef, int component)
 {
   SetNaturalBCs(trac_bdr, trac_bdr_coef, component);

--- a/src/solvers/nonlinear_solid_solver.hpp
+++ b/src/solvers/nonlinear_solid_solver.hpp
@@ -69,14 +69,14 @@ class NonlinearSolidSolver : public BaseSolver {
   NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh);
 
   /// Set the displacement essential boundary conditions
-  void SetDisplacementBCs(const std::vector<int> &disp_bdr, std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef);
+  void SetDisplacementBCs(const std::set<int> &disp_bdr, std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef);
 
   /// Set the displacement essential boundary conditions on a single component
-  void SetDisplacementBCs(const std::vector<int> &disp_bdr, std::shared_ptr<mfem::Coefficient> disp_bdr_coef,
+  void SetDisplacementBCs(const std::set<int> &disp_bdr, std::shared_ptr<mfem::Coefficient> disp_bdr_coef,
                           int component);
 
   /// Set the traction boundary conditions
-  void SetTractionBCs(const std::vector<int> &trac_bdr, std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef,
+  void SetTractionBCs(const std::set<int> &trac_bdr, std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef,
                       int component = -1);
 
   /// Set the viscosity coefficient

--- a/src/solvers/thermal_solver.cpp
+++ b/src/solvers/thermal_solver.cpp
@@ -33,12 +33,12 @@ void ThermalSolver::SetTemperature(mfem::Coefficient &temp)
   m_gf_initialized[0] = true;
 }
 
-void ThermalSolver::SetTemperatureBCs(const std::vector<int> &ess_bdr, std::shared_ptr<mfem::Coefficient> ess_bdr_coef)
+void ThermalSolver::SetTemperatureBCs(const std::set<int> &ess_bdr, std::shared_ptr<mfem::Coefficient> ess_bdr_coef)
 {
   SetEssentialBCs(ess_bdr, ess_bdr_coef, *m_temperature->space);
 }
 
-void ThermalSolver::SetFluxBCs(const std::vector<int> &nat_bdr, std::shared_ptr<mfem::Coefficient> nat_bdr_coef)
+void ThermalSolver::SetFluxBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfem::Coefficient> nat_bdr_coef)
 {
   // Set the natural (integral) boundary condition
   SetNaturalBCs(nat_bdr, nat_bdr_coef);

--- a/src/solvers/thermal_solver.hpp
+++ b/src/solvers/thermal_solver.hpp
@@ -74,10 +74,10 @@ class ThermalSolver : public BaseSolver {
   ThermalSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh);
 
   /// Set essential temperature boundary conditions (strongly enforced)
-  void SetTemperatureBCs(const std::vector<int> &temp_bdr, std::shared_ptr<mfem::Coefficient> temp_bdr_coef);
+  void SetTemperatureBCs(const std::set<int> &temp_bdr, std::shared_ptr<mfem::Coefficient> temp_bdr_coef);
 
   /// Set flux boundary conditions (weakly enforced)
-  void SetFluxBCs(const std::vector<int> &flux_bdr, std::shared_ptr<mfem::Coefficient> flux_bdr_coef);
+  void SetFluxBCs(const std::set<int> &flux_bdr, std::shared_ptr<mfem::Coefficient> flux_bdr_coef);
 
   /// Advance the timestep using the chosen integration scheme
   void AdvanceTimestep(double &dt);

--- a/src/solvers/thermal_structural_solver.hpp
+++ b/src/solvers/thermal_structural_solver.hpp
@@ -34,13 +34,13 @@ class ThermalStructuralSolver : public BaseSolver {
   ThermalStructuralSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh);
 
   /// Set essential temperature boundary conditions (strongly enforced)
-  void SetTemperatureBCs(const std::vector<int> &temp_bdr, std::shared_ptr<mfem::Coefficient> temp_bdr_coef)
+  void SetTemperatureBCs(const std::set<int> &temp_bdr, std::shared_ptr<mfem::Coefficient> temp_bdr_coef)
   {
     m_therm_solver.SetTemperatureBCs(temp_bdr, temp_bdr_coef);
   };
 
   /// Set flux boundary conditions (weakly enforced)
-  void SetFluxBCs(const std::vector<int> &flux_bdr, std::shared_ptr<mfem::Coefficient> flux_bdr_coef)
+  void SetFluxBCs(const std::set<int> &flux_bdr, std::shared_ptr<mfem::Coefficient> flux_bdr_coef)
   {
     m_therm_solver.SetFluxBCs(flux_bdr, flux_bdr_coef);
   };
@@ -61,20 +61,20 @@ class ThermalStructuralSolver : public BaseSolver {
   };
 
   /// Set the displacement essential boundary conditions
-  void SetDisplacementBCs(const std::vector<int> &disp_bdr, std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef)
+  void SetDisplacementBCs(const std::set<int> &disp_bdr, std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef)
   {
     m_solid_solver.SetDisplacementBCs(disp_bdr, disp_bdr_coef);
   };
 
   /// Set the displacement essential boundary conditions on a single component
-  void SetDisplacementBCs(const std::vector<int> &disp_bdr, std::shared_ptr<mfem::Coefficient> disp_bdr_coef,
+  void SetDisplacementBCs(const std::set<int> &disp_bdr, std::shared_ptr<mfem::Coefficient> disp_bdr_coef,
                           int component)
   {
     m_solid_solver.SetDisplacementBCs(disp_bdr, disp_bdr_coef, component);
   };
 
   /// Set the traction boundary conditions
-  void SetTractionBCs(const std::vector<int> &trac_bdr, std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef,
+  void SetTractionBCs(const std::set<int> &trac_bdr, std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef,
                       int component = -1)
   {
     m_solid_solver.SetTractionBCs(trac_bdr, trac_bdr_coef, component);

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -37,11 +37,8 @@ TEST(component_bc, qs_solve)
   // Define the solver object
   NonlinearSolidSolver solid_solver(1, pmesh);
 
-  // define a boundary attribute array and initialize to 0
-  std::vector<int> ess_bdr(pmesh->bdr_attributes.Max(), 0);
-
   // boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
-  ess_bdr[0] = 1;
+  std::set<int> ess_bdr = {1};
 
   // define the displacement vector
   auto disp_coef = std::make_shared<StdFunctionCoefficient>([](mfem::Vector& x) { return x[0] * -1.0e-1; });
@@ -135,13 +132,9 @@ TEST(component_bc, qs_attribute_solve)
   // Define the solver object
   NonlinearSolidSolver solid_solver(2, pmesh);
 
-  // define a boundary attribute array and initialize to 0
-  std::vector<int> ess_x_bdr(pmesh->bdr_attributes.Max(), 0);
-  std::vector<int> ess_y_bdr(pmesh->bdr_attributes.Max(), 0);
-
   // boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
-  ess_x_bdr[0] = 1;
-  ess_y_bdr[1] = 1;
+  std::set<int> ess_x_bdr = {1};
+  std::set<int> ess_y_bdr = {2};
 
   // define the displacement vector
   auto disp_x_coef = std::make_shared<StdFunctionCoefficient>([](mfem::Vector& x) { return x[0] * 3.0e-2; });

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -46,8 +46,7 @@ TEST(serac_dtor, test1)
   // Initialize the temperature boundary condition
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector &x) { return x.Norml2(); });
 
-  std::vector<int> temp_bdr(pmesh->bdr_attributes.Max(), 1);
-
+  std::set<int> temp_bdr = {1};
   // Set the temperature BC in the thermal solver
   therm_solver->SetTemperatureBCs(temp_bdr, u_0);
 

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -35,11 +35,7 @@ TEST(dynamic_solver, dyn_solve)
 
   int dim = pmesh->Dimension();
 
-  // define a boundary attribute array and initialize to 0
-  std::vector<int> ess_bdr(pmesh->bdr_attributes.Max(), 0);
-
-  // boundary attribute 1 (index 0) is fixed (Dirichlet)
-  ess_bdr[0] = 1;
+  std::set<int> ess_bdr = {1};
 
   auto visc   = std::make_shared<mfem::ConstantCoefficient>(0.0);
   auto deform = std::make_shared<mfem::VectorFunctionCoefficient>(dim, InitialDeformation);

--- a/tests/serac_linelastic_solver.cpp
+++ b/tests/serac_linelastic_solver.cpp
@@ -32,11 +32,7 @@ TEST(elastic_solver, static_solve)
 
   ElasticitySolver elas_solver(1, pmesh);
 
-  // define a boundary attribute array and initialize to 0
-  std::vector<int> disp_bdr(pmesh->bdr_attributes.Max(), 0);
-
-  // boundary attribute 1 (index 0) is fixed (Dirichlet)
-  disp_bdr[0] = 1;
+  std::set<int> disp_bdr = {1};
 
   // define the displacement vector
   mfem::Vector disp(pmesh->Dimension());
@@ -44,8 +40,7 @@ TEST(elastic_solver, static_solve)
   auto disp_coef = std::make_shared<mfem::VectorConstantCoefficient>(disp);
   elas_solver.SetDisplacementBCs(disp_bdr, disp_coef);
 
-  std::vector<int> trac_bdr(pmesh->bdr_attributes.Max(), 0);
-  trac_bdr[1] = 1;
+  std::set<int> trac_bdr = {2};
 
   // define the traction vector
   mfem::Vector traction(pmesh->Dimension());

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -36,19 +36,14 @@ TEST(nonlinear_solid_solver, qs_solve)
   // Define the solver object
   NonlinearSolidSolver solid_solver(1, pmesh);
 
-  // define a boundary attribute array and initialize to 0
-  std::vector<int> ess_bdr(pmesh->bdr_attributes.Max(), 0);
-
-  // boundary attribute 1 (index 0) is fixed (Dirichlet)
-  ess_bdr[0] = 1;
+  std::set<int> ess_bdr = {1};
 
   // define the displacement vector
   mfem::Vector disp(dim);
   disp           = 0.0;
   auto disp_coef = std::make_shared<mfem::VectorConstantCoefficient>(disp);
 
-  std::vector<int> trac_bdr(pmesh->bdr_attributes.Max(), 0);
-  trac_bdr[1] = 1;
+  std::set<int> trac_bdr = {2};
 
   // define the traction vector
   mfem::Vector traction(dim);

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -56,7 +56,7 @@ TEST(thermal_solver, static_solve)
   // Initialize the temperature boundary condition
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(BoundaryTemperature);
 
-  std::vector<int> temp_bdr(pmesh->bdr_attributes.Max(), 1);
+  std::set<int> temp_bdr = {1};
 
   // Set the temperature BC in the thermal solver
   therm_solver.SetTemperatureBCs(temp_bdr, u_0);
@@ -121,10 +121,8 @@ TEST(thermal_solver, static_solve_multiple_bcs)
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(BoundaryTemperature);
   auto u_1 = std::make_shared<mfem::ConstantCoefficient>(0.0);
 
-  std::vector<int> marked_1(pmesh->bdr_attributes.Max(), 0);
-  std::vector<int> marked_2(pmesh->bdr_attributes.Max(), 0);
-  marked_1[0] = 1;
-  marked_2[1] = 1;
+  std::set<int> marked_1 = {1};
+  std::set<int> marked_2 = {2};
 
   // Set the temperature BC in the thermal solver
   therm_solver.SetTemperatureBCs(marked_1, u_0);
@@ -196,7 +194,7 @@ TEST(thermal_solver, static_solve_repeated_bcs)
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(BoundaryTemperature);
   auto u_1 = std::make_shared<mfem::FunctionCoefficient>(OtherBoundaryTemperature);
 
-  std::vector<int> temp_bdr(pmesh->bdr_attributes.Max(), 1);
+  std::set<int> temp_bdr = {1};
 
   // Set the temperature BC in the thermal solver
   therm_solver.SetTemperatureBCs(temp_bdr, u_0);
@@ -262,8 +260,7 @@ TEST(thermal_solver, dyn_exp_solve)
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(InitialTemperature);
   therm_solver.SetTemperature(*u_0);
 
-  // Set the temperature BC in the thermal solver
-  std::vector<int> temp_bdr(pmesh->bdr_attributes.Max(), 1);
+  std::set<int> temp_bdr = {1};
   therm_solver.SetTemperatureBCs(temp_bdr, u_0);
 
   // Set the conductivity of the thermal operator
@@ -345,8 +342,7 @@ TEST(thermal_solver, dyn_imp_solve)
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(InitialTemperature);
   therm_solver.SetTemperature(*u_0);
 
-  // Set the temperature BC in the thermal solver
-  std::vector<int> temp_bdr(pmesh->bdr_attributes.Max(), 1);
+  std::set<int> temp_bdr = {1};
   therm_solver.SetTemperatureBCs(temp_bdr, u_0);
 
   // Set the conductivity of the thermal operator

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -32,11 +32,8 @@ TEST(dynamic_solver, dyn_solve)
 
   int dim = pmesh->Dimension();
 
-  // define a boundary attribute array and initialize to 0
-  std::vector<int> ess_bdr(pmesh->bdr_attributes.Max(), 0);
-
-  // boundary attribute 1 (index 0) is fixed (Dirichlet)
-  ess_bdr[0] = 1;
+  // define a boundary attribute set
+  std::set<int> ess_bdr = {1};
 
   auto deform = std::make_shared<StdFunctionVectorCoefficient>(dim, [](mfem::Vector &x, mfem::Vector &y) {
     y    = x;
@@ -56,8 +53,7 @@ TEST(dynamic_solver, dyn_solve)
   auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
 
   // set the traction boundary
-  std::vector<int> trac_bdr(pmesh->bdr_attributes.Max(), 0);
-  trac_bdr[1] = 1;
+  std::set<int> trac_bdr = {2};
 
   // define the traction vector
   mfem::Vector traction(dim);


### PR DESCRIPTION
This changes the user-facing interface for solvers to use `std::set`s instead of `std::vector`s of indicator values to denote the boundary attributes for applying boundary conditions