### PR TITLE
Add coefficient accessors to the BC class

### DIFF
--- a/src/common/boundary_condition.cpp
+++ b/src/common/boundary_condition.cpp
@@ -48,7 +48,7 @@ void BoundaryCondition::project(FiniteElementState& state) const
     SLIC_ASSERT_MSG(space, "Only BCs associated with a space can be projected.");
     mfem::Array<int> dof_list(size);
     std::transform(tdofs.begin(), tdofs.end(), dof_list.begin(),
-                   [& space = std::as_const(state.space())](int tdof) { return space.VDofToDof(tdof); });
+                   [&space = std::as_const(state.space())](int tdof) { return space.VDofToDof(tdof); });
 
     if (component_ == -1) {
       // If it contains all components, project the vector

--- a/src/common/boundary_condition.cpp
+++ b/src/common/boundary_condition.cpp
@@ -48,7 +48,7 @@ void BoundaryCondition::project(FiniteElementState& state) const
     SLIC_ASSERT_MSG(space, "Only BCs associated with a space can be projected.");
     mfem::Array<int> dof_list(size);
     std::transform(tdofs.begin(), tdofs.end(), dof_list.begin(),
-                   [&space = std::as_const(state.space())](int tdof) { return space.VDofToDof(tdof); });
+                   [& space = std::as_const(state.space())](int tdof) { return space.VDofToDof(tdof); });
 
     if (component_ == -1) {
       // If it contains all components, project the vector
@@ -121,6 +121,34 @@ void BoundaryCondition::apply(mfem::HypreParMatrix& k_mat_post_elim, mfem::Vecto
   projectBdr(state, time, should_be_scalar);
   state.initializeTrueVec();
   eliminateToRHS(k_mat_post_elim, state.trueVec(), rhs);
+}
+
+const mfem::Coefficient& BoundaryCondition::scalarCoefficient() const
+{
+  SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::Coefficient>>(coef_),
+                "Asing for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
+  return *std::get<std::shared_ptr<mfem::Coefficient>>(coef_);
+}
+
+mfem::Coefficient& BoundaryCondition::scalarCoefficient()
+{
+  SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::Coefficient>>(coef_),
+                "Asing for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
+  return *std::get<std::shared_ptr<mfem::Coefficient>>(coef_);
+}
+
+const mfem::VectorCoefficient& BoundaryCondition::vectorCoefficient() const
+{
+  SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::VectorCoefficient>>(coef_),
+                "Asing for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
+  return *std::get<std::shared_ptr<mfem::VectorCoefficient>>(coef_);
+}
+
+mfem::VectorCoefficient& BoundaryCondition::vectorCoefficient()
+{
+  SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::VectorCoefficient>>(coef_),
+                "Asing for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
+  return *std::get<std::shared_ptr<mfem::VectorCoefficient>>(coef_);
 }
 
 }  // namespace serac

--- a/src/common/boundary_condition.cpp
+++ b/src/common/boundary_condition.cpp
@@ -126,28 +126,28 @@ void BoundaryCondition::apply(mfem::HypreParMatrix& k_mat_post_elim, mfem::Vecto
 const mfem::Coefficient& BoundaryCondition::scalarCoefficient() const
 {
   SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::Coefficient>>(coef_),
-                "Asing for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
+                "Asking for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
   return *std::get<std::shared_ptr<mfem::Coefficient>>(coef_);
 }
 
 mfem::Coefficient& BoundaryCondition::scalarCoefficient()
 {
   SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::Coefficient>>(coef_),
-                "Asing for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
+                "Asking for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
   return *std::get<std::shared_ptr<mfem::Coefficient>>(coef_);
 }
 
 const mfem::VectorCoefficient& BoundaryCondition::vectorCoefficient() const
 {
   SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::VectorCoefficient>>(coef_),
-                "Asing for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
+                "Asking for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
   return *std::get<std::shared_ptr<mfem::VectorCoefficient>>(coef_);
 }
 
 mfem::VectorCoefficient& BoundaryCondition::vectorCoefficient()
 {
   SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::VectorCoefficient>>(coef_),
-                "Asing for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
+                "Asking for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
   return *std::get<std::shared_ptr<mfem::VectorCoefficient>>(coef_);
 }
 

--- a/src/common/boundary_condition.hpp
+++ b/src/common/boundary_condition.hpp
@@ -53,6 +53,46 @@ public:
   mfem::Array<int>& markers() { return markers_; }
 
   /**
+   * @brief Accessor for the underlying vector coefficient
+   *
+   * This method performs an internal check to verify the underlying GeneralCoefficient
+   * is in fact a vector.
+   *
+   * @return A non-owning reference to the underlying vector coefficient
+   */
+  const mfem::VectorCoefficient& vectorCoefficient() const;
+
+  /**
+   * @brief Accessor for the underlying vector coefficient
+   *
+   * This method performs an internal check to verify the underlying GeneralCoefficient
+   * is in fact a vector.
+   *
+   * @return A non-owning reference to the underlying vector coefficient
+   */
+  mfem::VectorCoefficient& vectorCoefficient();
+
+  /**
+   * @brief Accessor for the underlying scalar coefficient
+   *
+   * This method performs an internal check to verify the underlying GeneralCoefficient
+   * is in fact a scalar.
+   *
+   * @return A non-owning reference to the underlying scalar coefficient
+   */
+  const mfem::Coefficient& scalarCoefficient() const;
+
+  /**
+   * @brief Accessor for the underlying scalar coefficient
+   *
+   * This method performs an internal check to verify the underlying GeneralCoefficient
+   * is in fact a scalar.
+   *
+   * @return A non-owning reference to the underlying scalar coefficient
+   */
+  mfem::Coefficient& scalarCoefficient();
+
+  /**
    * "Manually" set the DOF indices without specifying the field to which they apply
    * @param[in] dofs The indices of the DOFs constrained by the boundary condition
    */
@@ -194,28 +234,6 @@ private:
    */
   mutable std::unique_ptr<mfem::HypreParMatrix> eliminated_matrix_entries_;
 };
-
-template <typename Integrator>
-std::unique_ptr<Integrator> BoundaryCondition::newVecIntegrator() const
-{
-  // Can't use std::visit here because integrators may only have a constructor accepting
-  // one coef type and not the other - contained types are only known at runtime
-  // One solution could be to switch between implementations with std::enable_if_t and
-  // std::is_constructible_v
-  static_assert(std::is_constructible_v<Integrator, mfem::VectorCoefficient&>);
-  SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::VectorCoefficient>>(coef_),
-                "Boundary condition had a non-vector coefficient when constructing an integrator.");
-  return std::make_unique<Integrator>(*std::get<std::shared_ptr<mfem::VectorCoefficient>>(coef_));
-}
-
-template <typename Integrator>
-std::unique_ptr<Integrator> BoundaryCondition::newIntegrator() const
-{
-  static_assert(std::is_constructible_v<Integrator, mfem::Coefficient&>);
-  SLIC_ERROR_IF(!std::holds_alternative<std::shared_ptr<mfem::Coefficient>>(coef_),
-                "Boundary condition had a non-vector coefficient when constructing an integrator.");
-  return std::make_unique<Integrator>(*std::get<std::shared_ptr<mfem::Coefficient>>(coef_));
-}
 
 }  // namespace serac
 

--- a/src/solvers/elasticity_solver.cpp
+++ b/src/solvers/elasticity_solver.cpp
@@ -62,9 +62,7 @@ void ElasticitySolver::completeSetup()
   // Add the traction integrator
   if (nat_bdr_.size() > 0) {
     for (auto& nat_bc : nat_bdr_) {
-      SLIC_ASSERT_MSG(std::holds_alternative<std::shared_ptr<mfem::VectorCoefficient>>(nat_bc.coef),
-                      "Traction boundary condition had a non-vector coefficient.");
-      l_form_->AddBoundaryIntegrator(nat_bc.newVecIntegrator<mfem::VectorBoundaryLFIntegrator>().release(),
+      l_form_->AddBoundaryIntegrator(new mfem::VectorBoundaryLFIntegrator(nat_bc.vectorCoefficient()),
                                      nat_bc.markers());
     }
     l_form_->Assemble();

--- a/src/solvers/nonlinear_solid_solver.cpp
+++ b/src/solvers/nonlinear_solid_solver.cpp
@@ -107,9 +107,7 @@ void NonlinearSolidSolver::completeSetup()
 
   // Add the traction integrator
   for (auto& nat_bc_data : nat_bdr_) {
-    SLIC_ASSERT_MSG(std::holds_alternative<std::shared_ptr<mfem::VectorCoefficient>>(nat_bc_data.coef),
-                    "Traction boundary condition had a non-vector coefficient.");
-    H_form->AddBdrFaceIntegrator(nat_bc_data.newVecIntegrator<HyperelasticTractionIntegrator>().release(),
+    H_form->AddBdrFaceIntegrator(new HyperelasticTractionIntegrator(nat_bc_data.vectorCoefficient()),
                                  nat_bc_data.markers());
   }
 


### PR DESCRIPTION
This adds accessors for the underlying boundary condition coefficients. It also uses the vanilla mfem constructors instead of special factory methods for the boundary integrators.