### PR TITLE
Move most of ODE logic into TimeDependentOperator wrappers

### DIFF
--- a/src/physics/base_physics.cpp
+++ b/src/physics/base_physics.cpp
@@ -56,11 +56,9 @@ void BasePhysics::setState(std::vector<serac::FiniteElementState>&& state)
 
 const std::vector<std::reference_wrapper<serac::FiniteElementState> >& BasePhysics::getState() const { return state_; }
 
-void BasePhysics::setTimestepper(const serac::TimestepMethod             timestepper,
-                                 const serac::DirichletEnforcementMethod enforcement_method)
+void BasePhysics::setTimestepper(const serac::TimestepMethod timestepper)
 {
-  timestepper_        = timestepper;
-  enforcement_method_ = enforcement_method;
+  timestepper_ = timestepper;
 
   switch (timestepper_) {
     case serac::TimestepMethod::QuasiStatic:

--- a/src/physics/base_physics.hpp
+++ b/src/physics/base_physics.hpp
@@ -84,11 +84,8 @@ public:
    * @brief Set the time integration method
    *
    * @param[in] timestepper The timestepping method for the solver
-   * @param[in] enforcement_method The method of enforcing time-varying dirichlet boundary conditions
    */
-  virtual void setTimestepper(
-      const serac::TimestepMethod             timestepper,
-      const serac::DirichletEnforcementMethod enforcement_method = serac::DirichletEnforcementMethod::RateControl);
+  virtual void setTimestepper(const serac::TimestepMethod timestepper);
 
   /**
    * @brief Set the current time
@@ -180,11 +177,6 @@ protected:
    *@brief Time integration method
    */
   serac::TimestepMethod timestepper_ = TimestepMethod::QuasiStatic;
-
-  /**
-   * @brief Method for enforcing time-varying dirichlet boundary conditions
-   */
-  serac::DirichletEnforcementMethod enforcement_method_;
 
   /**
    * @brief MFEM solver object for first-order ODEs

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -9,6 +9,7 @@
 #include "infrastructure/logger.hpp"
 #include "integrators/hyperelastic_traction_integrator.hpp"
 #include "integrators/inc_hyperelastic_integrator.hpp"
+#include "numerics/expr_template_ops.hpp"
 #include "numerics/mesh_utils.hpp"
 
 namespace serac {
@@ -47,6 +48,7 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
   // Check for dynamic mode
   if (params.dyn_params) {
     setTimestepper(params.dyn_params->timestepper, params.dyn_params->enforcement_method);
+    ode2_.setEnforcementMethod(params.dyn_params->enforcement_method);
   } else {
     setTimestepper(TimestepMethod::QuasiStatic);
   }

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -62,12 +62,6 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
 
   zero_.SetSize(true_size);
   zero_ = 0.0;
-
-  U_minus_.SetSize(true_size);
-  U_.SetSize(true_size);
-  U_plus_.SetSize(true_size);
-  dU_dt_.SetSize(true_size);
-  d2U_dt2_.SetSize(true_size);
 }
 
 NonlinearSolid::NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const NonlinearSolid::InputInfo& info)

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -47,7 +47,7 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
 
   // Check for dynamic mode
   if (params.dyn_params) {
-    setTimestepper(params.dyn_params->timestepper, params.dyn_params->enforcement_method);
+    setTimestepper(params.dyn_params->timestepper);
     ode2_.setEnforcementMethod(params.dyn_params->enforcement_method);
   } else {
     setTimestepper(TimestepMethod::QuasiStatic);

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -19,7 +19,9 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
     : BasePhysics(mesh, NUM_FIELDS, order),
       velocity_(*mesh, FiniteElementState::Options{.order = order, .name = "velocity"}),
       displacement_(*mesh, FiniteElementState::Options{.order = order, .name = "displacement"}),
-      residual_(displacement_.space().TrueVSize())
+      residual_(displacement_.space().TrueVSize()),
+      ode2_(displacement_.space().TrueVSize(), {.c0 = c0_, .c1 = c1_, .u = u_, .du_dt = du_dt_, .d2u_dt2 = previous_},
+            nonlin_solver_, bcs_)
 {
   state_.push_back(velocity_);
   state_.push_back(displacement_);
@@ -210,83 +212,6 @@ void NonlinearSolid::completeSetup()
           J_mat_.reset(M_->ParallelAssemble(localJ.get()));
           bcs_.eliminateAllEssentialDofsFromMatrix(*J_mat_);
           return *J_mat_;
-        });
-
-    ode2_ = SecondOrderODE(
-        u_.Size(), [this](const double t, const double fac0, const double fac1, const mfem::Vector& displacement,
-                          const mfem::Vector& velocity, mfem::Vector& acceleration) {
-          // this is intended to be temporary
-          // Ideally, epsilon should be "small" relative to the characteristic time
-          // of the ODE, but we can't ensure that at present (we don't have a
-          // critical timestep estimate)
-          constexpr double epsilon = 0.0001;
-
-          // assign these values to variables with greater scope,
-          // so that the residual operator can see them
-          c0_    = fac0;
-          c1_    = fac1;
-          u_     = displacement;
-          du_dt_ = velocity;
-
-          // TODO: take care of this last part of the ODE definition
-          //       automatically by wrapping mfem's ODE solvers
-          //
-          // evaluate the constraint functions at a 3-point
-          // stencil of times centered on the time of interest
-          // in order to compute finite-difference approximations
-          // to the time derivatives that appear in the residual
-          U_minus_ = 0.0;
-          U_       = 0.0;
-          U_plus_  = 0.0;
-          for (const auto& bc : bcs_.essentials()) {
-            bc.projectBdrToDofs(U_minus_, t - epsilon);
-            bc.projectBdrToDofs(U_, t);
-            bc.projectBdrToDofs(U_plus_, t + epsilon);
-          }
-
-          bool implicit = (c0_ != 0.0 || c1_ != 0.0);
-          if (implicit) {
-            if (enforcement_method_ == DirichletEnforcementMethod::DirectControl) {
-              d2U_dt2_ = (U_ - u_) / c0_;
-              dU_dt_   = du_dt_;
-              U_       = u_;
-            }
-
-            if (enforcement_method_ == DirichletEnforcementMethod::RateControl) {
-              d2U_dt2_ = (dU_dt_ - du_dt_) / c1_;
-              dU_dt_   = du_dt_;
-              U_       = u_;
-            }
-
-            if (enforcement_method_ == DirichletEnforcementMethod::FullControl) {
-              d2U_dt2_ = (U_minus_ - 2.0 * U_ + U_plus_) / (epsilon * epsilon);
-              dU_dt_   = (U_plus_ - U_minus_) / (2.0 * epsilon) - c1_ * d2U_dt2_;
-              U_       = U_ - c0_ * d2U_dt2_;
-            }
-          } else {
-            d2U_dt2_ = (U_minus_ - 2.0 * U_ + U_plus_) / (epsilon * epsilon);
-            dU_dt_   = (U_plus_ - U_minus_) / (2.0 * epsilon);
-          }
-
-          auto constrained_dofs = bcs_.allEssentialDofs();
-          u_.SetSubVector(constrained_dofs, 0.0);
-          U_.SetSubVectorComplement(constrained_dofs, 0.0);
-          u_ += U_;
-
-          du_dt_.SetSubVector(constrained_dofs, 0.0);
-          dU_dt_.SetSubVectorComplement(constrained_dofs, 0.0);
-          du_dt_ += dU_dt_;
-
-          // use the previous solution as our starting guess
-          acceleration = previous_;
-          acceleration.SetSubVector(constrained_dofs, 0.0);
-          d2U_dt2_.SetSubVectorComplement(constrained_dofs, 0.0);
-          acceleration += d2U_dt2_;
-
-          nonlin_solver_.Mult(zero_, acceleration);
-          SLIC_WARNING_IF(!nonlin_solver_.nonlinearSolver().GetConverged(), "Newton Solver did not converge.");
-
-          previous_ = acceleration;
         });
 
     second_order_ode_solver_->Init(ode2_);

--- a/src/physics/nonlinear_solid.hpp
+++ b/src/physics/nonlinear_solid.hpp
@@ -296,18 +296,6 @@ protected:
    */
   mfem::Vector previous_;
 
-  // TODO: wrap mfem's second order ODE solvers to incorporate this boundary condition info
-  //
-  // temporary values used to compute finite difference approximations
-  // to the derivatives of constrained degrees of freedom
-  mfem::Vector U_minus_;
-  mfem::Vector U_;
-  mfem::Vector U_plus_;
-
-  // time derivatives of the constraint function
-  mfem::Vector dU_dt_;
-  mfem::Vector d2U_dt2_;
-
   // current and previous timesteps
   double c0_, c1_;
 };

--- a/src/physics/operators/CMakeLists.txt
+++ b/src/physics/operators/CMakeLists.txt
@@ -5,12 +5,13 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 set(physics_operators_headers odes.hpp stdfunction_operator.hpp)
-
+set(physics_operators_sources odes.cpp)
 set(physics_operators_depends infrastructure physics_utilities numerics fmt mfem mpi axom)
 
 blt_add_library(
    NAME        physics_operators
    HEADERS     ${physics_operators_headers}
+   SOURCES     ${physics_operators_sources}
    DEPENDS_ON  ${physics_operators_depends}
    )
 

--- a/src/physics/operators/odes.cpp
+++ b/src/physics/operators/odes.cpp
@@ -1,0 +1,175 @@
+// Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "physics/operators/odes.hpp"
+
+#include "numerics/expr_template_ops.hpp"
+
+namespace serac {
+SecondOrderODE::SecondOrderODE(int n, State&& state, const EquationSolver& solver, const BoundaryConditionManager& bcs)
+    : mfem::SecondOrderTimeDependentOperator(n, 0.0), state_(std::move(state)), solver_(solver), bcs_(bcs), zero_(n)
+{
+  zero_ = 0.0;
+  U_minus_.SetSize(n);
+  U_.SetSize(n);
+  U_plus_.SetSize(n);
+  dU_dt_.SetSize(n);
+  d2U_dt2_.SetSize(n);
+}
+
+void SecondOrderODE::Solve(const double t, const double c0, const double c1, const mfem::Vector& u,
+                           const mfem::Vector& du_dt, mfem::Vector& d2u_dt2) const
+{
+  // this is intended to be temporary
+  // Ideally, epsilon should be "small" relative to the characteristic time
+  // of the ODE, but we can't ensure that at present (we don't have a
+  // critical timestep estimate)
+  constexpr double epsilon = 0.0001;
+
+  // assign these values to variables with greater scope,
+  // so that the residual operator can see them
+  state_.c0    = c0;
+  state_.c1    = c1;
+  state_.u     = u;
+  state_.du_dt = du_dt;
+
+  // TODO: take care of this last part of the ODE definition
+  //       automatically by wrapping mfem's ODE solvers
+  //
+  // evaluate the constraint functions at a 3-point
+  // stencil of times centered on the time of interest
+  // in order to compute finite-difference approximations
+  // to the time derivatives that appear in the residual
+  U_minus_ = 0.0;
+  U_       = 0.0;
+  U_plus_  = 0.0;
+  for (const auto& bc : bcs_.essentials()) {
+    bc.projectBdrToDofs(U_minus_, t - epsilon);
+    bc.projectBdrToDofs(U_, t);
+    bc.projectBdrToDofs(U_plus_, t + epsilon);
+  }
+
+  bool implicit = (c0 != 0.0 || c0 != 0.0);
+  if (implicit) {
+    if (enforcement_method_ == DirichletEnforcementMethod::DirectControl) {
+      d2U_dt2_ = (U_ - u) / c0;
+      dU_dt_   = du_dt;
+      U_       = u;
+    }
+
+    if (enforcement_method_ == DirichletEnforcementMethod::RateControl) {
+      d2U_dt2_ = (dU_dt_ - du_dt) / c0;
+      dU_dt_   = du_dt;
+      U_       = u;
+    }
+
+    if (enforcement_method_ == DirichletEnforcementMethod::FullControl) {
+      d2U_dt2_ = (U_minus_ - 2.0 * U_ + U_plus_) / (epsilon * epsilon);
+      dU_dt_   = (U_plus_ - U_minus_) / (2.0 * epsilon) - c0 * d2U_dt2_;
+      U_       = U_ - c0 * d2U_dt2_;
+    }
+  } else {
+    d2U_dt2_ = (U_minus_ - 2.0 * U_ + U_plus_) / (epsilon * epsilon);
+    dU_dt_   = (U_plus_ - U_minus_) / (2.0 * epsilon);
+  }
+
+  auto constrained_dofs = bcs_.allEssentialDofs();
+  state_.u.SetSubVector(constrained_dofs, 0.0);
+  U_.SetSubVectorComplement(constrained_dofs, 0.0);
+  state_.u += U_;
+
+  state_.du_dt.SetSubVector(constrained_dofs, 0.0);
+  dU_dt_.SetSubVectorComplement(constrained_dofs, 0.0);
+  state_.du_dt += dU_dt_;
+
+  // use the previous solution as our starting guess
+  d2u_dt2 = state_.d2u_dt2;
+  d2u_dt2.SetSubVector(constrained_dofs, 0.0);
+  d2U_dt2_.SetSubVectorComplement(constrained_dofs, 0.0);
+  d2u_dt2 += d2U_dt2_;
+
+  solver_.Mult(zero_, d2u_dt2);
+  SLIC_WARNING_IF(!solver_.nonlinearSolver().GetConverged(), "Newton Solver did not converge.");
+
+  state_.d2u_dt2 = d2u_dt2;
+}
+
+FirstOrderODE::FirstOrderODE(int n, State&& state, const EquationSolver& solver, const BoundaryConditionManager& bcs)
+    : mfem::TimeDependentOperator(n, 0.0), state_(std::move(state)), solver_(solver), bcs_(bcs), zero_(n)
+{
+  zero_ = 0.0;
+  U_minus_.SetSize(n);
+  U_.SetSize(n);
+  U_plus_.SetSize(n);
+  dU_dt_.SetSize(n);
+}
+
+void FirstOrderODE::Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const
+{
+  // this is intended to be temporary
+  // Ideally, epsilon should be "small" relative to the characteristic
+  // time of the ODE, but we can't ensure that at present (we don't have
+  // a critical timestep estimate)
+  constexpr double epsilon = 0.0001;
+
+  // assign these values to variables with greater scope,
+  // so that the residual operator can see them
+  state_.dt = dt;
+  state_.u  = u;
+
+  // TODO: take care of this last part of the ODE definition
+  //       automatically by wrapping mfem's ODE solvers
+  //
+  // evaluate the constraint functions at a 3-point
+  // stencil of times centered on the time of interest
+  // in order to compute finite-difference approximations
+  // to the time derivatives that appear in the residual
+  U_minus_ = 0.0;
+  U_       = 0.0;
+  U_plus_  = 0.0;
+  for (const auto& bc : bcs_.essentials()) {
+    bc.projectBdrToDofs(U_minus_, t - epsilon);
+    bc.projectBdrToDofs(U_, t);
+    bc.projectBdrToDofs(U_plus_, t + epsilon);
+  }
+
+  bool implicit = (dt != 0.0);
+  if (implicit) {
+    if (enforcement_method_ == DirichletEnforcementMethod::DirectControl) {
+      dU_dt_ = (U_ - u) / dt;
+      U_     = u;
+    }
+
+    if (enforcement_method_ == DirichletEnforcementMethod::RateControl) {
+      dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
+      U_     = u;
+    }
+
+    if (enforcement_method_ == DirichletEnforcementMethod::FullControl) {
+      dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
+      U_     = U_ - dt * dU_dt_;
+    }
+  } else {
+    dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
+  }
+
+  auto constrained_dofs = bcs_.allEssentialDofs();
+  state_.u.SetSubVector(constrained_dofs, 0.0);
+  U_.SetSubVectorComplement(constrained_dofs, 0.0);
+  state_.u += U_;
+
+  du_dt = state_.du_dt;
+  du_dt.SetSubVector(constrained_dofs, 0.0);
+  dU_dt_.SetSubVectorComplement(constrained_dofs, 0.0);
+  du_dt += dU_dt_;
+
+  solver_.Mult(zero_, du_dt);
+  SLIC_WARNING_IF(!solver_.nonlinearSolver().GetConverged(), "Newton Solver did not converge.");
+
+  state_.du_dt       = du_dt;
+  state_.previous_dt = dt;
+}
+}  // namespace serac

--- a/src/physics/operators/odes.hpp
+++ b/src/physics/operators/odes.hpp
@@ -121,11 +121,24 @@ private:
    * @param[in] du_dt The first time derivative of u
    * @param[out] d2u_dt2 The second time derivative of u
    */
-  void  Solve(const double t, const double c0, const double c1, const mfem::Vector& u, const mfem::Vector& du_dt,
-              mfem::Vector& d2u_dt2) const;
+  void Solve(const double t, const double c0, const double c1, const mfem::Vector& u, const mfem::Vector& du_dt,
+             mfem::Vector& d2u_dt2) const;
+
+  /**
+   * @brief Set of references to external variables used by residual operator
+   */
   State state_;
-  DirichletEnforcementMethod      enforcement_method_ = serac::DirichletEnforcementMethod::RateControl;
-  const EquationSolver&           solver_;
+  /**
+   * @brief The method of enforcing time-varying dirichlet boundary conditions
+   */
+  DirichletEnforcementMethod enforcement_method_ = serac::DirichletEnforcementMethod::RateControl;
+  /**
+   * @brief Reference to the equationsolver used to solve for d2u_dt2
+   */
+  const EquationSolver& solver_;
+  /**
+   * @brief Reference to boundary conditions used to constrain the solution
+   */
   const BoundaryConditionManager& bcs_;
   mfem::Vector                    zero_;
 
@@ -227,9 +240,21 @@ private:
    */
   void Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const;
 
-  State                           state_;
-  DirichletEnforcementMethod      enforcement_method_ = serac::DirichletEnforcementMethod::RateControl;
-  const EquationSolver&           solver_;
+  /**
+   * @brief Set of references to external variables used by residual operator
+   */
+  State state_;
+  /**
+   * @brief The method of enforcing time-varying dirichlet boundary conditions
+   */
+  DirichletEnforcementMethod enforcement_method_ = serac::DirichletEnforcementMethod::RateControl;
+  /**
+   * @brief Reference to the equationsolver used to solve for du_dt
+   */
+  const EquationSolver& solver_;
+  /**
+   * @brief Reference to boundary conditions used to constrain the solution
+   */
   const BoundaryConditionManager& bcs_;
   mfem::Vector                    zero_;
 

--- a/src/physics/operators/odes.hpp
+++ b/src/physics/operators/odes.hpp
@@ -9,7 +9,6 @@
 #include <functional>
 
 #include "mfem.hpp"
-#include "numerics/expr_template_ops.hpp"
 #include "physics/utilities/boundary_condition_manager.hpp"
 #include "physics/utilities/equation_solver.hpp"
 
@@ -27,6 +26,10 @@ namespace serac {
  */
 class SecondOrderODE : public mfem::SecondOrderTimeDependentOperator {
 public:
+  /**
+   * @brief A set of references to physics-module-owned variables
+   * used by the residual operator
+   */
   struct State {
     /**
      * @brief Current time step
@@ -58,129 +61,76 @@ public:
    * @brief Constructor defining the size and specific system of ordinary differential equations to be solved
    *
    * @param[in] n The number of components in each vector of the ODE
-   * @param[in] f The function that describing how to solve for the second derivative, given the current state
-   *    and its time derivative. The two functions
+   * @param[in] state The collection of references to input/output variables from the physics module
+   * @param[in] solver The solver that operates on the residual
+   * @param[in] bcs The set of Dirichlet conditions to enforce
    *
-   *      mfem::SecondOrderTimeDependentOperator::Mult and mfem::SecondOrderTimeDependentOperator::ImplicitSolve
+   * Implements mfem::SecondOrderTimeDependentOperator::Mult and mfem::SecondOrderTimeDependentOperator::ImplicitSolve
    *      (described in more detail here:
    * https://mfem.github.io/doxygen/html/classmfem_1_1SecondOrderTimeDependentOperator.html)
    *
-   *    are consolidated into a single std::function, where
+   * where
    *
-   *      mfem::SecondOrderTimeDependentOperator::Mult corresponds to the case where fac0, fac1 are both zero
-   *      mfem::SecondOrderTimeDependentOperator::ImplicitSolve corresponds to the case where either of fac0, fac1 are
+   * mfem::SecondOrderTimeDependentOperator::Mult corresponds to the case where fac0, fac1 are both zero
+   * mfem::SecondOrderTimeDependentOperator::ImplicitSolve corresponds to the case where either of fac0, fac1 are
    * nonzero
    *
    */
-  SecondOrderODE(int n, State&& state, const EquationSolver& solver, const BoundaryConditionManager& bcs)
-      : mfem::SecondOrderTimeDependentOperator(n, 0.0), state_(std::move(state)), solver_(solver), bcs_(bcs), zero_(n)
-  {
-    zero_ = 0.0;
-    U_minus_.SetSize(n);
-    U_.SetSize(n);
-    U_plus_.SetSize(n);
-    dU_dt_.SetSize(n);
-    d2U_dt2_.SetSize(n);
-  }
+  SecondOrderODE(int n, State&& state, const EquationSolver& solver, const BoundaryConditionManager& bcs);
 
+  /**
+   * @brief Solves the equation d2u_dt2 = f(u, du_dt, t)
+   *
+   * @param[in] u The true DOFs
+   * @param[in] du_dt The first time derivative of u
+   * @param[out] d2u_dt2 The second time derivative of u
+   */
   void Mult(const mfem::Vector& u, const mfem::Vector& du_dt, mfem::Vector& d2u_dt2) const
   {
     Solve(t, 0.0, 0.0, u, du_dt, d2u_dt2);
   }
 
+  /**
+   * @brief Solves the equation d2u_dt2 = f(u + 1/2 c1^2 * d2u_dt2, du_dt + c1 * d2u_dt2, t)
+   *
+   * @param[in] c0 The current time step
+   * @param[in] c1 The previous time step
+   * @param[in] u The true DOFs
+   * @param[in] du_dt The first time derivative of u
+   * @param[out] d2u_dt2 The second time derivative of u
+   */
   void ImplicitSolve(const double c0, const double c1, const mfem::Vector& u, const mfem::Vector& du_dt,
                      mfem::Vector& d2u_dt2)
   {
     Solve(t, c0, c1, u, du_dt, d2u_dt2);
   }
 
+  /**
+   * @brief Configures the Dirichlet enforcement method to use
+   * @param[in] method The selected method
+   */
+  void setEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
+
 private:
-  void Solve(const double t, const double c0, const double c1, const mfem::Vector& u, const mfem::Vector& du_dt,
-             mfem::Vector& d2u_dt2) const
-  {
-    // this is intended to be temporary
-    // Ideally, epsilon should be "small" relative to the characteristic time
-    // of the ODE, but we can't ensure that at present (we don't have a
-    // critical timestep estimate)
-    constexpr double epsilon = 0.0001;
-
-    // assign these values to variables with greater scope,
-    // so that the residual operator can see them
-    state_.c0    = c0;
-    state_.c1    = c1;
-    state_.u     = u;
-    state_.du_dt = du_dt;
-
-    // TODO: take care of this last part of the ODE definition
-    //       automatically by wrapping mfem's ODE solvers
-    //
-    // evaluate the constraint functions at a 3-point
-    // stencil of times centered on the time of interest
-    // in order to compute finite-difference approximations
-    // to the time derivatives that appear in the residual
-    U_minus_ = 0.0;
-    U_       = 0.0;
-    U_plus_  = 0.0;
-    for (const auto& bc : bcs_.essentials()) {
-      bc.projectBdrToDofs(U_minus_, t - epsilon);
-      bc.projectBdrToDofs(U_, t);
-      bc.projectBdrToDofs(U_plus_, t + epsilon);
-    }
-
-    bool implicit = (c0 != 0.0 || c0 != 0.0);
-    if (implicit) {
-      if (enforcement_method_ == DirichletEnforcementMethod::DirectControl) {
-        d2U_dt2_ = (U_ - u) / c0;
-        dU_dt_   = du_dt;
-        U_       = u;
-      }
-
-      if (enforcement_method_ == DirichletEnforcementMethod::RateControl) {
-        d2U_dt2_ = (dU_dt_ - du_dt) / c0;
-        dU_dt_   = du_dt;
-        U_       = u;
-      }
-
-      if (enforcement_method_ == DirichletEnforcementMethod::FullControl) {
-        d2U_dt2_ = (U_minus_ - 2.0 * U_ + U_plus_) / (epsilon * epsilon);
-        dU_dt_   = (U_plus_ - U_minus_) / (2.0 * epsilon) - c0 * d2U_dt2_;
-        U_       = U_ - c0 * d2U_dt2_;
-      }
-    } else {
-      d2U_dt2_ = (U_minus_ - 2.0 * U_ + U_plus_) / (epsilon * epsilon);
-      dU_dt_   = (U_plus_ - U_minus_) / (2.0 * epsilon);
-    }
-
-    auto constrained_dofs = bcs_.allEssentialDofs();
-    state_.u.SetSubVector(constrained_dofs, 0.0);
-    U_.SetSubVectorComplement(constrained_dofs, 0.0);
-    state_.u += U_;
-
-    state_.du_dt.SetSubVector(constrained_dofs, 0.0);
-    dU_dt_.SetSubVectorComplement(constrained_dofs, 0.0);
-    state_.du_dt += dU_dt_;
-
-    // use the previous solution as our starting guess
-    d2u_dt2 = state_.d2u_dt2;
-    d2u_dt2.SetSubVector(constrained_dofs, 0.0);
-    d2U_dt2_.SetSubVectorComplement(constrained_dofs, 0.0);
-    d2u_dt2 += d2U_dt2_;
-
-    solver_.Mult(zero_, d2u_dt2);
-    SLIC_WARNING_IF(!solver_.nonlinearSolver().GetConverged(), "Newton Solver did not converge.");
-
-    state_.d2u_dt2 = d2u_dt2;
-  }
-  State                           state_;
+  /**
+   * @brief the function that is used to implement mfem::TDO::Mult and mfem::TDO::ImplicitSolve
+   */
+  void  Solve(const double t, const double c0, const double c1, const mfem::Vector& u, const mfem::Vector& du_dt,
+              mfem::Vector& d2u_dt2) const;
+  State state_;
   DirichletEnforcementMethod      enforcement_method_;
   const EquationSolver&           solver_;
   const BoundaryConditionManager& bcs_;
   mfem::Vector                    zero_;
-  mutable mfem::Vector            U_minus_;
-  mutable mfem::Vector            U_;
-  mutable mfem::Vector            U_plus_;
-  mutable mfem::Vector            dU_dt_;
-  mutable mfem::Vector            d2U_dt2_;
+
+  /**
+   * @brief Working vectors for ODE outputs prior to constraint enforcement
+   */
+  mutable mfem::Vector U_minus_;
+  mutable mfem::Vector U_;
+  mutable mfem::Vector U_plus_;
+  mutable mfem::Vector dU_dt_;
+  mutable mfem::Vector d2U_dt2_;
 };
 
 /**
@@ -195,6 +145,10 @@ private:
  */
 class FirstOrderODE : public mfem::TimeDependentOperator {
 public:
+  /**
+   * @brief A set of references to physics-module-owned variables
+   * used by the residual operator
+   */
   struct State {
     /**
      * @brief Predicted true DOFs
@@ -224,110 +178,59 @@ public:
    * @param[in] f The function that describing how to solve for the first derivative, given the current state.
    *    The two functions
    *
-   *      mfem::TimeDependentOperator::Mult and mfem::TimeDependentOperator::ImplicitSolve
+   * Implements mfem::TimeDependentOperator::Mult and mfem::TimeDependentOperator::ImplicitSolve
    *      (described in more detail here: https://mfem.github.io/doxygen/html/classmfem_1_1TimeDependentOperator.html)
    *
-   *    are consolidated into a single std::function, where
+   * where
    *
-   *      mfem::TimeDependentOperator::Mult corresponds to the case where dt is zero
-   *      mfem::TimeDependentOperator::ImplicitSolve corresponds to the case where dt is nonzero
+   * mfem::TimeDependentOperator::Mult corresponds to the case where dt is zero
+   * mfem::TimeDependentOperator::ImplicitSolve corresponds to the case where dt is nonzero
    *
    */
-  FirstOrderODE(int n, State&& state, const EquationSolver& solver, const BoundaryConditionManager& bcs)
-      : mfem::TimeDependentOperator(n, 0.0), state_(std::move(state)), solver_(solver), bcs_(bcs), zero_(n)
-  {
-    zero_ = 0.0;
-    U_minus_.SetSize(n);
-    U_.SetSize(n);
-    U_plus_.SetSize(n);
-    dU_dt_.SetSize(n);
-  }
+  FirstOrderODE(int n, State&& state, const EquationSolver& solver, const BoundaryConditionManager& bcs);
 
+  /**
+   * @brief Solves the equation du_dt = f(u, t)
+   *
+   * @param[in] u The true DOFs
+   * @param[in] du_dt The first time derivative of u
+   */
   void Mult(const mfem::Vector& u, mfem::Vector& du_dt) const { Solve(0.0, u, du_dt); }
+
+  /**
+   * @brief Solves the equation du_dt = f(u + dt * du_dt, t)
+   *
+   * @param[in] dt The time step
+   * @param[in] u The true DOFs
+   * @param[in] du_dt The first time derivative of u
+   */
   void ImplicitSolve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) { Solve(dt, u, du_dt); }
 
+  /**
+   * @brief Configures the Dirichlet enforcement method to use
+   * @param[in] method The selected method
+   */
   void setEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
 
+private:
   /**
    * @brief the function that is used to implement mfem::TDO::Mult and mfem::TDO::ImplicitSolve
    */
-
-private:
-  void Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const
-  {
-    // this is intended to be temporary
-    // Ideally, epsilon should be "small" relative to the characteristic
-    // time of the ODE, but we can't ensure that at present (we don't have
-    // a critical timestep estimate)
-    constexpr double epsilon = 0.0001;
-
-    // assign these values to variables with greater scope,
-    // so that the residual operator can see them
-    state_.dt = dt;
-    state_.u  = u;
-
-    // TODO: take care of this last part of the ODE definition
-    //       automatically by wrapping mfem's ODE solvers
-    //
-    // evaluate the constraint functions at a 3-point
-    // stencil of times centered on the time of interest
-    // in order to compute finite-difference approximations
-    // to the time derivatives that appear in the residual
-    U_minus_ = 0.0;
-    U_       = 0.0;
-    U_plus_  = 0.0;
-    for (const auto& bc : bcs_.essentials()) {
-      bc.projectBdrToDofs(U_minus_, t - epsilon);
-      bc.projectBdrToDofs(U_, t);
-      bc.projectBdrToDofs(U_plus_, t + epsilon);
-    }
-
-    bool implicit = (dt != 0.0);
-    if (implicit) {
-      if (enforcement_method_ == DirichletEnforcementMethod::DirectControl) {
-        dU_dt_ = (U_ - u) / dt;
-        U_     = u;
-      }
-
-      if (enforcement_method_ == DirichletEnforcementMethod::RateControl) {
-        dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
-        U_     = u;
-      }
-
-      if (enforcement_method_ == DirichletEnforcementMethod::FullControl) {
-        dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
-        U_     = U_ - dt * dU_dt_;
-      }
-    } else {
-      dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
-    }
-
-    auto constrained_dofs = bcs_.allEssentialDofs();
-    state_.u.SetSubVector(constrained_dofs, 0.0);
-    U_.SetSubVectorComplement(constrained_dofs, 0.0);
-    state_.u += U_;
-
-    du_dt = state_.du_dt;
-    du_dt.SetSubVector(constrained_dofs, 0.0);
-    dU_dt_.SetSubVectorComplement(constrained_dofs, 0.0);
-    du_dt += dU_dt_;
-
-    solver_.Mult(zero_, du_dt);
-    SLIC_WARNING_IF(!solver_.nonlinearSolver().GetConverged(), "Newton Solver did not converge.");
-
-    state_.du_dt       = du_dt;
-    state_.previous_dt = dt;
-  }
+  void Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const;
 
   State                           state_;
   DirichletEnforcementMethod      enforcement_method_;
   const EquationSolver&           solver_;
   const BoundaryConditionManager& bcs_;
   mfem::Vector                    zero_;
-  mutable mfem::Vector            U_minus_;
-  mutable mfem::Vector            U_;
-  mutable mfem::Vector            U_plus_;
-  mutable mfem::Vector            dU_dt_;
+
+  /**
+   * @brief Working vectors for ODE outputs prior to constraint enforcement
+   */
+  mutable mfem::Vector U_minus_;
+  mutable mfem::Vector U_;
+  mutable mfem::Vector U_plus_;
+  mutable mfem::Vector dU_dt_;
 };
 
 }  // namespace serac

--- a/src/physics/operators/odes.hpp
+++ b/src/physics/operators/odes.hpp
@@ -1,12 +1,19 @@
+// Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
 #pragma once
 
 #include <functional>
-#include <variant>
 
 #include "mfem.hpp"
 #include "numerics/expr_template_ops.hpp"
 #include "physics/utilities/boundary_condition_manager.hpp"
 #include "physics/utilities/equation_solver.hpp"
+
+namespace serac {
 
 /**
  * @brief SecondOrderODE is a class wrapping mfem::SecondOrderTimeDependentOperator
@@ -80,10 +87,32 @@ class FirstOrderODE : public mfem::TimeDependentOperator {
 public:
   using TypeSignature = void(const double, const double, const mfem::Vector&, mfem::Vector&);
 
+  struct State {
+    /**
+     * @brief Predicted true DOFs
+     */
+    mfem::Vector& u;
+
+    /**
+     * @brief Current time step
+     */
+    double& dt;
+
+    /**
+     * @brief Previous value of du_dt
+     */
+    mfem::Vector& previous;
+
+    /**
+     * @brief Previous value of dt
+     */
+    double& previous_dt;
+  };
+
   /**
    * @brief Default constructor for creating an uninitialized FirstOrderODE
    */
-  FirstOrderODE() : mfem::TimeDependentOperator(0, 0.0) {}
+  // FirstOrderODE() : mfem::TimeDependentOperator(0, 0.0) {}
 
   /**
    * @brief Constructor defining the size and specific system of ordinary differential equations to be solved
@@ -101,15 +130,101 @@ public:
    *      mfem::TimeDependentOperator::ImplicitSolve corresponds to the case where dt is nonzero
    *
    */
-  FirstOrderODE(int n, std::function<TypeSignature> f) : mfem::TimeDependentOperator(n, 0.0), f_(f) {}
+  FirstOrderODE(int n, State&& state, const EquationSolver& solver, const BoundaryConditionManager& bcs)
+      : mfem::TimeDependentOperator(n, 0.0), state_(std::move(state)), solver_(solver), bcs_(bcs), zero_(n)
+  {
+    zero_ = 0.0;
+    U_minus_.SetSize(n);
+    U_.SetSize(n);
+    U_plus_.SetSize(n);
+    dU_dt_.SetSize(n);
+  }
 
-  void Mult(const mfem::Vector& u, mfem::Vector& du_dt) const { f_(t, 0.0, u, du_dt); }
-  void ImplicitSolve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) { f_(t, dt, u, du_dt); }
+  void Mult(const mfem::Vector& u, mfem::Vector& du_dt) const { Solve(0.0, u, du_dt); }
+  void ImplicitSolve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) { Solve(dt, u, du_dt); }
+
+  void setEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
 
   /**
    * @brief the function that is used to implement mfem::TDO::Mult and mfem::TDO::ImplicitSolve
    */
 
 private:
-  std::function<TypeSignature> f_;
+  void Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const
+  {
+    // this is intended to be temporary
+    // Ideally, epsilon should be "small" relative to the characteristic
+    // time of the ODE, but we can't ensure that at present (we don't have
+    // a critical timestep estimate)
+    constexpr double epsilon = 0.0001;
+
+    // assign these values to variables with greater scope,
+    // so that the residual operator can see them
+    state_.dt = dt;
+    state_.u  = u;
+
+    // TODO: take care of this last part of the ODE definition
+    //       automatically by wrapping mfem's ODE solvers
+    //
+    // evaluate the constraint functions at a 3-point
+    // stencil of times centered on the time of interest
+    // in order to compute finite-difference approximations
+    // to the time derivatives that appear in the residual
+    U_minus_ = 0.0;
+    U_       = 0.0;
+    U_plus_  = 0.0;
+    for (const auto& bc : bcs_.essentials()) {
+      bc.projectBdrToDofs(U_minus_, t - epsilon);
+      bc.projectBdrToDofs(U_, t);
+      bc.projectBdrToDofs(U_plus_, t + epsilon);
+    }
+
+    bool implicit = (dt != 0.0);
+    if (implicit) {
+      if (enforcement_method_ == DirichletEnforcementMethod::DirectControl) {
+        dU_dt_ = (U_ - u) / dt;
+        U_     = u;
+      }
+
+      if (enforcement_method_ == DirichletEnforcementMethod::RateControl) {
+        dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
+        U_     = u;
+      }
+
+      if (enforcement_method_ == DirichletEnforcementMethod::FullControl) {
+        dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
+        U_     = U_ - dt * dU_dt_;
+      }
+    } else {
+      dU_dt_ = (U_plus_ - U_minus_) / (2.0 * epsilon);
+    }
+
+    auto constrained_dofs = bcs_.allEssentialDofs();
+    state_.u.SetSubVector(constrained_dofs, 0.0);
+    U_.SetSubVectorComplement(constrained_dofs, 0.0);
+    state_.u += U_;
+
+    du_dt = state_.previous;
+    du_dt.SetSubVector(constrained_dofs, 0.0);
+    dU_dt_.SetSubVectorComplement(constrained_dofs, 0.0);
+    du_dt += dU_dt_;
+
+    solver_.Mult(zero_, du_dt);
+    SLIC_WARNING_IF(!solver_.nonlinearSolver().GetConverged(), "Newton Solver did not converge.");
+
+    state_.previous    = du_dt;
+    state_.previous_dt = dt;
+  }
+
+  State                           state_;
+  DirichletEnforcementMethod      enforcement_method_;
+  const EquationSolver&           solver_;
+  const BoundaryConditionManager& bcs_;
+  mfem::Vector                    zero_;
+  mutable mfem::Vector            U_minus_;
+  mutable mfem::Vector            U_;
+  mutable mfem::Vector            U_plus_;
+  mutable mfem::Vector            dU_dt_;
 };
+
+}  // namespace serac

--- a/src/physics/operators/odes.hpp
+++ b/src/physics/operators/odes.hpp
@@ -113,7 +113,13 @@ public:
 
 private:
   /**
-   * @brief the function that is used to implement mfem::TDO::Mult and mfem::TDO::ImplicitSolve
+   * @brief Internal implementation used for mfem::SOTDO::Mult and mfem::SOTDO::ImplicitSolve
+   * @param[in] t The current time
+   * @param[in] c0 The current time step
+   * @param[in] c1 The previous time step
+   * @param[in] u The true DOFs
+   * @param[in] du_dt The first time derivative of u
+   * @param[out] d2u_dt2 The second time derivative of u
    */
   void  Solve(const double t, const double c0, const double c1, const mfem::Vector& u, const mfem::Vector& du_dt,
               mfem::Vector& d2u_dt2) const;
@@ -214,7 +220,10 @@ public:
 
 private:
   /**
-   * @brief the function that is used to implement mfem::TDO::Mult and mfem::TDO::ImplicitSolve
+   * @brief Internal implementation used for mfem::TDO::Mult and mfem::TDO::ImplicitSolve
+   * @param[in] dt The time step
+   * @param[in] u The true DOFs
+   * @param[in] du_dt The first time derivative of u
    */
   void Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const;
 

--- a/src/physics/operators/odes.hpp
+++ b/src/physics/operators/odes.hpp
@@ -124,7 +124,7 @@ private:
   void  Solve(const double t, const double c0, const double c1, const mfem::Vector& u, const mfem::Vector& du_dt,
               mfem::Vector& d2u_dt2) const;
   State state_;
-  DirichletEnforcementMethod      enforcement_method_;
+  DirichletEnforcementMethod      enforcement_method_ = serac::DirichletEnforcementMethod::RateControl;
   const EquationSolver&           solver_;
   const BoundaryConditionManager& bcs_;
   mfem::Vector                    zero_;
@@ -228,7 +228,7 @@ private:
   void Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const;
 
   State                           state_;
-  DirichletEnforcementMethod      enforcement_method_;
+  DirichletEnforcementMethod      enforcement_method_ = serac::DirichletEnforcementMethod::RateControl;
   const EquationSolver&           solver_;
   const BoundaryConditionManager& bcs_;
   mfem::Vector                    zero_;

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -29,7 +29,7 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
 
   // Check for dynamic mode
   if (params.dyn_params) {
-    setTimestepper(params.dyn_params->timestepper, params.dyn_params->enforcement_method);
+    setTimestepper(params.dyn_params->timestepper);
     ode_.setEnforcementMethod(params.dyn_params->enforcement_method);
   } else {
     setTimestepper(TimestepMethod::QuasiStatic);

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -18,7 +18,7 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
                    FiniteElementState::Options{
                        .order = order, .space_dim = 1, .ordering = mfem::Ordering::byNODES, .name = "temperature"}),
       residual_(temperature_.space().TrueVSize()),
-      ode_(temperature_.space().TrueVSize(), {.u = u_, .dt = dt_, .previous = previous_, .previous_dt = previous_dt_},
+      ode_(temperature_.space().TrueVSize(), {.u = u_, .dt = dt_, .du_dt = previous_, .previous_dt = previous_dt_},
            nonlin_solver_, bcs_)
 {
   state_.push_back(temperature_);

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -46,11 +46,6 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
   zero_.SetSize(true_size);
   zero_ = 0.0;
 
-  U_minus_.SetSize(true_size);
-  U_.SetSize(true_size);
-  U_plus_.SetSize(true_size);
-  dU_dt_.SetSize(true_size);
-
   // Default to constant value of 1.0 for density and specific heat capacity
   cp_  = std::make_unique<mfem::ConstantCoefficient>(1.0);
   rho_ = std::make_unique<mfem::ConstantCoefficient>(1.0);

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -7,6 +7,7 @@
 #include "physics/thermal_conduction.hpp"
 
 #include "infrastructure/logger.hpp"
+#include "numerics/expr_template_ops.hpp"
 
 namespace serac {
 

--- a/src/physics/thermal_conduction.hpp
+++ b/src/physics/thermal_conduction.hpp
@@ -272,12 +272,6 @@ protected:
    * nonlinear solver
    */
   mfem::Vector previous_;
-
-  // TODO delete these with ODE refactor
-  mfem::Vector U_minus_;
-  mfem::Vector U_;
-  mfem::Vector U_plus_;
-  mfem::Vector dU_dt_;
 };
 
 }  // namespace serac

--- a/src/physics/thermal_conduction.hpp
+++ b/src/physics/thermal_conduction.hpp
@@ -235,17 +235,17 @@ protected:
   std::unique_ptr<mfem::Coefficient> mass_coef_;
 
   /**
+   * @brief mfem::Operator that describes the weight residual
+   * and its gradient with respect to temperature
+   */
+  StdFunctionOperator residual_;
+
+  /**
    * @brief the ordinary differential equation that describes
    * how to solve for the time derivative of temperature, given
    * the current temperature and source terms
    */
   FirstOrderODE ode_;
-
-  /**
-   * @brief mfem::Operator that describes the weight residual
-   * and its gradient with respect to temperature
-   */
-  StdFunctionOperator residual_;
 
   /**
    * @brief the specific methods and tolerances specified to

--- a/src/physics/thermal_solid.cpp
+++ b/src/physics/thermal_solid.cpp
@@ -42,11 +42,9 @@ void ThermalSolid::completeSetup()
   solid_solver_.completeSetup();
 }
 
-void ThermalSolid::setTimestepper(const serac::TimestepMethod             timestepper,
-                                  const serac::DirichletEnforcementMethod enforcement_method)
+void ThermalSolid::setTimestepper(const serac::TimestepMethod timestepper)
 {
-  timestepper_        = timestepper;
-  enforcement_method_ = enforcement_method;
+  timestepper_ = timestepper;
   therm_solver_.setTimestepper(timestepper);
   solid_solver_.setTimestepper(timestepper);
 }

--- a/src/physics/thermal_solid.hpp
+++ b/src/physics/thermal_solid.hpp
@@ -183,9 +183,7 @@ public:
    * @param[in] timestepper The timestepping method for the solver
    * @param[in] enforcement_method The method of enforcing time-varying dirichlet boundary conditions
    */
-  virtual void setTimestepper(const serac::TimestepMethod             timestepper,
-                              const serac::DirichletEnforcementMethod enforcement_method =
-                                  serac::DirichletEnforcementMethod::RateControl) override;
+  virtual void setTimestepper(const serac::TimestepMethod timestepper) override;
 
   /**
    * @brief Complete the initialization and allocation of the data structures.

--- a/src/physics/utilities/equation_solver.hpp
+++ b/src/physics/utilities/equation_solver.hpp
@@ -7,7 +7,7 @@
 /**
  * @file equation_solver.hpp
  *
- * @brief This file contains the declaration of an iterative solver wrapper
+ * @brief This file contains the declaration of an equation solver wrapper
  */
 
 #ifndef EQUATION_SOLVER


### PR DESCRIPTION
After some discussion with @samuelpmishLLNL it was determined that almost all of the content of the lambdas passed to `FirstOrderODE`/`SecondOrderODE` is physics-independent. 

This PR removes the `std::function` interface from the ODE classes and moves the logic in the lambdas (stencil, constraint application, etc) to the ODE classes.  Physics modules now pass references (to member variables) to the ODE class such that results are made available to the residual operator contained within the physics module.

A follow-up PR will implement a wrapper for MFEM's ODESolvers that accepts a TimeStepMethod and an ODE.