### PR TITLE
Resolve most Doxygen warnings

### DIFF
--- a/src/coefficients/stdfunction_coefficient.hpp
+++ b/src/coefficients/stdfunction_coefficient.hpp
@@ -126,7 +126,7 @@ mfem::Array<int> makeEssList(mfem::ParFiniteElementSpace& pfes, mfem::VectorCoef
  * @return An array holding the attributes that correspond to each element
  */
 mfem::Array<int> makeAttributeList(
-    mfem::Mesh& m, mfem::Coefficient& c, std::function<int(double)> = [](double v) { return v > 0. ? 2 : 1; });
+    mfem::Mesh& m, mfem::Coefficient& c, std::function<int(double)> digitize = [](double v) { return v > 0. ? 2 : 1; });
 
 /**
  * @brief This method creates an array of size(local_bdr_elems), and assigns
@@ -146,7 +146,8 @@ mfem::Array<int> makeAttributeList(
  * @return An array holding the attributes that correspond to each element
  */
 mfem::Array<int> makeBdrAttributeList(
-    mfem::Mesh& m, mfem::Coefficient& c, std::function<int(double)> = [](double v) { return v == 1. ? 2 : 1; });
+    mfem::Mesh& m, mfem::Coefficient& c,
+    std::function<int(double)> digitize = [](double v) { return v == 1. ? 2 : 1; });
 
 /**
  * @brief AttributemodifierCoefficient class
@@ -278,7 +279,7 @@ public:
   /**
    * @brief Evaluate the coefficient at a quadrature point
    *
-   * @param[in] Tr The element transformation for the evaluation
+   * @param[in] T The element transformation for the evaluation
    * @param[in] ip The integration point for the evaluation
    * @return The value of the coefficient at the quadrature point
    */

--- a/src/common/boundary_condition.hpp
+++ b/src/common/boundary_condition.hpp
@@ -30,7 +30,7 @@ namespace serac {
 class BoundaryCondition {
 public:
   /**
-   * Constructor for setting up a boundary condition using a set of attributes
+   * @brief Constructor for setting up a boundary condition using a set of attributes
    * @param[in] coef Either a mfem::Coefficient or mfem::VectorCoefficient representing the BC
    * @param[in] component The zero-indexed vector component if the BC applies to just one component,
    * should be -1 for all components
@@ -40,7 +40,7 @@ public:
   BoundaryCondition(GeneralCoefficient coef, const int component, const std::set<int>& attrs, const int num_attrs = 0);
 
   /**
-   * Minimal constructor for setting the true DOFs directly
+   * @brief Minimal constructor for setting the true DOFs directly
    * @param[in] coef Either a mfem::Coefficient or mfem::VectorCoefficient representing the BC
    * @param[in] component The zero-indexed vector component if the BC applies to just one component,
    * should be -1 for all components
@@ -48,8 +48,16 @@ public:
    */
   BoundaryCondition(GeneralCoefficient coef, const int component, const mfem::Array<int>& true_dofs);
 
+  /**
+   * @brief Returns a non-owning reference to the array of boundary
+   * attribute markers
+   */
   const mfem::Array<int>& markers() const { return markers_; }
 
+  /**
+   * @brief Returns a non-owning reference to the array of boundary
+   * attribute markers
+   */
   mfem::Array<int>& markers() { return markers_; }
 
   /**
@@ -93,18 +101,22 @@ public:
   mfem::Coefficient& scalarCoefficient();
 
   /**
-   * "Manually" set the DOF indices without specifying the field to which they apply
+   * @brief "Manually" set the DOF indices without specifying the field to which they apply
    * @param[in] dofs The indices of the DOFs constrained by the boundary condition
    */
   void setTrueDofs(const mfem::Array<int> dofs);
 
   /**
-   * Uses mfem::ParFiniteElementSpace::GetEssentialTrueDofs to
+   * @brief Uses mfem::ParFiniteElementSpace::GetEssentialTrueDofs to
    * determine the DOFs for the boundary condition
    * @param[in] state The finite element state for which the DOFs should be obtained
    */
   void setTrueDofs(FiniteElementState& state);
 
+  /**
+   * @brief Returns the DOF indices for an essential boundary condition
+   * @return A non-owning reference to the array of indices
+   */
   const mfem::Array<int>& getTrueDofs() const
   {
     SLIC_ERROR_IF(!true_dofs_, "True DOFs only available with essential BC.");
@@ -116,22 +128,20 @@ public:
   void removeAttr(const int attr) { markers_[attr - 1] = 0; }
 
   /**
-   * Projects the boundary condition over a field
+   * @brief Projects the boundary condition over a field
    * @param[inout] state The field to project over
-   * @param[in] fes The finite element space that should be used to generate
-   * the scalar DOF list
    */
   void project(FiniteElementState& state) const;
 
   /**
-   * Projects the boundary condition over a grid function
+   * @brief Projects the boundary condition over a grid function
    * @pre A corresponding field (FiniteElementState) has been associated
    * with the calling object via BoundaryCondition::setTrueDofs(FiniteElementState&)
    */
   void project() const;
 
   /**
-   * Projects the boundary condition over boundary DOFs of a grid function
+   * @brief Projects the boundary condition over boundary DOFs of a grid function
    * @param[inout] gf The grid function representing the field to project over
    * @param[in] time The time for the coefficient, used for time-varying coefficients
    * @param[in] should_be_scalar Whether the boundary condition coefficient should be a scalar coef
@@ -139,7 +149,7 @@ public:
   void projectBdr(mfem::ParGridFunction& gf, const double time, const bool should_be_scalar = true) const;
 
   /**
-   * Projects the boundary condition over boundary DOFs of a field
+   * @brief Projects the boundary condition over boundary DOFs of a field
    * @param[inout] state The field to project over
    * @param[in] time The time for the coefficient, used for time-varying coefficients
    * @param[in] should_be_scalar Whether the boundary condition coefficient should be a scalar coef
@@ -147,7 +157,7 @@ public:
   void projectBdr(FiniteElementState& state, const double time, const bool should_be_scalar = true) const;
 
   /**
-   * Projects the boundary condition over boundary DOFs
+   * @brief Projects the boundary condition over boundary DOFs
    * @param[in] time The time for the coefficient, used for time-varying coefficients
    * @param[in] should_be_scalar Whether the boundary condition coefficient should be a scalar coef
    * @pre A corresponding field (FiniteElementState) has been associated
@@ -156,7 +166,7 @@ public:
   void projectBdr(const double time, const bool should_be_scalar = true) const;
 
   /**
-   * Allocates an integrator of type "Integrator" on the heap,
+   * @brief Allocates an integrator of type "Integrator" on the heap,
    * constructing it with the boundary condition's vector coefficient,
    * intended to be passed to mfem::*LinearForm::Add*Integrator
    * @return An owning pointer to the new integrator
@@ -166,7 +176,7 @@ public:
   std::unique_ptr<Integrator> newVecIntegrator() const;
 
   /**
-   * Allocates an integrator of type "Integrator" on the heap,
+   * @brief Allocates an integrator of type "Integrator" on the heap,
    * constructing it with the boundary condition's coefficient,
    * intended to be passed to mfem::*LinearForm::Add*Integrator
    * @return An owning pointer to the new integrator
@@ -176,7 +186,7 @@ public:
   std::unique_ptr<Integrator> newIntegrator() const;
 
   /**
-   * Eliminates the rows and columns corresponding to the BC's true DOFS
+   * @brief Eliminates the rows and columns corresponding to the BC's true DOFS
    * from a stiffness matrix
    * @param[inout] k_mat The stiffness matrix to eliminate from,
    * will be modified.  These eliminated matrix entries can be
@@ -186,7 +196,7 @@ public:
   void eliminateFromMatrix(mfem::HypreParMatrix& k_mat) const;
 
   /**
-   * Eliminates boundary condition from solution to RHS
+   * @brief Eliminates boundary condition from solution to RHS
    * @param[in] k_mat_post_elim A stiffness matrix post-elimination
    * @param[in] soln The solution vector
    * @param[out] rhs The RHS vector for the system
@@ -195,7 +205,7 @@ public:
   void eliminateToRHS(mfem::HypreParMatrix& k_mat_post_elim, const mfem::Vector& soln, mfem::Vector& rhs) const;
 
   /**
-   * Applies an essential boundary condition to RHS
+   * @brief Applies an essential boundary condition to RHS
    * @param[in] k_mat_post_elim A stiffness (system) matrix post-elimination
    * @param[out] rhs The RHS vector for the system
    * @param[inout] state The state from which the solution DOF values are extracted and used to eliminate

--- a/src/common/mesh_utils.hpp
+++ b/src/common/mesh_utils.hpp
@@ -27,8 +27,8 @@ namespace serac {
  * in parallel as requested
  *
  * @param[in] mesh_file The mesh file to open
- * @param[in] ref_serial The number of serial refinements
- * @param[in] ref_parallel The number of parallel refinements
+ * @param[in] refine_serial The number of serial refinements
+ * @param[in] refine_parallel The number of parallel refinements
  * @param[in] MPI_Comm The MPI communicator
  * @return A shared_ptr containing the constructed and refined parallel mesh object
  */

--- a/src/common/profiling.hpp
+++ b/src/common/profiling.hpp
@@ -17,6 +17,26 @@
 
 #include "serac_config.hpp"
 
+/**
+ * @def SERAC_MARK_FUNCTION
+ * Marks a function for Caliper profiling
+ */
+
+/**
+ * @def SERAC_MARK_LOOP_START(id, name)
+ * Marks the beginning of a loop block for Caliper profiling
+ */
+
+/**
+ * @def SERAC_MARK_LOOP_ITER(id, i)
+ * Marks the beginning of a loop iteration for Caliper profiling
+ */
+
+/**
+ * @def SERAC_MARK_LOOP_END(id)
+ * Marks the end of a loop block for Caliper profiling
+ */
+
 #ifdef SERAC_USE_CALIPER
 
 #include "caliper/cali-manager.h"

--- a/src/common/serac_types.hpp
+++ b/src/common/serac_types.hpp
@@ -136,6 +136,9 @@ struct NonlinearSolverParameters {
   int print_level;
 };
 
+/**
+ * @brief A sum type for encapsulating either a scalar or vector coeffient
+ */
 using GeneralCoefficient = std::variant<std::shared_ptr<mfem::Coefficient>, std::shared_ptr<mfem::VectorCoefficient>>;
 
 }  // namespace serac

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -1779,18 +1779,6 @@ GENERATE_XML           = NO
 
 XML_OUTPUT             = xml
 
-# The XML_SCHEMA tag can be used to specify a XML schema, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_SCHEMA             =
-
-# The XML_DTD tag can be used to specify a XML DTD, which can be used by a
-# validating XML parser to check the syntax of the XML files.
-# This tag requires that the tag GENERATE_XML is set to YES.
-
-XML_DTD                =
-
 # If the XML_PROGRAMLISTING tag is set to YES doxygen will dump the program
 # listings (including syntax highlighting and cross-referencing information) to
 # the XML output. Note that enabling this will significantly increase the size
@@ -1991,12 +1979,6 @@ EXTERNAL_GROUPS        = YES
 
 EXTERNAL_PAGES         = YES
 
-# The PERL_PATH should be the absolute path and name of the perl script
-# interpreter (i.e. the result of 'which perl').
-# The default file (with absolute path) is: /usr/bin/perl.
-
-PERL_PATH              = /usr/bin/perl
-
 #---------------------------------------------------------------------------
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
@@ -2009,15 +1991,6 @@ PERL_PATH              = /usr/bin/perl
 # The default value is: YES.
 
 CLASS_DIAGRAMS         = YES
-
-# You can define message sequence charts within doxygen comments using the \msc
-# command. Doxygen will then run the mscgen tool (see:
-# http://www.mcternan.me.uk/mscgen/)) to produce the chart and insert it in the
-# documentation. The MSCGEN_PATH tag allows you to specify the directory where
-# the mscgen tool resides. If left empty the tool is assumed to be found in the
-# default search path.
-
-MSCGEN_PATH            =
 
 # If set to YES, the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.

--- a/src/docs/sphinx/expr_templates.rst
+++ b/src/docs/sphinx/expr_templates.rst
@@ -24,7 +24,7 @@ In particular, Serac currently provides the following operations:
 3. Vector negation with ``-a``
 4. Scalar multiplication with ``s * a`` or ``a * s`` for scalar ``s`` and vector ``a``.
 5. Application of an ``mfem::Operator`` with ``op * a`` for ``mfem::Operator op`` and vector ``a`` - note that 
-because ``mfem::Matrix`` inherits from ``mfem::Operator`` this functionality includes matrix-vector multiplication.
+    because ``mfem::Matrix`` inherits from ``mfem::Operator`` this functionality includes matrix-vector multiplication.
 
 
 Note that all of these expressions can be composed, that is, an expression can be used as an argument

--- a/src/solvers/base_solver.hpp
+++ b/src/solvers/base_solver.hpp
@@ -48,7 +48,7 @@ public:
    *
    * @param[in] ess_bdr The set of essential BC attributes
    * @param[in] ess_bdr_coef The essential BC value coefficient
-   * @param[in] fes The finite element state for the state
+   * @param[in] state The finite element state over which the BC should be applied
    * @param[in] component The component to set (-1 implies all components are set)
    */
   virtual void setEssentialBCs(const std::set<int>& ess_bdr, serac::GeneralCoefficient ess_bdr_coef,
@@ -133,7 +133,7 @@ public:
   /**
    * @brief Advance the state variables according to the chosen time integrator
    *
-   * @param[in/out]
+   * @param[inout] dt The timestep to advance. For adaptive time integration methods, the actual timestep is returned.
    */
   virtual void advanceTimestep(double& dt) = 0;
 

--- a/src/solvers/elasticity_solver.hpp
+++ b/src/solvers/elasticity_solver.hpp
@@ -62,7 +62,7 @@ public:
   /**
    * @brief Driver for advancing the timestep
    *
-   * @param[in/out] dt The timestep to attempt, adaptive methods could return the actual timestep completed
+   * @param[inout] dt The timestep to attempt, adaptive methods could return the actual timestep completed
    */
   void advanceTimestep(double& dt) override;
 
@@ -99,6 +99,9 @@ public:
   virtual ~ElasticitySolver();
 
 protected:
+  /**
+   * @brief Displacement field
+   */
   std::shared_ptr<serac::FiniteElementState> displacement_;
 
   /**

--- a/src/solvers/nonlinear_solid_solver.hpp
+++ b/src/solvers/nonlinear_solid_solver.hpp
@@ -123,7 +123,7 @@ public:
   /**
    * @brief Advance the timestep
    *
-   * @param[in/out] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping schemes
+   * @param[inout] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping schemes
    */
   void advanceTimestep(double& dt) override;
 
@@ -133,7 +133,14 @@ public:
   virtual ~NonlinearSolidSolver();
 
 protected:
+  /**
+   * @brief Velocity field
+   */
   std::shared_ptr<FiniteElementState> velocity_;
+
+  /**
+   * @brief Displacement field
+   */
   std::shared_ptr<FiniteElementState> displacement_;
 
   /**

--- a/src/solvers/thermal_operators.hpp
+++ b/src/solvers/thermal_operators.hpp
@@ -47,7 +47,7 @@ public:
   /**
    * @brief Set the thermal flux load vector
    *
-   * @param[in] The thermal flux (RHS vector)
+   * @param[in] rhs The thermal flux (RHS vector)
    */
   void setLoadVector(const mfem::Vector* rhs);
 

--- a/src/solvers/thermal_solver.hpp
+++ b/src/solvers/thermal_solver.hpp
@@ -58,7 +58,7 @@ public:
   /**
    * @brief Advance the timestep
    *
-   * @param[in/out] dt The timestep to advance. For adaptive time integration methods, the actual timestep is returned.
+   * @param[inout] dt The timestep to advance. For adaptive time integration methods, the actual timestep is returned.
    */
   void advanceTimestep(double& dt) override;
 
@@ -72,7 +72,7 @@ public:
   /**
    * @brief Set the temperature state vector from a coefficient
    *
-   * @param[in] The temperature coefficient
+   * @param[in] temp The temperature coefficient
    */
   void setTemperature(mfem::Coefficient& temp);
 

--- a/src/solvers/thermal_structural_solver.hpp
+++ b/src/solvers/thermal_structural_solver.hpp
@@ -65,7 +65,7 @@ public:
   /**
    * @brief Set the temperature state vector from a coefficient
    *
-   * @param[in] The temperature coefficient
+   * @param[in] temp The temperature coefficient
    */
   void SetTemperature(mfem::Coefficient& temp) { therm_solver_.setTemperature(temp); };
 
@@ -218,7 +218,7 @@ public:
   /**
    * @brief Advance the timestep
    *
-   * @param[in/out] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping schemes
+   * @param[inout] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping schemes
    */
   void advanceTimestep(double& dt) override;
 


### PR DESCRIPTION
The only significant remaining warnings are for the expression template operator overloads.  Any thoughts on whether there's value in documenting them?