### PR TITLE
Add link to tests directory

### DIFF
--- a/src/docs/sphinx/developer_guide.rst
+++ b/src/docs/sphinx/developer_guide.rst
@@ -29,7 +29,7 @@ If you would like to include Serac's simulation capabilities in your software pr
 #. Advance the timestep by calling ``advanceTimestep(double dt)``. 
 #. Output the state variables in GLVis, VisIt, or ParaView format by calling ``outputState()``. You can also access the underlying `state data <../doxygen/html/classserac_1_1FiniteElementState.html>`_ via the generic ``getState()`` or physics-specific calls (e.g. ``temperature()``).
 
-Examples of how to use each of the physics modules can be found in the `tests` directory.
+Examples of how to use each of the physics modules can be found in the `tests directory <https://github.com/LLNL/serac/tree/develop/tests>`_.
 
 Physics Module Developer Guide
 ------------------------------


### PR DESCRIPTION
This fixes a typo in the dev docs and actually adds a link to the tests in the github repo. Built docs are available for preview [here](https://serac.readthedocs.io/en/docs-bramwell-dev_doc_fixes/sphinx/developer_guide.html).