### PR TITLE
Add fake mpi target to using-with-cmake example

### DIFF
--- a/examples/using-with-cmake/CMakeLists.txt
+++ b/examples/using-with-cmake/CMakeLists.txt
@@ -5,11 +5,8 @@ include(CMakeFindDependencyMacro)
 find_dependency(serac REQUIRED NO_DEFAULT_PATH PATHS "${SERAC_DIR}/lib/cmake")
 
 ## BEGIN FIXME: REMOVE ASAP ONCE BLT_IMPORT_LIBRARY HAS EXPORTABLE OPTION
-foreach(_target serac::numerics serac::physics_utilities serac::physics_operators serac::physics serac::integrators serac::coefficients serac::infrastructure serac::serac)
-    get_target_property(_libs ${_target} INTERFACE_LINK_LIBRARIES)
-    list(REMOVE_ITEM _libs mpi)
-    set_target_properties(${_target} PROPERTIES INTERFACE_LINK_LIBRARIES "${_libs}")
-endforeach()
+# Create fake empty target, this stops CMake from adding -lmpi to the link line
+add_library(mpi INTERFACE)
 ## END FIXME
 
 add_executable(serac_example serac_example.cpp)


### PR DESCRIPTION
Slightly cleaner so we don't have to keep adding targets to this list.