### PR TITLE
Fix mfem cmake tpl search

### DIFF
--- a/cmake/thirdparty/FindMFEM.cmake
+++ b/cmake/thirdparty/FindMFEM.cmake
@@ -27,8 +27,8 @@ if(EXISTS ${_mfem_cmake_config})
     include(${_mfem_cmake_config})
 
     # TODO: This needs to be verified
-    set(MFEM_INCLUDE_DIRS  ${MFEM_INCLUDE_DIR} )
-    set(MFEM_LIBRARIES     ${MFEM_LIBRARY} )
+    set(MFEM_INCLUDE_DIRS  ${MFEM_INCLUDE_DIRS} )
+    set(MFEM_LIBRARIES     ${MFEM_LIBRARIES} )
 
 else()
     find_path(

--- a/cmake/thirdparty/FindMFEM.cmake
+++ b/cmake/thirdparty/FindMFEM.cmake
@@ -26,7 +26,6 @@ if(EXISTS ${_mfem_cmake_config})
 
     include(${_mfem_cmake_config})
 
-    # TODO: This needs to be verified
     set(MFEM_INCLUDE_DIRS  ${MFEM_INCLUDE_DIRS} )
     set(MFEM_LIBRARIES     ${MFEM_LIBRARIES} )
 


### PR DESCRIPTION
This change fixes the case when a user builds mfem with CMake and uses the generated CMake configuration files to find mfem as a TPL.