### PR TITLE
Make the quasi-static operator definitions overrideable

### DIFF
--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -280,7 +280,7 @@ void NonlinearSolid::completeSetup()
 // Solve the Quasi-static Newton system
 void NonlinearSolid::quasiStaticSolve() { nonlin_solver_.Mult(zero_, displacement_.trueVec()); }
 
-void StdFunctionOperator::buildQuasistaticOperator()
+StdFunctionOperator NonlinearSolid::buildQuasistaticOperator()
 {
   // the quasistatic case is entirely described by the residual,
   // there is no ordinary differential equation
@@ -299,6 +299,7 @@ void StdFunctionOperator::buildQuasistaticOperator()
         bcs_.eliminateAllEssentialDofsFromMatrix(J);
         return J;
       });
+  return residual;
 }
 
 // Advance the timestep

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -169,7 +169,7 @@ void NonlinearSolid::completeSetup()
   nonlin_solver_.nonlinearSolver().iterative_mode = true;
 
   if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
-    residual_ = NonlinearSolid::buildQuasistaticOperator();
+    residual_ = buildQuasistaticOperator();
 
   } else {
     // the dynamic case is described by a residual function and a second order

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -169,11 +169,20 @@ public:
   void completeSetup() override;
 
   /**
-   * @brief Advance the timestep
+   * @brief Build the quasi-static operator
    *
-   * @param[inout] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping schemes
+   * This is virtual if a user wants to augment the quasi-static physics with additional terms
    */
-  void advanceTimestep(double& dt) override;
+  virtual void buildQ
+
+      /**
+       * @brief Advance the timestep
+       *
+       * @param[inout] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping
+       * schemes
+       */
+      void
+      advanceTimestep(double& dt) override;
 
   /**
    * @brief Destroy the Nonlinear Solid Solver object
@@ -181,6 +190,21 @@ public:
   virtual ~NonlinearSolid();
 
 protected:
+  /**
+   * @brief Extensible means of constructing the nonlinear quasistatic
+   * operator
+   *
+   * @param[in] H_form The nonlinear form
+   *
+   * @return An owning pointer to the operator
+   */
+  virtual StdFunctionOperator buildQuasistaticOperator() override;
+
+  /**
+   * @brief Complete a quasi-static solve
+   */
+  virtual void quasiStaticSolve() override;
+
   /**
    * @brief Velocity field
    */

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -188,7 +188,7 @@ protected:
    *
    * @return The quasi-static operator
    */
-  virtual StdFunctionOperator buildQuasistaticOperator();
+  virtual std::unique_ptr<mfem::Operator> buildQuasistaticOperator();
 
   /**
    * @brief Complete a quasi-static solve
@@ -208,7 +208,7 @@ protected:
   /**
    * @brief The quasi-static operator for use with the MFEM newton solvers
    */
-  std::unique_ptr<mfem::Operator> nonlinear_oper_;
+  std::unique_ptr<mfem::Operator> residual_;
 
   /**
    * @brief Configuration for dynamic equation solver
@@ -279,11 +279,6 @@ protected:
    * @brief Nonlinear system solver instance
    */
   EquationSolver nonlin_solver_;
-
-  /**
-   * @brief mfem::Operator for computing the weighted residual
-   */
-  StdFunctionOperator residual_;
 
   /**
    * @brief the system of ordinary differential equations for the physics module

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -169,20 +169,12 @@ public:
   void completeSetup() override;
 
   /**
-   * @brief Build the quasi-static operator
+   * @brief Advance the timestep
    *
-   * This is virtual if a user wants to augment the quasi-static physics with additional terms
+   * @param[inout] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping
+   * schemes
    */
-  virtual void buildQ
-
-      /**
-       * @brief Advance the timestep
-       *
-       * @param[inout] dt The timestep to attempt. This will return the actual timestep for adaptive timestepping
-       * schemes
-       */
-      void
-      advanceTimestep(double& dt) override;
+  void advanceTimestep(double& dt) override;
 
   /**
    * @brief Destroy the Nonlinear Solid Solver object
@@ -194,16 +186,14 @@ protected:
    * @brief Extensible means of constructing the nonlinear quasistatic
    * operator
    *
-   * @param[in] H_form The nonlinear form
-   *
-   * @return An owning pointer to the operator
+   * @return The quasi-static operator
    */
-  virtual StdFunctionOperator buildQuasistaticOperator() override;
+  virtual StdFunctionOperator buildQuasistaticOperator();
 
   /**
    * @brief Complete a quasi-static solve
    */
-  virtual void quasiStaticSolve() override;
+  virtual void quasiStaticSolve();
 
   /**
    * @brief Velocity field


### PR DESCRIPTION
This makes the quasi-static operator definitions in the solid mechanics module overrideable in case a user wants to add other physics terms.