### PR TITLE
Improvements to expression templates (scalar division, removed duplicated overloads, no-alloc eval)

### DIFF
--- a/src/common/expr_template_internal.hpp
+++ b/src/common/expr_template_internal.hpp
@@ -33,7 +33,7 @@ template <typename vec, bool owns>
 using vec_t = typename std::conditional<owns, std::decay_t<vec>, const std::decay_t<vec>&>::type;
 
 /**
- * @brief Type alias for the constructior argument to a vector expression - an
+ * @brief Type alias for the constructor argument to a vector expression - an
  * rvalue reference if ownership is desired (will be moved from), otherwise,
  * an lvalue reference
  * @tparam vec The base vector expression type
@@ -42,6 +42,10 @@ using vec_t = typename std::conditional<owns, std::decay_t<vec>, const std::deca
 template <typename vec, bool owns>
 using vec_arg_t = typename std::conditional<owns, std::decay_t<vec>&&, const vec&>::type;
 
+/**
+ * @brief Determines whether a given type should be owned by a vector expression
+ * @tparam vec The vector expression type
+ */
 template <typename vec>
 inline constexpr bool owns_v = !std::is_same_v<vec, mfem::Vector> || std::is_rvalue_reference_v<vec>;
 
@@ -83,7 +87,7 @@ private:
 };
 
 /**
- * @brief Functor class for binding a scalar to a multiplication operatior
+ * @brief Functor class for binding a scalar to a multiplication operation
  */
 class ScalarMultOp {
 public:
@@ -96,6 +100,35 @@ public:
    * @brief Applies the partial application to the remaining argument
    */
   double operator()(const double arg) const { return arg * scalar_; }
+
+private:
+  double scalar_;
+};
+
+/**
+ * @brief Functor class for binding a scalar to a division operation
+ * @tparam is_divisor Whether the scalar is the divisor (vec divided by scalar)
+ * or the dividend (scalar divided by vector)
+ */
+template <bool is_divisor = true>
+class ScalarDivOp {
+public:
+  /**
+   * @brief Constructs a partial application of a scalar division
+   */
+  ScalarDivOp(const double scalar) : scalar_(scalar) {}
+
+  /**
+   * @brief Applies the partial application to the remaining argument
+   */
+  double operator()(const double arg) const
+  {
+    if constexpr (is_divisor) {
+      return arg / scalar_;
+    } else {
+      return scalar_ / arg;
+    }
+  }
 
 private:
   double scalar_;

--- a/src/common/expr_template_internal.hpp
+++ b/src/common/expr_template_internal.hpp
@@ -104,10 +104,10 @@ private:
 
 /**
  * @brief Functor class for binding a scalar to a division operation
- * @tparam is_divisor Whether the scalar is the divisor (vec divided by scalar)
+ * @tparam is_denominator Whether the scalar is the divisor/denominator (vec divided by scalar)
  * or the dividend (scalar divided by vector)
  */
-template <bool is_divisor = true>
+template <bool is_denominator = true>
 class ScalarDivOp {
 public:
   /**
@@ -120,7 +120,7 @@ public:
    */
   double operator()(const double arg) const
   {
-    if constexpr (is_divisor) {
+    if constexpr (is_denominator) {
       return arg / scalar_;
     } else {
       return scalar_ / arg;

--- a/src/common/expr_template_ops.hpp
+++ b/src/common/expr_template_ops.hpp
@@ -52,7 +52,43 @@ inline auto operator*(const double a, mfem::Vector&& u)
   return serac::internal::UnaryVectorExpr<mfem::Vector&&, ScalarMultOp>(std::move(u), ScalarMultOp{a});
 }
 
-inline auto operator*(mfem::Vector&& u, const double a) { return operator*(a, std::move(u)); }
+template <typename T>
+auto operator/(serac::VectorExpr<T>&& u, const double a)
+{
+  using serac::internal::ScalarDivOp;
+  return serac::internal::UnaryVectorExpr<T, ScalarDivOp<true>>(std::move(u.asDerived()), ScalarDivOp{a});
+}
+
+inline auto operator/(const mfem::Vector& u, const double a)
+{
+  using serac::internal::ScalarDivOp;
+  return serac::internal::UnaryVectorExpr<mfem::Vector, ScalarDivOp<true>>(u, ScalarDivOp{a});
+}
+
+inline auto operator/(mfem::Vector&& u, const double a)
+{
+  using serac::internal::ScalarDivOp;
+  return serac::internal::UnaryVectorExpr<mfem::Vector&&, ScalarDivOp<true>>(std::move(u), ScalarDivOp{a});
+}
+
+template <typename T>
+auto operator/(const double a, serac::VectorExpr<T>&& u)
+{
+  using serac::internal::ScalarDivOp;
+  return serac::internal::UnaryVectorExpr<T, ScalarDivOp<false>>(std::move(u.asDerived()), ScalarDivOp<false>{a});
+}
+
+inline auto operator/(const double a, const mfem::Vector& u)
+{
+  using serac::internal::ScalarDivOp;
+  return serac::internal::UnaryVectorExpr<mfem::Vector, ScalarDivOp<false>>(u, ScalarDivOp<false>{a});
+}
+
+inline auto operator/(const double a, mfem::Vector&& u)
+{
+  using serac::internal::ScalarDivOp;
+  return serac::internal::UnaryVectorExpr<mfem::Vector&&, ScalarDivOp<false>>(std::move(u), ScalarDivOp<false>{a});
+}
 
 template <typename S, typename T>
 auto operator+(serac::VectorExpr<S>&& u, serac::VectorExpr<T>&& v)

--- a/src/common/expr_template_ops.hpp
+++ b/src/common/expr_template_ops.hpp
@@ -18,18 +18,18 @@
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u)
 {
-  return serac::internal::UnaryNegation<T, true>(std::move(u.asDerived()));
+  return serac::internal::UnaryNegation<T>(std::move(u.asDerived()));
 }
 
-inline auto operator-(const mfem::Vector& u) { return serac::internal::UnaryNegation<mfem::Vector, false>(u); }
+inline auto operator-(const mfem::Vector& u) { return serac::internal::UnaryNegation<mfem::Vector>(u); }
 
-inline auto operator-(mfem::Vector&& u) { return serac::internal::UnaryNegation<mfem::Vector, true>(std::move(u)); }
+inline auto operator-(mfem::Vector&& u) { return serac::internal::UnaryNegation<mfem::Vector&&>(std::move(u)); }
 
 template <typename T>
 auto operator*(serac::VectorExpr<T>&& u, const double a)
 {
   using serac::internal::ScalarMultOp;
-  return serac::internal::UnaryVectorExpr<T, true, ScalarMultOp>(std::move(u.asDerived()), ScalarMultOp{a});
+  return serac::internal::UnaryVectorExpr<T, ScalarMultOp>(std::move(u.asDerived()), ScalarMultOp{a});
 }
 
 template <typename T>
@@ -41,7 +41,7 @@ auto operator*(const double a, serac::VectorExpr<T>&& u)
 inline auto operator*(const double a, const mfem::Vector& u)
 {
   using serac::internal::ScalarMultOp;
-  return serac::internal::UnaryVectorExpr<mfem::Vector, false, ScalarMultOp>(u, ScalarMultOp{a});
+  return serac::internal::UnaryVectorExpr<mfem::Vector, ScalarMultOp>(u, ScalarMultOp{a});
 }
 
 inline auto operator*(const mfem::Vector& u, const double a) { return operator*(a, u); }
@@ -49,7 +49,7 @@ inline auto operator*(const mfem::Vector& u, const double a) { return operator*(
 inline auto operator*(const double a, mfem::Vector&& u)
 {
   using serac::internal::ScalarMultOp;
-  return serac::internal::UnaryVectorExpr<mfem::Vector, true, ScalarMultOp>(std::move(u), ScalarMultOp{a});
+  return serac::internal::UnaryVectorExpr<mfem::Vector&&, ScalarMultOp>(std::move(u), ScalarMultOp{a});
 }
 
 inline auto operator*(mfem::Vector&& u, const double a) { return operator*(a, std::move(u)); }
@@ -57,13 +57,13 @@ inline auto operator*(mfem::Vector&& u, const double a) { return operator*(a, st
 template <typename S, typename T>
 auto operator+(serac::VectorExpr<S>&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorAddition<S, T, true, true>(std::move(u.asDerived()), std::move(v.asDerived()));
+  return serac::internal::VectorAddition<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
 }
 
 template <typename T>
 auto operator+(const mfem::Vector& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorAddition<mfem::Vector, T, false, true>(u, std::move(v.asDerived()));
+  return serac::internal::VectorAddition<mfem::Vector, T>(u, std::move(v.asDerived()));
 }
 
 template <typename T>
@@ -74,13 +74,13 @@ auto operator+(serac::VectorExpr<T>&& u, const mfem::Vector& v)
 
 inline auto operator+(const mfem::Vector& u, const mfem::Vector& v)
 {
-  return serac::internal::VectorAddition<mfem::Vector, mfem::Vector, false, false>(u, v);
+  return serac::internal::VectorAddition<mfem::Vector, mfem::Vector>(u, v);
 }
 
 template <typename T>
 auto operator+(mfem::Vector&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorAddition<mfem::Vector, T, true, true>(std::move(u), std::move(v.asDerived()));
+  return serac::internal::VectorAddition<mfem::Vector&&, T>(std::move(u), std::move(v.asDerived()));
 }
 
 template <typename T>
@@ -91,12 +91,12 @@ auto operator+(serac::VectorExpr<T>&& u, mfem::Vector&& v)
 
 inline auto operator+(mfem::Vector&& u, mfem::Vector&& v)
 {
-  return serac::internal::VectorAddition<mfem::Vector, mfem::Vector, true, true>(std::move(u), std::move(v));
+  return serac::internal::VectorAddition<mfem::Vector&&, mfem::Vector&&>(std::move(u), std::move(v));
 }
 
 inline auto operator+(const mfem::Vector& u, mfem::Vector&& v)
 {
-  return serac::internal::VectorAddition<mfem::Vector, mfem::Vector, false, true>(u, std::move(v));
+  return serac::internal::VectorAddition<mfem::Vector, mfem::Vector&&>(u, std::move(v));
 }
 
 inline auto operator+(mfem::Vector&& u, const mfem::Vector& v) { return operator+(v, std::move(u)); }
@@ -104,51 +104,51 @@ inline auto operator+(mfem::Vector&& u, const mfem::Vector& v) { return operator
 template <typename S, typename T>
 auto operator-(serac::VectorExpr<S>&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorSubtraction<S, T, true, true>(std::move(u.asDerived()), std::move(v.asDerived()));
+  return serac::internal::VectorSubtraction<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
 }
 
 template <typename T>
 auto operator-(const mfem::Vector& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorSubtraction<mfem::Vector, T, false, true>(u, std::move(v.asDerived()));
+  return serac::internal::VectorSubtraction<mfem::Vector, T>(u, std::move(v.asDerived()));
 }
 
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u, const mfem::Vector& v)
 {
-  return serac::internal::VectorSubtraction<T, mfem::Vector, true, false>(std::move(u.asDerived()), v);
+  return serac::internal::VectorSubtraction<T, mfem::Vector>(std::move(u.asDerived()), v);
 }
 
 inline auto operator-(const mfem::Vector& u, const mfem::Vector& v)
 {
-  return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector, false, false>(u, v);
+  return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector>(u, v);
 }
 
 template <typename T>
 auto operator-(mfem::Vector&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorSubtraction<mfem::Vector, T, true, true>(std::move(u), std::move(v.asDerived()));
+  return serac::internal::VectorSubtraction<mfem::Vector&&, T>(std::move(u), std::move(v.asDerived()));
 }
 
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u, mfem::Vector&& v)
 {
-  return serac::internal::VectorSubtraction<T, mfem::Vector, true, true>(std::move(u.asDerived()), std::move(v));
+  return serac::internal::VectorSubtraction<T, mfem::Vector&&>(std::move(u.asDerived()), std::move(v));
 }
 
 inline auto operator-(mfem::Vector&& u, mfem::Vector&& v)
 {
-  return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector, true, true>(std::move(u), std::move(v));
+  return serac::internal::VectorSubtraction<mfem::Vector&&, mfem::Vector&&>(std::move(u), std::move(v));
 }
 
 inline auto operator-(const mfem::Vector& u, mfem::Vector&& v)
 {
-  return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector, false, true>(u, std::move(v));
+  return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector&&>(u, std::move(v));
 }
 
 inline auto operator-(mfem::Vector&& u, const mfem::Vector& v)
 {
-  return serac::internal::VectorSubtraction<mfem::Vector, mfem::Vector, true, false>(std::move(u), v);
+  return serac::internal::VectorSubtraction<mfem::Vector&&, mfem::Vector>(std::move(u), v);
 }
 
 template <typename T>

--- a/src/common/vector_expression.hpp
+++ b/src/common/vector_expression.hpp
@@ -68,6 +68,7 @@ public:
 
 /**
  * @brief Fully evaluates a vector expression into an actual mfem::Vector
+ * @param expr The expression to evaluate
  * @return The fully evaluated vector
  * @see VectorExpr::operator mfem::Vector
  */
@@ -75,6 +76,21 @@ template <typename T>
 mfem::Vector evaluate(const VectorExpr<T>& expr)
 {
   return expr;
+}
+
+/**
+ * @brief Fully evaluates a vector expression into an actual mfem::Vector
+ * @param expr The expression to evaluate
+ * @param vec The vector to populate with the expression result
+ */
+template <typename T>
+void evaluate(const VectorExpr<T>& expr, mfem::Vector& result)
+{
+  SLIC_ERROR_IF(expr.Size() != static_cast<std::size_t>(result.Size()),
+                "Vector sizes in expression assignment must be equal");
+  for (size_t i = 0; i < expr.Size(); i++) {
+    result[i] = expr[i];
+  }
 }
 
 }  // namespace serac


### PR DESCRIPTION
Thanks to a suggestion from @samuelpmishLLNL, the ownership tags for vector expressions were removed from the template parameter lists and scalar division was added.

To minimize the number of copy-pasted operator overloads (was 9 per op for the binary operations), `mfem::Vector` parameters were converted to templates and perfect forwarding was used to instantiate the expression templates accordingly.  This reduces the work required to add a new operation and reduces the opportunity for error when writing a new op.

Also, the `evaluate` function was overloaded to accept a preallocated `mfem::Vector` that can be used as follows:
```cpp
mfem::Vector result(size);
evaluate(a + b - 0.3 * c, result);
```

New time comparison tests were added that do a single memory allocation at the beginning of the test, and thus avoid potentially expensive `malloc`s in the "kernels".