### PR TITLE
Update Inlet version to remove shared_ptr

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,12 +11,12 @@ jobs:
     matrix:
       linux_gcc8:
           VM_ImageName: 'ubuntu-16.04'
-          Compiler_ImageName: 'seracllnl/tpls:gcc-8_10-19-20_18h-06m'
+          Compiler_ImageName: 'seracllnl/tpls:gcc-8_10-28-20_22h-19m'
           TEST_TARGET: 'linux_gcc8'
           HOST_CONFIG: 'docker-linux-ubuntu16.04-x86_64-gcc@8.1.0.cmake'
       linux_clang10:
           VM_ImageName: 'ubuntu-18.04'
-          Compiler_ImageName: 'seracllnl/tpls:clang-10_10-19-20_22h-40m'
+          Compiler_ImageName: 'seracllnl/tpls:clang-10_10-28-20_22h-19m'
           TEST_TARGET: 'linux_clang10'
           HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0.cmake'
 
@@ -43,7 +43,7 @@ jobs:
   variables:
     DO_STYLE_CHECK: 'yes'
     VM_ImageName: 'ubuntu-18.04'
-    Compiler_ImageName: 'seracllnl/tpls:clang-10_10-19-20_22h-40m'
+    Compiler_ImageName: 'seracllnl/tpls:clang-10_10-28-20_22h-19m'
     TEST_TARGET: 'linux_clang10'
     HOST_CONFIG: 'docker-linux-ubuntu18.04-x86_64-clang@10.0.0'
   pool:

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@upstream_gfortran-cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@upstream_gfortran-cuda.cmake
@@ -57,7 +57,7 @@ set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rele
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_10_19_15_04_12/clang-upstream_gfortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_11_03_07_48_16/clang-upstream_gfortran" CACHE PATH "")
 
 set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 

--- a/host-configs/quartz-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -41,7 +41,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/bin/m
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_19_12_10_26/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_11_03_07_48_31/clang-10.0.0" CACHE PATH "")
 
 set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 

--- a/host-configs/quartz-toss_3_x86_64_ib-gcc@8.3.1.cmake
+++ b/host-configs/quartz-toss_3_x86_64_ib-gcc@8.3.1.cmake
@@ -35,7 +35,7 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.3.1/bin/mpic
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_19_12_10_26/gcc-8.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_11_03_07_48_31/gcc-8.3.1" CACHE PATH "")
 
 set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 

--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -55,7 +55,7 @@ class Axom(CMakePackage, CudaPackage):
     version('develop', branch='develop', submodules=True)
 
     # SERAC EDIT START
-    version('0.4.0serac', commit='64a562aa18669ac7babb2c876b7f1a22708d85b3', submodules="True")
+    version('0.4.0serac', commit='8907d1380be62b50df5e058422fa4e958ff0e8ad', submodules="True")
     # SERAC EDIT END
 
     version('0.4.0', tag='v0.4.0', submodules="True")

--- a/src/infrastructure/input.cpp
+++ b/src/infrastructure/input.cpp
@@ -16,17 +16,16 @@ namespace serac {
 
 namespace input {
 
-std::shared_ptr<axom::inlet::Inlet> initialize(axom::sidre::DataStore& datastore, const std::string& input_file_path)
+axom::inlet::Inlet initialize(axom::sidre::DataStore& datastore, const std::string& input_file_path)
 {
   // Initialize Inlet
-  auto luareader = std::make_shared<axom::inlet::LuaReader>();
+  auto luareader = std::make_unique<axom::inlet::LuaReader>();
   luareader->parseFile(input_file_path);
 
   // Store inlet data under its own group
-  axom::sidre::Group* inlet_root  = datastore.getRoot()->createGroup("input_file");
-  auto                serac_inlet = std::make_shared<axom::inlet::Inlet>(luareader, inlet_root);
+  axom::sidre::Group* inlet_root = datastore.getRoot()->createGroup("input_file");
 
-  return serac_inlet;
+  return axom::inlet::Inlet(std::move(luareader), inlet_root);
 }
 
 std::string findMeshFilePath(const std::string& mesh_path, const std::string& input_file_path)
@@ -75,11 +74,11 @@ void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension)
   if (dimension < 0 || dimension > 3) {
     SLIC_ERROR("Cannot define an input file schema for vector of invalid size" << dimension);
   }
-  table.addDouble("x", "x-component of vector")->required(true);
+  table.addDouble("x", "x-component of vector").required(true);
   if (dimension >= 2) {
-    table.addDouble("y", "y-component of vector")->required(true);
+    table.addDouble("y", "y-component of vector").required(true);
     if (dimension >= 3) {
-      table.addDouble("z", "z-component of vector")->required(true);
+      table.addDouble("z", "z-component of vector").required(true);
     }
   }
 }
@@ -87,7 +86,7 @@ void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension)
 }  // namespace input
 }  // namespace serac
 
-mfem::Vector FromInlet<mfem::Vector>::operator()(axom::inlet::Table& base)
+mfem::Vector FromInlet<mfem::Vector>::operator()(const axom::inlet::Table& base)
 {
   mfem::Vector result(3);  // Allocate up front since it's small
   result[0] = base["x"];

--- a/src/infrastructure/input.hpp
+++ b/src/infrastructure/input.hpp
@@ -31,7 +31,7 @@ namespace input {
  * @param[in] input_file_path Path to user given input file
  * @return initialized Inlet instance
  */
-std::shared_ptr<axom::inlet::Inlet> initialize(axom::sidre::DataStore& datastore, const std::string& input_file_path);
+axom::inlet::Inlet initialize(axom::sidre::DataStore& datastore, const std::string& input_file_path);
 
 /**
  * @brief Returns the absolute path of the given mesh either relative
@@ -64,7 +64,7 @@ void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension 
 // Template specializations
 template <>
 struct FromInlet<mfem::Vector> {
-  mfem::Vector operator()(axom::inlet::Table& base);
+  mfem::Vector operator()(const axom::inlet::Table& base);
 };
 
 #endif

--- a/src/numerics/mesh_utils.cpp
+++ b/src/numerics/mesh_utils.cpp
@@ -173,17 +173,17 @@ namespace mesh {
 void InputInfo::defineInputFileSchema(axom::inlet::Table& table)
 {
   // mesh path
-  table.addString("mesh", "Path to Mesh file")->required(true);
+  table.addString("mesh", "Path to Mesh file").required();
 
   // Refinement levels
-  table.addInt("ser_ref_levels", "Number of times to refine the mesh uniformly in serial.")->defaultValue(0);
-  table.addInt("par_ref_levels", "Number of times to refine the mesh uniformly in parallel.")->defaultValue(0);
+  table.addInt("ser_ref_levels", "Number of times to refine the mesh uniformly in serial.").defaultValue(0);
+  table.addInt("par_ref_levels", "Number of times to refine the mesh uniformly in parallel.").defaultValue(0);
 }
 
 }  // namespace mesh
 }  // namespace serac
 
-serac::mesh::InputInfo FromInlet<serac::mesh::InputInfo>::operator()(axom::inlet::Table& base)
+serac::mesh::InputInfo FromInlet<serac::mesh::InputInfo>::operator()(const axom::inlet::Table& base)
 {
   std::string mesh_path = base["mesh"];
   int         ser_ref   = base["ser_ref_levels"];

--- a/src/numerics/mesh_utils.hpp
+++ b/src/numerics/mesh_utils.hpp
@@ -101,7 +101,7 @@ struct InputInfo {
 // Prototype the specialization
 template <>
 struct FromInlet<serac::mesh::InputInfo> {
-  serac::mesh::InputInfo operator()(axom::inlet::Table& base);
+  serac::mesh::InputInfo operator()(const axom::inlet::Table& base);
 };
 
 #endif

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -212,30 +212,30 @@ NonlinearSolid::~NonlinearSolid() {}
 void NonlinearSolid::InputInfo::defineInputFileSchema(axom::inlet::Table& table)
 {
   // Polynomial interpolation order
-  table.addInt("order", "Order degree of the finite elements.")->defaultValue(1);
+  table.addInt("order", "Order degree of the finite elements.").defaultValue(1);
 
   // neo-Hookean material parameters
-  table.addDouble("mu", "Shear modulus in the Neo-Hookean hyperelastic model.")->defaultValue(0.25);
-  table.addDouble("K", "Bulk modulus in the Neo-Hookean hyperelastic model.")->defaultValue(5.0);
+  table.addDouble("mu", "Shear modulus in the Neo-Hookean hyperelastic model.").defaultValue(0.25);
+  table.addDouble("K", "Bulk modulus in the Neo-Hookean hyperelastic model.").defaultValue(5.0);
 
-  auto traction_table = table.addTable("traction", "Cantilever tip traction vector");
+  auto& traction_table = table.addTable("traction", "Cantilever tip traction vector");
 
   // loading parameters
-  input::defineVectorInputFileSchema(*traction_table);
+  input::defineVectorInputFileSchema(traction_table);
 
-  traction_table->getField("x")->defaultValue(0.0);
-  traction_table->getField("y")->defaultValue(1.0e-3);
-  traction_table->getField("z")->defaultValue(0.0);
+  traction_table.getField("x").defaultValue(0.0);
+  traction_table.getField("y").defaultValue(1.0e-3);
+  traction_table.getField("z").defaultValue(0.0);
 
-  auto solver_table = table.addTable("solver", "Linear and Nonlinear Solver Parameters.");
-  serac::EquationSolver::defineInputFileSchema(*solver_table);
+  auto& solver_table = table.addTable("solver", "Linear and Nonlinear Solver Parameters.");
+  serac::EquationSolver::defineInputFileSchema(solver_table);
 }
 
 }  // namespace serac
 
 using serac::NonlinearSolid;
 
-NonlinearSolid::InputInfo FromInlet<NonlinearSolid::InputInfo>::operator()(axom::inlet::Table& base)
+NonlinearSolid::InputInfo FromInlet<NonlinearSolid::InputInfo>::operator()(const axom::inlet::Table& base)
 {
   NonlinearSolid::InputInfo result;
 
@@ -248,10 +248,10 @@ NonlinearSolid::InputInfo FromInlet<NonlinearSolid::InputInfo>::operator()(axom:
 
   // TODO: "optional" concept within Inlet to support dynamic parameters
 
-  result.mu = base["mu"];
-  result.K  = base["K"];
   // Set the material parameters
   // neo-Hookean material parameters
+  result.mu = base["mu"];
+  result.K  = base["K"];
 
   return result;
 }

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -232,7 +232,7 @@ protected:
 
 template <>
 struct FromInlet<serac::NonlinearSolid::InputInfo> {
-  serac::NonlinearSolid::InputInfo operator()(axom::inlet::Table& base);
+  serac::NonlinearSolid::InputInfo operator()(const axom::inlet::Table& base);
 };
 
 #endif

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -168,21 +168,20 @@ mfem::Operator& EquationSolver::SuperLUNonlinearOperatorWrapper::GetGradient(con
 
 void EquationSolver::defineInputFileSchema(axom::inlet::Table& table)
 {
-  auto nonlinear_table = table.addTable("nonlinear", "Newton Equation Solver Parameters");
-  nonlinear_table->required(false);
-  nonlinear_table->addDouble("rel_tol", "Relative tolerance for the Newton solve.")->defaultValue(1.0e-2);
-  nonlinear_table->addDouble("abs_tol", "Absolute tolerance for the Newton solve.")->defaultValue(1.0e-4);
-  nonlinear_table->addInt("max_iter", "Maximum iterations for the Newton solve.")->defaultValue(500);
-  nonlinear_table->addInt("print_level", "Nonlinear print level.")->defaultValue(0);
-  nonlinear_table->addString("solver_type", "Not currently used.")->defaultValue("");
+  auto& linear_table = table.addTable("linear", "Linear Equation Solver Parameters").required();
+  linear_table.addDouble("rel_tol", "Relative tolerance for the linear solve.").defaultValue(1.0e-6);
+  linear_table.addDouble("abs_tol", "Absolute tolerance for the linear solve.").defaultValue(1.0e-8);
+  linear_table.addInt("max_iter", "Maximum iterations for the linear solve.").defaultValue(5000);
+  linear_table.addInt("print_level", "Linear print level.").defaultValue(0);
+  linear_table.addString("solver_type", "Solver type (gmres|minres).").defaultValue("gmres");
 
-  auto linear_table = table.addTable("linear", "Linear Equation Solver Parameters");
-  linear_table->required(false);
-  linear_table->addDouble("rel_tol", "Relative tolerance for the linear solve.")->defaultValue(1.0e-6);
-  linear_table->addDouble("abs_tol", "Absolute tolerance for the linear solve.")->defaultValue(1.0e-8);
-  linear_table->addInt("max_iter", "Maximum iterations for the linear solve.")->defaultValue(5000);
-  linear_table->addInt("print_level", "Linear print level.")->defaultValue(0);
-  linear_table->addString("solver_type", "Solver type (gmres|minres).")->defaultValue("gmres");
+  // Only needed for nonlinear problems
+  auto& nonlinear_table = table.addTable("nonlinear", "Newton Equation Solver Parameters").required(false);
+  nonlinear_table.addDouble("rel_tol", "Relative tolerance for the Newton solve.").defaultValue(1.0e-2);
+  nonlinear_table.addDouble("abs_tol", "Absolute tolerance for the Newton solve.").defaultValue(1.0e-4);
+  nonlinear_table.addInt("max_iter", "Maximum iterations for the Newton solve.").defaultValue(500);
+  nonlinear_table.addInt("print_level", "Nonlinear print level.").defaultValue(0);
+  nonlinear_table.addString("solver_type", "Not currently used.").defaultValue("");
 }
 
 }  // namespace serac
@@ -191,7 +190,7 @@ using serac::EquationSolver;
 using serac::IterativeSolverParameters;
 using serac::NonlinearSolverParameters;
 
-IterativeSolverParameters FromInlet<IterativeSolverParameters>::operator()(axom::inlet::Table& base)
+IterativeSolverParameters FromInlet<IterativeSolverParameters>::operator()(const axom::inlet::Table& base)
 {
   IterativeSolverParameters params;
   params.rel_tol          = base["rel_tol"];
@@ -213,7 +212,7 @@ IterativeSolverParameters FromInlet<IterativeSolverParameters>::operator()(axom:
   return params;
 }
 
-NonlinearSolverParameters FromInlet<NonlinearSolverParameters>::operator()(axom::inlet::Table& base)
+NonlinearSolverParameters FromInlet<NonlinearSolverParameters>::operator()(const axom::inlet::Table& base)
 {
   NonlinearSolverParameters params;
   params.rel_tol     = base["rel_tol"];
@@ -223,7 +222,7 @@ NonlinearSolverParameters FromInlet<NonlinearSolverParameters>::operator()(axom:
   return params;
 }
 
-EquationSolver FromInlet<EquationSolver>::operator()(axom::inlet::Table& base)
+EquationSolver FromInlet<EquationSolver>::operator()(const axom::inlet::Table& base)
 {
   auto lin = base["linear"].get<IterativeSolverParameters>();
   if (base.hasTable("nonlinear")) {

--- a/src/physics/utilities/equation_solver.hpp
+++ b/src/physics/utilities/equation_solver.hpp
@@ -211,17 +211,17 @@ inline LinearSolverParameters augmentAMGWithSpace(const LinearSolverParameters& 
 
 template <>
 struct FromInlet<serac::IterativeSolverParameters> {
-  serac::IterativeSolverParameters operator()(axom::inlet::Table& base);
+  serac::IterativeSolverParameters operator()(const axom::inlet::Table& base);
 };
 
 template <>
 struct FromInlet<serac::NonlinearSolverParameters> {
-  serac::NonlinearSolverParameters operator()(axom::inlet::Table& base);
+  serac::NonlinearSolverParameters operator()(const axom::inlet::Table& base);
 };
 
 template <>
 struct FromInlet<serac::EquationSolver> {
-  serac::EquationSolver operator()(axom::inlet::Table& base);
+  serac::EquationSolver operator()(const axom::inlet::Table& base);
 };
 
 #endif


### PR DESCRIPTION
Inlet was recently updated to not rely on shared pointers, meaning that we can remove all the messy deferencing when accessing with `operator[]`, for example.

The API should *hopefully* be more stable from here on out, so we can start look at extending inlet to the other modules.