### PR TITLE
added a way to make cuboid and ball meshes (WIP)

### DIFF
--- a/src/common/mesh_utils.cpp
+++ b/src/common/mesh_utils.cpp
@@ -14,7 +14,7 @@
 
 namespace serac {
 
-std::shared_ptr<mfem::ParMesh> buildParallelMesh(const std::string& mesh_file, const int refine_serial,
+std::shared_ptr<mfem::ParMesh> buildMeshFromFile(const std::string& mesh_file, const int refine_serial,
                                                  const int refine_parallel, const MPI_Comm comm)
 {
   // Get the MPI rank for logging purposes
@@ -49,6 +49,113 @@ std::shared_ptr<mfem::ParMesh> buildParallelMesh(const std::string& mesh_file, c
   }
 
   return par_mesh;
+}
+
+// a transformation from the unit disk/sphere (in L1 norm) to a unit disk/sphere (in L2 norm)
+void squish(mfem::Mesh& mesh)
+{
+  int num_vertices = mesh.GetNV();
+  int dim          = mesh.SpaceDimension();
+
+  mfem::Vector vertices;
+  mesh.GetVertices(vertices);
+  mfem::Vector vertex(dim);
+  for (int i = 0; i < num_vertices; i++) {
+    for (int d = 0; d < dim; d++) {
+      vertex(d) = vertices[d * num_vertices + i];
+    }
+
+    double L1_norm = vertex.Norml1();
+    double L2_norm = vertex.Norml2();
+    vertex *= (L2_norm < 1.0e-6) ? 0.0 : (L1_norm / L2_norm);
+
+    for (int d = 0; d < dim; d++) {
+      vertices[d * num_vertices + i] = vertex(d);
+    }
+  }
+  mesh.SetVertices(vertices);
+}
+
+std::shared_ptr<mfem::ParMesh> buildDiskMesh(int approx_number_of_elements, const MPI_Comm comm)
+{
+  static constexpr int dim                   = 2;
+  static constexpr int num_elems             = 4;
+  static constexpr int num_vertices          = 5;
+  static constexpr int num_boundary_elements = 4;
+
+  static constexpr double vertices[num_vertices][dim] = {{0, 0}, {1, 0}, {0, 1}, {-1, 0}, {0, -1}};
+  static constexpr int    triangles[num_elems][3]     = {{1, 2, 0}, {2, 3, 0}, {3, 4, 0}, {4, 1, 0}};
+  static constexpr int    segments[num_elems][2]      = {{1, 2}, {2, 3}, {3, 4}, {4, 1}};
+
+  auto mesh = mfem::Mesh(dim, num_vertices, num_elems, num_boundary_elements);
+
+  for (auto vertex : vertices) {
+    mesh.AddVertex(vertex);
+  }
+  for (auto triangle : triangles) {
+    mesh.AddTriangle(triangle);
+  }
+  for (auto segment : segments) {
+    mesh.AddBdrSegment(segment);
+  }
+  mesh.FinalizeTriMesh();
+
+  while (mesh.GetNE() < (0.5 * approx_number_of_elements)) {
+    mesh.UniformRefinement();
+  }
+
+  squish(mesh);
+
+  return std::make_shared<mfem::ParMesh>(comm, mesh);
+}
+
+std::shared_ptr<mfem::ParMesh> buildBallMesh(int approx_number_of_elements, const MPI_Comm comm)
+{
+  static constexpr int dim                   = 3;
+  static constexpr int num_elems             = 8;
+  static constexpr int num_vertices          = 7;
+  static constexpr int num_boundary_elements = 8;
+
+  static constexpr double vertices[num_vertices][dim] = {{0, 0, 0}, {-1, 0, 0}, {0, 1, 0}, {0, 0, -1},
+                                                         {0, 0, 1}, {0, -1, 0}, {1, 0, 0}};
+  static constexpr int    triangles[num_elems][3]     = {{4, 5, 6}, {4, 6, 2}, {4, 2, 1}, {4, 1, 5},
+                                                  {5, 1, 3}, {5, 3, 6}, {3, 1, 2}, {6, 3, 2}};
+  static constexpr int    tetrahedra[num_elems][4]    = {{0, 4, 5, 6}, {0, 4, 6, 2}, {0, 4, 2, 1}, {0, 4, 1, 5},
+                                                   {0, 5, 1, 3}, {0, 5, 3, 6}, {0, 3, 1, 2}, {0, 6, 3, 2}};
+
+  auto mesh = mfem::Mesh(dim, num_vertices, num_elems, num_boundary_elements);
+
+  for (auto vertex : vertices) {
+    mesh.AddVertex(vertex);
+  }
+  for (auto tetrahedron : tetrahedra) {
+    mesh.AddTet(tetrahedron);
+  }
+  for (auto triangle : triangles) {
+    mesh.AddBdrTriangle(triangle);
+  }
+  mesh.FinalizeTetMesh();
+
+  while (mesh.GetNE() < (0.25 * approx_number_of_elements)) {
+    mesh.UniformRefinement();
+  }
+
+  squish(mesh);
+
+  return std::make_shared<mfem::ParMesh>(comm, mesh);
+}
+
+std::shared_ptr<mfem::ParMesh> buildRectangleMesh(int elements_in_x, int elements_in_y, const MPI_Comm comm)
+{
+  mfem::Mesh mesh(elements_in_x, elements_in_y, mfem::Element::QUADRILATERAL, true);
+  return std::make_shared<mfem::ParMesh>(comm, mesh);
+}
+
+std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_in_y, int elements_in_z,
+                                               const MPI_Comm comm)
+{
+  mfem::Mesh mesh(elements_in_x, elements_in_y, elements_in_z, mfem::Element::HEXAHEDRON, true);
+  return std::make_shared<mfem::ParMesh>(comm, mesh);
 }
 
 }  // namespace serac

--- a/src/common/mesh_utils.hpp
+++ b/src/common/mesh_utils.hpp
@@ -32,8 +32,51 @@ namespace serac {
  * @param[in] MPI_Comm The MPI communicator
  * @return A shared_ptr containing the constructed and refined parallel mesh object
  */
-std::shared_ptr<mfem::ParMesh> buildParallelMesh(const std::string& mesh_file, const int refine_serial = 0,
+std::shared_ptr<mfem::ParMesh> buildMeshFromFile(const std::string& mesh_file, const int refine_serial = 0,
                                                  const int refine_parallel = 0, const MPI_Comm = MPI_COMM_WORLD);
+
+/**
+ * @brief Constructs a 2D MFEM mesh of a unit disk, centered at the origin
+ *
+ * This routine creates a mesh by refining a coarse disk mesh until the
+ * number of elements is as close as possible to the user-specified number of elements
+ *
+ * @param[in] approx_number_of_elements
+ * @return A shared_ptr containing the constructed mesh
+ */
+std::shared_ptr<mfem::ParMesh> buildDiskMesh(int approx_number_of_elements, const MPI_Comm = MPI_COMM_WORLD);
+
+/**
+ * @brief Constructs a 3D MFEM mesh of a unit ball, centered at the origin
+ *
+ * This routine creates a mesh by refining a coarse ball mesh until the
+ * number of elements is as close as possible to the user-specified number of elements
+ *
+ * @param[in] approx_number_of_elements
+ * @return A shared_ptr containing the constructed mesh
+ */
+std::shared_ptr<mfem::ParMesh> buildBallMesh(int approx_number_of_elements, const MPI_Comm = MPI_COMM_WORLD);
+
+/**
+ * @brief Constructs a 2D MFEM mesh of a rectangle
+ *
+ * @param[in] elements_in_x the number of elements in the x-direction
+ * @param[in] elements_in_y the number of elements in the y-direction
+ * @return A shared_ptr containing the constructed mesh
+ */
+std::shared_ptr<mfem::ParMesh> buildRectangleMesh(int elements_in_x, int elements_in_y,
+                                                  const MPI_Comm = MPI_COMM_WORLD);
+
+/**
+ * @brief Constructs a 3D MFEM mesh of a cuboid
+ *
+ * @param[in] elements_in_x the number of elements in the x-direction
+ * @param[in] elements_in_y the number of elements in the y-direction
+ * @param[in] elements_in_z the number of elements in the z-direction
+ * @return A shared_ptr containing the constructed mesh
+ */
+std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_in_y, int elements_in_z,
+                                               const MPI_Comm = MPI_COMM_WORLD);
 
 }  // namespace serac
 

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[])
   auto config_msg = app.config_to_str(true, true);
   SLIC_INFO_ROOT(rank, config_msg);
 
-  auto mesh = serac::buildParallelMesh(mesh_file, ser_ref_levels, par_ref_levels);
+  auto mesh = serac::buildMeshFromFile(mesh_file, ser_ref_levels, par_ref_levels);
 
   int dim = mesh->Dimension();
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ if (ENABLE_GTEST)
     endforeach()
 
     set(language_tests
+        mesh_generation.cpp
         copy_elision.cpp
         expr_templates.cpp
         mfem_array_std_algo.cpp)

--- a/tests/mesh_generation.cpp
+++ b/tests/mesh_generation.cpp
@@ -6,25 +6,17 @@
 
 #include <gtest/gtest.h>
 
-#include <fstream>
-
 #include "common/mesh_utils.hpp"
-#include "mfem.hpp"
-#include "serac_config.hpp"
-#include "solvers/elasticity_solver.hpp"
 
-namespace serac {
-
-TEST(mesh, load_exodus)
+TEST(meshgen, successful_creation)
 {
-  MPI_Barrier(MPI_COMM_WORLD);
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/bortel_echem.e";
-
-  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
-  MPI_Barrier(MPI_COMM_WORLD);
+  // the disk and ball meshes don't exactly hit the number
+  // of elements specified, they refine to get as close as possible
+  ASSERT_EQ(serac::buildDiskMesh(1000)->GetNE(), 1024);
+  ASSERT_EQ(serac::buildBallMesh(6000)->GetNE(), 4096);
+  ASSERT_EQ(serac::buildRectangleMesh(20, 20)->GetNE(), 400);
+  ASSERT_EQ(serac::buildCuboidMesh(20, 20, 20)->GetNE(), 8000);
 }
-
-}  // namespace serac
 
 //------------------------------------------------------------------------------
 #include "axom/slic/core/UnitTestLogger.hpp"
@@ -38,7 +30,8 @@ int main(int argc, char* argv[])
 
   MPI_Init(&argc, &argv);
 
-  UnitTestLogger logger;  // create & initialize test logger, finalized when exiting main scope
+  UnitTestLogger logger;  // create & initialize test logger, finalized when
+                          // exiting main scope
 
   result = RUN_ALL_TESTS();
 

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -23,7 +23,7 @@ TEST(component_bc, qs_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/square.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 2, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 2, 0);
 
   int dim = pmesh->Dimension();
 

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -24,7 +24,7 @@ TEST(serac_dtor, test1)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   // Initialize the second order thermal solver on the parallel mesh
   auto therm_solver = std::make_unique<ThermalSolver>(2, pmesh);

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -26,7 +26,7 @@ TEST(dynamic_solver, dyn_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   int dim = pmesh->Dimension();
 
@@ -114,7 +114,7 @@ TEST(dynamic_solver, dyn_direct_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   int dim = pmesh->Dimension();
 

--- a/tests/serac_linelastic_solver.cpp
+++ b/tests/serac_linelastic_solver.cpp
@@ -22,7 +22,7 @@ TEST(elastic_solver, static_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-quad.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   ElasticitySolver elas_solver(1, pmesh);
 

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -23,7 +23,7 @@ TEST(nonlinear_solid_solver, qs_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   int dim = pmesh->Dimension();
 
@@ -106,7 +106,7 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   int dim = pmesh->Dimension();
 

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -16,6 +16,7 @@
 
 namespace serac {
 
+double One(const mfem::Vector& /*x*/) { return 1.0; }
 double BoundaryTemperature(const mfem::Vector& x) { return x.Norml2(); }
 double OtherBoundaryTemperature(const mfem::Vector& x) { return 2 * x.Norml2(); }
 
@@ -32,10 +33,7 @@ TEST(thermal_solver, static_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);
 
-  // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
-
-  auto pmesh = buildParallelMesh(mesh_file, 1, 1);
+  auto pmesh = buildBallMesh(10000);
 
   // Initialize the second order thermal solver on the parallel mesh
   ThermalSolver therm_solver(2, pmesh);
@@ -44,7 +42,7 @@ TEST(thermal_solver, static_solve)
   therm_solver.setTimestepper(serac::TimestepMethod::QuasiStatic);
 
   // Initialize the temperature boundary condition
-  auto u_0 = std::make_shared<mfem::FunctionCoefficient>(BoundaryTemperature);
+  auto u_0 = std::make_shared<mfem::FunctionCoefficient>(One);
 
   std::set<int> temp_bdr = {1};
 
@@ -75,7 +73,7 @@ TEST(thermal_solver, static_solve)
   // Measure the L2 norm of the solution and check the value
   mfem::ConstantCoefficient zero(0.0);
   double                    u_norm = therm_solver.temperature()->gridFunc().ComputeLpError(2.0, zero);
-  EXPECT_NEAR(2.56980679, u_norm, 0.00001);
+  EXPECT_NEAR(2.02263, u_norm, 0.00001);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -87,7 +85,7 @@ TEST(thermal_solver, static_solve_multiple_bcs)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star_with_2_bdr_attributes.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 1);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
   ThermalSolver therm_solver(2, pmesh);
@@ -148,7 +146,7 @@ TEST(thermal_solver, static_solve_repeated_bcs)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 1);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
   ThermalSolver therm_solver(2, pmesh);
@@ -202,7 +200,7 @@ TEST(thermal_solver, dyn_exp_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 1);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
   ThermalSolver therm_solver(2, pmesh);
@@ -272,7 +270,7 @@ TEST(thermal_solver, dyn_imp_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/star.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 1);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
   ThermalSolver therm_solver(2, pmesh);
@@ -349,7 +347,8 @@ int main(int argc, char* argv[])
 
   MPI_Init(&argc, &argv);
 
-  UnitTestLogger logger;  // create & initialize test logger, finalized when exiting main scope
+  UnitTestLogger logger;  // create & initialize test logger, finalized when
+                          // exiting main scope
 
   result = RUN_ALL_TESTS();
 

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -23,7 +23,7 @@ TEST(dynamic_solver, dyn_solve)
   // Open the mesh
   std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
 
-  auto pmesh = buildParallelMesh(mesh_file, 1, 0);
+  auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   int dim = pmesh->Dimension();
 


### PR DESCRIPTION
see https://github.com/LLNL/serac/issues/170

adds 4 new functions to the serac namespace:

`serac::DiskMesh(1000 /* approximate number of elements */);`
![disk](https://user-images.githubusercontent.com/61714427/92038338-1846f680-ed28-11ea-8157-89a2e10779c0.png)

`serac::BallMesh(6000 /* approximate number of elements */)`
![ball](https://user-images.githubusercontent.com/61714427/92038331-15e49c80-ed28-11ea-8bba-382b3f58c203.png)

`serac::RectangleMesh(20 /* elements in x */, 20  /* elements in y */)`
![square](https://user-images.githubusercontent.com/61714427/92038341-18df8d00-ed28-11ea-9270-61141d0a9c65.png)

`serac::CuboidMesh(20  /* elements in x */, 20  /* elements in y */, 20  /* elements in z */)`
![cube](https://user-images.githubusercontent.com/61714427/92038337-1715c980-ed28-11ea-8ca4-daf47e07903b.png)