### PR TITLE
Create a mesh shared_ptr accessor

### DIFF
--- a/src/common/finite_element_state.hpp
+++ b/src/common/finite_element_state.hpp
@@ -83,7 +83,7 @@ public:
   mfem::ParMesh& mesh() { return *mesh_; }
 
   /**
-   * Returns a owning shared_ptr to the internal mesh object
+   * Returns an owning shared_ptr to the internal mesh object
    */ 
   std::shared_ptr<mfem::ParMesh> meshPointer() { return mesh_; }
    

--- a/src/common/finite_element_state.hpp
+++ b/src/common/finite_element_state.hpp
@@ -83,6 +83,11 @@ public:
   mfem::ParMesh& mesh() { return *mesh_; }
 
   /**
+   * Returns a owning shared_ptr to the internal mesh object
+   */ 
+  std::shared_ptr<mfem::ParMesh> meshPointer() { return mesh_; }
+   
+  /**
    * Returns a non-owning reference to the internal FESpace
    */
   mfem::ParFiniteElementSpace& space() { return space_; }


### PR DESCRIPTION
In the tribol work, I create a new `FiniteElementState` based on another one. This means I need access to the underlying `shared_ptr` to the mesh instead of just a reference. This is one simple solution, but there may be better ones. Any thoughts @joshessman-llnl @white238 ?