### PR TITLE
Add a .gitattributes file to force Unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Enforce LF (Unix) line endings for all text files
+
+# Source code
+*.cpp text eol=lf
+*.hpp text eol=lf
+
+# Plain or formatted text
+*.md text eol=lf
+*.rst text eol=lf
+*.txt text eol=lf
+
+# Scripts
+*.py text eol=lf
+*.sh text eol=lf
+
+# Configuration
+*.cmake text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf


### PR DESCRIPTION
This will force all text files to use LF (Unix-style) line endings regardless of how a developer has configured their `autocrlf`.
The image below demonstrates what will happen if a file is converted to CRLF - note that a switch to CRLF no longer counts as a "change" for the purposes of adding to a commit.  

![image](https://user-images.githubusercontent.com/68349992/93487518-f8d4cf80-f8ca-11ea-8aab-ae9a8d75149d.png)

Resolves #202 