### PR TITLE
Bugfix/white238/turnoffdocs

### DIFF
--- a/cmake/serac-config.cmake.in
+++ b/cmake/serac-config.cmake.in
@@ -88,13 +88,16 @@ if(NOT SERAC_FOUND)
     endif()
   endif()
 
-   # tribol
+  # tribol
   if(SERAC_USE_TRIBOL)
     set(SERAC_TRIBOL_DIR   "@TRIBOL_DIR@")
+    if(NOT TRIBOL_DIR) 
+      set(TRIBOL_DIR ${SERAC_TRIBOL_DIR}) 
+    endif()
     find_dependency(tribol REQUIRED NO_DEFAULT_PATH PATHS "${TRIBOL_DIR}/lib/cmake")
   endif()
 
-   # caliper
+  # caliper
   if(SERAC_USE_CALIPER)
     set(SERAC_CALIPER_DIR     "@CALIPER_DIR@")
     if(NOT CALIPER_DIR) 

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -74,15 +74,9 @@ include(cmake/thirdparty/FindMFEM.cmake)
 if(TRIBOL_DIR)
     serac_assert_is_directory(VARIABLE_NAME TRIBOL_DIR)
 
-    set(TRIBOL_INCLUDE_DIR ${TRIBOL_DIR}/include)
-
-    set(_target_file ${TRIBOL_DIR}/lib/cmake/tribol-targets.cmake)
-
-    if(NOT EXISTS ${_target_file})
-        message(FATAL_ERROR "Could not find Tribol CMake exported target file (${_target_file})")
-    endif()
-
-    include(${_target_file})
+    find_package(tribol REQUIRED
+                        NO_DEFAULT_PATH 
+                        PATHS ${TRIBOL_DIR}/lib/cmake)
 
     if(TARGET tribol)
         message(STATUS "Tribol CMake exported library loaded: tribol")
@@ -91,6 +85,7 @@ if(TRIBOL_DIR)
     endif()
 
     # Set include dir to system
+    set(TRIBOL_INCLUDE_DIR ${TRIBOL_DIR}/include)
     set_property(TARGET tribol
                  APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                  ${TRIBOL_INCLUDE_DIR})

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@ibm_gfortran-cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@ibm_gfortran-cuda.cmake
@@ -53,9 +53,9 @@ set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rele
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_10_27_14_15_37/clang-ibm_gfortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_11_09_11_28_50/clang-ibm_gfortran" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@upstream_gfortran-cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@upstream_gfortran-cuda.cmake
@@ -57,9 +57,9 @@ set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rele
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_10_27_14_15_37/clang-upstream_gfortran" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/blueos_3_ppc64le_ib_p9/2020_11_09_11_28_50/clang-upstream_gfortran" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-clang@10.0.0.cmake
@@ -41,9 +41,9 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-clang-10.0.0/bin/m
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_27_14_14_42/clang-10.0.0" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_11_09_11_27_15/clang-10.0.0" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 

--- a/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.3.1.cmake
+++ b/host-configs/rzgenie-toss_3_x86_64_ib-gcc@8.3.1.cmake
@@ -35,9 +35,9 @@ set(MPI_CXX_COMPILER "/usr/tce/packages/mvapich2/mvapich2-2.3-gcc-8.3.1/bin/mpic
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_10_27_14_14_42/gcc-8.3.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/toss_3_x86_64_ib/2020_11_09_11_27_15/gcc-8.3.1" CACHE PATH "")
 
-set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0p1" CACHE PATH "")
+set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 
 set(CONDUIT_DIR "${TPL_ROOT}/conduit-0.5.1p1" CACHE PATH "")
 

--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -234,7 +234,8 @@ def build_and_test_host_config(test_root,host_config, report_to_stdout = False):
     cfg_output_file = pjoin(test_root,"output.log.%s.configure.txt" % host_config_root)
     print("[starting configure of %s]" % host_config)
     print("[log file: %s]" % cfg_output_file)
-    res = sexe("python config-build.py  -bp %s -hc %s -ip %s" % (build_dir, host_config, install_dir),
+    # Disable docs until we build our own doxygen/sphinx to stop the random failures on LC
+    res = sexe("python config-build.py -DENABLE_DOCS=OFF -bp %s -hc %s -ip %s" % (build_dir, host_config, install_dir),
                output_file = cfg_output_file,
                echo=True)
     
@@ -285,22 +286,23 @@ def build_and_test_host_config(test_root,host_config, report_to_stdout = False):
         print("[ERROR: Tests for host-config: %s failed]\n" % host_config)
         return res
 
+    # Disable docs until we build our own doxygen/sphinx to stop the random failures on LC
     # build the docs
-    docs_output_file = pjoin(build_dir,"output.log.make.docs.txt")
-    print("[starting docs generation]")
-    print("[log file: %s]" % docs_output_file)
+    # docs_output_file = pjoin(build_dir,"output.log.make.docs.txt")
+    # print("[starting docs generation]")
+    # print("[log file: %s]" % docs_output_file)
 
-    res = sexe("cd %s && make docs " % build_dir,
-               output_file = docs_output_file,
-               echo=True)
+    # res = sexe("cd %s && make docs " % build_dir,
+    #            output_file = docs_output_file,
+    #            echo=True)
 
-    if report_to_stdout:
-        with open(docs_output_file, 'r') as docs_out:
-            print(docs_out.read())
+    # if report_to_stdout:
+    #     with open(docs_output_file, 'r') as docs_out:
+    #         print(docs_out.read())
 
-    if res != 0:
-        print("[ERROR: Docs generation for host-config: %s failed]\n\n" % host_config)
-        return res
+    # if res != 0:
+    #     print("[ERROR: Docs generation for host-config: %s failed]\n\n" % host_config)
+    #     return res
 
     # build the examples
     res = test_examples(host_config, build_dir, install_dir, report_to_stdout)

--- a/scripts/uberenv/packages/serac/package.py
+++ b/scripts/uberenv/packages/serac/package.py
@@ -411,11 +411,8 @@ class Serac(CMakePackage, CudaPackage):
                 path_replacements[devtools_root] = "${DEVTOOLS_ROOT}"
                 cfg.write("# Root directory for generated developer tools\n")
                 cfg.write(cmake_cache_entry("DEVTOOLS_ROOT",devtools_root))
-	
-        if spec.satisfies('target=ppc64le:'):
-            cfg.write("# Docs dont work on blueos machines, there is a prompt that waits for user input\n")
-            cfg.write(cmake_cache_option("ENABLE_DOCS", False))
-        elif "doxygen" in spec or "py-sphinx" in spec:
+
+        if "doxygen" in spec or "py-sphinx" in spec:
             cfg.write(cmake_cache_option("ENABLE_DOCS", True))
 
             if "doxygen" in spec:


### PR DESCRIPTION
LC's Sphinx and Doxygen keep failing with random incompatibilities.  This turns off docs for the build scripts until we rebuild a new set of Devtools with our own Sphinx/Doxygen.