### PR TITLE
Fix: Subtraction is not commutative

### DIFF
--- a/src/common/expr_template_ops.hpp
+++ b/src/common/expr_template_ops.hpp
@@ -146,7 +146,10 @@ inline auto operator-(const mfem::Vector& u, mfem::Vector&& v)
   return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector, false, true>(u, std::move(v));
 }
 
-inline auto operator-(mfem::Vector&& u, const mfem::Vector& v) { return operator-(v, std::move(u)); }
+inline auto operator-(mfem::Vector&& u, const mfem::Vector& v)
+{
+  return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector, true, false>(std::move(u), v);
+}
 
 template <typename T>
 auto operator*(const mfem::Operator& A, serac::VectorExpr<T>&& v)

--- a/src/common/expr_template_ops.hpp
+++ b/src/common/expr_template_ops.hpp
@@ -116,7 +116,7 @@ auto operator-(const mfem::Vector& u, serac::VectorExpr<T>&& v)
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u, const mfem::Vector& v)
 {
-  return operator-(v, std::move(u));
+  return serac::internal::VectorSubtraction<T, mfem::Vector, true, false>(std::move(u.asDerived()), v);
 }
 
 inline auto operator-(const mfem::Vector& u, const mfem::Vector& v)
@@ -133,7 +133,7 @@ auto operator-(mfem::Vector&& u, serac::VectorExpr<T>&& v)
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u, mfem::Vector&& v)
 {
-  return operator-(std::move(v), std::move(u));
+  return serac::internal::VectorSubtraction<T, mfem::Vector, true, true>(std::move(u.asDerived()), std::move(v));
 }
 
 inline auto operator-(mfem::Vector&& u, mfem::Vector&& v)

--- a/tests/expr_templates.cpp
+++ b/tests/expr_templates.cpp
@@ -67,8 +67,10 @@ TEST(expr_templates, subtraction_not_commutative)
     c[i] = i * i * i * 7 + 23;
   }
 
-  mfem::Vector result1 = a + c - b;
-  mfem::Vector result2 = c - b + a;
+  // Tests that switching the order of operations
+  // does not change the result
+  mfem::Vector result1 = a + c - b;  // Parsed as (a + c) - b
+  mfem::Vector result2 = c - b + a;  // Parsed as (c - b) + a
   for (int i = 0; i < size; i++) {
     EXPECT_FLOAT_EQ(result1[i], result2[i]);
   }

--- a/tests/expr_templates.cpp
+++ b/tests/expr_templates.cpp
@@ -54,6 +54,26 @@ TEST(expr_templates, basic_add_lambda)
   }
 }
 
+TEST(expr_templates, subtraction_not_commutative)
+{
+  constexpr int size = 10;
+  mfem::Vector  a(size);
+  mfem::Vector  b(size);
+  mfem::Vector  c(size);
+
+  for (int i = 0; i < size; i++) {
+    a[i] = i * 4 + 1;
+    b[i] = i * i * 3 + 2;
+    c[i] = i * i * i * 7 + 23;
+  }
+
+  mfem::Vector result1 = a + c - b;
+  mfem::Vector result2 = c - b + a;
+  for (int i = 0; i < size; i++) {
+    EXPECT_FLOAT_EQ(result1[i], result2[i]);
+  }
+}
+
 TEST(expr_templates, move_from_temp_lambda)
 {
   constexpr int size = 10;

--- a/tests/expr_templates.cpp
+++ b/tests/expr_templates.cpp
@@ -74,6 +74,71 @@ TEST(expr_templates, subtraction_not_commutative)
   for (int i = 0; i < size; i++) {
     EXPECT_FLOAT_EQ(result1[i], result2[i]);
   }
+
+  mfem::Vector result3 = a - c;
+  mfem::Vector result4 = c - a;
+  for (int i = 0; i < size; i++) {
+    EXPECT_FALSE(result3[i] == result4[i]);
+  }
+}
+
+TEST(expr_templates, subtraction_not_commutative_rvalue)
+{
+  constexpr int size           = 3;
+  double        a_values[size] = {-12.2692, 6.23918, -12.2692};
+  double        b_values[size] = {0.0850848, -0.17017, 0.0850848};
+
+  auto fext = [](const double t) {
+    mfem::Vector force(3);
+    force[0] = -10 * t;
+    force[1] = 0;
+    force[2] = 10 * t * t;
+    return force;
+  };
+
+  mfem::Vector a(a_values, size);
+  mfem::Vector b(b_values, size);
+  mfem::Vector c        = fext(0.0);
+  mfem::Vector resulta1 = c - a - b;
+  mfem::Vector resulta2 = fext(0.0) - a - b;
+  for (int i = 0; i < size; i++) {
+    EXPECT_FLOAT_EQ(resulta1[i], resulta2[i]);
+  }
+}
+
+TEST(expr_templates, addition_commutative)
+{
+  constexpr int size = 10;
+  mfem::Vector  a(size);
+  mfem::Vector  b(size);
+
+  for (int i = 0; i < size; i++) {
+    a[i] = i * 4 + 1;
+    b[i] = i * i * 3 + 2;
+  }
+
+  mfem::Vector result1 = a + b;
+  mfem::Vector result2 = b + a;
+  for (int i = 0; i < size; i++) {
+    EXPECT_FLOAT_EQ(result1[i], result2[i]);
+  }
+}
+
+TEST(expr_templates, scalar_mult_commutative)
+{
+  constexpr int size = 10;
+  mfem::Vector  a(size);
+  double        scalar = 0.3;
+
+  for (int i = 0; i < size; i++) {
+    a[i] = i * 4 + 1;
+  }
+
+  mfem::Vector result1 = scalar * a;
+  mfem::Vector result2 = a * scalar;
+  for (int i = 0; i < size; i++) {
+    EXPECT_FLOAT_EQ(result1[i], result2[i]);
+  }
 }
 
 TEST(expr_templates, move_from_temp_lambda)


### PR DESCRIPTION
I made an error copy-pasting the operator overloads that only works if subtraction is commutative, which it isn't.... 🤦 

Thanks @samuelpmishLLNL for catching this!