### PR TITLE
Have the solver (engine?) objects own the primary mesh

### DIFF
--- a/src/common/finite_element_state.cpp
+++ b/src/common/finite_element_state.cpp
@@ -8,11 +8,11 @@
 
 namespace serac {
 
-FiniteElementState::FiniteElementState(mfem::ParMesh& pmesh, FEStateOptions&& options)
-    : mesh_(pmesh),
+FiniteElementState::FiniteElementState(mfem::ParMesh& mesh, FEStateOptions&& options)
+    : mesh_(mesh),
       coll_(options.coll ? std::move(*options.coll)
-                         : std::make_unique<mfem::H1_FECollection>(options.order, pmesh.Dimension())),
-      space_(&pmesh, coll_.get(), options.space_dim ? *options.space_dim : pmesh.Dimension(), options.ordering),
+                         : std::make_unique<mfem::H1_FECollection>(options.order, mesh.Dimension())),
+      space_(&mesh, coll_.get(), options.space_dim ? *options.space_dim : mesh.Dimension(), options.ordering),
       gf_(std::make_unique<mfem::ParGridFunction>(&space_)),
       true_vec_(&space_),
       name_(options.name)

--- a/src/common/finite_element_state.cpp
+++ b/src/common/finite_element_state.cpp
@@ -8,11 +8,11 @@
 
 namespace serac {
 
-FiniteElementState::FiniteElementState(std::shared_ptr<mfem::ParMesh> pmesh, FEStateOptions&& options)
+FiniteElementState::FiniteElementState(mfem::ParMesh& pmesh, FEStateOptions&& options)
     : mesh_(pmesh),
       coll_(options.coll ? std::move(*options.coll)
-                         : std::make_unique<mfem::H1_FECollection>(options.order, pmesh->Dimension())),
-      space_(pmesh.get(), coll_.get(), options.space_dim ? *options.space_dim : pmesh->Dimension(), options.ordering),
+                         : std::make_unique<mfem::H1_FECollection>(options.order, pmesh.Dimension())),
+      space_(&pmesh, coll_.get(), options.space_dim ? *options.space_dim : pmesh.Dimension(), options.ordering),
       gf_(std::make_unique<mfem::ParGridFunction>(&space_)),
       true_vec_(&space_),
       name_(options.name)

--- a/src/common/finite_element_state.hpp
+++ b/src/common/finite_element_state.hpp
@@ -60,12 +60,12 @@ class FiniteElementState {
 public:
   /**
    * Main constructor for building a new state object
-   * @param[in] pmesh The problem mesh
+   * @param[in] mesh The problem mesh (object does not take ownership)
    * @param[in] options The options specified, namely those relating to the order of the problem,
    * the dimension of the FESpace, the type of FEColl, the DOF ordering that should be used,
    * and the name of the field
    */
-  FiniteElementState(mfem::ParMesh& pmesh, FEStateOptions&& options = FEStateOptions());
+  FiniteElementState(mfem::ParMesh& mesh, FEStateOptions&& options = FEStateOptions());
 
   /**
    * Returns the MPI communicator for the state

--- a/src/common/finite_element_state.hpp
+++ b/src/common/finite_element_state.hpp
@@ -65,7 +65,7 @@ public:
    * the dimension of the FESpace, the type of FEColl, the DOF ordering that should be used,
    * and the name of the field
    */
-  FiniteElementState(std::shared_ptr<mfem::ParMesh> pmesh, FEStateOptions&& options = FEStateOptions());
+  FiniteElementState(mfem::ParMesh& pmesh, FEStateOptions&& options = FEStateOptions());
 
   /**
    * Returns the MPI communicator for the state
@@ -80,7 +80,7 @@ public:
   /**
    * Returns a non-owning reference to the internal mesh object
    */
-  mfem::ParMesh& mesh() { return *mesh_; }
+  mfem::ParMesh& mesh() { return mesh_; }
 
   /**
    * Returns a non-owning reference to the internal FESpace
@@ -151,7 +151,7 @@ public:
   }
 
 private:
-  std::shared_ptr<mfem::ParMesh>                 mesh_;
+  mfem::ParMesh&                                 mesh_;
   std::unique_ptr<mfem::FiniteElementCollection> coll_;
   mfem::ParFiniteElementSpace                    space_;
   std::unique_ptr<mfem::ParGridFunction>         gf_;

--- a/src/common/mesh_utils.cpp
+++ b/src/common/mesh_utils.cpp
@@ -40,12 +40,12 @@ std::shared_ptr<mfem::ParMesh> buildParallelMesh(const std::string& mesh_file, c
   }
 
   // create the parallel mesh
-  auto pmesh = std::make_shared<mfem::ParMesh>(comm, *mesh);
+  auto par_mesh = std::make_shared<mfem::ParMesh>(comm, *mesh);
   for (int lev = 0; lev < refine_parallel; lev++) {
-    pmesh->UniformRefinement();
+    par_mesh->UniformRefinement();
   }
 
-  return pmesh;
+  return par_mesh;
 }
 
 }  // namespace serac

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -111,12 +111,12 @@ int main(int argc, char* argv[])
   auto config_msg = app.config_to_str(true, true);
   SLIC_INFO_ROOT(rank, config_msg);
 
-  auto pmesh = serac::buildParallelMesh(mesh_file, ser_ref_levels, par_ref_levels);
+  auto mesh = serac::buildParallelMesh(mesh_file, ser_ref_levels, par_ref_levels);
 
-  int dim = pmesh->Dimension();
+  int dim = mesh->Dimension();
 
   // Define the solid solver object
-  serac::NonlinearSolidSolver solid_solver(order, pmesh);
+  serac::NonlinearSolidSolver solid_solver(order, mesh);
 
   // Project the initial and reference configuration functions onto the
   // appropriate grid functions

--- a/src/solvers/base_solver.cpp
+++ b/src/solvers/base_solver.cpp
@@ -15,8 +15,8 @@
 
 namespace serac {
 
-BaseSolver::BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh)
-    : comm_(pmesh->GetComm()), mesh_(pmesh), output_type_(serac::OutputType::VisIt), time_(0.0), cycle_(0)
+BaseSolver::BaseSolver(std::shared_ptr<mfem::ParMesh> mesh)
+    : comm_(mesh->GetComm()), mesh_(mesh), output_type_(serac::OutputType::VisIt), time_(0.0), cycle_(0)
 {
   MPI_Comm_rank(comm_, &mpi_rank_);
   MPI_Comm_size(comm_, &mpi_size_);
@@ -24,7 +24,7 @@ BaseSolver::BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh)
   order_ = 1;
 }
 
-BaseSolver::BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh, int n, int p) : BaseSolver(pmesh)
+BaseSolver::BaseSolver(std::shared_ptr<mfem::ParMesh> mesh, int n, int p) : BaseSolver(mesh)
 {
   order_ = p;
   state_.resize(n);

--- a/src/solvers/base_solver.cpp
+++ b/src/solvers/base_solver.cpp
@@ -15,7 +15,8 @@
 
 namespace serac {
 
-BaseSolver::BaseSolver(MPI_Comm comm) : comm_(comm), output_type_(serac::OutputType::VisIt), time_(0.0), cycle_(0)
+BaseSolver::BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh)
+    : comm_(pmesh->GetComm()), mesh_(pmesh), output_type_(serac::OutputType::VisIt), time_(0.0), cycle_(0)
 {
   MPI_Comm_rank(comm_, &mpi_rank_);
   MPI_Comm_size(comm_, &mpi_size_);
@@ -23,7 +24,7 @@ BaseSolver::BaseSolver(MPI_Comm comm) : comm_(comm), output_type_(serac::OutputT
   order_ = 1;
 }
 
-BaseSolver::BaseSolver(MPI_Comm comm, int n, int p) : BaseSolver(comm)
+BaseSolver::BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh, int n, int p) : BaseSolver(pmesh)
 {
   order_ = p;
   state_.resize(n);

--- a/src/solvers/base_solver.hpp
+++ b/src/solvers/base_solver.hpp
@@ -30,18 +30,18 @@ public:
   /**
    * @brief Empty constructor
    *
-   * @param[in] comm MPI communicator
+   * @param[in] pmesh The primary mesh
    */
-  BaseSolver(MPI_Comm comm);
+  BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh);
 
   /**
    * @brief Constructor that creates n entries in state_ of order p
    *
-   * @param[in] comm MPI communicator
+   * @param[in] pmesh The primary mesh
    * @param[in] n Number of state variables
    * @param[in] p Order of the solver
    */
-  BaseSolver(MPI_Comm comm, int n, int p);
+  BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh, int n, int p);
 
   /**
    * @brief Set the essential boundary conditions from a list of boundary markers and a coefficient
@@ -161,6 +161,11 @@ protected:
    * @brief The MPI communicator
    */
   MPI_Comm comm_;
+
+  /**
+   * @brief The primary mesh
+   */
+  std::shared_ptr<mfem::ParMesh> mesh_;
 
   /**
    * @brief List of finite element data structures

--- a/src/solvers/base_solver.hpp
+++ b/src/solvers/base_solver.hpp
@@ -30,18 +30,18 @@ public:
   /**
    * @brief Empty constructor
    *
-   * @param[in] pmesh The primary mesh
+   * @param[in] mesh The primary mesh
    */
-  BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh);
+  BaseSolver(std::shared_ptr<mfem::ParMesh> mesh);
 
   /**
    * @brief Constructor that creates n entries in state_ of order p
    *
-   * @param[in] pmesh The primary mesh
+   * @param[in] mesh The primary mesh
    * @param[in] n Number of state variables
    * @param[in] p Order of the solver
    */
-  BaseSolver(std::shared_ptr<mfem::ParMesh> pmesh, int n, int p);
+  BaseSolver(std::shared_ptr<mfem::ParMesh> mesh, int n, int p);
 
   /**
    * @brief Set the essential boundary conditions from a list of boundary markers and a coefficient

--- a/src/solvers/elasticity_solver.cpp
+++ b/src/solvers/elasticity_solver.cpp
@@ -13,8 +13,9 @@ namespace serac {
 constexpr int NUM_FIELDS = 1;
 
 ElasticitySolver::ElasticitySolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh->GetComm(), NUM_FIELDS, order),
-      displacement_(std::make_shared<FiniteElementState>(pmesh, FEStateOptions{.order = order, .name = "displacement"}))
+    : BaseSolver(pmesh, NUM_FIELDS, order),
+      displacement_(
+          std::make_shared<FiniteElementState>(*pmesh, FEStateOptions{.order = order, .name = "displacement"}))
 {
   pmesh->EnsureNodes();
   state_[0] = displacement_;

--- a/src/solvers/elasticity_solver.cpp
+++ b/src/solvers/elasticity_solver.cpp
@@ -12,12 +12,11 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 1;
 
-ElasticitySolver::ElasticitySolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh, NUM_FIELDS, order),
-      displacement_(
-          std::make_shared<FiniteElementState>(*pmesh, FEStateOptions{.order = order, .name = "displacement"}))
+ElasticitySolver::ElasticitySolver(int order, std::shared_ptr<mfem::ParMesh> mesh)
+    : BaseSolver(mesh, NUM_FIELDS, order),
+      displacement_(std::make_shared<FiniteElementState>(*mesh, FEStateOptions{.order = order, .name = "displacement"}))
 {
-  pmesh->EnsureNodes();
+  mesh->EnsureNodes();
   state_[0] = displacement_;
 }
 

--- a/src/solvers/elasticity_solver.hpp
+++ b/src/solvers/elasticity_solver.hpp
@@ -35,9 +35,9 @@ public:
    * @brief Construct a new Elasticity Solver object
    *
    * @param[in] order The polynomial order of the solver
-   * @param[in] pmesh The parallel MFEM mesh
+   * @param[in] mesh The parallel MFEM mesh
    */
-  ElasticitySolver(const int order, std::shared_ptr<mfem::ParMesh> pmesh);
+  ElasticitySolver(const int order, std::shared_ptr<mfem::ParMesh> mesh);
 
   /**
    * @brief Set the vector-valued essential displacement boundary conditions

--- a/src/solvers/nonlinear_solid_solver.cpp
+++ b/src/solvers/nonlinear_solid_solver.cpp
@@ -14,19 +14,18 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 2;
 
-NonlinearSolidSolver::NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh, NUM_FIELDS, order),
-      velocity_(std::make_shared<FiniteElementState>(*pmesh, FEStateOptions{.order = order, .name = "velocity"})),
-      displacement_(
-          std::make_shared<FiniteElementState>(*pmesh, FEStateOptions{.order = order, .name = "displacement"}))
+NonlinearSolidSolver::NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParMesh> mesh)
+    : BaseSolver(mesh, NUM_FIELDS, order),
+      velocity_(std::make_shared<FiniteElementState>(*mesh, FEStateOptions{.order = order, .name = "velocity"})),
+      displacement_(std::make_shared<FiniteElementState>(*mesh, FEStateOptions{.order = order, .name = "displacement"}))
 {
   state_[0] = velocity_;
   state_[1] = displacement_;
 
   // Initialize the mesh node pointers
   reference_nodes_ = displacement_->createOnSpace<mfem::ParGridFunction>();
-  pmesh->GetNodes(*reference_nodes_);
-  pmesh->NewNodes(*reference_nodes_);
+  mesh->GetNodes(*reference_nodes_);
+  mesh->NewNodes(*reference_nodes_);
 
   deformed_nodes_ = std::make_unique<mfem::ParGridFunction>(*reference_nodes_);
 

--- a/src/solvers/nonlinear_solid_solver.hpp
+++ b/src/solvers/nonlinear_solid_solver.hpp
@@ -32,9 +32,9 @@ public:
    * @brief Construct a new Nonlinear Solid Solver object
    *
    * @param[in] order The order of the displacement field
-   * @param[in] pmesh The MFEM parallel mesh to solve on
+   * @param[in] mesh The MFEM parallel mesh to solve on
    */
-  NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh);
+  NonlinearSolidSolver(int order, std::shared_ptr<mfem::ParMesh> mesh);
 
   /**
    * @brief Set displacement boundary conditions

--- a/src/solvers/thermal_solver.cpp
+++ b/src/solvers/thermal_solver.cpp
@@ -12,10 +12,10 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 1;
 
-ThermalSolver::ThermalSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh, NUM_FIELDS, order),
+ThermalSolver::ThermalSolver(int order, std::shared_ptr<mfem::ParMesh> mesh)
+    : BaseSolver(mesh, NUM_FIELDS, order),
       temperature_(std::make_shared<FiniteElementState>(
-          *pmesh,
+          *mesh,
           FEStateOptions{.order = order, .space_dim = 1, .ordering = mfem::Ordering::byNODES, .name = "temperature"}))
 {
   state_[0] = temperature_;

--- a/src/solvers/thermal_solver.cpp
+++ b/src/solvers/thermal_solver.cpp
@@ -13,9 +13,9 @@ namespace serac {
 constexpr int NUM_FIELDS = 1;
 
 ThermalSolver::ThermalSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh->GetComm(), NUM_FIELDS, order),
+    : BaseSolver(pmesh, NUM_FIELDS, order),
       temperature_(std::make_shared<FiniteElementState>(
-          pmesh,
+          *pmesh,
           FEStateOptions{.order = order, .space_dim = 1, .ordering = mfem::Ordering::byNODES, .name = "temperature"}))
 {
   state_[0] = temperature_;

--- a/src/solvers/thermal_solver.hpp
+++ b/src/solvers/thermal_solver.hpp
@@ -35,9 +35,9 @@ public:
    * @brief Construct a new Thermal Solver object
    *
    * @param[in] order The order of the thermal field discretization
-   * @param[in] pmesh The MFEM parallel mesh to solve the PDE on
+   * @param[in] mesh The MFEM parallel mesh to solve the PDE on
    */
-  ThermalSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh);
+  ThermalSolver(int order, std::shared_ptr<mfem::ParMesh> mesh);
 
   /**
    * @brief Set essential temperature boundary conditions (strongly enforced)

--- a/src/solvers/thermal_structural_solver.cpp
+++ b/src/solvers/thermal_structural_solver.cpp
@@ -14,7 +14,7 @@ namespace serac {
 constexpr int NUM_FIELDS = 3;
 
 ThermalStructuralSolver::ThermalStructuralSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh->GetComm(), NUM_FIELDS, order), therm_solver_(order, pmesh), solid_solver_(order, pmesh)
+    : BaseSolver(pmesh, NUM_FIELDS, order), therm_solver_(order, pmesh), solid_solver_(order, pmesh)
 {
   temperature_  = therm_solver_.temperature();
   velocity_     = solid_solver_.velocity();

--- a/src/solvers/thermal_structural_solver.cpp
+++ b/src/solvers/thermal_structural_solver.cpp
@@ -13,8 +13,8 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 3;
 
-ThermalStructuralSolver::ThermalStructuralSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh)
-    : BaseSolver(pmesh, NUM_FIELDS, order), therm_solver_(order, pmesh), solid_solver_(order, pmesh)
+ThermalStructuralSolver::ThermalStructuralSolver(int order, std::shared_ptr<mfem::ParMesh> mesh)
+    : BaseSolver(mesh, NUM_FIELDS, order), therm_solver_(order, mesh), solid_solver_(order, mesh)
 {
   temperature_  = therm_solver_.temperature();
   velocity_     = solid_solver_.velocity();

--- a/src/solvers/thermal_structural_solver.hpp
+++ b/src/solvers/thermal_structural_solver.hpp
@@ -29,9 +29,9 @@ public:
    * @brief Construct a new Thermal Structural Solver object
    *
    * @param[in] order The order of the temperature and displacement discretizations
-   * @param[in] pmesh The parallel mesh object on which to solve
+   * @param[in] mesh The parallel mesh object on which to solve
    */
-  ThermalStructuralSolver(int order, std::shared_ptr<mfem::ParMesh> pmesh);
+  ThermalStructuralSolver(int order, std::shared_ptr<mfem::ParMesh> mesh);
 
   /**
    * @brief Set essential temperature boundary conditions (strongly enforced)


### PR DESCRIPTION
A future PR may eliminate the need for sharing the mesh at all (i.e. use `unique_ptr`) once the exact interface for things like AMR is defined.

This PR intends that solvers that require more than one mesh should initialize the BaseSolver object with the primary mesh and store remaining meshes within the relevant derived solver object.  Further work on #118 may separate interface, data, and functionality that is currently all handled by the BaseSolver class, in which case this intention may change.

Resolves #143 