### PR TITLE
Begin utilizing inlet to read in structs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,12 +11,12 @@ jobs:
     matrix:
       linux_gcc8:
           VM_ImageName: 'ubuntu-16.04'
-          Compiler_ImageName: 'seracllnl/tpls:gcc-8'
+          Compiler_ImageName: 'seracllnl/tpls:gcc-8_10-14-20_19h-51m'
           TEST_TARGET: 'linux_gcc8'
           HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake'
       linux_clang10:
           VM_ImageName: 'ubuntu-18.04'
-          Compiler_ImageName: 'seracllnl/tpls:clang-10'
+          Compiler_ImageName: 'seracllnl/tpls:clang-10_10-14-20_19h-51m'
           TEST_TARGET: 'linux_clang10'
           HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0.cmake'
 
@@ -43,7 +43,7 @@ jobs:
   variables:
     DO_STYLE_CHECK: 'yes'
     VM_ImageName: 'ubuntu-18.04'
-    Compiler_ImageName: 'seracllnl/tpls:clang-10'
+    Compiler_ImageName: 'seracllnl/tpls:clang-10_10-14-20_19h-51m'
     TEST_TARGET: 'linux_clang10'
     HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
   pool:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,12 +11,12 @@ jobs:
     matrix:
       linux_gcc8:
           VM_ImageName: 'ubuntu-16.04'
-          Compiler_ImageName: 'seracllnl/tpls:gcc-8_10-14-20_19h-51m'
+          Compiler_ImageName: 'seracllnl/tpls:gcc-8_10-19-20_18h-06m'
           TEST_TARGET: 'linux_gcc8'
           HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake'
       linux_clang10:
           VM_ImageName: 'ubuntu-18.04'
-          Compiler_ImageName: 'seracllnl/tpls:clang-10_10-14-20_19h-51m'
+          Compiler_ImageName: 'seracllnl/tpls:clang-10_10-19-20_22h-40m'
           TEST_TARGET: 'linux_clang10'
           HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0.cmake'
 
@@ -43,7 +43,7 @@ jobs:
   variables:
     DO_STYLE_CHECK: 'yes'
     VM_ImageName: 'ubuntu-18.04'
-    Compiler_ImageName: 'seracllnl/tpls:clang-10_10-14-20_19h-51m'
+    Compiler_ImageName: 'seracllnl/tpls:clang-10_10-19-20_22h-40m'
     TEST_TARGET: 'linux_clang10'
     HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
   pool:

--- a/data/input_files/default.lua
+++ b/data/input_files/default.lua
@@ -2,7 +2,7 @@
 t_final = 1.0
 dt      = 0.25
 
-primary_mesh = {
+main_mesh = {
     -- mesh file
     mesh = "../meshes/beam-hex.mesh",
     -- serial and parallel refinement levels
@@ -12,7 +12,7 @@ primary_mesh = {
 
 -- Solver parameters
 nonlinear_solid = {
-    mesh_info = primary_mesh,
+    mesh_info = main_mesh,
 
     solver = {
         nonlinear = {

--- a/data/input_files/default.lua
+++ b/data/input_files/default.lua
@@ -39,7 +39,9 @@ nonlinear_solid = {
     K  = 5.0,
 
     -- loading parameters
-    tx = 0.0,
-    ty = 1.0e-3,
-    tz = 0.0,
+    traction = {
+        x = 0.0,
+        y = 1.0e-3,
+        z = 0.0,
+    },
 }

--- a/data/input_files/default.lua
+++ b/data/input_files/default.lua
@@ -1,15 +1,17 @@
-mesh = "../meshes/beam-hex.mesh"
-
--- serial and parallel refinement levels
-ser_ref_levels = 0
-par_ref_levels = 0
-
 -- Simulation time parameters
 t_final = 1.0
 dt      = 0.25
 
 -- Solver parameters
 nonlinear_solid = {
+    mesh_info = {
+        -- mesh file
+        mesh = "../data/meshes/beam-hex.mesh",
+        -- serial and parallel refinement levels
+        ser_ref_levels = 0,
+        par_ref_levels = 0,
+    },
+
     solver = {
         nonlinear = {
             rel_tol     = 1.0e-2,

--- a/data/input_files/default.lua
+++ b/data/input_files/default.lua
@@ -2,15 +2,17 @@
 t_final = 1.0
 dt      = 0.25
 
+primary_mesh = {
+    -- mesh file
+    mesh = "../meshes/beam-hex.mesh",
+    -- serial and parallel refinement levels
+    ser_ref_levels = 0,
+    par_ref_levels = 0,
+}
+
 -- Solver parameters
 nonlinear_solid = {
-    mesh_info = {
-        -- mesh file
-        mesh = "../data/meshes/beam-hex.mesh",
-        -- serial and parallel refinement levels
-        ser_ref_levels = 0,
-        par_ref_levels = 0,
-    },
+    mesh_info = primary_mesh,
 
     solver = {
         nonlinear = {

--- a/data/input_files/default.lua
+++ b/data/input_files/default.lua
@@ -12,8 +12,6 @@ main_mesh = {
 
 -- Solver parameters
 nonlinear_solid = {
-    mesh_info = main_mesh,
-
     solver = {
         nonlinear = {
             rel_tol     = 1.0e-2,

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: linux-ubuntu16.04-ivybridge
 # Compiler Spec: gcc@8.1.0
-# CMake executable path: /home/serac/serac_tpls/gcc-8.1.0/cmake-3.10.1/bin/cmake
+# CMake executable path: /usr/bin/cmake
 #---------------------------------------
 
 #---------------------------------------
@@ -21,6 +21,10 @@ set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
 
 set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
 
+set(CMAKE_C_FLAGS "-pthread" CACHE PATH "")
+
+set(CMAKE_CXX_FLAGS "-pthread" CACHE PATH "")
+
 set(ENABLE_CUDA OFF CACHE BOOL "")
 
 #---------------------------------------
@@ -28,11 +32,11 @@ set(ENABLE_CUDA OFF CACHE BOOL "")
 #---------------------------------------
 set(ENABLE_MPI "ON" CACHE PATH "")
 
-set(MPI_C_COMPILER "/home/serac/serac_tpls/gcc-8.1.0/mpich-3.3.2/bin/mpicc" CACHE PATH "")
+set(MPI_C_COMPILER "/usr/bin/mpicc" CACHE PATH "")
 
-set(MPI_CXX_COMPILER "/home/serac/serac_tpls/gcc-8.1.0/mpich-3.3.2/bin/mpic++" CACHE PATH "")
+set(MPI_CXX_COMPILER "/usr/bin/mpic++" CACHE PATH "")
 
-set(MPIEXEC_EXECUTABLE "/home/serac/serac_tpls/gcc-8.1.0/mpich-3.3.2/bin/mpiexec" CACHE PATH "")
+set(MPIEXEC_EXECUTABLE "/usr/bin/mpiexec" CACHE PATH "")
 
 #---------------------------------------
 # Library Dependencies
@@ -53,7 +57,7 @@ set(NETCDF_DIR "${TPL_ROOT}/netcdf-c-4.7.4" CACHE PATH "")
 
 set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
 
-set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-6.1.1" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0p1" CACHE PATH "")
 
@@ -62,5 +66,3 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0p1" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 set(ENABLE_DOCS OFF CACHE BOOL "")
-
-

--- a/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake
@@ -43,7 +43,7 @@ set(MPIEXEC_EXECUTABLE "/usr/bin/mpiexec" CACHE PATH "")
 #---------------------------------------
 set(TPL_ROOT "/home/serac/serac_tpls/gcc-8.1.0" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 

--- a/host-configs/docker/docker-linux-ubuntu18.04-x86_64-clang@10.0.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu18.04-x86_64-clang@10.0.0.cmake
@@ -21,6 +21,8 @@ set(CMAKE_C_COMPILER "/usr/bin/clang" CACHE PATH "")
 
 set(CMAKE_CXX_COMPILER "/usr/bin/clang++" CACHE PATH "")
 
+set(CMAKE_C_FLAGS "-fPIC" CACHE PATH "")
+
 set(BLT_EXE_LINKER_FLAGS " -Wl,-rpath,/usr/lib" CACHE PATH "Adds a missing libstdc++ rpath")
 
 set(ENABLE_CUDA OFF CACHE BOOL "")
@@ -41,7 +43,7 @@ set(MPIEXEC_EXECUTABLE "/usr/bin/mpiexec" CACHE PATH "")
 #---------------------------------------
 set(TPL_ROOT "/home/serac/serac_tpls/clang-10.0.0" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 

--- a/host-configs/docker/docker-linux-ubuntu18.04-x86_64-clang@10.0.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu18.04-x86_64-clang@10.0.0.cmake
@@ -11,7 +11,7 @@
 #---------------------------------------
 # SYS_TYPE: linux-ubuntu18.04-ivybridge
 # Compiler Spec: clang@10.0.0
-# CMake executable path: /home/serac/serac_tpls/clang-10.0.0/cmake-3.10.1/bin/cmake
+# CMake executable path: /usr/bin/cmake
 #---------------------------------------
 
 #---------------------------------------
@@ -55,7 +55,7 @@ set(NETCDF_DIR "${TPL_ROOT}/netcdf-c-4.7.4" CACHE PATH "")
 
 set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
 
-set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-6.1.1" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0p1" CACHE PATH "")
 
@@ -64,5 +64,3 @@ set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0p1" CACHE PATH "")
 #------------------------------------------------------------------------------
 
 set(ENABLE_DOCS OFF CACHE BOOL "")
-
-

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@upstream_gfortran-cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@upstream_gfortran-cuda.cmake
@@ -57,9 +57,9 @@ set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rele
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_10_01_22_41_43/clang-upstream_gfortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_10_19_15_04_12/clang-upstream_gfortran" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 
@@ -73,7 +73,7 @@ set(NETCDF_DIR "${TPL_ROOT}/netcdf-c-4.7.4" CACHE PATH "")
 
 set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
 
-set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-6.1.1" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0p1" CACHE PATH "")
 
@@ -92,3 +92,5 @@ set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-forma
 set(CLANGTIDY_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-tidy" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-2.1/bin/cppcheck" CACHE PATH "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -41,9 +41,9 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/bin/m
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_02_18_02_26/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_19_12_10_26/clang-10.0.0" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 
@@ -57,7 +57,7 @@ set(NETCDF_DIR "${TPL_ROOT}/netcdf-c-4.7.4" CACHE PATH "")
 
 set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
 
-set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-6.1.1" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0p1" CACHE PATH "")
 
@@ -79,3 +79,5 @@ set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-forma
 set(CLANGTIDY_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-tidy" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.3.1.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.3.1.cmake
@@ -35,9 +35,9 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.3.1/bin/mpic
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_02_18_02_26/gcc-8.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_19_12_10_26/gcc-8.3.1" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 
@@ -51,7 +51,7 @@ set(NETCDF_DIR "${TPL_ROOT}/netcdf-c-4.7.4" CACHE PATH "")
 
 set(PARMETIS_DIR "${TPL_ROOT}/parmetis-4.0.3" CACHE PATH "")
 
-set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-5.4.0" CACHE PATH "")
+set(SUPERLUDIST_DIR "${TPL_ROOT}/superlu-dist-6.1.1" CACHE PATH "")
 
 set(MFEM_DIR "${TPL_ROOT}/mfem-4.1.0p1" CACHE PATH "")
 
@@ -73,3 +73,5 @@ set(CLANGFORMAT_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-forma
 set(CLANGTIDY_EXECUTABLE "/usr/tce/packages/clang/clang-10.0.0/bin/clang-tidy" CACHE PATH "")
 
 set(CPPCHECK_EXECUTABLE "${DEVTOOLS_ROOT}/cppcheck-1.87/bin/cppcheck" CACHE PATH "")
+
+

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -55,7 +55,7 @@ class Axom(CMakePackage, CudaPackage):
     version('develop', branch='develop', submodules=True)
 
     # SERAC EDIT START
-    version('0.4.0p1', commit='d74c5d971c62a2263efa438736440ff28620dc3d', submodules="True")
+    version('0.4.0p1', commit='bd9b1f9df980352b55240a9177bed846dbc13eef', submodules="True")
     # SERAC EDIT END
 
     version('0.4.0', tag='v0.4.0', submodules="True")

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -42,7 +42,7 @@ void defineInputFileSchema(std::shared_ptr<axom::inlet::Inlet> inlet, int rank)
   inlet->addDouble("dt", "Time step.")->defaultValue(0.25);
 
   // Physics
-  serac::NonlinearSolid::defineInputFileSchema(inlet);
+  serac::NonlinearSolid::defineInputFileSchema(*inlet->getGlobalTable());
 
   // Verify input file
   if (!inlet->verify()) {

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -112,18 +112,8 @@ int main(int argc, char* argv[])
   std::set<int> trac_bdr = {2};
 
   // loading parameters
-  double tx = (*inlet)["nonlinear_solid/tx"];  // has default value
-  double ty = (*inlet)["nonlinear_solid/ty"];  // has default value
-  double tz = (*inlet)["nonlinear_solid/tz"];  // has default value
-
   // define the traction vector
-  mfem::Vector traction(dim);
-  traction(0) = tx;
-  traction(1) = ty;
-  if (dim == 3) {
-    traction(2) = tz;
-  }
-
+  auto traction      = (*inlet)["nonlinear_solid/traction"].get<mfem::Vector>();
   auto traction_coef = std::make_shared<serac::VectorScaledConstantCoefficient>(traction);
 
   // Set the boundary condition information

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -37,9 +37,6 @@ namespace serac {
 
 void defineInputFileSchema(std::shared_ptr<axom::inlet::Inlet> inlet, int rank)
 {
-  // mesh
-  serac::mesh::defineInputFileSchema(inlet);
-
   // Simulation time parameters
   inlet->addDouble("t_final", "Final time for simulation.")->defaultValue(1.0);
   inlet->addDouble("dt", "Time step.")->defaultValue(0.25);
@@ -81,26 +78,12 @@ int main(int argc, char* argv[])
   // Save input values to file
   datastore.getRoot()->save("serac_input.json", "json");
 
-  // serial and parallel refinement levels
-  int ser_ref_levels;
-  inlet->get("ser_ref_levels", ser_ref_levels);  // has default value
-  int par_ref_levels;
-  inlet->get("par_ref_levels", par_ref_levels);  // has default value
-
-  // Build mesh
-  std::string mesh_file_path;
-  inlet->get("mesh", mesh_file_path);  // required in input file
-  mesh_file_path = serac::input::findMeshFilePath(mesh_file_path, input_file_path);
-  auto mesh      = serac::buildMeshFromFile(mesh_file_path, ser_ref_levels, par_ref_levels);
-
   // Define the solid solver object
-  int order;
-  inlet->get("nonlinear_solid/order", order);  // has default value
-  serac::NonlinearSolid solid_solver(order, mesh);
+  auto solid_solver = (*inlet)["nonlinear_solid"].get<serac::NonlinearSolid>();
 
   // Project the initial and reference configuration functions onto the
   // appropriate grid functions
-  int dim = mesh->Dimension();
+  int dim = solid_solver.mesh().Dimension();
 
   mfem::VectorFunctionCoefficient defo_coef(dim, serac::initialDeformation);
 
@@ -125,10 +108,9 @@ int main(int argc, char* argv[])
   std::set<int> trac_bdr = {2};
 
   // loading parameters
-  double tx, ty, tz;
-  inlet->get("nonlinear_solid/tx", tx);  // has default value
-  inlet->get("nonlinear_solid/ty", ty);  // has default value
-  inlet->get("nonlinear_solid/tz", tz);  // has default value
+  double tx = (*inlet)["nonlinear_solid/tx"];  // has default value
+  double ty = (*inlet)["nonlinear_solid/ty"];  // has default value
+  double tz = (*inlet)["nonlinear_solid/tz"];  // has default value
 
   // define the traction vector
   mfem::Vector traction(dim);
@@ -144,44 +126,6 @@ int main(int argc, char* argv[])
   solid_solver.setDisplacementBCs(ess_bdr, disp_coef);
   solid_solver.setTractionBCs(trac_bdr, traction_coef);
 
-  // neo-Hookean material parameters
-  double mu, K;
-  inlet->get("nonlinear_solid/mu", mu);  // has default value
-  inlet->get("nonlinear_solid/K", K);    // has default value
-
-  // Set the material parameters
-  solid_solver.setHyperelasticMaterialParameters(mu, K);
-
-  // Solver parameters
-  serac::NonlinearSolverParameters nonlin_params;
-  inlet->get("nonlinear_solid/solver/nonlinear/rel_tol", nonlin_params.rel_tol);          // has default value
-  inlet->get("nonlinear_solid/solver/nonlinear/abs_tol", nonlin_params.abs_tol);          // has default value
-  inlet->get("nonlinear_solid/solver/nonlinear/max_iter", nonlin_params.max_iter);        // has default value
-  inlet->get("nonlinear_solid/solver/nonlinear/print_level", nonlin_params.print_level);  // has default value
-
-  serac::LinearSolverParameters lin_params;
-  inlet->get("nonlinear_solid/solver/linear/rel_tol", lin_params.rel_tol);          // has default value
-  inlet->get("nonlinear_solid/solver/linear/abs_tol", lin_params.abs_tol);          // has default value
-  inlet->get("nonlinear_solid/solver/linear/max_iter", lin_params.max_iter);        // has default value
-  inlet->get("nonlinear_solid/solver/linear/print_level", lin_params.print_level);  // has default value
-
-  // solver input args
-  std::string solver_type;
-  inlet->get("nonlinear_solid/solver/linear/solver_type", solver_type);  // has default value
-  if (solver_type == "gmres") {
-    lin_params.prec       = serac::Preconditioner::BoomerAMG;
-    lin_params.lin_solver = serac::LinearSolver::GMRES;
-  } else if (solver_type == "minres") {
-    lin_params.prec       = serac::Preconditioner::Jacobi;
-    lin_params.lin_solver = serac::LinearSolver::MINRES;
-  } else {
-    serac::logger::flush();
-    std::string msg = fmt::format("Unknown Linear solver type given: {0}", solver_type);
-    SLIC_ERROR_ROOT(rank, msg);
-    serac::exitGracefully(true);
-  }
-  solid_solver.setSolverParameters(lin_params, nonlin_params);
-
   // Set the time step method
   solid_solver.setTimestepper(serac::TimestepMethod::QuasiStatic);
 
@@ -189,10 +133,9 @@ int main(int argc, char* argv[])
   solid_solver.completeSetup();
 
   // initialize/set the time
-  double t = 0;
-  double t_final, dt;
-  inlet->get("t_final", t_final);  // has default value
-  inlet->get("dt", dt);            // has default value
+  double t       = 0;
+  double t_final = (*inlet)["t_final"];  // has default value
+  double dt      = (*inlet)["dt"];       // has default value
 
   bool last_step = false;
 

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -42,7 +42,8 @@ void defineInputFileSchema(std::shared_ptr<axom::inlet::Inlet> inlet, int rank)
   inlet->addDouble("dt", "Time step.")->defaultValue(0.25);
 
   // Physics
-  serac::NonlinearSolid::defineInputFileSchema(*inlet->getGlobalTable());
+  auto solid_solver_table = inlet->addTable("nonlinear_solid", "Finite deformation solid mechanics module");
+  serac::NonlinearSolid::defineInputFileSchema(*solid_solver_table);
 
   // Verify input file
   if (!inlet->verify()) {

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -78,6 +78,9 @@ int main(int argc, char* argv[])
   // Save input values to file
   datastore.getRoot()->save("serac_input.json", "json");
 
+  // Annotate the mesh with the input filename
+  inlet->addTable("nonlinear_solid/mesh_info")->addString("input_file_path")->defaultValue(input_file_path);
+
   // Define the solid solver object
   auto solid_solver = (*inlet)["nonlinear_solid"].get<serac::NonlinearSolid>();
 

--- a/src/infrastructure/input.hpp
+++ b/src/infrastructure/input.hpp
@@ -18,6 +18,7 @@
 
 #include "axom/inlet.hpp"
 #include "axom/sidre.hpp"
+#include "mfem.hpp"
 
 namespace serac {
 
@@ -50,7 +51,20 @@ std::string findMeshFilePath(const std::string& mesh_path, const std::string& in
  */
 std::string fullDirectoryFromPath(const std::string& file_path);
 
+/**
+ * @brief Defines the schema for a vector in R^{1,2,3} space
+ * @param[inout] table The base table on which to define the schema
+ * @param[in] dimension The expected dimension of the vector
+ */
+void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension = 3);
+
 }  // namespace input
 }  // namespace serac
+
+// Template specializations
+template <>
+struct FromInlet<mfem::Vector> {
+  mfem::Vector operator()(axom::inlet::Table& base);
+};
 
 #endif

--- a/src/numerics/mesh_utils.cpp
+++ b/src/numerics/mesh_utils.cpp
@@ -183,3 +183,12 @@ void defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCreator> schema_cr
 
 }  // namespace mesh
 }  // namespace serac
+
+template <>
+std::shared_ptr<mfem::ParMesh> from_inlet<std::shared_ptr<mfem::ParMesh>>(axom::inlet::Table& base)
+{
+  std::string filename = base["mesh"];
+  int         ser_ref  = base["ser_ref_levels"];
+  int         par_ref  = base["par_ref_levels"];
+  return serac::buildMeshFromFile(filename, ser_ref, par_ref);
+}

--- a/src/numerics/mesh_utils.cpp
+++ b/src/numerics/mesh_utils.cpp
@@ -185,8 +185,8 @@ void defineInputFileSchema(axom::inlet::Table& schema_creator)
 
 std::shared_ptr<mfem::ParMesh> FromInlet<std::shared_ptr<mfem::ParMesh>>::operator()(axom::inlet::Table& base)
 {
-  std::string filename = base["mesh"];
-  int         ser_ref  = base["ser_ref_levels"];
-  int         par_ref  = base["par_ref_levels"];
-  return serac::buildMeshFromFile(filename, ser_ref, par_ref);
+  auto mesh_path = serac::input::findMeshFilePath(base["mesh"], base["input_file_path"]);
+  int  ser_ref   = base["ser_ref_levels"];
+  int  par_ref   = base["par_ref_levels"];
+  return serac::buildMeshFromFile(mesh_path, ser_ref, par_ref);
 }

--- a/src/numerics/mesh_utils.cpp
+++ b/src/numerics/mesh_utils.cpp
@@ -170,14 +170,14 @@ std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_i
 
 namespace mesh {
 
-void defineInputFileSchema(axom::inlet::Table& schema_creator)
+void defineInputFileSchema(axom::inlet::Table& table)
 {
   // mesh path
-  schema_creator.addString("mesh", "Path to Mesh file")->required(true);
+  table.addString("mesh", "Path to Mesh file")->required(true);
 
   // Refinement levels
-  schema_creator.addInt("ser_ref_levels", "Number of times to refine the mesh uniformly in serial.")->defaultValue(0);
-  schema_creator.addInt("par_ref_levels", "Number of times to refine the mesh uniformly in parallel.")->defaultValue(0);
+  table.addInt("ser_ref_levels", "Number of times to refine the mesh uniformly in serial.")->defaultValue(0);
+  table.addInt("par_ref_levels", "Number of times to refine the mesh uniformly in parallel.")->defaultValue(0);
 }
 
 }  // namespace mesh

--- a/src/numerics/mesh_utils.cpp
+++ b/src/numerics/mesh_utils.cpp
@@ -170,7 +170,7 @@ std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_i
 
 namespace mesh {
 
-void defineInputFileSchema(axom::inlet::Table& table)
+void InputInfo::defineInputFileSchema(axom::inlet::Table& table)
 {
   // mesh path
   table.addString("mesh", "Path to Mesh file")->required(true);
@@ -183,10 +183,10 @@ void defineInputFileSchema(axom::inlet::Table& table)
 }  // namespace mesh
 }  // namespace serac
 
-std::shared_ptr<mfem::ParMesh> FromInlet<std::shared_ptr<mfem::ParMesh>>::operator()(axom::inlet::Table& base)
+serac::mesh::InputInfo FromInlet<serac::mesh::InputInfo>::operator()(axom::inlet::Table& base)
 {
-  auto mesh_path = serac::input::findMeshFilePath(base["mesh"], base["input_file_path"]);
-  int  ser_ref   = base["ser_ref_levels"];
-  int  par_ref   = base["par_ref_levels"];
-  return serac::buildMeshFromFile(mesh_path, ser_ref, par_ref);
+  std::string mesh_path = base["mesh"];
+  int         ser_ref   = base["ser_ref_levels"];
+  int         par_ref   = base["par_ref_levels"];
+  return {mesh_path, ser_ref, par_ref};
 }

--- a/src/numerics/mesh_utils.cpp
+++ b/src/numerics/mesh_utils.cpp
@@ -170,22 +170,20 @@ std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_i
 
 namespace mesh {
 
-void defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCreator> schema_creator)
+void defineInputFileSchema(axom::inlet::Table& schema_creator)
 {
   // mesh path
-  schema_creator->addString("mesh", "Path to Mesh file")->required(true);
+  schema_creator.addString("mesh", "Path to Mesh file")->required(true);
 
   // Refinement levels
-  schema_creator->addInt("ser_ref_levels", "Number of times to refine the mesh uniformly in serial.")->defaultValue(0);
-  schema_creator->addInt("par_ref_levels", "Number of times to refine the mesh uniformly in parallel.")
-      ->defaultValue(0);
+  schema_creator.addInt("ser_ref_levels", "Number of times to refine the mesh uniformly in serial.")->defaultValue(0);
+  schema_creator.addInt("par_ref_levels", "Number of times to refine the mesh uniformly in parallel.")->defaultValue(0);
 }
 
 }  // namespace mesh
 }  // namespace serac
 
-template <>
-std::shared_ptr<mfem::ParMesh> from_inlet<std::shared_ptr<mfem::ParMesh>>(axom::inlet::Table& base)
+std::shared_ptr<mfem::ParMesh> FromInlet<std::shared_ptr<mfem::ParMesh>>::operator()(axom::inlet::Table& base)
 {
   std::string filename = base["mesh"];
   int         ser_ref  = base["ser_ref_levels"];

--- a/src/numerics/mesh_utils.hpp
+++ b/src/numerics/mesh_utils.hpp
@@ -81,20 +81,27 @@ std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_i
 
 namespace mesh {
 
-/**
- * @brief Input file parameters specific to this class
- *
- * @param[in] table Inlet's SchemaCreator that input files will be added too
- **/
-void defineInputFileSchema(axom::inlet::Table& table);
+struct InputInfo {
+  /**
+   * @brief Input file parameters specific to this class
+   *
+   * @param[in] table Inlet's SchemaCreator that input files will be added to
+   **/
+  static void defineInputFileSchema(axom::inlet::Table& table);
+
+  std::string relative_mesh_file_name;
+  // Serial/parallel refinement iterations
+  int ser_ref_levels;
+  int par_ref_levels;
+};
 
 }  // namespace mesh
 }  // namespace serac
 
 // Prototype the specialization
 template <>
-struct FromInlet<std::shared_ptr<mfem::ParMesh>> {
-  std::shared_ptr<mfem::ParMesh> operator()(axom::inlet::Table& base);
+struct FromInlet<serac::mesh::InputInfo> {
+  serac::mesh::InputInfo operator()(axom::inlet::Table& base);
 };
 
 #endif

--- a/src/numerics/mesh_utils.hpp
+++ b/src/numerics/mesh_utils.hpp
@@ -84,9 +84,9 @@ namespace mesh {
 /**
  * @brief Input file parameters specific to this class
  *
- * @param[in] schema_creator Inlet's SchemaCreator that input files will be added too
+ * @param[in] table Inlet's SchemaCreator that input files will be added too
  **/
-void defineInputFileSchema(axom::inlet::Table& schema_creator);
+void defineInputFileSchema(axom::inlet::Table& table);
 
 }  // namespace mesh
 }  // namespace serac

--- a/src/numerics/mesh_utils.hpp
+++ b/src/numerics/mesh_utils.hpp
@@ -86,9 +86,15 @@ namespace mesh {
  *
  * @param[in] schema_creator Inlet's SchemaCreator that input files will be added too
  **/
-void defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCreator> schema_creator);
+void defineInputFileSchema(axom::inlet::Table& schema_creator);
 
 }  // namespace mesh
 }  // namespace serac
+
+// Prototype the specialization
+template <>
+struct FromInlet<std::shared_ptr<mfem::ParMesh>> {
+  std::shared_ptr<mfem::ParMesh> operator()(axom::inlet::Table& base);
+};
 
 #endif

--- a/src/physics/base_physics.hpp
+++ b/src/physics/base_physics.hpp
@@ -43,6 +43,8 @@ public:
    */
   BasePhysics(std::shared_ptr<mfem::ParMesh> mesh, int n, int p);
 
+  BasePhysics(BasePhysics&& other) = default;
+
   /**
    * @brief Set a list of true degrees of freedom from a coefficient
    *
@@ -135,6 +137,11 @@ public:
    * @brief Destroy the Base Solver object
    */
   virtual ~BasePhysics() = default;
+
+  /**
+   * @brief Returns a reference to the mesh object
+   */
+  const mfem::ParMesh& mesh() const { return *mesh_; }
 
 protected:
   /**

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -212,9 +212,9 @@ void NonlinearSolid::advanceTimestep(double& dt)
 
 NonlinearSolid::~NonlinearSolid() {}
 
-void NonlinearSolid::defineInputFileSchema(axom::inlet::Table& schema_creator)
+void NonlinearSolid::defineInputFileSchema(axom::inlet::Table& table)
 {
-  auto table = schema_creator.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
+  auto table = table.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
 
   auto mesh_table = table->addTable("mesh_info", "File location and refinement info for the mesh");
   serac::mesh::defineInputFileSchema(*mesh_table);

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -214,24 +214,22 @@ NonlinearSolid::~NonlinearSolid() {}
 
 void NonlinearSolid::defineInputFileSchema(axom::inlet::Table& table)
 {
-  auto table = table.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
-
-  auto mesh_table = table->addTable("mesh_info", "File location and refinement info for the mesh");
+  auto mesh_table = table.addTable("mesh_info", "File location and refinement info for the mesh");
   serac::mesh::defineInputFileSchema(*mesh_table);
 
   // Polynomial interpolation order
-  table->addInt("order", "Order degree of the finite elements.")->defaultValue(1);
+  table.addInt("order", "Order degree of the finite elements.")->defaultValue(1);
 
   // neo-Hookean material parameters
-  table->addDouble("mu", "Shear modulus in the Neo-Hookean hyperelastic model.")->defaultValue(0.25);
-  table->addDouble("K", "Bulk modulus in the Neo-Hookean hyperelastic model.")->defaultValue(5.0);
+  table.addDouble("mu", "Shear modulus in the Neo-Hookean hyperelastic model.")->defaultValue(0.25);
+  table.addDouble("K", "Bulk modulus in the Neo-Hookean hyperelastic model.")->defaultValue(5.0);
 
   // loading parameters
-  table->addDouble("tx", "Cantilever tip traction in the x direction.")->defaultValue(0.0);
-  table->addDouble("ty", "Cantilever tip traction in the y direction.")->defaultValue(1.0e-3);
-  table->addDouble("tz", "Cantilever tip traction in the z direction.")->defaultValue(0.0);
+  table.addDouble("tx", "Cantilever tip traction in the x direction.")->defaultValue(0.0);
+  table.addDouble("ty", "Cantilever tip traction in the y direction.")->defaultValue(1.0e-3);
+  table.addDouble("tz", "Cantilever tip traction in the z direction.")->defaultValue(0.0);
 
-  auto solver_table = table->addTable("solver", "Linear and Nonlinear Solver Parameters.");
+  auto solver_table = table.addTable("solver", "Linear and Nonlinear Solver Parameters.");
   serac::EquationSolver::defineInputFileSchema(*solver_table);
 }
 

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -213,10 +213,14 @@ void NonlinearSolid::defineInputFileSchema(axom::inlet::Table& table)
   table.addDouble("mu", "Shear modulus in the Neo-Hookean hyperelastic model.")->defaultValue(0.25);
   table.addDouble("K", "Bulk modulus in the Neo-Hookean hyperelastic model.")->defaultValue(5.0);
 
+  auto traction_table = table.addTable("traction", "Cantilever tip traction vector");
+
   // loading parameters
-  table.addDouble("tx", "Cantilever tip traction in the x direction.")->defaultValue(0.0);
-  table.addDouble("ty", "Cantilever tip traction in the y direction.")->defaultValue(1.0e-3);
-  table.addDouble("tz", "Cantilever tip traction in the z direction.")->defaultValue(0.0);
+  input::defineVectorInputFileSchema(*traction_table);
+
+  traction_table->getField("x")->defaultValue(0.0);
+  traction_table->getField("y")->defaultValue(1.0e-3);
+  traction_table->getField("z")->defaultValue(0.0);
 
   auto solver_table = table.addTable("solver", "Linear and Nonlinear Solver Parameters.");
   serac::EquationSolver::defineInputFileSchema(*solver_table);

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -212,12 +212,12 @@ void NonlinearSolid::advanceTimestep(double& dt)
 
 NonlinearSolid::~NonlinearSolid() {}
 
-void NonlinearSolid::defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCreator> schema_creator)
+void NonlinearSolid::defineInputFileSchema(axom::inlet::Table& schema_creator)
 {
-  auto table = schema_creator->addTable("nonlinear_solid", "Finite deformation solid mechanics module");
+  auto table = schema_creator.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
 
   auto mesh_table = table->addTable("mesh_info", "File location and refinement info for the mesh");
-  serac::mesh::defineInputFileSchema(mesh_table);
+  serac::mesh::defineInputFileSchema(*mesh_table);
 
   // Polynomial interpolation order
   table->addInt("order", "Order degree of the finite elements.")->defaultValue(1);
@@ -232,15 +232,14 @@ void NonlinearSolid::defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCr
   table->addDouble("tz", "Cantilever tip traction in the z direction.")->defaultValue(0.0);
 
   auto solver_table = table->addTable("solver", "Linear and Nonlinear Solver Parameters.");
-  serac::EquationSolver::defineInputFileSchema(solver_table);
+  serac::EquationSolver::defineInputFileSchema(*solver_table);
 }
 
 }  // namespace serac
 
 using serac::NonlinearSolid;
 
-template <>
-NonlinearSolid from_inlet<NonlinearSolid>(axom::inlet::Table& base)
+NonlinearSolid FromInlet<NonlinearSolid>::operator()(axom::inlet::Table& base)
 {
   auto           mesh = base["mesh_info"].get<std::shared_ptr<mfem::ParMesh>>();
   NonlinearSolid solid_solver(base["order"], mesh);

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -37,6 +37,8 @@ public:
    */
   NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh);
 
+  NonlinearSolid(NonlinearSolid&& other) = default;
+
   /**
    * @brief Set displacement boundary conditions
    *

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -47,6 +47,26 @@ public:
   };
 
   /**
+   * @brief Stores all information held in the input file that
+   * is used to configure the solver
+   */
+  struct InputInfo {
+    /**
+     * @brief Input file parameters specific to this class
+     *
+     * @param[in] table Inlet's SchemaCreator that input files will be added to
+     **/
+    static void defineInputFileSchema(axom::inlet::Table& table);
+
+    // The order of the field
+    int              order;
+    SolverParameters solver_params;
+    // Lame parameters
+    double mu;
+    double K;
+  };
+
+  /**
    * @brief Construct a new Nonlinear Solid Solver object
    *
    * @param[in] order The order of the displacement field
@@ -55,7 +75,13 @@ public:
    */
   NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverParameters& params);
 
-  NonlinearSolid(NonlinearSolid&& other) = default;
+  /**
+   * @brief Construct a new Nonlinear Solid Solver object
+   *
+   * @param[in] mesh The MFEM parallel mesh to solve on
+   * @param[in] info The solver information parsed from the input file
+   */
+  NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const InputInfo& info);
 
   /**
    * @brief Set displacement boundary conditions
@@ -145,13 +171,6 @@ public:
    */
   virtual ~NonlinearSolid();
 
-  /**
-   * @brief Input file parameters specific to this class
-   *
-   * @param[in] table Inlet's SchemaCreator that input files will be added too
-   **/
-  static void defineInputFileSchema(axom::inlet::Table& table);
-
 protected:
   /**
    * @brief Velocity field
@@ -212,8 +231,8 @@ protected:
 }  // namespace serac
 
 template <>
-struct FromInlet<serac::NonlinearSolid> {
-  serac::NonlinearSolid operator()(axom::inlet::Table& base);
+struct FromInlet<serac::NonlinearSolid::InputInfo> {
+  serac::NonlinearSolid::InputInfo operator()(axom::inlet::Table& base);
 };
 
 #endif

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -140,7 +140,7 @@ public:
    *
    * @param[in] schema_creator Inlet's SchemaCreator that input files will be added too
    **/
-  static void defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCreator> schema_creator);
+  static void defineInputFileSchema(axom::inlet::Table& schema_creator);
 
 protected:
   /**
@@ -210,5 +210,10 @@ protected:
 };
 
 }  // namespace serac
+
+template <>
+struct FromInlet<serac::NonlinearSolid> {
+  serac::NonlinearSolid operator()(axom::inlet::Table& base);
+};
 
 #endif

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -138,9 +138,9 @@ public:
   /**
    * @brief Input file parameters specific to this class
    *
-   * @param[in] schema_creator Inlet's SchemaCreator that input files will be added too
+   * @param[in] table Inlet's SchemaCreator that input files will be added too
    **/
-  static void defineInputFileSchema(axom::inlet::Table& schema_creator);
+  static void defineInputFileSchema(axom::inlet::Table& table);
 
 protected:
   /**

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -206,7 +206,6 @@ IterativeSolverParameters FromInlet<IterativeSolverParameters>::operator()(axom:
     serac::logger::flush();
     std::string msg = fmt::format("Unknown Linear solver type given: {0}", solver_type);
     SLIC_ERROR(msg);
-    serac::exitGracefully(true);
   }
   return params;
 }

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -144,16 +144,18 @@ mfem::Operator& EquationSolver::SuperLUNonlinearOperatorWrapper::GetGradient(con
   return *superlu_grad_mat_;
 }
 
-void EquationSolver::defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCreator> schema_creator)
+void EquationSolver::defineInputFileSchema(axom::inlet::Table& schema_creator)
 {
-  auto nonlinear_table = schema_creator->addTable("nonlinear", "Newton Equation Solver Parameters")->required(true);
+  auto nonlinear_table = schema_creator.addTable("nonlinear", "Newton Equation Solver Parameters");
+  nonlinear_table->required(false);
   nonlinear_table->addDouble("rel_tol", "Relative tolerance for the Newton solve.")->defaultValue(1.0e-2);
   nonlinear_table->addDouble("abs_tol", "Absolute tolerance for the Newton solve.")->defaultValue(1.0e-4);
   nonlinear_table->addInt("max_iter", "Maximum iterations for the Newton solve.")->defaultValue(500);
   nonlinear_table->addInt("print_level", "Nonlinear print level.")->defaultValue(0);
   nonlinear_table->addString("solver_type", "Not currently used.")->defaultValue("");
 
-  auto linear_table = schema_creator->addTable("linear", "Linear Equation Solver Parameters")->required(true);
+  auto linear_table = schema_creator.addTable("linear", "Linear Equation Solver Parameters");
+  linear_table->required(false);
   linear_table->addDouble("rel_tol", "Relative tolerance for the linear solve.")->defaultValue(1.0e-6);
   linear_table->addDouble("abs_tol", "Absolute tolerance for the linear solve.")->defaultValue(1.0e-8);
   linear_table->addInt("max_iter", "Maximum iterations for the linear solve.")->defaultValue(5000);
@@ -167,8 +169,7 @@ using serac::EquationSolver;
 using serac::LinearSolverParameters;
 using serac::NonlinearSolverParameters;
 
-template <>
-LinearSolverParameters from_inlet<LinearSolverParameters>(axom::inlet::Table& base)
+LinearSolverParameters FromInlet<LinearSolverParameters>::operator()(axom::inlet::Table& base)
 {
   LinearSolverParameters params;
   params.rel_tol          = base["rel_tol"];
@@ -191,8 +192,7 @@ LinearSolverParameters from_inlet<LinearSolverParameters>(axom::inlet::Table& ba
   return params;
 }
 
-template <>
-NonlinearSolverParameters from_inlet<NonlinearSolverParameters>(axom::inlet::Table& base)
+NonlinearSolverParameters FromInlet<NonlinearSolverParameters>::operator()(axom::inlet::Table& base)
 {
   NonlinearSolverParameters params;
   params.rel_tol     = base["rel_tol"];
@@ -202,8 +202,7 @@ NonlinearSolverParameters from_inlet<NonlinearSolverParameters>(axom::inlet::Tab
   return params;
 }
 
-template <>
-EquationSolver from_inlet<EquationSolver>(axom::inlet::Table& base)
+EquationSolver FromInlet<EquationSolver>::operator()(axom::inlet::Table& base)
 {
   auto lin = base["linear"].get<LinearSolverParameters>();
   if (base.hasTable("nonlinear")) {

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -144,9 +144,9 @@ mfem::Operator& EquationSolver::SuperLUNonlinearOperatorWrapper::GetGradient(con
   return *superlu_grad_mat_;
 }
 
-void EquationSolver::defineInputFileSchema(axom::inlet::Table& schema_creator)
+void EquationSolver::defineInputFileSchema(axom::inlet::Table& table)
 {
-  auto nonlinear_table = schema_creator.addTable("nonlinear", "Newton Equation Solver Parameters");
+  auto nonlinear_table = table.addTable("nonlinear", "Newton Equation Solver Parameters");
   nonlinear_table->required(false);
   nonlinear_table->addDouble("rel_tol", "Relative tolerance for the Newton solve.")->defaultValue(1.0e-2);
   nonlinear_table->addDouble("abs_tol", "Absolute tolerance for the Newton solve.")->defaultValue(1.0e-4);
@@ -154,7 +154,7 @@ void EquationSolver::defineInputFileSchema(axom::inlet::Table& schema_creator)
   nonlinear_table->addInt("print_level", "Nonlinear print level.")->defaultValue(0);
   nonlinear_table->addString("solver_type", "Not currently used.")->defaultValue("");
 
-  auto linear_table = schema_creator.addTable("linear", "Linear Equation Solver Parameters");
+  auto linear_table = table.addTable("linear", "Linear Equation Solver Parameters");
   linear_table->required(false);
   linear_table->addDouble("rel_tol", "Relative tolerance for the linear solve.")->defaultValue(1.0e-6);
   linear_table->addDouble("abs_tol", "Absolute tolerance for the linear solve.")->defaultValue(1.0e-8);

--- a/src/physics/utilities/equation_solver.hpp
+++ b/src/physics/utilities/equation_solver.hpp
@@ -102,7 +102,7 @@ public:
   /**
    * Input file parameters specific to this class
    **/
-  static void defineInputFileSchema(axom::inlet::Table& schema_creator);
+  static void defineInputFileSchema(axom::inlet::Table& table);
 
 private:
   /**

--- a/src/physics/utilities/equation_solver.hpp
+++ b/src/physics/utilities/equation_solver.hpp
@@ -102,7 +102,7 @@ public:
   /**
    * Input file parameters specific to this class
    **/
-  static void defineInputFileSchema(std::shared_ptr<axom::inlet::SchemaCreator> schema_creator);
+  static void defineInputFileSchema(axom::inlet::Table& schema_creator);
 
 private:
   /**
@@ -199,5 +199,22 @@ private:
 };
 
 }  // namespace serac
+
+// Prototype the specialization
+
+template <>
+struct FromInlet<serac::LinearSolverParameters> {
+  serac::LinearSolverParameters operator()(axom::inlet::Table& base);
+};
+
+template <>
+struct FromInlet<serac::NonlinearSolverParameters> {
+  serac::NonlinearSolverParameters operator()(axom::inlet::Table& base);
+};
+
+template <>
+struct FromInlet<serac::EquationSolver> {
+  serac::EquationSolver operator()(axom::inlet::Table& base);
+};
 
 #endif


### PR DESCRIPTION
This PR bumps the axom version (and SuperLU for some reason - it may be worth trying to re-enable the direct solver tests).

It also allows the driver to be simplified by delegating the reading of data to struct-specific template specializations.

To solve the issue we discussed without waiting on an Axom PR, a line was added to the driver to add the input file path to the Inlet structure.