### PR TITLE
fix: 10 more minutes for full dependency build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -54,7 +54,7 @@ stages:
     - *run_update_uberenv
     - EXEC_PREFIX="srun ${SLURM_ACCOUNT}"
     #DEPENDENCIES
-    - RESOURCES="-t 20 -N 1"
+    - RESOURCES="-t 30 -N 1"
     - echo -e "section_start:$(date +%s):dependencies\r\e[0K
       Build dependencies and generate host-config file (uberenv)"
     - ${EXEC_PREFIX} ${RESOURCES} scripts/llnl/build_tpls.py --spec=${SPEC} --directory=${CI_PROJECT_NAME}


### PR DESCRIPTION
The dependency stage of the build (unrelated to the Lassen/CUDA stuff or the devtools) is now failing on Quartz as it appears to be taking ~30 seconds longer than usual.  It finishes the build but is [killed](https://lc.llnl.gov/gitlab/smith/serac/-/jobs/92528#L242) when setting permissions.  