### PR TITLE
Move boundary attribute information to input file, use input files in tests

### DIFF
--- a/data/input_files/default.lua
+++ b/data/input_files/default.lua
@@ -13,19 +13,20 @@ main_mesh = {
 -- Solver parameters
 nonlinear_solid = {
     solver = {
-        nonlinear = {
-            rel_tol     = 1.0e-2,
-            abs_tol     = 1.0e-4,
-            max_iter    = 500,
-            print_level = 0,
-        },
-
         linear = {
             rel_tol     = 1.0e-6,
             abs_tol     = 1.0e-8,
             max_iter    = 5000,
             print_level = 0,
             solver_type = "gmres",
+            prec_type   = "AMG",
+        },
+
+        nonlinear = {
+            rel_tol     = 1.0e-2,
+            abs_tol     = 1.0e-4,
+            max_iter    = 500,
+            print_level = 0,
         },
     },
 
@@ -41,5 +42,17 @@ nonlinear_solid = {
         x = 0.0,
         y = 1.0e-3,
         z = 0.0,
+    },
+
+    -- boundary condition parameters
+    boundary_conds = {
+        [1] = {
+            name = "displacement",
+            attrs = {1},
+        },
+        [2] = {
+            name = "traction",
+            attrs = {2},
+        },
     },
 }

--- a/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_attribute_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_attribute_solve.lua
@@ -1,0 +1,63 @@
+-- Comparison information
+expected_l2norm = 0.03330115
+epsilon = 0.0001
+
+-- Simulation time parameters
+dt      = 1.0
+
+main_mesh = {
+    -- mesh file
+    mesh = "../../../../meshes/square.mesh",
+    -- serial and parallel refinement levels
+    ser_ref_levels = 2,
+    par_ref_levels = 0,
+}
+
+-- Solver parameters
+nonlinear_solid = {
+    solver = {
+        linear = {
+            rel_tol     = 1.0e-8,
+            abs_tol     = 1.0e-12,
+            max_iter    = 5000,
+            print_level = 0,
+            solver_type = "minres",
+            prec_type   = "L1JacobiSmoother",
+        },
+
+        nonlinear = {
+            rel_tol     = 1.0e-6,
+            abs_tol     = 1.0e-8,
+            max_iter    = 5000,
+            print_level = 1,
+        },
+    },
+
+    -- polynomial interpolation order
+    order = 2,
+
+    -- neo-Hookean material parameters
+    mu = 0.25,
+    K  = 10.0,
+
+    -- loading parameters
+    traction = {
+        x = 0.0,
+        y = 1.0e-3,
+        z = 0.0,
+    },
+
+    -- boundary condition parameters
+    boundary_conds = {
+        {
+            name = "displacement_x",
+            -- boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
+            attrs = {1},
+        },
+        {
+            name = "displacement_y",
+            -- boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
+            attrs = {2},
+        },
+    },
+}

--- a/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_attribute_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_attribute_solve.lua
@@ -40,13 +40,6 @@ nonlinear_solid = {
     mu = 0.25,
     K  = 10.0,
 
-    -- loading parameters
-    traction = {
-        x = 0.0,
-        y = 1.0e-3,
-        z = 0.0,
-    },
-
     -- boundary condition parameters
     boundary_conds = {
         {
@@ -56,7 +49,6 @@ nonlinear_solid = {
         },
         {
             name = "displacement_y",
-            -- boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
             attrs = {2},
         },
     },

--- a/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_solve.lua
@@ -40,13 +40,6 @@ nonlinear_solid = {
     mu = 0.25,
     K  = 10.0,
 
-    -- loading parameters
-    traction = {
-        x = 0.0,
-        y = 1.0e-3,
-        z = 0.0,
-    },
-
     -- boundary condition parameters
     boundary_conds = {
         {

--- a/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_solve.lua
@@ -1,12 +1,15 @@
+-- Comparison information
+expected_l2norm = 0.08363646
+epsilon = 0.0001
+
 -- Simulation time parameters
-t_final = 1.0
-dt      = 0.25
+dt      = 1.0
 
 main_mesh = {
     -- mesh file
-    mesh = "../meshes/beam-hex.mesh",
+    mesh = "../../../../meshes/square.mesh",
     -- serial and parallel refinement levels
-    ser_ref_levels = 0,
+    ser_ref_levels = 2,
     par_ref_levels = 0,
 }
 
@@ -14,19 +17,19 @@ main_mesh = {
 nonlinear_solid = {
     solver = {
         linear = {
-            rel_tol     = 1.0e-6,
-            abs_tol     = 1.0e-8,
+            rel_tol     = 1.0e-8,
+            abs_tol     = 1.0e-12,
             max_iter    = 5000,
             print_level = 0,
-            solver_type = "gmres",
-            prec_type   = "AMG",
+            solver_type = "minres",
+            prec_type   = "L1JacobiSmoother",
         },
 
         nonlinear = {
-            rel_tol     = 1.0e-2,
-            abs_tol     = 1.0e-4,
-            max_iter    = 500,
-            print_level = 0,
+            rel_tol     = 1.0e-6,
+            abs_tol     = 1.0e-8,
+            max_iter    = 5000,
+            print_level = 1,
         },
     },
 
@@ -35,7 +38,7 @@ nonlinear_solid = {
 
     -- neo-Hookean material parameters
     mu = 0.25,
-    K  = 5.0,
+    K  = 10.0,
 
     -- loading parameters
     traction = {
@@ -48,11 +51,8 @@ nonlinear_solid = {
     boundary_conds = {
         {
             name = "displacement",
+            -- boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
             attrs = {1},
-        },
-        {
-            name = "traction",
-            attrs = {2},
         },
     },
 }

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -119,13 +119,15 @@ int main(int argc, char* argv[])
   auto traction_coef = std::make_shared<serac::VectorScaledConstantCoefficient>(traction);
 
   // Set the boundary condition information
-  const auto disp_info = solid_solver_info.boundary_conditions.find("displacement");
-  SLIC_ERROR_ROOT_IF(disp_info == solid_solver_info.boundary_conditions.end(), rank, "No displacement BC specified");
-  solid_solver.setDisplacementBCs(disp_info->second.attrs, disp_coef);
-
-  const auto trac_info = solid_solver_info.boundary_conditions.find("traction");
-  SLIC_ERROR_ROOT_IF(trac_info == solid_solver_info.boundary_conditions.end(), rank, "No traction BC specified");
-  solid_solver.setTractionBCs(trac_info->second.attrs, traction_coef);
+  for (const auto& bc : solid_solver_info.boundary_conditions) {
+    if (bc.name == "displacement") {
+      solid_solver.setDisplacementBCs(bc.attrs, disp_coef);
+    } else if (bc.name == "traction") {
+      solid_solver.setTractionBCs(bc.attrs, traction_coef);
+    } else {
+      SLIC_WARNING_ROOT(rank, "Ignoring unrecognized boundary condition: " << bc.name);
+    }
+  }
 
   // Set the time step method
   solid_solver.setTimestepper(serac::TimestepMethod::QuasiStatic);

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -108,14 +108,10 @@ int main(int argc, char* argv[])
   solid_solver.setDisplacement(defo_coef);
   solid_solver.setVelocity(velo_coef);
 
-  std::set<int> ess_bdr = {1};
-
   // define the displacement vector
   mfem::Vector disp(dim);
   disp           = 0.0;
   auto disp_coef = std::make_shared<mfem::VectorConstantCoefficient>(disp);
-
-  std::set<int> trac_bdr = {2};
 
   // loading parameters
   // define the traction vector
@@ -123,8 +119,13 @@ int main(int argc, char* argv[])
   auto traction_coef = std::make_shared<serac::VectorScaledConstantCoefficient>(traction);
 
   // Set the boundary condition information
-  solid_solver.setDisplacementBCs(ess_bdr, disp_coef);
-  solid_solver.setTractionBCs(trac_bdr, traction_coef);
+  const auto disp_info = solid_solver_info.boundary_conditions.find("displacement");
+  SLIC_ERROR_ROOT_IF(disp_info == solid_solver_info.boundary_conditions.end(), rank, "No displacement BC specified");
+  solid_solver.setDisplacementBCs(disp_info->second.attrs, disp_coef);
+
+  const auto trac_info = solid_solver_info.boundary_conditions.find("traction");
+  SLIC_ERROR_ROOT_IF(trac_info == solid_solver_info.boundary_conditions.end(), rank, "No traction BC specified");
+  solid_solver.setTractionBCs(trac_info->second.attrs, traction_coef);
 
   // Set the time step method
   solid_solver.setTimestepper(serac::TimestepMethod::QuasiStatic);

--- a/src/infrastructure/input.cpp
+++ b/src/infrastructure/input.cpp
@@ -83,6 +83,12 @@ void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension)
   }
 }
 
+void BoundaryConditionInputInfo::defineInputFileSchema(axom::inlet::Table& table)
+{
+  table.addString("name", "Name used to identify the boundary condition").required();
+  table.addIntArray("attrs", "Boundary attributes to which the BC should be applied").required();
+}
+
 }  // namespace input
 }  // namespace serac
 
@@ -100,5 +106,18 @@ mfem::Vector FromInlet<mfem::Vector>::operator()(const axom::inlet::Table& base)
   } else {
     result.SetSize(1);  // Shrink to a 1D vector, leaving the data intact
   }
+  return result;
+}
+
+serac::input::BoundaryConditionInputInfo FromInlet<serac::input::BoundaryConditionInputInfo>::operator()(
+    const axom::inlet::Table& base)
+{
+  serac::input::BoundaryConditionInputInfo result;
+  // Build a set with just the values of the map
+  auto bdr_attr_map = base["attrs"].get<std::unordered_map<int, int>>();
+  for (const auto& [_, val] : bdr_attr_map) {
+    result.attrs.insert(val);
+  }
+  result.name = base["name"];
   return result;
 }

--- a/src/infrastructure/input.hpp
+++ b/src/infrastructure/input.hpp
@@ -58,6 +58,21 @@ std::string fullDirectoryFromPath(const std::string& file_path);
  */
 void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension = 3);
 
+/**
+ * @brief The information required from the input deck for a boundary condition
+ */
+struct BoundaryConditionInputInfo {
+  // Just store the attributes and a name for now
+  std::string   name;
+  std::set<int> attrs;
+  /**
+   * @brief Input file parameters specific to this class
+   *
+   * @param[in] table Inlet's Table to which fields should be added
+   **/
+  static void defineInputFileSchema(axom::inlet::Table& table);
+};
+
 }  // namespace input
 }  // namespace serac
 
@@ -65,6 +80,11 @@ void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension 
 template <>
 struct FromInlet<mfem::Vector> {
   mfem::Vector operator()(const axom::inlet::Table& base);
+};
+
+template <>
+struct FromInlet<serac::input::BoundaryConditionInputInfo> {
+  serac::input::BoundaryConditionInputInfo operator()(const axom::inlet::Table& base);
 };
 
 #endif

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -229,6 +229,9 @@ void NonlinearSolid::InputInfo::defineInputFileSchema(axom::inlet::Table& table)
 
   auto& solver_table = table.addTable("solver", "Linear and Nonlinear Solver Parameters.");
   serac::EquationSolver::defineInputFileSchema(solver_table);
+
+  auto& bc_table = table.addGenericArray("boundary_conds", "Boundary condition information");
+  serac::input::BoundaryConditionInputInfo::defineInputFileSchema(bc_table);
 }
 
 }  // namespace serac
@@ -252,6 +255,11 @@ NonlinearSolid::InputInfo FromInlet<NonlinearSolid::InputInfo>::operator()(const
   // neo-Hookean material parameters
   result.mu = base["mu"];
   result.K  = base["K"];
+
+  auto bdr_map = base["boundary_conds"].get<std::unordered_map<int, serac::input::BoundaryConditionInputInfo>>();
+  for (const auto& [_, val] : bdr_map) {
+    result.boundary_conditions[val.name] = val;
+  }
 
   return result;
 }

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -257,8 +257,8 @@ NonlinearSolid::InputInfo FromInlet<NonlinearSolid::InputInfo>::operator()(const
   result.K  = base["K"];
 
   auto bdr_map = base["boundary_conds"].get<std::unordered_map<int, serac::input::BoundaryConditionInputInfo>>();
-  for (const auto& [_, val] : bdr_map) {
-    result.boundary_conditions[val.name] = val;
+  for (const auto& [idx, val] : bdr_map) {
+    result.boundary_conditions.push_back(val);
   }
 
   return result;

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -66,7 +66,7 @@ public:
     double K;
 
     // Boundary condition information
-    std::unordered_map<std::string, input::BoundaryConditionInputInfo> boundary_conditions;
+    std::vector<input::BoundaryConditionInputInfo> boundary_conditions;
   };
 
   /**

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -64,6 +64,9 @@ public:
     // Lame parameters
     double mu;
     double K;
+
+    // Boundary condition information
+    std::unordered_map<std::string, input::BoundaryConditionInputInfo> boundary_conditions;
   };
 
   /**

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 
 #include "coefficients/stdfunction_coefficient.hpp"
+#include "infrastructure/input.hpp"
 #include "mfem.hpp"
 #include "numerics/mesh_utils.hpp"
 #include "physics/nonlinear_solid.hpp"
@@ -16,42 +17,59 @@
 
 namespace serac {
 
+void defineInputFileSchema(axom::inlet::Inlet& inlet)
+{
+  // Simulation time parameters
+  inlet.addDouble("dt", "Time step.");
+
+  // Integration test parameters
+  inlet.addDouble("expected_l2norm", "Correct L2 norm of the solution field");
+  inlet.addDouble("epsilon", "Threshold to be used in the comparison");
+
+  auto& mesh_table = inlet.addTable("main_mesh", "The main mesh for the problem");
+  serac::mesh::InputInfo::defineInputFileSchema(mesh_table);
+
+  // Physics
+  auto& solid_solver_table = inlet.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
+  serac::NonlinearSolid::InputInfo::defineInputFileSchema(solid_solver_table);
+
+  // Verify input file
+  if (!inlet.verify()) {
+    SLIC_ERROR("Input file failed to verify.");
+  }
+}
+
 TEST(component_bc, qs_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);
 
-  // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/meshes/square.mesh";
+  std::string input_file_path =
+      std::string(SERAC_REPO_DIR) + "/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_solve.lua";
 
-  auto pmesh = buildMeshFromFile(mesh_file, 2, 0);
+  // Create DataStore
+  axom::sidre::DataStore datastore;
 
-  int dim = pmesh->Dimension();
+  // Initialize Inlet and read input file
+  auto inlet = serac::input::initialize(datastore, input_file_path);
 
-  // Set the linear solver params
-  IterativeSolverParameters params = {.rel_tol     = 1.0e-6,
-                                      .abs_tol     = 1.0e-8,
-                                      .print_level = 0,
-                                      .max_iter    = 5000,
-                                      .lin_solver  = LinearSolver::MINRES,
-                                      .prec        = HypreSmootherPrec{mfem::HypreSmoother::l1Jacobi}};
-  params.rel_tol                   = 1.0e-8;
-  params.abs_tol                   = 1.0e-12;
+  defineInputFileSchema(inlet);
 
-  NonlinearSolverParameters nl_params = {.rel_tol = 1.0e-3, .abs_tol = 1.0e-6, .max_iter = 5000, .print_level = 1};
-  nl_params.rel_tol                   = 1.0e-6;
-  nl_params.abs_tol                   = 1.0e-8;
+  // Build the mesh
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
+  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
-  // Define the solver object
-  NonlinearSolid solid_solver(1, pmesh, {params, nl_params});
+  // Define the solid solver object
+  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
 
-  // boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
-  std::set<int> ess_bdr = {1};
+  int dim = mesh->Dimension();
 
   // define the displacement vector
   auto disp_coef = std::make_shared<StdFunctionCoefficient>([](mfem::Vector& x) { return x[0] * -1.0e-1; });
 
   // Pass the BC information to the solver object setting only the z direction
-  solid_solver.setDisplacementBCs(ess_bdr, disp_coef, 0);
+  solid_solver.setDisplacementBCs(solid_solver_info.boundary_conditions.at("displacement").attrs, disp_coef, 0);
 
   // Create an indicator function to set all vertices that are x=0
   StdFunctionVectorCoefficient zero_bc(dim, [](mfem::Vector& x, mfem::Vector& X) {
@@ -66,16 +84,13 @@ TEST(component_bc, qs_solve)
 
   solid_solver.setTrueDofs(ess_corner_bc_list, disp_coef, 0);
 
-  // Set the material parameters
-  solid_solver.setHyperelasticMaterialParameters(0.25, 10.0);
-
   // Setup glvis output
   solid_solver.initializeOutput(serac::OutputType::VisIt, "component_bc");
 
   // Complete the solver setup
   solid_solver.completeSetup();
 
-  double dt = 1.0;
+  double dt = inlet["dt"];
   solid_solver.advanceTimestep(dt);
 
   // Output the state
@@ -89,7 +104,7 @@ TEST(component_bc, qs_solve)
 
   double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
-  EXPECT_NEAR(0.08363646, x_norm, 0.0001);
+  EXPECT_NEAR(inlet["expected_l2norm"], x_norm, inlet["epsilon"]);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -98,53 +113,35 @@ TEST(component_bc, qs_attribute_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);
 
-  // Open the mesh
-  std::string  mesh_file = std::string(SERAC_REPO_DIR) + "/data/meshes/square.mesh";
-  std::fstream imesh(mesh_file);
+  std::string input_file_path =
+      std::string(SERAC_REPO_DIR) + "/data/input_files/tests/nonlinear_solid/serac_component_bc/qs_attribute_solve.lua";
 
-  auto mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);
-  imesh.close();
+  // Create DataStore
+  axom::sidre::DataStore datastore;
 
-  // refine and declare pointer to parallel mesh object
-  for (int i = 0; i < 2; ++i) {
-    mesh->UniformRefinement();
-  }
+  // Initialize Inlet and read input file
+  auto inlet = serac::input::initialize(datastore, input_file_path);
 
-  auto pmesh = std::make_shared<mfem::ParMesh>(MPI_COMM_WORLD, *mesh);
+  defineInputFileSchema(inlet);
 
-  int dim = pmesh->Dimension();
+  // Build the mesh
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
+  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
-  // Set the linear solver params
-  IterativeSolverParameters params = {.rel_tol     = 1.0e-6,
-                                      .abs_tol     = 1.0e-8,
-                                      .print_level = 0,
-                                      .max_iter    = 5000,
-                                      .lin_solver  = LinearSolver::MINRES,
-                                      .prec        = HypreSmootherPrec{mfem::HypreSmoother::l1Jacobi}};
-  params.rel_tol                   = 1.0e-8;
-  params.abs_tol                   = 1.0e-12;
+  // Define the solid solver object
+  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
 
-  NonlinearSolverParameters nl_params = {.rel_tol = 1.0e-3, .abs_tol = 1.0e-6, .max_iter = 5000, .print_level = 1};
-  nl_params.rel_tol                   = 1.0e-6;
-  nl_params.abs_tol                   = 1.0e-8;
-
-  // Define the solver object
-  NonlinearSolid solid_solver(2, pmesh, {params, nl_params});
-
-  // boundary attribute 1 (index 0) is fixed (Dirichlet) in the x direction
-  std::set<int> ess_x_bdr = {1};
-  std::set<int> ess_y_bdr = {2};
+  int dim = mesh->Dimension();
 
   // define the displacement vector
   auto disp_x_coef = std::make_shared<StdFunctionCoefficient>([](mfem::Vector& x) { return x[0] * 3.0e-2; });
   auto disp_y_coef = std::make_shared<StdFunctionCoefficient>([](mfem::Vector& x) { return x[1] * -5.0e-2; });
 
   // Pass the BC information to the solver object setting only the z direction
-  solid_solver.setDisplacementBCs(ess_x_bdr, disp_x_coef, 0);
-  solid_solver.setDisplacementBCs(ess_y_bdr, disp_y_coef, 1);
-
-  // Set the material parameters
-  solid_solver.setHyperelasticMaterialParameters(0.25, 10.0);
+  solid_solver.setDisplacementBCs(solid_solver_info.boundary_conditions.at("displacement_x").attrs, disp_x_coef, 0);
+  solid_solver.setDisplacementBCs(solid_solver_info.boundary_conditions.at("displacement_y").attrs, disp_y_coef, 1);
 
   // Setup glvis output
   solid_solver.initializeOutput(serac::OutputType::GLVis, "component_attr_bc");
@@ -152,7 +149,7 @@ TEST(component_bc, qs_attribute_solve)
   // Complete the solver setup
   solid_solver.completeSetup();
 
-  double dt = 1.0;
+  double dt = inlet["dt"];
   solid_solver.advanceTimestep(dt);
 
   // Output the state
@@ -164,7 +161,7 @@ TEST(component_bc, qs_attribute_solve)
 
   double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
 
-  EXPECT_NEAR(0.03330115, x_norm, 0.0001);
+  EXPECT_NEAR(inlet["expected_l2norm"], x_norm, inlet["epsilon"]);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -69,7 +69,13 @@ TEST(component_bc, qs_solve)
   auto disp_coef = std::make_shared<StdFunctionCoefficient>([](mfem::Vector& x) { return x[0] * -1.0e-1; });
 
   // Pass the BC information to the solver object setting only the z direction
-  solid_solver.setDisplacementBCs(solid_solver_info.boundary_conditions.at("displacement").attrs, disp_coef, 0);
+  for (const auto& bc : solid_solver_info.boundary_conditions) {
+    if (bc.name == "displacement") {
+      solid_solver.setDisplacementBCs(bc.attrs, disp_coef, 0);
+    } else {
+      SLIC_WARNING("Ignoring unrecognized boundary condition: " << bc.name);
+    }
+  }
 
   // Create an indicator function to set all vertices that are x=0
   StdFunctionVectorCoefficient zero_bc(dim, [](mfem::Vector& x, mfem::Vector& X) {
@@ -140,8 +146,15 @@ TEST(component_bc, qs_attribute_solve)
   auto disp_y_coef = std::make_shared<StdFunctionCoefficient>([](mfem::Vector& x) { return x[1] * -5.0e-2; });
 
   // Pass the BC information to the solver object setting only the z direction
-  solid_solver.setDisplacementBCs(solid_solver_info.boundary_conditions.at("displacement_x").attrs, disp_x_coef, 0);
-  solid_solver.setDisplacementBCs(solid_solver_info.boundary_conditions.at("displacement_y").attrs, disp_y_coef, 1);
+  for (const auto& bc : solid_solver_info.boundary_conditions) {
+    if (bc.name == "displacement_x") {
+      solid_solver.setDisplacementBCs(bc.attrs, disp_x_coef, 0);
+    } else if (bc.name == "displacement_y") {
+      solid_solver.setDisplacementBCs(bc.attrs, disp_y_coef, 1);
+    } else {
+      SLIC_WARNING("Ignoring unrecognized boundary condition: " << bc.name);
+    }
+  }
 
   // Setup glvis output
   solid_solver.initializeOutput(serac::OutputType::GLVis, "component_attr_bc");


### PR DESCRIPTION
This PR moves some boundary condition information (the attribute set) to the input file via a new `BoundaryConditionInputInfo` struct, which just contains its name and attribute set for now.  

This allows tests to be described (mostly) in the input file instead of the C++ source.  I've converted the `serac_component_bc` test as an example.

The only big remaining test-specific information is the coefficients, so the next logical step after this PR is determining how coefficients should be described in inlet (and by extension Lua).  The rest is boilerplate that could possibly be abstracted into a function - this would make the tests more readable.