### PR TITLE
Add initialize function for use in drivers

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -7,6 +7,7 @@
 set(common_headers
     boundary_condition.hpp
     common.hpp
+    initialize.hpp
     serac_types.hpp
     logger.hpp
     mesh_utils.hpp
@@ -15,6 +16,7 @@ set(common_headers
 
 set(common_sources
     boundary_condition.cpp
+    initialize.cpp
     logger.cpp
     mesh_utils.cpp
     terminator.cpp

--- a/src/common/common.hpp
+++ b/src/common/common.hpp
@@ -14,6 +14,7 @@
 #define COMMON
 
 #include "common/boundary_condition.hpp"
+#include "common/initialize.hpp"
 #include "common/logger.hpp"
 #include "common/serac_types.hpp"
 #include "common/terminator.hpp"

--- a/src/common/initialize.cpp
+++ b/src/common/initialize.cpp
@@ -1,0 +1,33 @@
+// Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "common/initialize.hpp"
+
+#include "common/logger.hpp"
+#include "common/terminator.hpp"
+
+namespace serac {
+
+std::pair<int, int> initialize(int argc, char* argv[], MPI_Comm comm)
+{
+  // Initialize MPI.
+  int num_procs, rank;
+  MPI_Init(&argc, &argv);
+  MPI_Comm_size(comm, &num_procs);
+  MPI_Comm_rank(comm, &rank);
+
+  // Initialize the signal handler
+  terminator::registerSignals();
+
+  // Initialize SLIC logger
+  if (!logger::initialize(comm)) {
+    serac::exitGracefully(true);
+  }
+
+  return {num_procs, rank};
+}
+
+}  // namespace serac

--- a/src/common/initialize.hpp
+++ b/src/common/initialize.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file initialize.hpp
+ *
+ * @brief A function intended to be used as part of a driver to initialize common libraries
+ */
+#ifndef INITIALIZE
+#define INITIALIZE
+
+#include <utility>
+
+#include "mpi.h"
+
+namespace serac {
+/**
+ * @brief Initializes MPI, signal handling, and logging
+ * @param argc The number of command-line arguments
+ * @param argv The command-line arguments, as C-strings
+ * @param comm The MPI communicator to initialize with
+ * @return A pair containing the size and rank relative to the provided MPI communicator
+ */
+std::pair<int, int> initialize(int argc, char* argv[], MPI_Comm comm = MPI_COMM_WORLD);
+}  // namespace serac
+
+#endif

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -27,16 +27,7 @@
 
 int main(int argc, char* argv[])
 {
-  // Initialize MPI.
-  int num_procs, rank;
-  MPI_Init(&argc, &argv);
-  MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
-  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-
-  // Initialize SLIC logger
-  if (!serac::logger::initialize(MPI_COMM_WORLD)) {
-    serac::exitGracefully(true);
-  }
+  auto [num_procs, rank] = serac::initialize(argc, argv);
 
   // mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";


### PR DESCRIPTION
This adds a function that encapsulates the three "boilerplate" components of a serac driver, namely:
- MPI init
- logger init
- signal handler init

Before merging, some possible additions:

1. Right now this is probably overkill, but we could look at RAII to handle init/cleanup:
```cpp
int main(argc, argv)
{
  // Calls init functions
  serac::Driver driver(argc, argv);
  // ... all the driver code ...
} // <- "driver" goes out of scope here, destructor would call MPI_Finalize, logger finalize, etc
```

2. Depending on how subsequent drivers may work, the CLI parse + help logic could also be handled by this `initialize` function, but this is probably less of a concern if Inlet will be replacing most of the CLI arguments.

Resolves #134 