### PR TITLE
Add mpi rank and size to the base solver class

### DIFF
--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -6,19 +6,19 @@
 
 #include "common/logger.hpp"
 
-#include "axom/slic.hpp"
-
 #include <cstdlib>
+
+#include "axom/slic.hpp"
 #include "mpi.h"
 
 namespace serac {
 
 void ExitGracefully(bool error)
 {
-    serac::logger::Flush();
-    serac::logger::Finalize();
-    MPI_Finalize();
-    error ? exit(EXIT_FAILURE) : exit(EXIT_SUCCESS);
+  serac::logger::Flush();
+  serac::logger::Finalize();
+  MPI_Finalize();
+  error ? exit(EXIT_FAILURE) : exit(EXIT_SUCCESS);
 }
 
 namespace logger {
@@ -27,8 +27,7 @@ bool Initialize(MPI_Comm comm)
 {
   namespace slic = axom::slic;
 
-  if ( ! slic::isInitialized() )
-  {
+  if (!slic::isInitialized()) {
     slic::initialize();
   }
 
@@ -39,8 +38,7 @@ bool Initialize(MPI_Comm comm)
   std::string loggerName = numRanks > 1 ? "serac_parallel_logger" : "serac_serial_logger";
   slic::createLogger(loggerName);
   slic::activateLogger(loggerName);
-  if (!slic::activateLogger(loggerName))
-  {
+  if (!slic::activateLogger(loggerName)) {
     // Can't log through SLIC since it just failed to activate
     std::cerr << "Error: Failed to activate logger: " << loggerName << std::endl;
     return false;
@@ -54,22 +52,19 @@ bool Initialize(MPI_Comm comm)
   std::string fmt_we = "[<LEVEL> (<FILE>:<LINE>)]\n<MESSAGE>\n\n";
 
   // Only create a parallel logger when there is more than one rank
-  if( numRanks > 1 )
-  {
+  if (numRanks > 1) {
     fmt_id = "[<RANK>]" + fmt_id;
     fmt_we = "[<RANK>]" + fmt_we;
 
-    #ifdef SERAC_USE_LUMBERJACK
-      const int RLIMIT = 8;
-      idStream = new slic::LumberjackStream(&std::cout, comm, RLIMIT, fmt_id);
-      weStream = new slic::LumberjackStream(&std::cerr, comm, RLIMIT, fmt_we);
-    #else
-      idStream = new slic::SynchronizedStream(&std::cout, comm, fmt_id);
-      weStream = new slic::SynchronizedStream(&std::cerr, comm, fmt_we);
-    #endif
-  }  
-  else
-  {
+#ifdef SERAC_USE_LUMBERJACK
+    const int RLIMIT = 8;
+    idStream         = new slic::LumberjackStream(&std::cout, comm, RLIMIT, fmt_id);
+    weStream         = new slic::LumberjackStream(&std::cerr, comm, RLIMIT, fmt_we);
+#else
+    idStream = new slic::SynchronizedStream(&std::cout, comm, fmt_id);
+    weStream = new slic::SynchronizedStream(&std::cerr, comm, fmt_we);
+#endif
+  } else {
     idStream = new slic::GenericOutputStream(&std::cout, fmt_id);
     weStream = new slic::GenericOutputStream(&std::cerr, fmt_we);
   }
@@ -91,15 +86,9 @@ bool Initialize(MPI_Comm comm)
   return true;
 }
 
-void Finalize()
-{
-  axom::slic::finalize();
-}
+void Finalize() { axom::slic::finalize(); }
 
-void Flush()
-{
-  axom::slic::flushStreams();
-}
+void Flush() { axom::slic::flushStreams(); }
 
-} // namespace logger
-} // namespace serac
+}  // namespace logger
+}  // namespace serac

--- a/src/common/logger.hpp
+++ b/src/common/logger.hpp
@@ -17,58 +17,57 @@
 #define SERAC_LOGGER
 
 #include "axom/slic.hpp"
-
-#include "mpi.h"
 #include "fmt/fmt.hpp"
+#include "mpi.h"
 
 namespace serac {
-  /*!
-   *****************************************************************************
-   * \brief Exits the program gracefully after cleaning up necessary tasks.
-   *
-   * This performs finalization work needed by the program such as finalizing MPI
-   * and flushing and closing the SLIC logger.
-   *
-   * \param [in] error True if the program should return an error code
-   *****************************************************************************
-   */
-  void ExitGracefully(bool error=false);
+/*!
+ *****************************************************************************
+ * \brief Exits the program gracefully after cleaning up necessary tasks.
+ *
+ * This performs finalization work needed by the program such as finalizing MPI
+ * and flushing and closing the SLIC logger.
+ *
+ * \param [in] error True if the program should return an error code
+ *****************************************************************************
+ */
+void ExitGracefully(bool error = false);
 
 // Logger functionality
 namespace logger {
-  /*!
-   *****************************************************************************
-   * \brief Initializes and setups the logger.
-   *
-   * Setups and tailors the SLIC logger for Serac.  Sets the SLIC loggings streams
-   * and tells SLIC how to format the messages.  This function also creates different
-   * logging streams if you are running serial, parallel, or parallel with Lumberjack
-   * support.
-   *
-   * \param [in] comm MPI communicator that the logger will use
-   *****************************************************************************
-   */
-  bool Initialize(MPI_Comm comm);
+/*!
+ *****************************************************************************
+ * \brief Initializes and setups the logger.
+ *
+ * Setups and tailors the SLIC logger for Serac.  Sets the SLIC loggings streams
+ * and tells SLIC how to format the messages.  This function also creates different
+ * logging streams if you are running serial, parallel, or parallel with Lumberjack
+ * support.
+ *
+ * \param [in] comm MPI communicator that the logger will use
+ *****************************************************************************
+ */
+bool Initialize(MPI_Comm comm);
 
-  /*!
-   *****************************************************************************
-   * \brief Finalizes the logger.
-   *
-   * Closes and finalizes the SLIC logger.
-   *****************************************************************************
-   */
-  void Finalize();
+/*!
+ *****************************************************************************
+ * \brief Finalizes the logger.
+ *
+ * Closes and finalizes the SLIC logger.
+ *****************************************************************************
+ */
+void Finalize();
 
-  /*!
-   *****************************************************************************
-   * \brief Flushes messages currently held by the logger.
-   *
-   * If running in parallel, SLIC doesn't output messages immediately.  This flushes
-   * all messages currently held by SLIC.  This is a collective operation because
-   * messages can be spread across MPI ranks.
-   *****************************************************************************
-   */
-  void Flush();
+/*!
+ *****************************************************************************
+ * \brief Flushes messages currently held by the logger.
+ *
+ * If running in parallel, SLIC doesn't output messages immediately.  This flushes
+ * all messages currently held by SLIC.  This is a collective operation because
+ * messages can be spread across MPI ranks.
+ *****************************************************************************
+ */
+void Flush();
 
 }  // namespace logger
 }  // namespace serac
@@ -80,27 +79,27 @@ namespace logger {
 * \brief Macro that logs given error message only on rank 0.
 *****************************************************************************
 */
-#define SLIC_ERROR_ROOT(rank,msg)   SLIC_ERROR_IF(rank==0, msg)
+#define SLIC_ERROR_ROOT(rank, msg) SLIC_ERROR_IF(rank == 0, msg)
 
 /*!
 *****************************************************************************
 * \brief Macro that logs given warning message only on rank 0.
 *****************************************************************************
 */
-#define SLIC_WARNING_ROOT(rank,msg) SLIC_WARNING_IF(rank==0, msg)
+#define SLIC_WARNING_ROOT(rank, msg) SLIC_WARNING_IF(rank == 0, msg)
 
 /*!
 *****************************************************************************
 * \brief Macro that logs given info message only on rank 0.
 *****************************************************************************
 */
-#define SLIC_INFO_ROOT(rank,msg)    SLIC_INFO_IF(rank==0, msg)
+#define SLIC_INFO_ROOT(rank, msg) SLIC_INFO_IF(rank == 0, msg)
 
 /*!
 *****************************************************************************
 * \brief Macro that logs given debug message only on rank 0.
 *****************************************************************************
 */
-#define SLIC_DEBUG_ROOT(rank,msg)   SLIC_DEBUG_IF(rank==0, msg)
+#define SLIC_DEBUG_ROOT(rank, msg) SLIC_DEBUG_IF(rank == 0, msg)
 
 #endif

--- a/src/common/serac_types.hpp
+++ b/src/common/serac_types.hpp
@@ -94,6 +94,6 @@ struct BoundaryCondition {
   std::unique_ptr<mfem::HypreParMatrix>    eliminated_matrix_entries;
 };
 
-} // namespace serac
+}  // namespace serac
 
 #endif

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -23,10 +23,10 @@
 #include "CLI11/CLI11.hpp"
 #include "coefficients/loading_functions.hpp"
 #include "coefficients/traction_coefficient.hpp"
+#include "common/logger.hpp"
 #include "mfem.hpp"
 #include "serac_config.hpp"
 #include "solvers/nonlinear_solid_solver.hpp"
-#include "common/logger.hpp"
 
 int main(int argc, char *argv[])
 {
@@ -37,8 +37,7 @@ int main(int argc, char *argv[])
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
   // Initialize SLIC logger
-  if(!serac::logger::Initialize(MPI_COMM_WORLD))
-  {
+  if (!serac::logger::Initialize(MPI_COMM_WORLD)) {
     serac::ExitGracefully(true);
   }
 
@@ -83,30 +82,32 @@ int main(int argc, char *argv[])
 
   // specify all input arguments
   CLI::App app{"serac: a high order nonlinear thermomechanical simulation code"};
-  app.add_option("-m, --mesh", mesh_file,  "Mesh file to use.", true);
-  app.add_option("--rs, --refine-serial", ser_ref_levels,  "Number of times to refine the mesh uniformly in serial.", true);
-  app.add_option("--rp, --refine-parallel", par_ref_levels, 
-                  "Number of times to refine the mesh uniformly in parallel.", true);
-  app.add_option("-o, --order", order,  "Order degree of the finite elements.", true);
-  app.add_option("--mu, --shear-modulus", mu,  "Shear modulus in the Neo-Hookean hyperelastic model.", true);
-  app.add_option("-K, --bulk-modulus", K,  "Bulk modulus in the Neo-Hookean hyperelastic model.", true);
-  app.add_option("--tx, --traction-x", tx,  "Cantilever tip traction in the x direction.", true);
-  app.add_option("--ty, --traction-y", ty,  "Cantilever tip traction in the y direction.", true);
-  app.add_option("--tz, --traction-z", tz,  "Cantilever tip traction in the z direction.", true);
-  app.add_flag("--slu, --superlu, !--no-slu, !--no-superlu", slu_solver,  "Use the SuperLU Solver.");
-  app.add_option("--lrel, --linear-relative-tolerance", lin_params.rel_tol, 
-                  "Relative tolerance for the lienar solve.", true);
-  app.add_option("--labs, --linear-absolute-tolerance", lin_params.abs_tol, 
-                  "Absolute tolerance for the linear solve.", true);
-  app.add_option("--lit, --linear-iterations", lin_params.max_iter,  "Maximum iterations for the linear solve.", true);
-  app.add_option("--lpl, --linear-print-level", lin_params.print_level,  "Linear print level.", true);
-  app.add_option("--nrel, --newton-relative-tolerance", nonlin_params.rel_tol, 
-                  "Relative tolerance for the Newton solve.", true);
-  app.add_option("--nabs, --newton-absolute-tolerance", nonlin_params.abs_tol, 
-                  "Absolute tolerance for the Newton solve.", true);
-  app.add_option("--nit, --newton-iterations", nonlin_params.max_iter,  "Maximum iterations for the Newton solve.", true);
-  app.add_option("--npl, --newton-print-level", nonlin_params.print_level,  "Newton print level.", true);
-  app.add_option("--dt, --time-step", dt,  "Time step.", true);
+  app.add_option("-m, --mesh", mesh_file, "Mesh file to use.", true);
+  app.add_option("--rs, --refine-serial", ser_ref_levels, "Number of times to refine the mesh uniformly in serial.",
+                 true);
+  app.add_option("--rp, --refine-parallel", par_ref_levels, "Number of times to refine the mesh uniformly in parallel.",
+                 true);
+  app.add_option("-o, --order", order, "Order degree of the finite elements.", true);
+  app.add_option("--mu, --shear-modulus", mu, "Shear modulus in the Neo-Hookean hyperelastic model.", true);
+  app.add_option("-K, --bulk-modulus", K, "Bulk modulus in the Neo-Hookean hyperelastic model.", true);
+  app.add_option("--tx, --traction-x", tx, "Cantilever tip traction in the x direction.", true);
+  app.add_option("--ty, --traction-y", ty, "Cantilever tip traction in the y direction.", true);
+  app.add_option("--tz, --traction-z", tz, "Cantilever tip traction in the z direction.", true);
+  app.add_flag("--slu, --superlu, !--no-slu, !--no-superlu", slu_solver, "Use the SuperLU Solver.");
+  app.add_option("--lrel, --linear-relative-tolerance", lin_params.rel_tol, "Relative tolerance for the lienar solve.",
+                 true);
+  app.add_option("--labs, --linear-absolute-tolerance", lin_params.abs_tol, "Absolute tolerance for the linear solve.",
+                 true);
+  app.add_option("--lit, --linear-iterations", lin_params.max_iter, "Maximum iterations for the linear solve.", true);
+  app.add_option("--lpl, --linear-print-level", lin_params.print_level, "Linear print level.", true);
+  app.add_option("--nrel, --newton-relative-tolerance", nonlin_params.rel_tol,
+                 "Relative tolerance for the Newton solve.", true);
+  app.add_option("--nabs, --newton-absolute-tolerance", nonlin_params.abs_tol,
+                 "Absolute tolerance for the Newton solve.", true);
+  app.add_option("--nit, --newton-iterations", nonlin_params.max_iter, "Maximum iterations for the Newton solve.",
+                 true);
+  app.add_option("--npl, --newton-print-level", nonlin_params.print_level, "Newton print level.", true);
+  app.add_option("--dt, --time-step", dt, "Time step.", true);
 
   // Parse the arguments and check if they are good
   try {
@@ -236,4 +237,4 @@ int main(int argc, char *argv[])
   }
 
   serac::ExitGracefully();
-} 
+}

--- a/src/solvers/base_solver.cpp
+++ b/src/solvers/base_solver.cpp
@@ -15,12 +15,15 @@
 
 BaseSolver::BaseSolver(MPI_Comm comm) : m_comm(comm), m_output_type(serac::OutputType::VisIt), m_time(0.0), m_cycle(0)
 {
-  MPI_Comm_rank(m_comm, &m_rank);
+  MPI_Comm_rank(m_comm, &m_mpi_rank);
+  MPI_Comm_size(m_comm, &m_mpi_size);
   SetTimestepper(serac::TimestepMethod::ForwardEuler);
+  m_order = 1;
 }
 
-BaseSolver::BaseSolver(MPI_Comm comm, int n) : BaseSolver(comm)
+BaseSolver::BaseSolver(MPI_Comm comm, int n, int p) : BaseSolver(comm)
 {
+  m_order = p;
   m_state.resize(n);
 
   for (auto &state : m_state) {
@@ -30,7 +33,7 @@ BaseSolver::BaseSolver(MPI_Comm comm, int n) : BaseSolver(comm)
   m_gf_initialized.assign(n, false);
 }
 
-void BaseSolver::SetEssentialBCs(const std::set<int> &                 ess_bdr,
+void BaseSolver::SetEssentialBCs(const std::set<int> &                    ess_bdr,
                                  std::shared_ptr<mfem::VectorCoefficient> ess_bdr_vec_coef,
                                  mfem::ParFiniteElementSpace &fes, int component)
 {
@@ -41,14 +44,14 @@ void BaseSolver::SetEssentialBCs(const std::set<int> &                 ess_bdr,
 
   for (int attr : ess_bdr) {
     SLIC_ASSERT_MSG(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
-    bc->markers[attr-1] = 1;
+    bc->markers[attr - 1] = 1;
     for (auto &existing_bc : m_ess_bdr) {
-      if (existing_bc->markers[attr-1] == 1) {
+      if (existing_bc->markers[attr - 1] == 1) {
         SLIC_WARNING("Multiple definition of essential boundary! Using first definition given.");
-        bc->markers[attr-1] = 0;
+        bc->markers[attr - 1] = 0;
         break;
       }
-    }    
+    }
   }
 
   bc->vec_coef  = ess_bdr_vec_coef;
@@ -73,17 +76,17 @@ void BaseSolver::SetTrueDofs(const mfem::Array<int> &                 true_dofs,
   m_ess_bdr.push_back(bc);
 }
 
-void BaseSolver::SetNaturalBCs(const std::set<int> &                 nat_bdr,
-                               std::shared_ptr<mfem::VectorCoefficient> nat_bdr_vec_coef, int component)
+void BaseSolver::SetNaturalBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfem::VectorCoefficient> nat_bdr_vec_coef,
+                               int component)
 {
   auto bc = std::make_shared<serac::BoundaryCondition>();
 
   bc->markers.SetSize(m_state.front()->mesh->bdr_attributes.Max());
   bc->markers = 0;
 
-  for (int attr : nat_bdr) {  
+  for (int attr : nat_bdr) {
     SLIC_ASSERT_MSG(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
-    bc->markers[attr-1] = 1;
+    bc->markers[attr - 1] = 1;
   }
 
   bc->vec_coef  = nat_bdr_vec_coef;
@@ -102,14 +105,14 @@ void BaseSolver::SetEssentialBCs(const std::set<int> &ess_bdr, std::shared_ptr<m
 
   for (int attr : ess_bdr) {
     SLIC_ASSERT_MSG(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
-    bc->markers[attr-1] = 1;
+    bc->markers[attr - 1] = 1;
     for (auto &existing_bc : m_ess_bdr) {
-      if (existing_bc->markers[attr-1] == 1) {
+      if (existing_bc->markers[attr - 1] == 1) {
         SLIC_WARNING("Multiple definition of essential boundary! Using first definition given.");
-        bc->markers[attr-1] = 0;
+        bc->markers[attr - 1] = 0;
         break;
       }
-    }    
+    }
   }
 
   bc->scalar_coef = ess_bdr_coef;
@@ -141,9 +144,9 @@ void BaseSolver::SetNaturalBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfe
   bc->markers.SetSize(m_state.front()->mesh->bdr_attributes.Max());
   bc->markers = 0;
 
-  for (int attr : nat_bdr) {  
+  for (int attr : nat_bdr) {
     SLIC_ASSERT_MSG(attr <= bc->markers.Size(), "Attribute specified larger than what is found in the mesh.");
-    bc->markers[attr-1] = 1;
+    bc->markers[attr - 1] = 1;
   }
 
   bc->scalar_coef = nat_bdr_coef;
@@ -218,7 +221,7 @@ void BaseSolver::SetTimestepper(const serac::TimestepMethod timestepper)
       m_ode_solver = std::make_unique<mfem::SDIRK34Solver>();
       break;
     default:
-      SLIC_ERROR_ROOT(m_rank, "Timestep method not recognized!");
+      SLIC_ERROR_ROOT(m_mpi_rank, "Timestep method not recognized!");
       serac::ExitGracefully(true);
   }
 }
@@ -249,7 +252,7 @@ void BaseSolver::InitializeOutput(const serac::OutputType output_type, std::stri
     }
 
     default:
-      SLIC_ERROR_ROOT(m_rank, "OutputType not recognized!");
+      SLIC_ERROR_ROOT(m_mpi_rank, "OutputType not recognized!");
       serac::ExitGracefully(true);
   }
 }
@@ -265,14 +268,14 @@ void BaseSolver::OutputState() const
     }
 
     case serac::OutputType::GLVis: {
-      std::string   mesh_name = fmt::format("{0}-mesh.{1:0>6}.{2:0>6}", m_root_name, m_cycle, m_rank);
-      std::ofstream omesh(mesh_name.c_str());
+      std::string   mesh_name = fmt::format("{0}-mesh.{1:0>6}.{2:0>6}", m_root_name, m_cycle, m_mpi_rank);
+      std::ofstream omesh(mesh_name);
       omesh.precision(8);
       m_state.front()->mesh->Print(omesh);
 
       for (auto &state : m_state) {
-        std::string   sol_name = fmt::format("{0}-{1}.{2:0>6}.{3:0>6}", m_root_name, state->name, m_cycle, m_rank);
-        std::ofstream osol(sol_name.c_str());
+        std::string   sol_name = fmt::format("{0}-{1}.{2:0>6}.{3:0>6}", m_root_name, state->name, m_cycle, m_mpi_rank);
+        std::ofstream osol(sol_name);
         osol.precision(8);
         state->gf->Save(osol);
       }
@@ -280,7 +283,7 @@ void BaseSolver::OutputState() const
     }
 
     default:
-      SLIC_ERROR_ROOT(m_rank, "OutputType not recognized!");
+      SLIC_ERROR_ROOT(m_mpi_rank, "OutputType not recognized!");
       serac::ExitGracefully(true);
   }
 }

--- a/src/solvers/base_solver.cpp
+++ b/src/solvers/base_solver.cpp
@@ -157,8 +157,7 @@ void BaseSolver::SetNaturalBCs(const std::set<int> &nat_bdr, std::shared_ptr<mfe
 
 void BaseSolver::SetState(const std::vector<std::shared_ptr<mfem::Coefficient> > &state_coef)
 {
-  SLIC_ASSERT_MSG(state_coef.size() == m_state.size(),
-                  "State and coefficient bundles not the same size.");
+  SLIC_ASSERT_MSG(state_coef.size() == m_state.size(), "State and coefficient bundles not the same size.");
 
   for (unsigned int i = 0; i < state_coef.size(); ++i) {
     m_state[i]->gf->ProjectCoefficient(*state_coef[i]);
@@ -167,8 +166,7 @@ void BaseSolver::SetState(const std::vector<std::shared_ptr<mfem::Coefficient> >
 
 void BaseSolver::SetState(const std::vector<std::shared_ptr<mfem::VectorCoefficient> > &state_vec_coef)
 {
-  SLIC_ASSERT_MSG(state_vec_coef.size() == m_state.size(),
-                  "State and coefficient bundles not the same size.");
+  SLIC_ASSERT_MSG(state_vec_coef.size() == m_state.size(), "State and coefficient bundles not the same size.");
 
   for (unsigned int i = 0; i < state_vec_coef.size(); ++i) {
     m_state[i]->gf->ProjectCoefficient(*state_vec_coef[i]);

--- a/src/solvers/base_solver.hpp
+++ b/src/solvers/base_solver.hpp
@@ -50,7 +50,13 @@ class BaseSolver {
   int m_cycle;
 
   /// MPI rank
-  int m_rank;
+  int m_mpi_rank;
+
+  /// MPI size
+  int m_mpi_size;
+
+  /// Order of basis functions
+  int m_order;
 
   /// VisIt data collection pointer
   std::unique_ptr<mfem::VisItDataCollection> m_visit_dc;
@@ -62,8 +68,8 @@ class BaseSolver {
   /// Empty constructor
   BaseSolver(MPI_Comm comm);
 
-  /// Constructor that creates n entries in m_state
-  BaseSolver(MPI_Comm comm, int n);
+  /// Constructor that creates n entries in m_state of order p
+  BaseSolver(MPI_Comm comm, int n, int p);
 
   /// Set the essential boundary conditions from a list of boundary markers and
   /// a coefficient
@@ -72,8 +78,7 @@ class BaseSolver {
 
   /// Set the vector-valued essential boundary conditions from a list of
   /// boundary markers and a coefficient
-  virtual void SetEssentialBCs(const std::set<int> &                 ess_bdr,
-                               std::shared_ptr<mfem::VectorCoefficient> ess_bdr_vec_coef,
+  virtual void SetEssentialBCs(const std::set<int> &ess_bdr, std::shared_ptr<mfem::VectorCoefficient> ess_bdr_vec_coef,
                                mfem::ParFiniteElementSpace &fes, int component = -1);
 
   /// Set a list of true degrees of freedom from a coefficient

--- a/src/solvers/nonlinear_solid_operators.cpp
+++ b/src/solvers/nonlinear_solid_operators.cpp
@@ -9,9 +9,8 @@
 #include "common/logger.hpp"
 
 NonlinearSolidQuasiStaticOperator::NonlinearSolidQuasiStaticOperator(std::shared_ptr<mfem::ParNonlinearForm> H_form)
-    : mfem::Operator(H_form->FESpace()->GetTrueVSize())
+    : mfem::Operator(H_form->FESpace()->GetTrueVSize()), m_H_form(H_form)
 {
-  m_H_form = H_form;
 }
 
 // compute: y = H(x,p)

--- a/src/solvers/nonlinear_solid_operators.cpp
+++ b/src/solvers/nonlinear_solid_operators.cpp
@@ -31,8 +31,9 @@ NonlinearSolidQuasiStaticOperator::~NonlinearSolidQuasiStaticOperator() {}
 
 NonlinearSolidDynamicOperator::NonlinearSolidDynamicOperator(
     std::shared_ptr<mfem::ParNonlinearForm> H_form, std::shared_ptr<mfem::ParBilinearForm> S_form,
-    std::shared_ptr<mfem::ParBilinearForm> M_form, const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr,
-    mfem::NewtonSolver &newton_solver, const serac::LinearSolverParameters &lin_params)
+    std::shared_ptr<mfem::ParBilinearForm>                         M_form,
+    const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr, mfem::NewtonSolver &newton_solver,
+    const serac::LinearSolverParameters &lin_params)
     : mfem::TimeDependentOperator(M_form->ParFESpace()->TrueVSize() * 2),
       m_M_form(M_form),
       m_S_form(S_form),
@@ -110,7 +111,8 @@ NonlinearSolidDynamicOperator::~NonlinearSolidDynamicOperator() {}
 
 NonlinearSolidReducedSystemOperator::NonlinearSolidReducedSystemOperator(
     std::shared_ptr<mfem::ParNonlinearForm> H_form, std::shared_ptr<mfem::ParBilinearForm> S_form,
-    std::shared_ptr<mfem::ParBilinearForm> M_form, const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr)
+    std::shared_ptr<mfem::ParBilinearForm>                         M_form,
+    const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr)
     : mfem::Operator(M_form->ParFESpace()->TrueVSize()),
       m_M_form(M_form),
       m_S_form(S_form),

--- a/src/solvers/nonlinear_solid_operators.hpp
+++ b/src/solvers/nonlinear_solid_operators.hpp
@@ -67,9 +67,9 @@ class NonlinearSolidReducedSystemOperator : public mfem::Operator {
 
  public:
   /// The constructor
-  NonlinearSolidReducedSystemOperator(std::shared_ptr<mfem::ParNonlinearForm>                 H_form,
-                                      std::shared_ptr<mfem::ParBilinearForm>                  S_form,
-                                      std::shared_ptr<mfem::ParBilinearForm>                  M_form,
+  NonlinearSolidReducedSystemOperator(std::shared_ptr<mfem::ParNonlinearForm>                        H_form,
+                                      std::shared_ptr<mfem::ParBilinearForm>                         S_form,
+                                      std::shared_ptr<mfem::ParBilinearForm>                         M_form,
                                       const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr);
 
   /// Set current dt, v, x values - needed to compute action and Jacobian.
@@ -123,9 +123,9 @@ class NonlinearSolidDynamicOperator : public mfem::TimeDependentOperator {
 
  public:
   /// The constructor
-  NonlinearSolidDynamicOperator(std::shared_ptr<mfem::ParNonlinearForm>                 H_form,
-                                std::shared_ptr<mfem::ParBilinearForm>                  S_form,
-                                std::shared_ptr<mfem::ParBilinearForm>                  M_form,
+  NonlinearSolidDynamicOperator(std::shared_ptr<mfem::ParNonlinearForm>                        H_form,
+                                std::shared_ptr<mfem::ParBilinearForm>                         S_form,
+                                std::shared_ptr<mfem::ParBilinearForm>                         M_form,
                                 const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr,
                                 mfem::NewtonSolver &newton_solver, const serac::LinearSolverParameters &lin_params);
 

--- a/src/solvers/nonlinear_solid_solver.cpp
+++ b/src/solvers/nonlinear_solid_solver.cpp
@@ -13,7 +13,7 @@
 const int num_fields = 2;
 
 NonlinearSolidSolver::NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh->GetComm(), num_fields),
+    : BaseSolver(pmesh->GetComm(), num_fields, order),
       m_velocity(m_state[0]),
       m_displacement(m_state[1]),
       m_newton_solver(pmesh->GetComm())
@@ -60,19 +60,19 @@ NonlinearSolidSolver::NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParM
   *m_velocity->true_vec = 0.0;
 }
 
-void NonlinearSolidSolver::SetDisplacementBCs(const std::set<int> &                 disp_bdr,
+void NonlinearSolidSolver::SetDisplacementBCs(const std::set<int> &                    disp_bdr,
                                               std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef)
 {
   SetEssentialBCs(disp_bdr, disp_bdr_coef, *m_displacement->space, -1);
 }
 
-void NonlinearSolidSolver::SetDisplacementBCs(const std::set<int> &           disp_bdr,
+void NonlinearSolidSolver::SetDisplacementBCs(const std::set<int> &              disp_bdr,
                                               std::shared_ptr<mfem::Coefficient> disp_bdr_coef, int component)
 {
   SetEssentialBCs(disp_bdr, disp_bdr_coef, *m_displacement->space, component);
 }
 
-void NonlinearSolidSolver::SetTractionBCs(const std::set<int> &                 trac_bdr,
+void NonlinearSolidSolver::SetTractionBCs(const std::set<int> &                    trac_bdr,
                                           std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef, int component)
 {
   SetNaturalBCs(trac_bdr, trac_bdr_coef, component);

--- a/src/solvers/nonlinear_solid_solver.hpp
+++ b/src/solvers/nonlinear_solid_solver.hpp
@@ -92,7 +92,8 @@ class NonlinearSolidSolver : public BaseSolver {
   void SetVelocity(mfem::VectorCoefficient &velo_state);
 
   /// Set the linear and nonlinear solver params
-  void SetSolverParameters(const serac::LinearSolverParameters &lin_params, const serac::NonlinearSolverParameters &nonlin_params);
+  void SetSolverParameters(const serac::LinearSolverParameters &   lin_params,
+                           const serac::NonlinearSolverParameters &nonlin_params);
 
   /// Get the displacement state
   std::shared_ptr<serac::FiniteElementState> GetDisplacement() { return m_displacement; };

--- a/src/solvers/thermal_operators.cpp
+++ b/src/solvers/thermal_operators.cpp
@@ -8,9 +8,9 @@
 
 #include "common/logger.hpp"
 
-DynamicConductionOperator::DynamicConductionOperator(std::shared_ptr<mfem::ParFiniteElementSpace>            fespace,
-                                                     const serac::LinearSolverParameters &                          params,
-                                                     const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr)
+DynamicConductionOperator::DynamicConductionOperator(
+    std::shared_ptr<mfem::ParFiniteElementSpace> fespace, const serac::LinearSolverParameters &params,
+    const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr)
     : mfem::TimeDependentOperator(fespace->GetTrueVSize(), 0.0),
       m_fespace(fespace),
       m_ess_bdr(ess_bdr),

--- a/src/solvers/thermal_operators.hpp
+++ b/src/solvers/thermal_operators.hpp
@@ -64,7 +64,8 @@ class DynamicConductionOperator : public mfem::TimeDependentOperator {
 
  public:
   /// Constructor. Height is the true degree of freedom size
-  DynamicConductionOperator(std::shared_ptr<mfem::ParFiniteElementSpace> fespace, const serac::LinearSolverParameters &params,
+  DynamicConductionOperator(std::shared_ptr<mfem::ParFiniteElementSpace>                   fespace,
+                            const serac::LinearSolverParameters &                          params,
                             const std::vector<std::shared_ptr<serac::BoundaryCondition> > &ess_bdr);
 
   /// Set the mass matrix

--- a/src/solvers/thermal_solver.cpp
+++ b/src/solvers/thermal_solver.cpp
@@ -11,7 +11,7 @@
 const int num_fields = 1;
 
 ThermalSolver::ThermalSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh->GetComm(), num_fields), m_temperature(m_state[0])
+    : BaseSolver(pmesh->GetComm(), num_fields, order), m_temperature(m_state[0])
 {
   m_temperature->mesh     = pmesh;
   m_temperature->coll     = std::make_shared<mfem::H1_FECollection>(order, pmesh->Dimension());

--- a/src/solvers/thermal_structural_solver.cpp
+++ b/src/solvers/thermal_structural_solver.cpp
@@ -11,7 +11,7 @@
 const int num_fields = 3;
 
 ThermalStructuralSolver::ThermalStructuralSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh->GetComm(), num_fields), m_therm_solver(order, pmesh), m_solid_solver(order, pmesh)
+    : BaseSolver(pmesh->GetComm(), num_fields, order), m_therm_solver(order, pmesh), m_solid_solver(order, pmesh)
 {
   m_temperature  = m_therm_solver.GetTemperature();
   m_velocity     = m_solid_solver.GetVelocity();

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -18,7 +18,7 @@ TEST(component_bc, qs_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/square.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/square.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();
@@ -111,7 +111,7 @@ TEST(component_bc, qs_attribute_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/square.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/square.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -19,7 +19,7 @@ TEST(serac_dtor, test1)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();
@@ -40,7 +40,7 @@ TEST(serac_dtor, test1)
   therm_solver->SetTimestepper(serac::TimestepMethod::QuasiStatic);
 
   // Initialize the temperature boundary condition
-  auto u_0 = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector &x) { return x.Norml2(); });
+  auto u_0 = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector& x) { return x.Norml2(); });
 
   std::set<int> temp_bdr = {1};
   // Set the temperature BC in the thermal solver

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -21,7 +21,7 @@ TEST(dynamic_solver, dyn_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();
@@ -105,7 +105,6 @@ TEST(dynamic_solver, dyn_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-
 void InitialDeformation(const mfem::Vector &x, mfem::Vector &y)
 {
   // set the initial configuration to be the same as the reference, stress
@@ -127,7 +126,7 @@ void InitialVelocity(const mfem::Vector &x, mfem::Vector &v)
 #include "axom/slic/core/UnitTestLogger.hpp"
 using axom::slic::UnitTestLogger;
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   int result = 0;
 

--- a/tests/serac_linelastic_solver.cpp
+++ b/tests/serac_linelastic_solver.cpp
@@ -17,7 +17,7 @@ TEST(elastic_solver, static_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-quad.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-quad.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -18,7 +18,7 @@ TEST(nonlinear_solid_solver, qs_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();

--- a/tests/serac_stdfunction_coefficient.cpp
+++ b/tests/serac_stdfunction_coefficient.cpp
@@ -9,9 +9,9 @@
 
 #include <memory>
 
+#include "axom/slic.hpp"
 #include "coefficients/stdfunction_coefficient.hpp"
 #include "mfem.hpp"
-#include "axom/slic.hpp"
 
 using namespace mfem;
 using namespace std;
@@ -257,7 +257,7 @@ TEST_F(StdFunctionCoefficientTest, EssentialBCCube)
 #include "axom/slic/core/UnitTestLogger.hpp"
 using axom::slic::UnitTestLogger;
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   int result = 0;
 

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -30,7 +30,7 @@ TEST(thermal_solver, static_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();
@@ -91,7 +91,7 @@ TEST(thermal_solver, static_solve_multiple_bcs)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star_with_2_bdr_attributes.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/star_with_2_bdr_attributes.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();
@@ -161,7 +161,7 @@ TEST(thermal_solver, static_solve_repeated_bcs)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();
@@ -224,7 +224,7 @@ TEST(thermal_solver, dyn_exp_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();
@@ -303,7 +303,7 @@ TEST(thermal_solver, dyn_imp_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -18,7 +18,7 @@ TEST(dynamic_solver, dyn_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
+  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
   std::fstream imesh(mesh_file);
   auto         mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
   imesh.close();

--- a/tests/serac_wrapper_tests.cpp
+++ b/tests/serac_wrapper_tests.cpp
@@ -217,7 +217,7 @@ TEST_F(WrapperTests, nonlinear_linear_thermal)
 #include "axom/slic/core/UnitTestLogger.hpp"
 using axom::slic::UnitTestLogger;
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
   int result = 0;
 


### PR DESCRIPTION
This adds some minor fixes that came out of my Tribol integration work. 

- Adds MPI rank and size data members to the base solver class for easy access
- Make style