### PR TITLE
Moving to the new spack approved llvm package for clang-format / clang-tidy

### DIFF
--- a/scripts/uberenv/packages/axom/package.py
+++ b/scripts/uberenv/packages/axom/package.py
@@ -142,6 +142,7 @@ class Axom(CMakePackage, CudaPackage):
     depends_on("python", when="+devtools")
     depends_on("py-sphinx", when="+devtools")
     depends_on("py-shroud", when="+devtools")
+    depends_on("llvm+clang@10.0.0", when="+devtools")
 
     def flag_handler(self, name, flags):
         if name in ('cflags', 'cxxflags', 'fflags'):
@@ -431,22 +432,9 @@ class Axom(CMakePackage, CudaPackage):
 
         # Only turn on clangformat support if devtools is on
         if "+devtools" in spec:
-            cf_paths = []
-            lc_clangpath = "/usr/tce/packages/clang/clang-10.0.0"
-            cf_paths.append(pjoin(lc_clangpath, "bin/clang-format"))
-            cf_paths.append("/usr/bin/clang-format-10")
-            cf_paths.append("/usr/bin/clang-format")
-
-            cf_found = False
-            for path in cf_paths:
-                if os.path.exists(path):
-                    cf_found = True
-                    cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE",
-                                                path))
-
-            if not cf_found:
-                cfg.write("# Unable to find clang-format\n\n")
-                cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))
+            clang_fmt_path = spec['llvm'].prefix.bin.join('clang-format')
+            cfg.write(cmake_cache_entry("CLANGFORMAT_EXECUTABLE",
+                                        clang_fmt_path))
         else:
             cfg.write("# ClangFormat disabled due to disabled devtools\n")
             cfg.write(cmake_cache_option("ENABLE_CLANGFORMAT", False))

--- a/scripts/uberenv/packages/serac_devtools/package.py
+++ b/scripts/uberenv/packages/serac_devtools/package.py
@@ -13,5 +13,6 @@ class SeracDevtools(BundlePackage):
     depends_on('cmake')
     depends_on('cppcheck')
     depends_on('doxygen')
+    depends_on("llvm+clang@10.0.0")
     depends_on('python')
     depends_on('py-sphinx')

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/devtools/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/devtools/packages.yaml
@@ -93,6 +93,12 @@ packages:
     externals:
     - spec: cmake
       prefix: /usr/tce/packages/cmake/cmake-3.14.5
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr/tce/packages/clang/clang-10.0.0
   python:
     version: [3.8.2]
     buildable: false

--- a/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/uberenv/spack_configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -134,6 +134,12 @@ packages:
       - spec: doxygen@1.8.17
         prefix: /usr/WS2/smithdev/devtools/blueos_3_ppc64le_ib_p9/latest/doxygen-1.8.17
     buildable: false
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr/tce/packages/clang/clang-10.0.0
   python:
     version: [3.8.2]
     externals:

--- a/scripts/uberenv/spack_configs/docker/ubuntu16/packages.yaml
+++ b/scripts/uberenv/spack_configs/docker/ubuntu16/packages.yaml
@@ -105,3 +105,9 @@ packages:
     externals:
     - spec: cmake@3.10.1
       prefix: /usr
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr

--- a/scripts/uberenv/spack_configs/docker/ubuntu18/packages.yaml
+++ b/scripts/uberenv/spack_configs/docker/ubuntu18/packages.yaml
@@ -101,3 +101,9 @@ packages:
     externals:
     - spec: cmake@3.10.1
       prefix: /usr
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr

--- a/scripts/uberenv/spack_configs/linux_ubuntu_18/packages.yaml
+++ b/scripts/uberenv/spack_configs/linux_ubuntu_18/packages.yaml
@@ -94,6 +94,12 @@ packages:
     externals:
     - spec: doxygen
       prefix: /usr
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr
   python:
     version: [3.6.9]
     buildable: false

--- a/scripts/uberenv/spack_configs/linux_ubuntu_20/packages.yaml
+++ b/scripts/uberenv/spack_configs/linux_ubuntu_20/packages.yaml
@@ -85,6 +85,12 @@ packages:
     externals:
     - spec: doxygen
       prefix: /usr
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr
   python:
     version: [3.8.2]
     buildable: false

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/devtools/packages.yaml
@@ -117,6 +117,12 @@ packages:
     externals:
     - spec: cmake
       prefix: /usr/tce/packages/cmake/cmake-3.14.5
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr/tce/packages/clang/clang-10.0.0
   python:
     buildable: false
     externals:

--- a/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/uberenv/spack_configs/toss_3_x86_64_ib/packages.yaml
@@ -130,6 +130,12 @@ packages:
     externals:
     - spec: doxygen
       prefix: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/doxygen-1.8.17
+  llvm:
+    version: [10.0.0]
+    buildable: false
+    externals:
+    - spec: llvm+clang
+      prefix: /usr/tce/packages/clang/clang-10.0.0
   python:
     buildable: false
     externals:


### PR DESCRIPTION
This moves our hardcoded path to a use the `llvm+clang` spack package