### PR TITLE
Re-enable direct solver tests

### DIFF
--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -107,10 +107,6 @@ TEST(dynamic_solver, dyn_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-/*
-TODO this test is disabled as it was failing CI due to a memory leak in MFEM.
-Once that leak is fixed, it should be re-enabled
-
 TEST(dynamic_solver, dyn_direct_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);
@@ -177,7 +173,6 @@ TEST(dynamic_solver, dyn_direct_solve)
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
-*/
 
 #ifdef MFEM_USE_SUNDIALS
 TEST(dynamic_solver, dyn_linesearch_solve)

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -87,10 +87,6 @@ TEST(nonlinear_solid_solver, qs_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-/*
-TODO this test is disabled as it was failing CI due to a memory leak in MFEM.
-Once that leak is fixed, it should be re-enabled
-
 TEST(nonlinear_solid_solver, qs_direct_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);
@@ -103,7 +99,7 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   int dim = pmesh->Dimension();
 
   // Define the solver object
-  NonlinearSolidSolver solid_solver(1, pmesh, default_quasistatic);
+  NonlinearSolid solid_solver(1, pmesh, default_quasistatic);
 
   std::set<int> ess_bdr = {1};
 
@@ -149,7 +145,6 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
-*/
 
 TEST(nonlinear_solid_solver, qs_custom_solve)
 {


### PR DESCRIPTION
In #248 we upgraded our SuperLU version to 6.1.1 from 5.4.0 - the memory safety issues that we were running into appear to have been resolved between those versions, so it should be safe to re-enable the direct solver tests.  I've ran the tests on a couple machines and none of them report any memory issues as they did previously.