### PR TITLE
Small WSL build fixes

### DIFF
--- a/scripts/uberenv/spack_configs/linux_ubuntu_18/compilers.yaml
+++ b/scripts/uberenv/spack_configs/linux_ubuntu_18/compilers.yaml
@@ -6,7 +6,8 @@ compilers:
       cxx: /usr/bin/g++
       f77: /usr/bin/gfortran
       fc: /usr/bin/gfortran
-    flags: {}
+    flags: 
+      ldlibs: -lpthread
     operating_system: ubuntu18.04
     target: x86_64
     modules: []

--- a/src/docs/index.rst
+++ b/src/docs/index.rst
@@ -222,7 +222,7 @@ and the following commands for Ubuntu 18.04:
    $ sudo apt-get upgrade
    $ sudo apt-get install g++-8 gcc-8
    $ sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
-   $ sudo apt-get install cmake libopenblas-dev libopenblas-base mpich mesa-common-dev libglu1-mesa-dev freeglut3-dev cppcheck doxygen libreadline-dev
+   $ sudo apt-get install cmake libopenblas-dev libopenblas-base mpich mesa-common-dev libglu1-mesa-dev freeglut3-dev cppcheck doxygen libreadline-dev python3-distutils
    $ sudo ln -s /usr/lib/x86_64-linux-gnu/* /usr/lib
 
 Note that the last line is required since Spack expects the system libraries to exist in a directory named ``lib``. During the third


### PR DESCRIPTION
This is a small build fix for the Ubuntu 18/WSL build. It also updates the docs to include the new required python dist utils dependency installation.