### PR TITLE
Fix operator precedence warnings, add support for HypreParVector expr templates

### DIFF
--- a/src/docs/sphinx/expr_templates.rst
+++ b/src/docs/sphinx/expr_templates.rst
@@ -26,9 +26,11 @@ In particular, Serac currently provides the following operations:
 5. Application of an ``mfem::Operator`` with ``op * a`` for ``mfem::Operator op`` and vector ``a`` - note that 
     because ``mfem::Matrix`` inherits from ``mfem::Operator`` this functionality includes matrix-vector multiplication.
 
-
 Note that all of these expressions can be composed, that is, an expression can be used as an argument
 to another expression.  This allows for chaining, e.g., ``-a + b + 0.3 * c``.
+
+Memory Safety
+-------------
 
 Because these expression objects are imperfect closures (as with lambdas in C++), care should be taken to
 ensure that objects are not used after they go out of scope.  
@@ -76,3 +78,29 @@ As with the previous example, this should be resolved by moving the ``mfem::Vect
         auto a3 = evaluate(a * 3.0); // a is of type mfem::Vector
         return std::move(a3) - b; // return value is of expression type
     };
+
+
+Avoiding Allocations
+--------------------
+
+Currently, assigning an expression template to a vector, e.g. ``mfem::Vector c = a + b``
+will result in an allocation.  To avoid this, use the ``evaluate`` function:
+
+.. code-block:: cpp
+
+    // Preallocate
+    mfem::Vector c(size);
+    evaluate(a + b, c);
+
+
+
+Distributed Expression Templates
+--------------------------------
+
+.. note::
+    This functionality is under active development and may change significantly.
+
+Distributed expression templates (with ``mfem::HypreParVector``) are **experimentally** supported. 
+Mixed operations (where some operands are global ``mfem::Vector``s and others are distributed vectors)
+are not supported.  Additionally, an expression cannot be assigned to a ``HypreParVector``.  Use the 
+``evaluate`` function described above.

--- a/src/numerics/expr_template_ops.hpp
+++ b/src/numerics/expr_template_ops.hpp
@@ -17,10 +17,10 @@
 
 /**
  * @brief A utility for conditionally enabling templates if a given type
- * is an mfem::Vector
+ * is an mfem::Vector (including by inheritance)
  */
 template <typename MFEMVec>
-using enable_if_mfem_vec = std::enable_if_t<std::is_same_v<std::decay_t<MFEMVec>, mfem::Vector>>;
+using enable_if_mfem_vec = std::enable_if_t<std::is_base_of_v<mfem::Vector, std::decay_t<MFEMVec>>>;
 
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u)

--- a/src/numerics/vector_expression.hpp
+++ b/src/numerics/vector_expression.hpp
@@ -88,8 +88,10 @@ void evaluate(const VectorExpr<T>& expr, mfem::Vector& result)
 {
   SLIC_ERROR_IF(expr.Size() != static_cast<std::size_t>(result.Size()),
                 "Vector sizes in expression assignment must be equal");
+  // Get the underlying array for indexing compatibility with mfem::HypreParVector
+  double* result_arr = result;
   for (size_t i = 0; i < expr.Size(); i++) {
-    result[i] = expr[i];
+    result_arr[i] = expr[i];
   }
 }
 
@@ -116,7 +118,7 @@ void evaluate(const VectorExpr<T>& expr, mfem::Vector& result, MPI_Comm comm)
   double* result_arr = result;
 
   // If the array size is not divisible by # elements, add one
-  const long long per_proc = (SIZE / num_procs) + (SIZE % num_procs != 0) ? 1 : 0;
+  const long long per_proc = (SIZE / num_procs) + ((SIZE % num_procs != 0) ? 1 : 0);
 
   // Truncate the number of elements for the last process
   const long long n_entries = (rank == num_procs - 1) ? SIZE - ((num_procs - 1) * per_proc) : per_proc;


### PR DESCRIPTION
The distribution of expression template evaluation isn't particularly useful outside the context of a distributed memory model, so this PR adds experimental support for using `mfem::HypreParVector` with expression templates.  The Sphinx docs have been updated to reflect this new functionality and its limitations.


Resolves #209 