### PR TITLE
Modify CI scripts to reflect switch to gitflow and renaming of primary branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,11 +23,11 @@ stages:
 
 .pr_workflow:
   rules:
-    - if: '$CI_COMMIT_BRANCH != "master" && $BUILD_DEPS != "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH != "main" && $CI_COMMIT_BRANCH != "develop" && $BUILD_DEPS != "ON"' #run only if ...
 
-.master_workflow:
+.main_workflow:
   rules:
-    - if: '$CI_COMMIT_BRANCH == "master" || $BUILD_DEPS == "ON"' #run only if ...
+    - if: '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH == "develop" || $BUILD_DEPS == "ON"' #run only if ...
 
 ####
 # Template

--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -39,9 +39,9 @@ release_resources_build_quartz:
   stage: build
   extends: [.srun_build_script, .on_quartz, .pr_workflow]
 
-.master_build_with_deps_on_quartz:
+.main_build_with_deps_on_quartz:
   stage: build_with_deps
-  extends: [.srun_build_with_deps_script, .on_quartz, .master_workflow]
+  extends: [.srun_build_with_deps_script, .on_quartz, .main_workflow]
 
 ####
 # Build jobs
@@ -63,20 +63,20 @@ intel_19_0_4 (PR build_on_quartz):
     HOST_CONFIG: "quartz-toss_3_x86_64_ib-intel@19.0.4.cmake"
   extends: .pr_build_on_quartz
 
-clang_9_0_0 (Master build_with_deps_on_quartz):
+clang_9_0_0 (Main build_with_deps_on_quartz):
   variables:
     COMPILER: "clang@9.0.0"
     SPEC: "@develop%${COMPILER}"
-  extends: .master_build_with_deps_on_quartz
+  extends: .main_build_with_deps_on_quartz
 
-gcc_8_1_0 (Master build_with_deps_on_quartz):
+gcc_8_1_0 (Main build_with_deps_on_quartz):
   variables:
     COMPILER: "gcc@8.1.0"
     SPEC: "@develop%${COMPILER}"
-  extends: .master_build_with_deps_on_quartz
+  extends: .main_build_with_deps_on_quartz
 
-intel_19_0_4 (Master build_with_deps_on_quartz):
+intel_19_0_4 (Main build_with_deps_on_quartz):
   variables:
     COMPILER: "intel@19.0.4"
     SPEC: "@develop%${COMPILER}"
-  extends: .master_build_with_deps_on_quartz
+  extends: .main_build_with_deps_on_quartz

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Serac
 ====
 
 [![Build
-Status](https://dev.azure.com/llnl-serac/serac/_apis/build/status/LLNL.serac?branchName=master)](https://dev.azure.com/llnl-serac/serac/_build/latest?definitionId=1&branchName=master)
+Status](https://dev.azure.com/llnl-serac/serac/_apis/build/status/LLNL.serac?branchName=develop)](https://dev.azure.com/llnl-serac/serac/_build/latest?definitionId=1&branchName=develop)
 [![Documentation Status](https://readthedocs.org/projects/serac/badge/?version=latest)](https://serac.readthedocs.io/en/latest/?badge=latest)
 [![License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](./LICENSE)
 

--- a/src/docs/sphinx/index.rst
+++ b/src/docs/sphinx/index.rst
@@ -187,7 +187,7 @@ We provide the following useful build targets that can be run from the build dir
 Copyright and License Information
 ======================================================
 
-Please see the `LICENSE <https://github.com/LLNL/serac/blob/master/LICENSE>`_ file in the repository.
+Please see the `LICENSE <https://github.com/LLNL/serac/blob/develop/LICENSE>`_ file in the repository.
 
 Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC.
 Produced at the Lawrence Livermore National Laboratory.


### PR DESCRIPTION
Picking back up on the discussion in #80 , does the build with dependencies need to happen for `develop`, `main`, or both?

Resolves #77 