### PR TITLE
Actually use the direct solver in the direct solver tests

### DIFF
--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -125,7 +125,10 @@ TEST(dynamic_solver, dyn_direct_solve)
   auto velo   = std::make_shared<mfem::VectorFunctionCoefficient>(dim, initialVelocity);
 
   // initialize the dynamic solver object
-  NonlinearSolid dyn_solver(1, pmesh, default_dynamic);
+  auto solver_params                 = default_dynamic;
+  solver_params.H_lin_params         = DirectSolverParameters{0};
+  solver_params.dyn_params->M_params = DirectSolverParameters{0};
+  NonlinearSolid dyn_solver(1, pmesh, solver_params);
   dyn_solver.setDisplacementBCs(ess_bdr, deform);
   dyn_solver.setHyperelasticMaterialParameters(0.25, 5.0);
   dyn_solver.setViscosity(std::move(visc));

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -99,6 +99,8 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   int dim = pmesh->Dimension();
 
   // Define the solver object
+  auto solver_params         = default_quasistatic;
+  solver_params.H_lin_params = DirectSolverParameters{0};
   NonlinearSolid solid_solver(1, pmesh, default_quasistatic);
 
   std::set<int> ess_bdr = {1};

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -101,7 +101,7 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   // Define the solver object
   auto solver_params         = default_quasistatic;
   solver_params.H_lin_params = DirectSolverParameters{0};
-  NonlinearSolid solid_solver(1, pmesh, default_quasistatic);
+  NonlinearSolid solid_solver(1, pmesh, solver_params);
 
   std::set<int> ess_bdr = {1};
 


### PR DESCRIPTION
Thanks to @samuelpmishLLNL for catching this mistake I made when updating the tests to use the new way of passing parameters