### PR TITLE
Add conflict with intel in spack package with explanation

### DIFF
--- a/.gitlab/ci/build_quartz.yml
+++ b/.gitlab/ci/build_quartz.yml
@@ -57,15 +57,16 @@ gcc_8_1_0 (PR build_on_quartz):
     HOST_CONFIG: "quartz-toss_3_x86_64_ib-gcc@8.1.0.cmake"
   extends: .pr_build_on_quartz
 
-# Intel C++ compiler has poor C++17 support and will no longer be 
-# supported until issues are resolved. 
+# Intel C++ compiler has poor C++17 support and will no longer be
+# supported until issues are resolved.
 # See CMPLRIL0-32507
 # https://community.intel.com/t5/Intel-C-Compiler/Converting-constructor-issue-with-std-variant/td-p/1182651
-# intel_19_0_4 (PR build_on_quartz):
-#   variables:
-#     COMPILER: "intel@19.0.4"
-#     HOST_CONFIG: "quartz-toss_3_x86_64_ib-intel@19.0.4.cmake"
-#   extends: .pr_build_on_quartz
+intel_19_0_4 (PR build_on_quartz):
+  variables:
+    COMPILER: "intel@19.0.4"
+    HOST_CONFIG: "quartz-toss_3_x86_64_ib-intel@19.0.4.cmake"
+  extends: .pr_build_on_quartz
+  allow_failure: true
 
 clang_9_0_0 (Main build_with_deps_on_quartz):
   variables:
@@ -79,8 +80,13 @@ gcc_8_1_0 (Main build_with_deps_on_quartz):
     SPEC: "@develop%${COMPILER}"
   extends: .main_build_with_deps_on_quartz
 
-# intel_19_0_4 (Main build_with_deps_on_quartz):
-#   variables:
-#     COMPILER: "intel@19.0.4"
-#     SPEC: "@develop%${COMPILER}"
-#   extends: .main_build_with_deps_on_quartz
+# Intel C++ compiler has poor C++17 support and will no longer be
+# supported until issues are resolved.
+# See CMPLRIL0-32507
+# https://community.intel.com/t5/Intel-C-Compiler/Converting-constructor-issue-with-std-variant/td-p/1182651
+intel_19_0_4 (Main build_with_deps_on_quartz):
+  variables:
+    COMPILER: "intel@19.0.4"
+    SPEC: "@develop%${COMPILER}"
+  extends: .main_build_with_deps_on_quartz
+  allow_failure: true

--- a/scripts/uberenv/packages/serac/package.py
+++ b/scripts/uberenv/packages/serac/package.py
@@ -118,6 +118,8 @@ class Serac(CMakePackage):
     # Libraries that we do not build debug
     depends_on("glvis@3.4~fonts", when='+glvis')
 
+    conflicts('%intel', msg="Intel has a bug with c++17 support as of May 2020")
+
     phases = ['hostconfig', 'cmake', 'build',' install']
 
     def _get_sys_type(self, spec):


### PR DESCRIPTION
Relates to #108 and #121 

Since Serac can’t be compiled with Intel, it’s worth mentioning it in the spack package.

I would have been further and kept the tests in CI, but simply allowing them to fail. That’s because we should be able to compile with intel again someday, and I like the idea of covering the major compilers in CI. But I’m probably being picky :).