### PR TITLE
Quiet the warning about unused parameters in the blockilu test

### DIFF
--- a/tests/mfem_ex9p_blockilu.cpp
+++ b/tests/mfem_ex9p_blockilu.cpp
@@ -745,7 +745,7 @@ double u0_function(const Vector& x)
 }
 
 // Inflow boundary condition (zero for the problems considered in this example)
-double inflow_function(const Vector& x)
+double inflow_function(const Vector&)
 {
   switch (problem) {
     case 0:


### PR DESCRIPTION
This quiets a compiler warning about unused variables. Related: should we upgrade warnings to errors in our build system?