### PR TITLE
Unambiguous ownership of FiniteElementState objects

### DIFF
--- a/src/physics/base_physics.cpp
+++ b/src/physics/base_physics.cpp
@@ -26,7 +26,6 @@ BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh)
 BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh, int n, int p) : BasePhysics(mesh)
 {
   order_ = p;
-  // state_.resize(n);
   gf_initialized_.assign(n, false);
 }
 

--- a/src/physics/base_physics.cpp
+++ b/src/physics/base_physics.cpp
@@ -26,7 +26,7 @@ BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh)
 BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh, int n, int p) : BasePhysics(mesh)
 {
   order_ = p;
-  state_.resize(n);
+  // state_.resize(n);
   gf_initialized_.assign(n, false);
 }
 
@@ -40,17 +40,22 @@ void BasePhysics::setState(const std::vector<serac::GeneralCoefficient>& state_c
   SLIC_ASSERT_MSG(state_coef.size() == state_.size(), "State and coefficient bundles not the same size.");
 
   for (unsigned int i = 0; i < state_coef.size(); ++i) {
-    state_[i]->project(state_coef[i]);
+    state_[i].get().project(state_coef[i]);
   }
 }
 
-void BasePhysics::setState(const std::vector<std::shared_ptr<serac::FiniteElementState> >& state)
+void BasePhysics::setState(std::vector<serac::FiniteElementState>&& state)
 {
   SLIC_ASSERT_MSG(state.size() > 0, "State vector array of size 0.");
-  state_ = state;
+  // To avoid making a shallow copy of the references, we move individually
+  for (std::size_t i = 0; i < state.size(); i++) {
+    // Assigning to the FiniteElementState being referenced,
+    // not the reference itself
+    state_[i].get() = std::move(state[i]);
+  }
 }
 
-std::vector<std::shared_ptr<serac::FiniteElementState> > BasePhysics::getState() const { return state_; }
+const std::vector<std::reference_wrapper<serac::FiniteElementState> >& BasePhysics::getState() const { return state_; }
 
 void BasePhysics::setTimestepper(const serac::TimestepMethod timestepper)
 {
@@ -109,20 +114,20 @@ void BasePhysics::initializeOutput(const serac::OutputType output_type, const st
 
   switch (output_type_) {
     case serac::OutputType::VisIt: {
-      dc_ = std::make_unique<mfem::VisItDataCollection>(root_name_, &state_.front()->mesh());
-
-      for (const auto& state : state_) {
-        dc_->RegisterField(state->name(), &state->gridFunc());
+      dc_ = std::make_unique<mfem::VisItDataCollection>(root_name_, &state_.front().get().mesh());
+      // Implicitly convert from ref_wrapper
+      for (FiniteElementState& state : state_) {
+        dc_->RegisterField(state.name(), &state.gridFunc());
       }
       break;
     }
 
     case serac::OutputType::ParaView: {
-      auto pv_dc               = std::make_unique<mfem::ParaViewDataCollection>(root_name_, &state_.front()->mesh());
+      auto pv_dc = std::make_unique<mfem::ParaViewDataCollection>(root_name_, &state_.front().get().mesh());
       int  max_order_in_fields = 0;
-      for (const auto& state : state_) {
-        pv_dc->RegisterField(state->name(), &state->gridFunc());
-        max_order_in_fields = std::max(max_order_in_fields, state->space().GetOrder(0));
+      for (FiniteElementState& state : state_) {
+        pv_dc->RegisterField(state.name(), &state.gridFunc());
+        max_order_in_fields = std::max(max_order_in_fields, state.space().GetOrder(0));
       }
       pv_dc->SetLevelsOfDetail(max_order_in_fields);
       pv_dc->SetHighOrderOutput(true);
@@ -163,13 +168,13 @@ void BasePhysics::outputState() const
       std::string   mesh_name = fmt::format("{0}-mesh.{1:0>6}.{2:0>6}", root_name_, cycle_, mpi_rank_);
       std::ofstream omesh(mesh_name);
       omesh.precision(FLOAT_PRECISION_);
-      state_.front()->mesh().Print(omesh);
+      state_.front().get().mesh().Print(omesh);
 
-      for (auto& state : state_) {
-        std::string   sol_name = fmt::format("{0}-{1}.{2:0>6}.{3:0>6}", root_name_, state->name(), cycle_, mpi_rank_);
+      for (FiniteElementState& state : state_) {
+        std::string   sol_name = fmt::format("{0}-{1}.{2:0>6}.{3:0>6}", root_name_, state.name(), cycle_, mpi_rank_);
         std::ofstream osol(sol_name);
         osol.precision(FLOAT_PRECISION_);
-        state->gridFunc().Save(osol);
+        state.gridFunc().Save(osol);
       }
       break;
     }

--- a/src/physics/base_physics.hpp
+++ b/src/physics/base_physics.hpp
@@ -13,6 +13,7 @@
 #ifndef BASE_PHYSICS
 #define BASE_PHYSICS
 
+#include <functional>
 #include <memory>
 
 #include "mfem.hpp"
@@ -67,14 +68,14 @@ public:
    *
    * @param[in] state A vector of finite element states to initialze the solver
    */
-  virtual void setState(const std::vector<std::shared_ptr<serac::FiniteElementState> >& state);
+  virtual void setState(std::vector<serac::FiniteElementState>&& state);
 
   /**
    * @brief Get the list of state variable grid functions
    *
    * @return the current vector of finite element states
    */
-  virtual std::vector<std::shared_ptr<serac::FiniteElementState> > getState() const;
+  virtual const std::vector<std::reference_wrapper<serac::FiniteElementState> >& getState() const;
 
   /**
    * @brief Set the time integration method
@@ -157,7 +158,7 @@ protected:
   /**
    * @brief List of finite element data structures
    */
-  std::vector<std::shared_ptr<serac::FiniteElementState> > state_;
+  std::vector<std::reference_wrapper<serac::FiniteElementState> > state_;
 
   /**
    * @brief Block vector storage of the true state

--- a/src/physics/base_physics.hpp
+++ b/src/physics/base_physics.hpp
@@ -67,6 +67,9 @@ public:
    * @brief Set the state variables from an existing grid function
    *
    * @param[in] state A vector of finite element states to initialze the solver
+   * @note This will move from each element of the vector, so the vector cannot
+   * be used in the calling scope after this function is called (as it has been
+   * moved from)
    */
   virtual void setState(std::vector<serac::FiniteElementState>&& state);
 

--- a/src/physics/elasticity.cpp
+++ b/src/physics/elasticity.cpp
@@ -14,14 +14,14 @@ namespace serac {
 constexpr int NUM_FIELDS = 1;
 
 Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverParameters& params)
-    : BasePhysics(mesh, NUM_FIELDS, order),
-      displacement_(std::make_shared<FiniteElementState>(*mesh, FEStateOptions{.order = order, .name = "displacement"}))
+    : BasePhysics(mesh, NUM_FIELDS, order), displacement_(*mesh, FEStateOptions{.order = order, .name = "displacement"})
 {
   mesh->EnsureNodes();
-  state_[0] = displacement_;
+  // state_[0] = displacement_;
+  state_.push_back(displacement_);
 
   // If the user wants the AMG preconditioner with a linear solver, set the pfes to be the displacement
-  const auto& augmented_params = augmentAMGWithSpace(params, displacement_->space());
+  const auto& augmented_params = augmentAMGWithSpace(params, displacement_.space());
 
   K_inv_ = EquationSolver(mesh->GetComm(), augmented_params);
   setTimestepper(TimestepMethod::QuasiStatic);
@@ -30,7 +30,7 @@ Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const Lin
 void Elasticity::setDisplacementBCs(const std::set<int>&                     disp_bdr,
                                     std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef, const int component)
 {
-  bcs_.addEssential(disp_bdr, disp_bdr_coef, *displacement_, component);
+  bcs_.addEssential(disp_bdr, disp_bdr_coef, displacement_, component);
 }
 
 void Elasticity::setTractionBCs(const std::set<int>& trac_bdr, std::shared_ptr<mfem::VectorCoefficient> trac_bdr_coef,
@@ -53,7 +53,7 @@ void Elasticity::completeSetup()
   SLIC_ASSERT_MSG(lambda_ != nullptr, "Lame lambda not set in ElasticitySolver!");
 
   // Define the parallel bilinear form
-  K_form_ = displacement_->createOnSpace<mfem::ParBilinearForm>();
+  K_form_ = displacement_.createOnSpace<mfem::ParBilinearForm>();
 
   // Add the elastic integrator
   K_form_->AddDomainIntegrator(new mfem::ElasticityIntegrator(*lambda_, *mu_));
@@ -62,7 +62,7 @@ void Elasticity::completeSetup()
 
   // Define the parallel linear form
 
-  l_form_ = displacement_->createOnSpace<mfem::ParLinearForm>();
+  l_form_ = displacement_.createOnSpace<mfem::ParLinearForm>();
 
   // Add the traction integrator
   if (bcs_.naturals().size() > 0) {
@@ -73,7 +73,7 @@ void Elasticity::completeSetup()
     l_form_->Assemble();
     rhs_.reset(l_form_->ParallelAssemble());
   } else {
-    rhs_  = displacement_->createOnSpace<mfem::HypreParVector>();
+    rhs_  = displacement_.createOnSpace<mfem::HypreParVector>();
     *rhs_ = 0.0;
   }
 
@@ -86,17 +86,17 @@ void Elasticity::completeSetup()
   }
 
   // Initialize the eliminate BC RHS vector
-  bc_rhs_  = displacement_->createOnSpace<mfem::HypreParVector>();
+  bc_rhs_  = displacement_.createOnSpace<mfem::HypreParVector>();
   *bc_rhs_ = 0.0;
 
   // Initialize the true vector
-  displacement_->initializeTrueVec();
+  displacement_.initializeTrueVec();
 }
 
 void Elasticity::advanceTimestep(double&)
 {
   // Initialize the true vector
-  displacement_->initializeTrueVec();
+  displacement_.initializeTrueVec();
 
   if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
     QuasiStaticSolve();
@@ -106,7 +106,7 @@ void Elasticity::advanceTimestep(double&)
   }
 
   // Distribute the shared DOFs
-  displacement_->distributeSharedDofs();
+  displacement_.distributeSharedDofs();
   cycle_ += 1;
 }
 
@@ -117,12 +117,12 @@ void Elasticity::QuasiStaticSolve()
   *bc_rhs_ = *rhs_;
   for (auto& bc : bcs_.essentials()) {
     bool should_be_scalar = false;
-    bc.apply(*K_mat_, *bc_rhs_, *displacement_, time_, should_be_scalar);
+    bc.apply(*K_mat_, *bc_rhs_, displacement_, time_, should_be_scalar);
   }
 
   K_inv_.SetOperator(*K_mat_);
 
-  K_inv_.Mult(*bc_rhs_, displacement_->trueVec());
+  K_inv_.Mult(*bc_rhs_, displacement_.trueVec());
 }
 
 Elasticity::~Elasticity() {}

--- a/src/physics/elasticity.cpp
+++ b/src/physics/elasticity.cpp
@@ -17,7 +17,6 @@ Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const Lin
     : BasePhysics(mesh, NUM_FIELDS, order), displacement_(*mesh, FEStateOptions{.order = order, .name = "displacement"})
 {
   mesh->EnsureNodes();
-  // state_[0] = displacement_;
   state_.push_back(displacement_);
 
   // If the user wants the AMG preconditioner with a linear solver, set the pfes to be the displacement

--- a/src/physics/elasticity.hpp
+++ b/src/physics/elasticity.hpp
@@ -96,7 +96,7 @@ protected:
   /**
    * @brief Displacement field
    */
-  std::shared_ptr<serac::FiniteElementState> displacement_;
+  serac::FiniteElementState displacement_;
 
   /**
    * @brief Stiffness bilinear form

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -17,14 +17,16 @@ constexpr int NUM_FIELDS = 2;
 
 NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverParameters& params)
     : BasePhysics(mesh, NUM_FIELDS, order),
-      velocity_(std::make_shared<FiniteElementState>(*mesh, FEStateOptions{.order = order, .name = "velocity"})),
-      displacement_(std::make_shared<FiniteElementState>(*mesh, FEStateOptions{.order = order, .name = "displacement"}))
+      velocity_(*mesh, FEStateOptions{.order = order, .name = "velocity"}),
+      displacement_(*mesh, FEStateOptions{.order = order, .name = "displacement"})
 {
-  state_[0] = velocity_;
-  state_[1] = displacement_;
+  // state_[0] = velocity_;
+  // state_[1] = displacement_;
+  state_.push_back(velocity_);
+  state_.push_back(displacement_);
 
   // Initialize the mesh node pointers
-  reference_nodes_ = displacement_->createOnSpace<mfem::ParGridFunction>();
+  reference_nodes_ = displacement_.createOnSpace<mfem::ParGridFunction>();
   mesh->GetNodes(*reference_nodes_);
   mesh->NewNodes(*reference_nodes_);
 
@@ -32,21 +34,21 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
 
   // Initialize the true DOF vector
   mfem::Array<int> true_offset(NUM_FIELDS + 1);
-  int              true_size = velocity_->space().TrueVSize();
+  int              true_size = velocity_.space().TrueVSize();
   true_offset[0]             = 0;
   true_offset[1]             = true_size;
   true_offset[2]             = 2 * true_size;
   block_                     = std::make_unique<mfem::BlockVector>(true_offset);
 
-  block_->GetBlockView(1, displacement_->trueVec());
-  displacement_->trueVec() = 0.0;
+  block_->GetBlockView(1, displacement_.trueVec());
+  displacement_.trueVec() = 0.0;
 
-  block_->GetBlockView(0, velocity_->trueVec());
-  velocity_->trueVec() = 0.0;
+  block_->GetBlockView(0, velocity_.trueVec());
+  velocity_.trueVec() = 0.0;
 
   const auto& lin_params = params.H_lin_params;
   // If the user wants the AMG preconditioner with a linear solver, set the pfes to be the displacement
-  const auto& augmented_params = augmentAMGWithSpace(lin_params, displacement_->space());
+  const auto& augmented_params = augmentAMGWithSpace(lin_params, displacement_.space());
 
   nonlin_solver_ = EquationSolver(mesh->GetComm(), augmented_params, params.H_nonlin_params);
   // Check for dynamic mode
@@ -69,13 +71,13 @@ NonlinearSolid::NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const Nonlin
 void NonlinearSolid::setDisplacementBCs(const std::set<int>&                     disp_bdr,
                                         std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef)
 {
-  bcs_.addEssential(disp_bdr, disp_bdr_coef, *displacement_, -1);
+  bcs_.addEssential(disp_bdr, disp_bdr_coef, displacement_, -1);
 }
 
 void NonlinearSolid::setDisplacementBCs(const std::set<int>& disp_bdr, std::shared_ptr<mfem::Coefficient> disp_bdr_coef,
                                         int component)
 {
-  bcs_.addEssential(disp_bdr, disp_bdr_coef, *displacement_, component);
+  bcs_.addEssential(disp_bdr, disp_bdr_coef, displacement_, component);
 }
 
 void NonlinearSolid::setTractionBCs(const std::set<int>&                     trac_bdr,
@@ -94,21 +96,21 @@ void NonlinearSolid::setViscosity(std::unique_ptr<mfem::Coefficient>&& visc_coef
 void NonlinearSolid::setDisplacement(mfem::VectorCoefficient& disp_state)
 {
   disp_state.SetTime(time_);
-  displacement_->project(disp_state);
+  displacement_.project(disp_state);
   gf_initialized_[1] = true;
 }
 
 void NonlinearSolid::setVelocity(mfem::VectorCoefficient& velo_state)
 {
   velo_state.SetTime(time_);
-  velocity_->project(velo_state);
+  velocity_.project(velo_state);
   gf_initialized_[0] = true;
 }
 
 void NonlinearSolid::completeSetup()
 {
   // Define the nonlinear form
-  auto H_form = displacement_->createOnSpace<mfem::ParNonlinearForm>();
+  auto H_form = displacement_.createOnSpace<mfem::ParNonlinearForm>();
 
   // Add the hyperelastic integrator
   if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
@@ -124,12 +126,12 @@ void NonlinearSolid::completeSetup()
   }
 
   // Build the dof array lookup tables
-  displacement_->space().BuildDofToArrays();
+  displacement_.space().BuildDofToArrays();
 
   // Project the essential boundary coefficients
   for (auto& bc : bcs_.essentials()) {
     // Project the coefficient
-    bc.project(*displacement_);
+    bc.project(displacement_);
   }
 
   // The abstract mass bilinear form
@@ -143,13 +145,13 @@ void NonlinearSolid::completeSetup()
     const double              ref_density = 1.0;  // density in the reference configuration
     mfem::ConstantCoefficient rho0(ref_density);
 
-    M_form = displacement_->createOnSpace<mfem::ParBilinearForm>();
+    M_form = displacement_.createOnSpace<mfem::ParBilinearForm>();
 
     M_form->AddDomainIntegrator(new mfem::VectorMassIntegrator(rho0));
     M_form->Assemble(0);
     M_form->Finalize(0);
 
-    S_form = displacement_->createOnSpace<mfem::ParBilinearForm>();
+    S_form = displacement_.createOnSpace<mfem::ParBilinearForm>();
     S_form->AddDomainIntegrator(new mfem::VectorDiffusionIntegrator(*viscosity_));
     S_form->Assemble(0);
     S_form->Finalize(0);
@@ -172,15 +174,15 @@ void NonlinearSolid::completeSetup()
 void NonlinearSolid::quasiStaticSolve()
 {
   mfem::Vector zero;
-  nonlin_solver_.Mult(zero, displacement_->trueVec());
+  nonlin_solver_.Mult(zero, displacement_.trueVec());
 }
 
 // Advance the timestep
 void NonlinearSolid::advanceTimestep(double& dt)
 {
   // Initialize the true vector
-  velocity_->initializeTrueVec();
-  displacement_->initializeTrueVec();
+  velocity_.initializeTrueVec();
+  displacement_.initializeTrueVec();
 
   // Set the mesh nodes to the reference configuration
   mesh_->NewNodes(*reference_nodes_);
@@ -192,11 +194,11 @@ void NonlinearSolid::advanceTimestep(double& dt)
   }
 
   // Distribute the shared DOFs
-  velocity_->distributeSharedDofs();
-  displacement_->distributeSharedDofs();
+  velocity_.distributeSharedDofs();
+  displacement_.distributeSharedDofs();
 
   // Update the mesh with the new deformed nodes
-  deformed_nodes_->Set(1.0, displacement_->gridFunc());
+  deformed_nodes_->Set(1.0, displacement_.gridFunc());
 
   if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
     deformed_nodes_->Add(1.0, *reference_nodes_);

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -20,8 +20,6 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
       velocity_(*mesh, FEStateOptions{.order = order, .name = "velocity"}),
       displacement_(*mesh, FEStateOptions{.order = order, .name = "displacement"})
 {
-  // state_[0] = velocity_;
-  // state_[1] = displacement_;
   state_.push_back(velocity_);
   state_.push_back(displacement_);
 

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -145,14 +145,16 @@ public:
    *
    * @return The displacement state field
    */
-  std::shared_ptr<FiniteElementState> displacement() { return displacement_; };
+  const FiniteElementState& displacement() const { return displacement_; };
+  FiniteElementState&       displacement() { return displacement_; };
 
   /**
    * @brief Get the velocity state
    *
    * @return The velocity state field
    */
-  std::shared_ptr<FiniteElementState> velocity() { return velocity_; };
+  const FiniteElementState& velocity() const { return velocity_; };
+  FiniteElementState&       velocity() { return velocity_; };
 
   /**
    * @brief Complete the setup of all of the internal MFEM objects and prepare for timestepping
@@ -175,12 +177,12 @@ protected:
   /**
    * @brief Velocity field
    */
-  std::shared_ptr<FiniteElementState> velocity_;
+  FiniteElementState velocity_;
 
   /**
    * @brief Displacement field
    */
-  std::shared_ptr<FiniteElementState> displacement_;
+  FiniteElementState displacement_;
 
   /**
    * @brief The quasi-static operator for use with the MFEM newton solvers

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -18,7 +18,6 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
           *mesh,
           FEStateOptions{.order = order, .space_dim = 1, .ordering = mfem::Ordering::byNODES, .name = "temperature"})
 {
-  // state_[0] = temperature_;
   state_.push_back(temperature_);
 
   // If it's just the single set of params for a quasistatic K solve...

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -14,11 +14,12 @@ constexpr int NUM_FIELDS = 1;
 
 ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverParameters& params)
     : BasePhysics(mesh, NUM_FIELDS, order),
-      temperature_(std::make_shared<FiniteElementState>(
+      temperature_(
           *mesh,
-          FEStateOptions{.order = order, .space_dim = 1, .ordering = mfem::Ordering::byNODES, .name = "temperature"}))
+          FEStateOptions{.order = order, .space_dim = 1, .ordering = mfem::Ordering::byNODES, .name = "temperature"})
 {
-  state_[0] = temperature_;
+  // state_[0] = temperature_;
+  state_.push_back(temperature_);
 
   // If it's just the single set of params for a quasistatic K solve...
   if (std::holds_alternative<LinearSolverParameters>(params)) {
@@ -40,14 +41,14 @@ void ThermalConduction::setTemperature(mfem::Coefficient& temp)
 {
   // Project the coefficient onto the grid function
   temp.SetTime(time_);
-  temperature_->project(temp);
+  temperature_.project(temp);
   gf_initialized_[0] = true;
 }
 
 void ThermalConduction::setTemperatureBCs(const std::set<int>&               temp_bdr,
                                           std::shared_ptr<mfem::Coefficient> temp_bdr_coef)
 {
-  bcs_.addEssential(temp_bdr, temp_bdr_coef, *temperature_);
+  bcs_.addEssential(temp_bdr, temp_bdr_coef, temperature_);
 }
 
 void ThermalConduction::setFluxBCs(const std::set<int>& flux_bdr, std::shared_ptr<mfem::Coefficient> flux_bdr_coef)
@@ -73,18 +74,18 @@ void ThermalConduction::completeSetup()
   SLIC_ASSERT_MSG(kappa_ != nullptr, "Conductivity not set in ThermalSolver!");
 
   // Add the domain diffusion integrator to the K form and assemble the matrix
-  K_form_ = temperature_->createOnSpace<mfem::ParBilinearForm>();
+  K_form_ = temperature_.createOnSpace<mfem::ParBilinearForm>();
   K_form_->AddDomainIntegrator(new mfem::DiffusionIntegrator(*kappa_));
   K_form_->Assemble(0);  // keep sparsity pattern of M and K the same
   K_form_->Finalize();
 
   // Add the body source to the RS if specified
-  l_form_ = temperature_->createOnSpace<mfem::ParLinearForm>();
+  l_form_ = temperature_.createOnSpace<mfem::ParLinearForm>();
   if (source_ != nullptr) {
     l_form_->AddDomainIntegrator(new mfem::DomainLFIntegrator(*source_));
     rhs_.reset(l_form_->ParallelAssemble());
   } else {
-    rhs_  = temperature_->createOnSpace<mfem::HypreParVector>();
+    rhs_  = temperature_.createOnSpace<mfem::HypreParVector>();
     *rhs_ = 0.0;
   }
 
@@ -97,15 +98,15 @@ void ThermalConduction::completeSetup()
   }
 
   // Initialize the eliminated BC RHS vector
-  bc_rhs_  = temperature_->createOnSpace<mfem::HypreParVector>();
+  bc_rhs_  = temperature_.createOnSpace<mfem::HypreParVector>();
   *bc_rhs_ = 0.0;
 
   // Initialize the true vector
-  temperature_->initializeTrueVec();
+  temperature_.initializeTrueVec();
 
   if (timestepper_ != serac::TimestepMethod::QuasiStatic) {
     // If dynamic, assemble the mass matrix
-    M_form_ = temperature_->createOnSpace<mfem::ParBilinearForm>();
+    M_form_ = temperature_.createOnSpace<mfem::ParBilinearForm>();
     M_form_->AddDomainIntegrator(new mfem::MassIntegrator());
     M_form_->Assemble(0);  // keep sparsity pattern of M and K the same
     M_form_->Finalize();
@@ -113,8 +114,7 @@ void ThermalConduction::completeSetup()
     M_mat_.reset(M_form_->ParallelAssemble());
 
     // Make the time integration operator and set the appropriate matrices
-    dyn_oper_ =
-        std::make_unique<DynamicConductionOperator>(temperature_->space(), *dyn_M_params_, *dyn_T_params_, bcs_);
+    dyn_oper_ = std::make_unique<DynamicConductionOperator>(temperature_.space(), *dyn_M_params_, *dyn_T_params_, bcs_);
     dyn_oper_->setMatrices(M_mat_.get(), K_mat_.get());
     dyn_oper_->setLoadVector(rhs_.get());
 
@@ -127,20 +127,20 @@ void ThermalConduction::quasiStaticSolve()
   // Apply the boundary conditions
   *bc_rhs_ = *rhs_;
   for (auto& bc : bcs_.essentials()) {
-    bc.apply(*K_mat_, *bc_rhs_, *temperature_, time_);
+    bc.apply(*K_mat_, *bc_rhs_, temperature_, time_);
   }
 
   K_inv_->linearSolver().iterative_mode = false;
   K_inv_->SetOperator(*K_mat_);
 
   // Perform the linear solve
-  K_inv_->Mult(*bc_rhs_, temperature_->trueVec());
+  K_inv_->Mult(*bc_rhs_, temperature_.trueVec());
 }
 
 void ThermalConduction::advanceTimestep(double& dt)
 {
   // Initialize the true vector
-  temperature_->initializeTrueVec();
+  temperature_.initializeTrueVec();
 
   if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
     quasiStaticSolve();
@@ -148,11 +148,11 @@ void ThermalConduction::advanceTimestep(double& dt)
     SLIC_ASSERT_MSG(gf_initialized_[0], "Thermal state not initialized!");
 
     // Step the time integrator
-    ode_solver_->Step(temperature_->trueVec(), time_, dt);
+    ode_solver_->Step(temperature_.trueVec(), time_, dt);
   }
 
   // Distribute the shared DOFs
-  temperature_->distributeSharedDofs();
+  temperature_.distributeSharedDofs();
   cycle_ += 1;
 }
 

--- a/src/physics/thermal_conduction.hpp
+++ b/src/physics/thermal_conduction.hpp
@@ -103,9 +103,10 @@ public:
   /**
    * @brief Get the temperature state
    *
-   * @return A pointer to the current temperature finite element state
+   * @return A reference to the current temperature finite element state
    */
-  std::shared_ptr<serac::FiniteElementState> temperature() { return temperature_; };
+  const serac::FiniteElementState& temperature() const { return temperature_; };
+  serac::FiniteElementState&       temperature() { return temperature_; };
 
   /**
    * @brief Complete the initialization and allocation of the data structures.
@@ -124,7 +125,7 @@ protected:
   /**
    * @brief The temperature finite element state
    */
-  std::shared_ptr<serac::FiniteElementState> temperature_;
+  serac::FiniteElementState temperature_;
 
   /**
    * @brief Mass bilinear form object

--- a/src/physics/thermal_solid.cpp
+++ b/src/physics/thermal_solid.cpp
@@ -18,15 +18,17 @@ ThermalSolid::ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh,
                            const NonlinearSolid::SolverParameters&    solid_params)
     : BasePhysics(mesh, NUM_FIELDS, order),
       therm_solver_(order, mesh, therm_params),
-      solid_solver_(order, mesh, solid_params)
+      solid_solver_(order, mesh, solid_params),
+      temperature_(therm_solver_.temperature()),
+      velocity_(solid_solver_.velocity()),
+      displacement_(solid_solver_.displacement())
 {
-  temperature_  = therm_solver_.temperature();
-  velocity_     = solid_solver_.velocity();
-  displacement_ = solid_solver_.displacement();
-
-  state_[0] = temperature_;
-  state_[1] = velocity_;
-  state_[2] = displacement_;
+  // state_[0] = therm_solver_.temperature();
+  // state_[1] = solid_solver_.velocity();
+  // state_[2] = solid_solver_.displacement();
+  state_.push_back(therm_solver_.temperature());
+  state_.push_back(solid_solver_.velocity());
+  state_.push_back(solid_solver_.displacement());
 
   coupling_ = serac::CouplingScheme::OperatorSplit;
 }

--- a/src/physics/thermal_solid.cpp
+++ b/src/physics/thermal_solid.cpp
@@ -23,9 +23,9 @@ ThermalSolid::ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh,
       velocity_(solid_solver_.velocity()),
       displacement_(solid_solver_.displacement())
 {
-  // state_[0] = therm_solver_.temperature();
-  // state_[1] = solid_solver_.velocity();
-  // state_[2] = solid_solver_.displacement();
+  // The temperature_, velocity_, displacement_ members are not currently used
+  // but presumably will be needed when further coupling schemes are implemented
+  // This calls the non-const version
   state_.push_back(therm_solver_.temperature());
   state_.push_back(solid_solver_.velocity());
   state_.push_back(solid_solver_.displacement());

--- a/src/physics/thermal_solid.hpp
+++ b/src/physics/thermal_solid.hpp
@@ -178,7 +178,7 @@ public:
   /**
    * @brief Get the temperature state
    *
-   * @return A pointer to the current temperature finite element state
+   * @return A reference to the current temperature finite element state
    */
   const serac::FiniteElementState& temperature() { return temperature_; };
 

--- a/src/physics/thermal_solid.hpp
+++ b/src/physics/thermal_solid.hpp
@@ -180,21 +180,21 @@ public:
    *
    * @return A pointer to the current temperature finite element state
    */
-  std::shared_ptr<serac::FiniteElementState> temperature() { return temperature_; };
+  const serac::FiniteElementState& temperature() { return temperature_; };
 
   /**
    * @brief Get the displacement state
    *
    * @return The displacement state field
    */
-  std::shared_ptr<serac::FiniteElementState> displacement() { return displacement_; };
+  const serac::FiniteElementState& displacement() { return displacement_; };
 
   /**
    * @brief Get the velocity state
    *
    * @return The velocity state field
    */
-  std::shared_ptr<serac::FiniteElementState> velocity() { return velocity_; };
+  const serac::FiniteElementState& velocity() { return velocity_; };
 
   /**
    * @brief Advance the timestep
@@ -210,21 +210,6 @@ public:
 
 protected:
   /**
-   * @brief The temperature finite element state
-   */
-  std::shared_ptr<serac::FiniteElementState> temperature_;
-
-  /**
-   * @brief The velocity finite element state
-   */
-  std::shared_ptr<serac::FiniteElementState> velocity_;
-
-  /**
-   * @brief The displacement finite element state
-   */
-  std::shared_ptr<serac::FiniteElementState> displacement_;
-
-  /**
    * @brief The single physics thermal solver
    */
   ThermalConduction therm_solver_;
@@ -233,6 +218,21 @@ protected:
    * @brief The single physics nonlinear solid solver
    */
   NonlinearSolid solid_solver_;
+
+  /**
+   * @brief The temperature finite element state
+   */
+  const serac::FiniteElementState& temperature_;
+
+  /**
+   * @brief The velocity finite element state
+   */
+  const serac::FiniteElementState& velocity_;
+
+  /**
+   * @brief The displacement finite element state
+   */
+  const serac::FiniteElementState& displacement_;
 
   /**
    * @brief The coupling strategy

--- a/src/physics/utilities/finite_element_state.hpp
+++ b/src/physics/utilities/finite_element_state.hpp
@@ -13,6 +13,7 @@
 #ifndef FINITE_ELEMENT_STATE
 #define FINITE_ELEMENT_STATE
 
+#include <functional>
 #include <memory>
 #include <optional>
 #include <type_traits>
@@ -81,7 +82,8 @@ public:
   /**
    * Returns a non-owning reference to the internal grid function
    */
-  mfem::ParGridFunction& gridFunc() { return *gf_; }
+  mfem::ParGridFunction&       gridFunc() { return *gf_; }
+  const mfem::ParGridFunction& gridFunc() const { return *gf_; }
 
   /**
    * Returns a non-owning reference to the internal mesh object
@@ -157,7 +159,8 @@ public:
   }
 
 private:
-  mfem::ParMesh&                                 mesh_;
+  // Allows for copy/move assignment
+  std::reference_wrapper<mfem::ParMesh>          mesh_;
   std::unique_ptr<mfem::FiniteElementCollection> coll_;
   mfem::ParFiniteElementSpace                    space_;
   std::unique_ptr<mfem::ParGridFunction>         gf_;

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -62,7 +62,7 @@ TEST(component_bc, qs_solve)
       }
   });
 
-  mfem::Array<int> ess_corner_bc_list = makeTrueEssList(solid_solver.displacement()->space(), zero_bc);
+  mfem::Array<int> ess_corner_bc_list = makeTrueEssList(solid_solver.displacement().space(), zero_bc);
 
   solid_solver.setTrueDofs(ess_corner_bc_list, disp_coef, 0);
 
@@ -87,7 +87,7 @@ TEST(component_bc, qs_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double x_norm = solid_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(0.08363646, x_norm, 0.0001);
 
@@ -162,7 +162,7 @@ TEST(component_bc, qs_attribute_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double x_norm = solid_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(0.03330115, x_norm, 0.0001);
 

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -98,8 +98,8 @@ TEST(dynamic_solver, dyn_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double v_norm = dyn_solver.velocity()->gridFunc().ComputeLpError(2.0, zerovec);
-  double x_norm = dyn_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double v_norm = dyn_solver.velocity().gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = dyn_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(12.86733, x_norm, 0.0001);
   EXPECT_NEAR(0.22298, v_norm, 0.0001);
@@ -169,8 +169,8 @@ TEST(dynamic_solver, dyn_direct_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double v_norm = dyn_solver.velocity()->gridFunc().ComputeLpError(2.0, zerovec);
-  double x_norm = dyn_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double v_norm = dyn_solver.velocity().gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = dyn_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(12.86733, x_norm, 0.0001);
   EXPECT_NEAR(0.22298, v_norm, 0.0001);
@@ -241,8 +241,8 @@ TEST(dynamic_solver, dyn_linesearch_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double v_norm = dyn_solver.velocity()->gridFunc().ComputeLpError(2.0, zerovec);
-  double x_norm = dyn_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double v_norm = dyn_solver.velocity().gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = dyn_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(12.86733, x_norm, 0.0001);
   EXPECT_NEAR(0.22298, v_norm, 0.0001);

--- a/tests/serac_linelastic_solver.cpp
+++ b/tests/serac_linelastic_solver.cpp
@@ -67,7 +67,7 @@ TEST(elastic_solver, static_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double x_norm = elas_solver.getState()[0]->gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = elas_solver.getState()[0].get().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(0.128065, x_norm, 0.00001);
 

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -80,7 +80,7 @@ TEST(nonlinear_solid_solver, qs_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double x_norm = solid_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(2.2309025, x_norm, 0.001);
 
@@ -143,7 +143,7 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double x_norm = solid_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(2.2309025, x_norm, 0.001);
 
@@ -219,7 +219,7 @@ TEST(nonlinear_solid_solver, qs_custom_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double x_norm = solid_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(2.2309025, x_norm, 0.001);
 

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -67,7 +67,7 @@ TEST(thermal_solver, static_solve)
 
   // Measure the L2 norm of the solution and check the value
   mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature()->gridFunc().ComputeLpError(2.0, zero);
+  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
   EXPECT_NEAR(2.02263, u_norm, 0.00001);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -116,7 +116,7 @@ TEST(thermal_solver, static_solve_multiple_bcs)
 
   // Measure the L2 norm of the solution and check the value
   mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature()->gridFunc().ComputeLpError(2.0, zero);
+  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
   EXPECT_NEAR(0.9168086318, u_norm, 0.00001);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -158,7 +158,7 @@ TEST(thermal_solver, static_solve_repeated_bcs)
 
   // Measure the L2 norm of the solution and check the value
   mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature()->gridFunc().ComputeLpError(2.0, zero);
+  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
   EXPECT_NEAR(2.56980679, u_norm, 0.00001);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -219,7 +219,7 @@ TEST(thermal_solver, dyn_exp_solve)
 
   // Measure the L2 norm of the solution and check the value
   mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature()->gridFunc().ComputeLpError(2.0, zero);
+  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
   EXPECT_NEAR(2.6493029, u_norm, 0.00001);
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -280,7 +280,7 @@ TEST(thermal_solver, dyn_imp_solve)
 
   // Measure the L2 norm of the solution and check the value
   mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature()->gridFunc().ComputeLpError(2.0, zero);
+  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
   EXPECT_NEAR(2.18201099, u_norm, 0.00001);
 
   MPI_Barrier(MPI_COMM_WORLD);

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -102,7 +102,7 @@ TEST(dynamic_solver, dyn_solve)
   double offset = 0.1;
   double scale  = 1.0;
 
-  auto temp_gf_coef = std::make_shared<mfem::GridFunctionCoefficient>(&ts_solver.temperature()->gridFunc());
+  auto temp_gf_coef = std::make_shared<mfem::GridFunctionCoefficient>(&ts_solver.temperature().gridFunc());
   auto visc_coef    = std::make_unique<TransformedScalarCoefficient>(
       temp_gf_coef, [offset, scale](const double x) { return scale * x + offset; });
   ts_solver.SetViscosity(std::move(visc_coef));
@@ -139,9 +139,9 @@ TEST(dynamic_solver, dyn_solve)
   zero = 0.0;
   mfem::VectorConstantCoefficient zerovec(zero);
 
-  double v_norm    = ts_solver.velocity()->gridFunc().ComputeLpError(2.0, zerovec);
-  double x_norm    = ts_solver.displacement()->gridFunc().ComputeLpError(2.0, zerovec);
-  double temp_norm = ts_solver.temperature()->gridFunc().ComputeLpError(2.0, zerovec);
+  double v_norm    = ts_solver.velocity().gridFunc().ComputeLpError(2.0, zerovec);
+  double x_norm    = ts_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
+  double temp_norm = ts_solver.temperature().gridFunc().ComputeLpError(2.0, zerovec);
 
   EXPECT_NEAR(13.28049, x_norm, 0.001);
   EXPECT_NEAR(0.005227, v_norm, 0.001);


### PR DESCRIPTION
Assigning ownership of the `FEState` objects to just the "base" solver allows them to be moved from the heap to the stack.
That is, instead of `ThermalSolid` sharing ownership of the temperature field with its `ThermalConduction` module, the conduction module has exclusive ownership and the `ThermalSolid` just holds a reference.  

The `BaseSolver::state_` vector now also holds non-owning references.  This adds a little bit of extra code to dereference the `reference_wrapper` with `get()`, but this is internal to the `BaseSolver` only.  Alternatively, a vector of raw pointers could be used, though the absence of ownership might not be as clear as with a vector of `ref_wrapper`s.