### PR TITLE
Second memory audit

### DIFF
--- a/src/coefficients/stdfunction_coefficient.cpp
+++ b/src/coefficients/stdfunction_coefficient.cpp
@@ -13,10 +13,10 @@ namespace serac {
 
 StdFunctionCoefficient::StdFunctionCoefficient(std::function<double(mfem::Vector&)> func) : func_(func) {}
 
-double StdFunctionCoefficient::Eval(mfem::ElementTransformation& T, const mfem::IntegrationPoint& ip)
+double StdFunctionCoefficient::Eval(mfem::ElementTransformation& Tr, const mfem::IntegrationPoint& ip)
 {
-  mfem::Vector transip(T.GetSpaceDim());
-  T.Transform(ip, transip);
+  mfem::Vector transip(Tr.GetSpaceDim());
+  Tr.Transform(ip, transip);
   return func_(transip);
 }
 

--- a/src/coefficients/traction_coefficient.hpp
+++ b/src/coefficients/traction_coefficient.hpp
@@ -31,7 +31,7 @@ private:
   /**
    * @brief The mutable scaling factor
    */
-  double scale_;
+  double scale_ = 1.0;
 
 public:
   /**

--- a/src/docs/sphinx/style_guide.rst
+++ b/src/docs/sphinx/style_guide.rst
@@ -19,6 +19,16 @@ with the following amendments:
 The Google style guide is meant for style enforcement only. The design principles outlined in the 
 `C++ Core Guidelines <http://isocpp.github.io/CppCoreGuidelines/>`_ should be followed.
 
+Of particular importance are the guidelines proposed for managing object lifetime:
+
+    1. Use raw pointers and references [only] to denote non-ownership (R.3 - R.4)
+    #. Prefer ``unique_ptr`` to ``shared_ptr`` (R.21)
+
+For example, if an object ``A`` creates a subobject ``B`` whose constructor requires a reference
+to one of ``A``'s instance variables ``Foo f``, ``B`` should store a non-owning reference to ``f``,
+either ``Foo&`` or ``Foo*``.  This should be ``const`` if at all possible.  In this case, shared ownership
+is not required because the lifetime of ``B`` is entirely dependent on the lifetime of ``A``.
+
 Documentation
 -------------
 

--- a/src/solvers/CMakeLists.txt
+++ b/src/solvers/CMakeLists.txt
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
 set(solvers_sources
-    algebraic_solver.cpp
     base_solver.cpp
+    equation_solver.cpp
     nonlinear_solid_solver.cpp
     nonlinear_solid_operators.cpp
     thermal_solver.cpp
@@ -16,8 +16,8 @@ set(solvers_sources
     )
 
 set(solvers_headers
-    algebraic_solver.hpp
     base_solver.hpp
+    equation_solver.hpp
     nonlinear_solid_solver.hpp
     nonlinear_solid_operators.hpp
     thermal_solver.hpp

--- a/src/solvers/base_solver.hpp
+++ b/src/solvers/base_solver.hpp
@@ -18,7 +18,7 @@
 
 #include "common/common.hpp"
 #include "mfem.hpp"
-#include "solvers/algebraic_solver.hpp"
+#include "solvers/equation_solver.hpp"
 
 namespace serac {
 
@@ -240,7 +240,7 @@ protected:
   /**
    * @brief System solver instance
    */
-  AlgebraicSolver solver_;
+  EquationSolver solver_;
 };
 
 }  // namespace serac

--- a/src/solvers/elasticity_solver.cpp
+++ b/src/solvers/elasticity_solver.cpp
@@ -99,7 +99,7 @@ void ElasticitySolver::completeSetup()
   // Initialize the true vector
   displacement_->gf->GetTrueDofs(*displacement_->true_vec);
 
-  solver_ = AlgebraicSolver(displacement_->space->GetComm(), lin_params_);
+  solver_ = EquationSolver(displacement_->space->GetComm(), lin_params_);
   if (lin_params_.prec == serac::Preconditioner::BoomerAMG) {
     SLIC_WARNING_IF(displacement_->space->GetOrdering() == mfem::Ordering::byVDIM,
                     "Attempting to use BoomerAMG with nodal ordering.");

--- a/src/solvers/equation_solver.cpp
+++ b/src/solvers/equation_solver.cpp
@@ -4,14 +4,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include "solvers/algebraic_solver.hpp"
+#include "solvers/equation_solver.hpp"
 
 #include "common/common.hpp"
 
 namespace serac {
 
-AlgebraicSolver::AlgebraicSolver(MPI_Comm comm, const LinearSolverParameters& lin_params,
-                                 const std::optional<NonlinearSolverParameters>& nonlin_params)
+EquationSolver::EquationSolver(MPI_Comm comm, const LinearSolverParameters& lin_params,
+                               const std::optional<NonlinearSolverParameters>& nonlin_params)
 {
   // Preconditioner configuration is too varied, maybe a PrecondParams is needed?
   // Maybe a redesign to better support custom preconditioners as well

--- a/src/solvers/equation_solver.hpp
+++ b/src/solvers/equation_solver.hpp
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /**
- * @file algebraic_solver.hpp
+ * @file equation_solver.hpp
  *
  * @brief This file contains the declaration of an iterative solver wrapper
  */
 
-#ifndef ALGEBRAIC_SOLVER
-#define ALGEBRAIC_SOLVER
+#ifndef EQUATION_SOLVER
+#define EQUATION_SOLVER
 
 #include <memory>
 #include <optional>
@@ -26,10 +26,10 @@ namespace serac {
  * Wraps a (currently iterative) system solver and handles the configuration of linear
  * or nonlinear solvers.  This class solves a generic global system of (possibly) nonlinear algebraic equations.
  */
-class AlgebraicSolver : public mfem::Solver {
+class EquationSolver : public mfem::Solver {
 public:
   // TODO: Eliminate this once a dependency injection approach is used for the solvers
-  AlgebraicSolver() = default;
+  EquationSolver() = default;
   /**
    * Constructs a new solver wrapper
    * @param[in] comm The MPI communicator object
@@ -38,8 +38,8 @@ public:
    * @see serac::LinearSolverParameters
    * @see serac::NonlinearSolverParameters
    */
-  AlgebraicSolver(MPI_Comm comm, const LinearSolverParameters& lin_params,
-                  const std::optional<NonlinearSolverParameters>& nonlin_params = std::nullopt);
+  EquationSolver(MPI_Comm comm, const LinearSolverParameters& lin_params,
+                 const std::optional<NonlinearSolverParameters>& nonlin_params = std::nullopt);
 
   /**
    * Sets a preconditioner for the underlying linear solver object

--- a/src/solvers/nonlinear_solid_operators.cpp
+++ b/src/solvers/nonlinear_solid_operators.cpp
@@ -52,7 +52,7 @@ NonlinearSolidDynamicOperator::NonlinearSolidDynamicOperator(std::unique_ptr<mfe
     auto Me = std::unique_ptr<mfem::HypreParMatrix>(M_mat_->EliminateRowsCols(bc.getTrueDofs()));
   }
 
-  M_solver_ = AlgebraicSolver(H_form_->ParFESpace()->GetComm(), lin_params);
+  M_solver_ = EquationSolver(H_form_->ParFESpace()->GetComm(), lin_params);
 
   auto M_prec                       = std::make_unique<mfem::HypreSmoother>();
   M_solver_.solver().iterative_mode = false;

--- a/src/solvers/nonlinear_solid_operators.cpp
+++ b/src/solvers/nonlinear_solid_operators.cpp
@@ -10,8 +10,8 @@
 
 namespace serac {
 
-NonlinearSolidQuasiStaticOperator::NonlinearSolidQuasiStaticOperator(std::shared_ptr<mfem::ParNonlinearForm> H_form)
-    : mfem::Operator(H_form->FESpace()->GetTrueVSize()), H_form_(H_form)
+NonlinearSolidQuasiStaticOperator::NonlinearSolidQuasiStaticOperator(std::unique_ptr<mfem::ParNonlinearForm> H_form)
+    : mfem::Operator(H_form->FESpace()->GetTrueVSize()), H_form_(std::move(H_form))
 {
 }
 

--- a/src/solvers/nonlinear_solid_operators.hpp
+++ b/src/solvers/nonlinear_solid_operators.hpp
@@ -17,7 +17,7 @@
 
 #include "common/common.hpp"
 #include "mfem.hpp"
-#include "solvers/algebraic_solver.hpp"
+#include "solvers/equation_solver.hpp"
 
 namespace serac {
 
@@ -196,8 +196,8 @@ public:
    * This is the only requirement for high-order SDIRK implicit integration.
    *
    * @param[in] dt The timestep
-   * @param[in] vx The state vector
-   * @param[out] dvx_dt The implicit time derivative
+   * @param[in] vx The state block vector of velocities and displacements
+   * @param[out] dvx_dt The time rate of vx
    */
   virtual void ImplicitSolve(const double dt, const mfem::Vector& vx, mfem::Vector& dvx_dt);
 
@@ -230,7 +230,7 @@ protected:
   /**
    * @brief The CG solver for the mass matrix
    */
-  AlgebraicSolver M_solver_;
+  EquationSolver M_solver_;
 
   /**
    * @brief The reduced system operator for applying the bilinear and nonlinear forms

--- a/src/solvers/nonlinear_solid_operators.hpp
+++ b/src/solvers/nonlinear_solid_operators.hpp
@@ -251,10 +251,10 @@ public:
    * This is the only requirement for high-order SDIRK implicit integration.
    *
    * @param[in] dt The timestep
-   * @param[in] x The state vector
-   * @param[out] k The implicit time derivative
+   * @param[in] vx The state vector
+   * @param[out] dvx_dt The implicit time derivative
    */
-  virtual void ImplicitSolve(const double dt, const mfem::Vector& x, mfem::Vector& k);
+  virtual void ImplicitSolve(const double dt, const mfem::Vector& vx, mfem::Vector& dvx_dt);
 
   /**
    * @brief Destroy the Nonlinear Solid Dynamic Operator object

--- a/src/solvers/nonlinear_solid_operators.hpp
+++ b/src/solvers/nonlinear_solid_operators.hpp
@@ -28,7 +28,7 @@ protected:
   /**
    * @brief The nonlinear form
    */
-  std::shared_ptr<mfem::ParNonlinearForm> H_form_;
+  std::unique_ptr<mfem::ParNonlinearForm> H_form_;
 
   /**
    * @brief The linearized jacobian at the current state
@@ -41,7 +41,7 @@ public:
    *
    * @param[in] H_form The nonlinear form of the PDE
    */
-  explicit NonlinearSolidQuasiStaticOperator(std::shared_ptr<mfem::ParNonlinearForm> H_form);
+  explicit NonlinearSolidQuasiStaticOperator(std::unique_ptr<mfem::ParNonlinearForm> H_form);
 
   /**
    * @brief Get the Gradient of the nonlinear form

--- a/src/solvers/nonlinear_solid_solver.cpp
+++ b/src/solvers/nonlinear_solid_solver.cpp
@@ -172,7 +172,7 @@ void NonlinearSolidSolver::completeSetup()
     S_form->Finalize(0);
   }
 
-  solver_ = AlgebraicSolver(displacement_->space->GetComm(), lin_params_, nonlin_params_);
+  solver_ = EquationSolver(displacement_->space->GetComm(), lin_params_, nonlin_params_);
   // Set up the jacbian solver based on the linear solver options
   if (lin_params_.prec == serac::Preconditioner::BoomerAMG) {
     SLIC_WARNING_IF(displacement_->space->GetOrdering() == mfem::Ordering::byVDIM,

--- a/src/solvers/nonlinear_solid_solver.cpp
+++ b/src/solvers/nonlinear_solid_solver.cpp
@@ -85,7 +85,10 @@ void NonlinearSolidSolver::setHyperelasticMaterialParameters(const double mu, co
   model_.reset(new mfem::NeoHookeanModel(mu, K));
 }
 
-void NonlinearSolidSolver::setViscosity(std::unique_ptr<mfem::Coefficient>&& visc) { viscosity_ = std::move(visc); }
+void NonlinearSolidSolver::setViscosity(std::unique_ptr<mfem::Coefficient>&& visc_coef)
+{
+  viscosity_ = std::move(visc_coef);
+}
 
 void NonlinearSolidSolver::setDisplacement(mfem::VectorCoefficient& disp_state)
 {

--- a/src/solvers/nonlinear_solid_solver.cpp
+++ b/src/solvers/nonlinear_solid_solver.cpp
@@ -85,7 +85,7 @@ void NonlinearSolidSolver::setHyperelasticMaterialParameters(const double mu, co
   model_.reset(new mfem::NeoHookeanModel(mu, K));
 }
 
-void NonlinearSolidSolver::setViscosity(std::shared_ptr<mfem::Coefficient> visc) { viscosity_ = visc; }
+void NonlinearSolidSolver::setViscosity(std::unique_ptr<mfem::Coefficient>&& visc) { viscosity_ = std::move(visc); }
 
 void NonlinearSolidSolver::setDisplacement(mfem::VectorCoefficient& disp_state)
 {
@@ -228,11 +228,11 @@ void NonlinearSolidSolver::completeSetup()
   // Set the MFEM abstract operators for use with the internal MFEM solvers
   if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
     newton_solver_.iterative_mode = true;
-    nonlinear_oper_               = std::make_shared<NonlinearSolidQuasiStaticOperator>(std::move(H_form));
+    nonlinear_oper_               = std::make_unique<NonlinearSolidQuasiStaticOperator>(std::move(H_form));
     newton_solver_.SetOperator(*nonlinear_oper_);
   } else {
     newton_solver_.iterative_mode = false;
-    timedep_oper_                 = std::make_shared<NonlinearSolidDynamicOperator>(
+    timedep_oper_                 = std::make_unique<NonlinearSolidDynamicOperator>(
         std::move(H_form), std::move(S_form), std::move(M_form), ess_bdr_, newton_solver_, lin_params_);
     ode_solver_->Init(*timedep_oper_);
   }

--- a/src/solvers/nonlinear_solid_solver.hpp
+++ b/src/solvers/nonlinear_solid_solver.hpp
@@ -34,12 +34,12 @@ protected:
   /**
    * @brief The quasi-static operator for use with the MFEM newton solvers
    */
-  std::shared_ptr<mfem::Operator> nonlinear_oper_;
+  std::unique_ptr<mfem::Operator> nonlinear_oper_;
 
   /**
    * @brief The time dependent operator for use with the MFEM ODE solvers
    */
-  std::shared_ptr<mfem::TimeDependentOperator> timedep_oper_;
+  std::unique_ptr<mfem::TimeDependentOperator> timedep_oper_;
 
   /**
    * @brief The Newton solver for the nonlinear iterations
@@ -59,12 +59,12 @@ protected:
   /**
    * @brief The viscosity coefficient
    */
-  std::shared_ptr<mfem::Coefficient> viscosity_;
+  std::unique_ptr<mfem::Coefficient> viscosity_;
 
   /**
    * @brief The hyperelastic material model
    */
-  std::shared_ptr<mfem::HyperelasticModel> model_;
+  std::unique_ptr<mfem::HyperelasticModel> model_;
 
   /**
    * @brief Linear solver parameters
@@ -133,7 +133,7 @@ public:
    *
    * @param[in] visc_coef The abstract viscosity coefficient
    */
-  void setViscosity(std::shared_ptr<mfem::Coefficient> visc_coef);
+  void setViscosity(std::unique_ptr<mfem::Coefficient>&& visc_coef);
 
   /**
    * @brief Set the hyperelastic material parameters

--- a/src/solvers/thermal_operators.cpp
+++ b/src/solvers/thermal_operators.cpp
@@ -10,19 +10,19 @@
 
 namespace serac {
 
-DynamicConductionOperator::DynamicConductionOperator(std::shared_ptr<mfem::ParFiniteElementSpace> fespace,
+DynamicConductionOperator::DynamicConductionOperator(mfem::ParFiniteElementSpace& fespace,
                                                      const serac::LinearSolverParameters&         params,
                                                      std::vector<serac::BoundaryCondition>&       ess_bdr)
-    : mfem::TimeDependentOperator(fespace->GetTrueVSize(), 0.0),
-      fespace_(fespace),
+    : mfem::TimeDependentOperator(fespace.GetTrueVSize(), 0.0),
+      // fespace_(fespace),
       ess_bdr_(ess_bdr),
-      z_(fespace->GetTrueVSize()),
-      y_(fespace->GetTrueVSize()),
-      x_(fespace->GetTrueVSize()),
+      z_(fespace.GetTrueVSize()),
+      y_(fespace.GetTrueVSize()),
+      x_(fespace.GetTrueVSize()),
       old_dt_(-1.0)
 {
   // Set the mass solver options (CG and Jacobi for now)
-  M_solver_ = std::make_unique<mfem::CGSolver>(fespace_->GetComm());
+  M_solver_ = std::make_unique<mfem::CGSolver>(fespace.GetComm());
   M_prec_   = std::make_unique<mfem::HypreSmoother>();
 
   M_solver_->iterative_mode = false;
@@ -34,7 +34,7 @@ DynamicConductionOperator::DynamicConductionOperator(std::shared_ptr<mfem::ParFi
   M_solver_->SetPreconditioner(*M_prec_);
 
   // Use the same options for the T (= M + dt K) solver
-  T_solver_ = std::make_unique<mfem::CGSolver>(fespace_->GetComm());
+  T_solver_ = std::make_unique<mfem::CGSolver>(fespace.GetComm());
   T_prec_   = std::make_unique<mfem::HypreSmoother>();
 
   T_solver_->iterative_mode = false;
@@ -44,8 +44,8 @@ DynamicConductionOperator::DynamicConductionOperator(std::shared_ptr<mfem::ParFi
   T_solver_->SetPrintLevel(params.print_level);
   T_solver_->SetPreconditioner(*T_prec_);
 
-  state_gf_ = std::make_shared<mfem::ParGridFunction>(fespace_.get());
-  bc_rhs_   = std::make_shared<mfem::Vector>(fespace->GetTrueVSize());
+  state_gf_ = std::make_shared<mfem::ParGridFunction>(&fespace);
+  bc_rhs_   = std::make_shared<mfem::Vector>(fespace.GetTrueVSize());
 }
 
 void DynamicConductionOperator::setMatrices(std::shared_ptr<mfem::HypreParMatrix> M_mat,

--- a/src/solvers/thermal_operators.cpp
+++ b/src/solvers/thermal_operators.cpp
@@ -14,7 +14,6 @@ DynamicConductionOperator::DynamicConductionOperator(mfem::ParFiniteElementSpace
                                                      const serac::LinearSolverParameters&   params,
                                                      std::vector<serac::BoundaryCondition>& ess_bdr)
     : mfem::TimeDependentOperator(fespace.GetTrueVSize(), 0.0),
-      // fespace_(fespace),
       ess_bdr_(ess_bdr),
       z_(fespace.GetTrueVSize()),
       y_(fespace.GetTrueVSize()),

--- a/src/solvers/thermal_operators.cpp
+++ b/src/solvers/thermal_operators.cpp
@@ -21,7 +21,7 @@ DynamicConductionOperator::DynamicConductionOperator(mfem::ParFiniteElementSpace
       old_dt_(-1.0)
 {
   // Set the mass solver options (CG and Jacobi for now)
-  M_solver_ = AlgebraicSolver(fespace.GetComm(), params);
+  M_solver_ = EquationSolver(fespace.GetComm(), params);
 
   M_solver_.solver().iterative_mode = false;
   auto M_prec                       = std::make_unique<mfem::HypreSmoother>();
@@ -29,7 +29,7 @@ DynamicConductionOperator::DynamicConductionOperator(mfem::ParFiniteElementSpace
   M_solver_.SetPreconditioner(std::move(M_prec));
 
   // Use the same options for the T (= M + dt K) solver
-  T_solver_ = AlgebraicSolver(fespace.GetComm(), params);
+  T_solver_ = EquationSolver(fespace.GetComm(), params);
 
   T_solver_.solver().iterative_mode = false;
 

--- a/src/solvers/thermal_operators.cpp
+++ b/src/solvers/thermal_operators.cpp
@@ -10,9 +10,9 @@
 
 namespace serac {
 
-DynamicConductionOperator::DynamicConductionOperator(mfem::ParFiniteElementSpace& fespace,
-                                                     const serac::LinearSolverParameters&         params,
-                                                     std::vector<serac::BoundaryCondition>&       ess_bdr)
+DynamicConductionOperator::DynamicConductionOperator(mfem::ParFiniteElementSpace&           fespace,
+                                                     const serac::LinearSolverParameters&   params,
+                                                     std::vector<serac::BoundaryCondition>& ess_bdr)
     : mfem::TimeDependentOperator(fespace.GetTrueVSize(), 0.0),
       // fespace_(fespace),
       ess_bdr_(ess_bdr),
@@ -44,18 +44,17 @@ DynamicConductionOperator::DynamicConductionOperator(mfem::ParFiniteElementSpace
   T_solver_->SetPrintLevel(params.print_level);
   T_solver_->SetPreconditioner(*T_prec_);
 
-  state_gf_ = std::make_shared<mfem::ParGridFunction>(&fespace);
-  bc_rhs_   = std::make_shared<mfem::Vector>(fespace.GetTrueVSize());
+  state_gf_ = std::make_unique<mfem::ParGridFunction>(&fespace);
+  bc_rhs_   = std::make_unique<mfem::Vector>(fespace.GetTrueVSize());
 }
 
-void DynamicConductionOperator::setMatrices(std::shared_ptr<mfem::HypreParMatrix> M_mat,
-                                            std::shared_ptr<mfem::HypreParMatrix> K_mat)
+void DynamicConductionOperator::setMatrices(mfem::HypreParMatrix* M_mat, mfem::HypreParMatrix* K_mat)
 {
   M_mat_ = M_mat;
   K_mat_ = K_mat;
 }
 
-void DynamicConductionOperator::setLoadVector(std::shared_ptr<mfem::Vector> rhs) { rhs_ = rhs; }
+void DynamicConductionOperator::setLoadVector(mfem::Vector* rhs) { rhs_ = rhs; }
 
 // TODO: allow for changing thermal essential boundary conditions
 void DynamicConductionOperator::Mult(const mfem::Vector& u, mfem::Vector& du_dt) const

--- a/src/solvers/thermal_operators.hpp
+++ b/src/solvers/thermal_operators.hpp
@@ -53,7 +53,7 @@ protected:
   /**
    * @brief Non-owning pointer to the assembled M matrix
    */
-  mfem::HypreParMatrix* M_mat_ = nullptr;
+  const mfem::HypreParMatrix* M_mat_ = nullptr;
 
   /**
    * @brief Non-owning pointer to the assembled K matrix
@@ -73,7 +73,7 @@ protected:
   /**
    * @brief Non-owning ptr to assembled RHS vector
    */
-  mfem::Vector* rhs_ = nullptr;
+  const mfem::Vector* rhs_ = nullptr;
 
   /**
    * @brief RHS vector including essential boundary elimination

--- a/src/solvers/thermal_operators.hpp
+++ b/src/solvers/thermal_operators.hpp
@@ -26,11 +26,6 @@ namespace serac {
 class DynamicConductionOperator : public mfem::TimeDependentOperator {
 protected:
   /**
-   * @brief Finite Element space
-   */
-  std::shared_ptr<mfem::ParFiniteElementSpace> fespace_;
-
-  /**
    * @brief Grid function for boundary condition projection
    */
   std::shared_ptr<mfem::ParGridFunction> state_gf_;
@@ -110,7 +105,7 @@ public:
    * @param[in] params The linear solver parameters
    * @param[in] ess_bdr The essential boundary condition objects
    */
-  DynamicConductionOperator(std::shared_ptr<mfem::ParFiniteElementSpace> fespace,
+  DynamicConductionOperator(mfem::ParFiniteElementSpace& fespace,
                             const serac::LinearSolverParameters&         params,
                             std::vector<serac::BoundaryCondition>&       ess_bdr);
 

--- a/src/solvers/thermal_operators.hpp
+++ b/src/solvers/thermal_operators.hpp
@@ -28,7 +28,7 @@ protected:
   /**
    * @brief Grid function for boundary condition projection
    */
-  std::shared_ptr<mfem::ParGridFunction> state_gf_;
+  std::unique_ptr<mfem::ParGridFunction> state_gf_;
 
   /**
    * @brief Solver for the mass matrix
@@ -51,14 +51,14 @@ protected:
   std::unique_ptr<mfem::HypreSmoother> T_prec_;
 
   /**
-   * @brief Pointer to the assembled M matrix
+   * @brief Non-owning pointer to the assembled M matrix
    */
-  std::shared_ptr<mfem::HypreParMatrix> M_mat_;
+  mfem::HypreParMatrix* M_mat_;
 
   /**
-   * @brief Pointer to the assembled K matrix
+   * @brief Non-owning pointer to the assembled K matrix
    */
-  std::shared_ptr<mfem::HypreParMatrix> K_mat_;
+  mfem::HypreParMatrix* K_mat_;
 
   /**
    * @brief Pointer to the assembled T ( = M + dt K) matrix
@@ -71,14 +71,14 @@ protected:
   std::unique_ptr<mfem::HypreParMatrix> T_e_mat_;
 
   /**
-   * @brief Assembled RHS vector
+   * @brief Non-owning ptr to assembled RHS vector
    */
-  std::shared_ptr<mfem::Vector> rhs_;
+  mfem::Vector* rhs_;
 
   /**
    * @brief RHS vector including essential boundary elimination
    */
-  std::shared_ptr<mfem::Vector> bc_rhs_;
+  std::unique_ptr<mfem::Vector> bc_rhs_;
 
   /**
    * @brief Temperature essential boundary coefficient
@@ -105,9 +105,8 @@ public:
    * @param[in] params The linear solver parameters
    * @param[in] ess_bdr The essential boundary condition objects
    */
-  DynamicConductionOperator(mfem::ParFiniteElementSpace& fespace,
-                            const serac::LinearSolverParameters&         params,
-                            std::vector<serac::BoundaryCondition>&       ess_bdr);
+  DynamicConductionOperator(mfem::ParFiniteElementSpace& fespace, const serac::LinearSolverParameters& params,
+                            std::vector<serac::BoundaryCondition>& ess_bdr);
 
   /**
    * @brief Set the mass and stiffness matrices
@@ -115,14 +114,14 @@ public:
    * @param[in] M_mat The mass matrix
    * @param[in] K_mat The stiffness matrix
    */
-  void setMatrices(std::shared_ptr<mfem::HypreParMatrix> M_mat, std::shared_ptr<mfem::HypreParMatrix> K_mat);
+  void setMatrices(mfem::HypreParMatrix* M_mat, mfem::HypreParMatrix* K_mat);
 
   /**
    * @brief Set the thermal flux load vector
    *
    * @param[in] The thermal flux (RHS vector)
    */
-  void setLoadVector(std::shared_ptr<mfem::Vector> rhs);
+  void setLoadVector(mfem::Vector* rhs);
 
   /**
    * @brief Calculate du_dt = M^-1 (-Ku + f)

--- a/src/solvers/thermal_operators.hpp
+++ b/src/solvers/thermal_operators.hpp
@@ -53,12 +53,12 @@ protected:
   /**
    * @brief Non-owning pointer to the assembled M matrix
    */
-  mfem::HypreParMatrix* M_mat_;
+  mfem::HypreParMatrix* M_mat_ = nullptr;
 
   /**
    * @brief Non-owning pointer to the assembled K matrix
    */
-  mfem::HypreParMatrix* K_mat_;
+  mfem::HypreParMatrix* K_mat_ = nullptr;
 
   /**
    * @brief Pointer to the assembled T ( = M + dt K) matrix
@@ -73,7 +73,7 @@ protected:
   /**
    * @brief Non-owning ptr to assembled RHS vector
    */
-  mfem::Vector* rhs_;
+  mfem::Vector* rhs_ = nullptr;
 
   /**
    * @brief RHS vector including essential boundary elimination

--- a/src/solvers/thermal_operators.hpp
+++ b/src/solvers/thermal_operators.hpp
@@ -17,7 +17,7 @@
 
 #include "common/common.hpp"
 #include "mfem.hpp"
-#include "solvers/algebraic_solver.hpp"
+#include "solvers/equation_solver.hpp"
 
 namespace serac {
 
@@ -86,12 +86,12 @@ protected:
   /**
    * @brief Solver for the mass matrix
    */
-  AlgebraicSolver M_solver_;
+  EquationSolver M_solver_;
 
   /**
    * @brief Solver for the T matrix
    */
-  AlgebraicSolver T_solver_;
+  EquationSolver T_solver_;
 
   /**
    * @brief Non-owning pointer to the assembled M matrix

--- a/src/solvers/thermal_solver.cpp
+++ b/src/solvers/thermal_solver.cpp
@@ -35,15 +35,15 @@ void ThermalSolver::setTemperature(mfem::Coefficient& temp)
   gf_initialized_[0] = true;
 }
 
-void ThermalSolver::setTemperatureBCs(const std::set<int>& ess_bdr, std::shared_ptr<mfem::Coefficient> ess_bdr_coef)
+void ThermalSolver::setTemperatureBCs(const std::set<int>& temp_bdr, std::shared_ptr<mfem::Coefficient> temp_bdr_coef)
 {
-  setEssentialBCs(ess_bdr, ess_bdr_coef, *temperature_->space);
+  setEssentialBCs(temp_bdr, temp_bdr_coef, *temperature_->space);
 }
 
-void ThermalSolver::setFluxBCs(const std::set<int>& nat_bdr, std::shared_ptr<mfem::Coefficient> nat_bdr_coef)
+void ThermalSolver::setFluxBCs(const std::set<int>& flux_bdr, std::shared_ptr<mfem::Coefficient> flux_bdr_coef)
 {
   // Set the natural (integral) boundary condition
-  setNaturalBCs(nat_bdr, nat_bdr_coef);
+  setNaturalBCs(flux_bdr, flux_bdr_coef);
 }
 
 void ThermalSolver::setConductivity(std::unique_ptr<mfem::Coefficient>&& kappa)

--- a/src/solvers/thermal_solver.cpp
+++ b/src/solvers/thermal_solver.cpp
@@ -110,7 +110,7 @@ void ThermalSolver::completeSetup()
     M_mat_.reset(M_form_->ParallelAssemble());
 
     // Make the time integration operator and set the appropriate matricies
-    dyn_oper_ = std::make_unique<DynamicConductionOperator>(temperature_->space, lin_params_, ess_bdr_);
+    dyn_oper_ = std::make_unique<DynamicConductionOperator>(*temperature_->space, lin_params_, ess_bdr_);
     dyn_oper_->setMatrices(M_mat_, K_mat_);
     dyn_oper_->setLoadVector(rhs_);
 

--- a/src/solvers/thermal_solver.cpp
+++ b/src/solvers/thermal_solver.cpp
@@ -130,7 +130,7 @@ void ThermalSolver::quasiStaticSolve()
 
   // Solve the stiffness using CG with Jacobi preconditioning
   // and the given solverparams
-  solver_ = AlgebraicSolver(temperature_->space->GetComm(), lin_params_);
+  solver_ = EquationSolver(temperature_->space->GetComm(), lin_params_);
 
   auto hypre_smoother = std::make_unique<mfem::HypreSmoother>();
   hypre_smoother->SetType(mfem::HypreSmoother::Jacobi);

--- a/src/solvers/thermal_solver.hpp
+++ b/src/solvers/thermal_solver.hpp
@@ -49,22 +49,12 @@ protected:
   /**
    * @brief Assembled mass matrix
    */
-  std::shared_ptr<mfem::HypreParMatrix> M_mat_;
-
-  /**
-   * @brief Eliminated mass matrix
-   */
-  std::shared_ptr<mfem::HypreParMatrix> M_e_mat_;
+  std::unique_ptr<mfem::HypreParMatrix> M_mat_;
 
   /**
    * @brief Assembled stiffness matrix
    */
-  std::shared_ptr<mfem::HypreParMatrix> K_mat_;
-
-  /**
-   * @brief Eliminated stiffness matrix
-   */
-  std::shared_ptr<mfem::HypreParMatrix> K_e_mat_;
+  std::unique_ptr<mfem::HypreParMatrix> K_mat_;
 
   /**
    * @brief Thermal load linear form
@@ -74,32 +64,32 @@ protected:
   /**
    * @brief Assembled BC load vector
    */
-  std::shared_ptr<mfem::HypreParVector> bc_rhs_;
+  std::unique_ptr<mfem::HypreParVector> bc_rhs_;
 
   /**
    * @brief Assembled RHS vector
    */
-  std::shared_ptr<mfem::HypreParVector> rhs_;
+  std::unique_ptr<mfem::HypreParVector> rhs_;
 
   /**
    * @brief Linear solver for the K operator
    */
-  std::shared_ptr<mfem::CGSolver> K_solver_;
+  std::unique_ptr<mfem::CGSolver> K_solver_;
 
   /**
    * @brief Preconditioner for the K operator
    */
-  std::shared_ptr<mfem::HypreSmoother> K_prec_;
+  std::unique_ptr<mfem::HypreSmoother> K_prec_;
 
   /**
    * @brief Conduction coefficient
    */
-  std::shared_ptr<mfem::Coefficient> kappa_;
+  std::unique_ptr<mfem::Coefficient> kappa_;
 
   /**
    * @brief Body source coefficient
    */
-  std::shared_ptr<mfem::Coefficient> source_;
+  std::unique_ptr<mfem::Coefficient> source_;
 
   /**
    * @brief Time integration operator
@@ -153,7 +143,7 @@ public:
    *
    * @param[in] kappa The thermal conductivity
    */
-  void setConductivity(std::shared_ptr<mfem::Coefficient> kappa);
+  void setConductivity(std::unique_ptr<mfem::Coefficient>&& kappa);
 
   /**
    * @brief Set the temperature state vector from a coefficient
@@ -167,7 +157,7 @@ public:
    *
    * @param[in] source The source function coefficient
    */
-  void setSource(std::shared_ptr<mfem::Coefficient> source);
+  void setSource(std::unique_ptr<mfem::Coefficient>&& source);
 
   /**
    * @brief Get the temperature state

--- a/src/solvers/thermal_structural_solver.hpp
+++ b/src/solvers/thermal_structural_solver.hpp
@@ -91,7 +91,7 @@ public:
    *
    * @param[in] kappa The thermal conductivity
    */
-  void SetConductivity(std::shared_ptr<mfem::Coefficient> kappa) { therm_solver_.setConductivity(kappa); };
+  void SetConductivity(std::unique_ptr<mfem::Coefficient>&& kappa) { therm_solver_.setConductivity(std::move(kappa)); };
 
   /**
    * @brief Set the temperature state vector from a coefficient
@@ -105,7 +105,7 @@ public:
    *
    * @param[in] source The source function coefficient
    */
-  void SetSource(std::shared_ptr<mfem::Coefficient> source) { therm_solver_.setSource(source); };
+  void SetSource(std::shared_ptr<mfem::Coefficient>&& source) { therm_solver_.setSource(std::move(source)); };
 
   /**
    * @brief Set the linear solver parameters for both the M and K matrices
@@ -159,7 +159,7 @@ public:
    *
    * @param[in] visc_coef The abstract viscosity coefficient
    */
-  void SetViscosity(std::shared_ptr<mfem::Coefficient> visc_coef) { solid_solver_.setViscosity(visc_coef); };
+  void SetViscosity(std::unique_ptr<mfem::Coefficient>&& visc_coef) { solid_solver_.setViscosity(std::move(visc_coef)); };
 
   /**
    * @brief Set the hyperelastic material parameters

--- a/src/solvers/thermal_structural_solver.hpp
+++ b/src/solvers/thermal_structural_solver.hpp
@@ -105,7 +105,7 @@ public:
    *
    * @param[in] source The source function coefficient
    */
-  void SetSource(std::shared_ptr<mfem::Coefficient>&& source) { therm_solver_.setSource(std::move(source)); };
+  void SetSource(std::unique_ptr<mfem::Coefficient>&& source) { therm_solver_.setSource(std::move(source)); };
 
   /**
    * @brief Set the linear solver parameters for both the M and K matrices
@@ -159,7 +159,10 @@ public:
    *
    * @param[in] visc_coef The abstract viscosity coefficient
    */
-  void SetViscosity(std::unique_ptr<mfem::Coefficient>&& visc_coef) { solid_solver_.setViscosity(std::move(visc_coef)); };
+  void SetViscosity(std::unique_ptr<mfem::Coefficient>&& visc_coef)
+  {
+    solid_solver_.setViscosity(std::move(visc_coef));
+  };
 
   /**
    * @brief Set the hyperelastic material parameters

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -40,8 +40,8 @@ TEST(serac_dtor, test1)
   therm_solver->setTemperatureBCs(temp_bdr, u_0);
 
   // Set the conductivity of the thermal operator
-  auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
-  therm_solver->setConductivity(kappa);
+  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
+  therm_solver->setConductivity(std::move(kappa));
 
   // Define the linear solver params
   serac::LinearSolverParameters params;

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -32,7 +32,7 @@ TEST(dynamic_solver, dyn_solve)
 
   std::set<int> ess_bdr = {1};
 
-  auto visc   = std::make_shared<mfem::ConstantCoefficient>(0.0);
+  auto visc   = std::make_unique<mfem::ConstantCoefficient>(0.0);
   auto deform = std::make_shared<mfem::VectorFunctionCoefficient>(dim, initialDeformation);
   auto velo   = std::make_shared<mfem::VectorFunctionCoefficient>(dim, initialVelocity);
 
@@ -40,7 +40,7 @@ TEST(dynamic_solver, dyn_solve)
   NonlinearSolidSolver dyn_solver(1, pmesh);
   dyn_solver.setDisplacementBCs(ess_bdr, deform);
   dyn_solver.setHyperelasticMaterialParameters(0.25, 5.0);
-  dyn_solver.setViscosity(visc);
+  dyn_solver.setViscosity(std::move(visc));
   dyn_solver.setDisplacement(*deform);
   dyn_solver.setVelocity(*velo);
   dyn_solver.setTimestepper(serac::TimestepMethod::SDIRK33);

--- a/tests/serac_stdfunction_coefficient.cpp
+++ b/tests/serac_stdfunction_coefficient.cpp
@@ -55,7 +55,7 @@ TEST_F(StdFunctionCoefficientTest, Xtest)
 
   double x_mult = 1.5;
   // Here we stretch the "x-component" of the coordinate by x_mult
-  StdFunctionVectorCoefficient x_stretch(3, [x_mult](mfem::Vector& p, mfem::Vector& u) {
+  StdFunctionVectorCoefficient x_stretch(3, [x_mult](const mfem::Vector& p, mfem::Vector& u) {
     u = p;
     u[0] *= x_mult;
   });
@@ -158,7 +158,7 @@ TEST_F(StdFunctionCoefficientTest, AttributeListSet)
 TEST_F(StdFunctionCoefficientTest, EssentialBC)
 {
   // Create an indicator function to set all vertices that are x=0
-  StdFunctionVectorCoefficient zero_bc(3, [](Vector& x, Vector& X) {
+  StdFunctionVectorCoefficient zero_bc(3, [](const Vector& x, Vector& X) {
     X = 0.;
     for (int i = 0; i < 3; i++)
       if (abs(x[i]) < 1.e-13) {
@@ -190,7 +190,7 @@ TEST_F(StdFunctionCoefficientTest, EssentialBC)
 TEST_F(StdFunctionCoefficientTest, EssentialBCCube)
 {
   // Create an indicator function to set vertex at the origin
-  StdFunctionVectorCoefficient origin_bc(3, [](Vector& x, Vector& X) {
+  StdFunctionVectorCoefficient origin_bc(3, [](const Vector& x, Vector& X) {
     X = 0.;
 
     if (abs(x[0]) < 1.e-13 && abs(x[1]) < 1.e-13 && abs(x[2]) < 1.e-13) {
@@ -201,7 +201,7 @@ TEST_F(StdFunctionCoefficientTest, EssentialBCCube)
   Array<int> ess_origin_bc_list = serac::makeEssList(*pfes_v_, origin_bc);
 
   // Define bottom indicator list
-  StdFunctionVectorCoefficient bottom_bc_z(pfes_v_->GetVDim(), [](Vector& x, Vector& X) {
+  StdFunctionVectorCoefficient bottom_bc_z(pfes_v_->GetVDim(), [](const Vector& x, Vector& X) {
     X = 0.;
 
     if (abs(x[2]) < 1.e-13) {
@@ -212,7 +212,7 @@ TEST_F(StdFunctionCoefficientTest, EssentialBCCube)
   Array<int> ess_bottom_bc_list = serac::makeEssList(*pfes_v_, bottom_bc_z);
 
   // Define top indicator list
-  StdFunctionVectorCoefficient top_bc_z(pfes_v_->GetVDim(), [](Vector& x, Vector& X) {
+  StdFunctionVectorCoefficient top_bc_z(pfes_v_->GetVDim(), [](const Vector& x, Vector& X) {
     X = 0.;
 
     if (abs(x[2] - 1.) < 1.e-13) {
@@ -222,7 +222,7 @@ TEST_F(StdFunctionCoefficientTest, EssentialBCCube)
   Array<int>                   ess_top_bc_list = serac::makeEssList(*pfes_v_, top_bc_z);
 
   // Project displacement values z = 0.5*z
-  StdFunctionVectorCoefficient vals(pfes_v_->GetVDim(), [](Vector& x, Vector& disp) {
+  StdFunctionVectorCoefficient vals(pfes_v_->GetVDim(), [](const Vector& x, Vector& disp) {
     disp    = 0.;
     disp[2] = x[2] * 0.5;
   });

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -52,8 +52,8 @@ TEST(thermal_solver, static_solve)
   therm_solver.setTemperatureBCs(temp_bdr, u_0);
 
   // Set the conductivity of the thermal operator
-  auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(kappa);
+  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
+  therm_solver.setConductivity(std::move(kappa));
 
   // Define the linear solver params
   serac::LinearSolverParameters params;
@@ -106,8 +106,8 @@ TEST(thermal_solver, static_solve_multiple_bcs)
   therm_solver.setTemperatureBCs(marked_2, u_1);
 
   // Set the conductivity of the thermal operator
-  auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(kappa);
+  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
+  therm_solver.setConductivity(std::move(kappa));
 
   // Define the linear solver params
   serac::LinearSolverParameters params;
@@ -165,8 +165,8 @@ TEST(thermal_solver, static_solve_repeated_bcs)
   therm_solver.setTemperatureBCs(temp_bdr, u_1);
 
   // Set the conductivity of the thermal operator
-  auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(kappa);
+  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
+  therm_solver.setConductivity(std::move(kappa));
 
   // Define the linear solver params
   serac::LinearSolverParameters params;
@@ -215,8 +215,8 @@ TEST(thermal_solver, dyn_exp_solve)
   therm_solver.setTemperatureBCs(temp_bdr, u_0);
 
   // Set the conductivity of the thermal operator
-  auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(kappa);
+  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
+  therm_solver.setConductivity(std::move(kappa));
 
   // Define the linear solver params
   serac::LinearSolverParameters params;
@@ -284,8 +284,8 @@ TEST(thermal_solver, dyn_imp_solve)
   therm_solver.setTemperatureBCs(temp_bdr, u_0);
 
   // Set the conductivity of the thermal operator
-  auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(kappa);
+  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
+  therm_solver.setConductivity(std::move(kappa));
 
   // Define the linear solver params
   serac::LinearSolverParameters params;

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -45,7 +45,7 @@ TEST(dynamic_solver, dyn_solve)
     return temp;
   });
 
-  auto kappa = std::make_shared<mfem::ConstantCoefficient>(0.5);
+  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
 
   // set the traction boundary
   std::set<int> trac_bdr = {2};
@@ -61,7 +61,7 @@ TEST(dynamic_solver, dyn_solve)
   ts_solver.SetDisplacementBCs(ess_bdr, deform);
   ts_solver.SetTractionBCs(trac_bdr, traction_coef);
   ts_solver.SetHyperelasticMaterialParameters(0.25, 5.0);
-  ts_solver.SetConductivity(kappa);
+  ts_solver.SetConductivity(std::move(kappa));
   ts_solver.SetDisplacement(*deform);
   ts_solver.SetVelocity(*velo);
   ts_solver.SetTemperature(*temp);
@@ -73,9 +73,9 @@ TEST(dynamic_solver, dyn_solve)
   double scale  = 1.0;
 
   auto temp_gf_coef = std::make_shared<mfem::GridFunctionCoefficient>(ts_solver.temperature()->gf.get());
-  auto visc_coef    = std::make_shared<TransformedScalarCoefficient>(
+  auto visc_coef    = std::make_unique<TransformedScalarCoefficient>(
       temp_gf_coef, [offset, scale](const double x) { return scale * x + offset; });
-  ts_solver.SetViscosity(visc_coef);
+  ts_solver.SetViscosity(std::move(visc_coef));
 
   // Set the linear solver parameters
   serac::LinearSolverParameters params;

--- a/tests/serac_wrapper_tests.cpp
+++ b/tests/serac_wrapper_tests.cpp
@@ -120,11 +120,6 @@ void SolveMixedNonlinear(std::shared_ptr<ParFiniteElementSpace> pfes_, Array<int
   A_nonlin.AddDomainIntegrator(new MixedBilinearToNonlinearFormIntegrator(diffusion, pfes_));
   A_nonlin.SetEssentialTrueDofs(ess_tdof_list);
 
-  ParLinearForm f_lin(pfes_.get());
-
-  f_lin                             = 0.;
-  std::unique_ptr<HypreParVector> F = std::unique_ptr<HypreParVector>(f_lin.ParallelAssemble());
-
   // The temperature solution vector already contains the essential boundary condition values
   std::unique_ptr<HypreParVector> T = std::unique_ptr<HypreParVector>(temp.GetTrueDofs());
 
@@ -144,7 +139,7 @@ void SolveMixedNonlinear(std::shared_ptr<ParFiniteElementSpace> pfes_, Array<int
 TEST_F(WrapperTests, nonlinear_linear_thermal)
 {
   // Create a coefficient that indicates the x == 0 border of the cube
-  StdFunctionCoefficient x_zero([](Vector& x) {
+  StdFunctionCoefficient x_zero([](const Vector& x) {
     if (x[0] < 1.e-12) {
       return 1.;
     }
@@ -152,7 +147,7 @@ TEST_F(WrapperTests, nonlinear_linear_thermal)
   });
 
   // Create a coefficient that indicates the x == 1 border of the cube
-  StdFunctionCoefficient x_one([](Vector& x) {
+  StdFunctionCoefficient x_one([](const Vector& x) {
     if ((1. - x[0]) < 1.e-12) {
       return 1.;
     }


### PR DESCRIPTION
This is intended to be another step in the general direction of hierarchical ownership, in which objects distribute non-owning handles to the sub-objects they create (e.g. a solver class giving a non-owning reference to an operator it creates).  Primarily this is via the removal of `shared_ptr`s which introduce [incidental data structures](https://sean-parent.stlab.cc/presentations/2016-08-08-data-structures/2016-08-08-data-structures.pdf).

The only remaining `shared_ptr`s in the solver classes are for boundary conditions, meshes, and FEStates, which are currently pending the merging of other branches.

This PR also addresses minor style issues like parameter names differing between function declarations and implementations.