### PR TITLE
Fix pulling exact commits for external repos

### DIFF
--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -55,7 +55,7 @@ class Axom(CMakePackage, CudaPackage):
     version('develop', branch='develop', submodules=True)
 
     # SERAC EDIT START
-    version('0.4.0p1', SHA='d74c5d971c62a2263efa438736440ff28620dc3d', submodules="True")
+    version('0.4.0p1', commit='d74c5d971c62a2263efa438736440ff28620dc3d', submodules="True")
     # SERAC EDIT END
 
     version('0.4.0', tag='v0.4.0', submodules="True")

--- a/scripts/uberenv/packages/conduit/package.py
+++ b/scripts/uberenv/packages/conduit/package.py
@@ -40,7 +40,7 @@ class Conduit(Package):
     version('master', branch='master', submodules=True, preferred=True)
 
     # SERAC EDIT START
-    version('0.5.1p1', SHA='edc3f72add4bec69ec19352865618f32dadc0356', submodules="True")
+    version('0.5.1p1', commit='edc3f72add4bec69ec19352865618f32dadc0356', submodules="True")
     # SERAC EDIT END
 
     version('0.5.1', sha256='68a3696d1ec6d3a4402b44a464d723e6529ec41016f9b44c053676affe516d44')

--- a/scripts/uberenv/packages/mfem/package.py
+++ b/scripts/uberenv/packages/mfem/package.py
@@ -43,7 +43,7 @@ class Mfem(Package):
 
     # SERAC EDIT BEGIN
     # Version spec used in serac based on mfem@develop commit SHA
-    version('4.1.0p1', SHA='bb3c788a05f430bcfed03065ba39868974964924')
+    version('4.1.0p1', commit='bb3c788a05f430bcfed03065ba39868974964924')
     # SERAC EDIT END
 
     # 'develop' is a special version that is always larger (or newer) than any

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -193,7 +193,7 @@ TEST(dynamic_solver, dyn_linesearch_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/beam-hex.mesh";
+  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/meshes/beam-hex.mesh";
 
   auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 


### PR DESCRIPTION
It turns out we were not pulling the specific git commit for our external repos that are not at a version number. This fixes that as well as the Sundials test to reflect the new file structure.

Resolves https://github.com/LLNL/serac/issues/239 .