### PR TITLE
hotfix: explicit dependency on mfem

### DIFF
--- a/src/infrastructure/CMakeLists.txt
+++ b/src/infrastructure/CMakeLists.txt
@@ -22,7 +22,7 @@ set(infrastructure_sources
     terminator.cpp
     )
 
-set(infrastructure_depends axom fmt mpi cli11)
+set(infrastructure_depends axom fmt mpi cli11 mfem)
 blt_list_append( TO infrastructure_depends ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
 blt_add_library(


### PR DESCRIPTION
Having the code that reads in a vector from Inlet in the infrastructure directory as part of input.cpp/input.hpp required an explicit dependency on MFEM - not sure why this didn't cause any problems until the full TPL builds.