### PR TITLE
Detect clang-format-10 on Debian/Ubuntu

### DIFF
--- a/scripts/uberenv/packages/serac/package.py
+++ b/scripts/uberenv/packages/serac/package.py
@@ -410,9 +410,14 @@ class Serac(CMakePackage, CudaPackage):
         else:
             cfg.write(cmake_cache_option("ENABLE_DOCS", False))
 
-        clangformatpath = "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format"
-        if os.path.exists(clangformatpath):
-            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", clangformatpath))
+        lc_clangformatpath = "/usr/tce/packages/clang/clang-10.0.0/bin/clang-format"
+        # This works only with Ubuntu + Debian - other distros (Arch/Fedora) use
+        # /usr/bin/clang-format which would require actually running the executable to grab the version
+        apt_clangformatpath = "/usr/bin/clang-format-10"
+        if os.path.exists(lc_clangformatpath):
+            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", lc_clangformatpath))
+        elif os.path.exists(apt_clangformatpath):
+            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE", apt_clangformatpath))
 
         if "cppcheck" in spec:
             cppcheck_bin_dir = get_spec_path(spec, "cppcheck", path_replacements, use_bin=True)


### PR DESCRIPTION
To my knowledge no current serac users use a distro that is not Ubuntu or Debian (when not on LC).  If/when this changes we can check the version of the binary as described in my comment.

It may also be useful to add an option to the `blt_add_code_checks` macro to require a particular version of `clang-format` and explicit version options for the other formatting tools BLT supports, e.g. `astyle`.

Resolves #198 