### PR TITLE
Removed no-longer-needed #includes

### DIFF
--- a/src/infrastructure/logger.cpp
+++ b/src/infrastructure/logger.cpp
@@ -6,8 +6,6 @@
 
 #include "infrastructure/logger.hpp"
 
-#include "infrastructure/terminator.hpp"
-
 namespace serac {
 
 namespace logger {
@@ -19,8 +17,6 @@ bool initialize(MPI_Comm comm)
   if (!slic::isInitialized()) {
     slic::initialize();
   }
-
-  terminator::registerSignals();
 
   int numRanks, rank;
   MPI_Comm_size(comm, &numRanks);

--- a/src/infrastructure/profiling.cpp
+++ b/src/infrastructure/profiling.cpp
@@ -6,11 +6,11 @@
 
 #include "infrastructure/profiling.hpp"
 
-#include <optional>
-
 #include "infrastructure/logger.hpp"
 
 #ifdef SERAC_USE_CALIPER
+#include <optional>
+
 namespace {
 std::optional<cali::ConfigManager> mgr;
 }  // namespace

--- a/src/infrastructure/terminator.cpp
+++ b/src/infrastructure/terminator.cpp
@@ -20,7 +20,7 @@ namespace {
  */
 void signalHandler(int signal)
 {
-  std::cerr << "[SIGNAL]: Received signal " << signal << ", exiting" << std::endl;
+  std::cerr << "[SIGNAL]: Received signal " << signal << " (" << strsignal(signal) << "), exiting" << std::endl;
   serac::exitGracefully(true);
 }
 

--- a/src/physics/base_physics.cpp
+++ b/src/physics/base_physics.cpp
@@ -6,9 +6,7 @@
 
 #include "physics/base_physics.hpp"
 
-#include <algorithm>
 #include <fstream>
-#include <iostream>
 
 #include "fmt/fmt.hpp"
 #include "infrastructure/logger.hpp"

--- a/src/physics/base_physics.hpp
+++ b/src/physics/base_physics.hpp
@@ -13,14 +13,12 @@
 #ifndef BASE_PHYSICS
 #define BASE_PHYSICS
 
-#include <map>
 #include <memory>
 
 #include "mfem.hpp"
 #include "physics/utilities/boundary_condition_manager.hpp"
 #include "physics/utilities/equation_solver.hpp"
 #include "physics/utilities/finite_element_state.hpp"
-#include "physics/utilities/solver_config.hpp"
 
 namespace serac {
 

--- a/src/physics/operators/nonlinear_solid_operators.hpp
+++ b/src/physics/operators/nonlinear_solid_operators.hpp
@@ -18,7 +18,6 @@
 #include "mfem.hpp"
 #include "physics/utilities/boundary_condition_manager.hpp"
 #include "physics/utilities/equation_solver.hpp"
-#include "physics/utilities/finite_element_state.hpp"
 #include "physics/utilities/solver_config.hpp"
 
 namespace serac {

--- a/src/physics/utilities/boundary_condition.hpp
+++ b/src/physics/utilities/boundary_condition.hpp
@@ -19,11 +19,9 @@
 #include <type_traits>
 #include <typeinfo>
 #include <utility>
-#include <variant>
 
 #include "infrastructure/logger.hpp"
 #include "physics/utilities/finite_element_state.hpp"
-#include "physics/utilities/solver_config.hpp"
 
 namespace serac {
 
@@ -192,26 +190,6 @@ public:
    * with the calling object via BoundaryCondition::setTrueDofs(FiniteElementState&)
    */
   void projectBdr(const double time, const bool should_be_scalar = true) const;
-
-  /**
-   * @brief Allocates an integrator of type "Integrator" on the heap,
-   * constructing it with the boundary condition's vector coefficient,
-   * intended to be passed to mfem::*LinearForm::Add*Integrator
-   * @return An owning pointer to the new integrator
-   * @pre Requires Integrator::Integrator(mfem::VectorCoefficient&)
-   */
-  template <typename Integrator>
-  std::unique_ptr<Integrator> newVecIntegrator() const;
-
-  /**
-   * @brief Allocates an integrator of type "Integrator" on the heap,
-   * constructing it with the boundary condition's coefficient,
-   * intended to be passed to mfem::*LinearForm::Add*Integrator
-   * @return An owning pointer to the new integrator
-   * @pre Requires Integrator::Integrator(mfem::Coefficient&)
-   */
-  template <typename Integrator>
-  std::unique_ptr<Integrator> newIntegrator() const;
 
   /**
    * @brief Eliminates the rows and columns corresponding to the BC's true DOFS

--- a/src/physics/utilities/boundary_condition_manager.hpp
+++ b/src/physics/utilities/boundary_condition_manager.hpp
@@ -18,7 +18,6 @@
 
 #include "physics/utilities/boundary_condition.hpp"
 #include "physics/utilities/finite_element_state.hpp"
-#include "physics/utilities/solver_config.hpp"
 
 namespace serac {
 

--- a/src/physics/utilities/finite_element_state.hpp
+++ b/src/physics/utilities/finite_element_state.hpp
@@ -19,7 +19,6 @@
 #include <variant>
 
 #include "mfem.hpp"
-#include "physics/utilities/solver_config.hpp"
 
 namespace serac {
 


### PR DESCRIPTION
I went through and removed most of the dead includes, and also augmented the signal handler to include the name of the signal - a Ctrl-C now prints `[SIGNAL]: Received signal 2 (Interrupt), exiting` instead of `[SIGNAL]: Received signal 2, exiting`.