### PR TITLE
Move ODE solver into ODE class

### DIFF
--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -130,9 +130,6 @@ int main(int argc, char* argv[])
     }
   }
 
-  // Set the time step method
-  solid_solver.setTimestepper(serac::TimestepMethod::QuasiStatic);
-
   // Complete the solver setup
   solid_solver.completeSetup();
 

--- a/src/physics/base_physics.cpp
+++ b/src/physics/base_physics.cpp
@@ -19,8 +19,7 @@ BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh)
     : comm_(mesh->GetComm()), mesh_(mesh), output_type_(serac::OutputType::VisIt), time_(0.0), cycle_(0), bcs_(*mesh)
 {
   std::tie(mpi_size_, mpi_rank_) = getMPIInfo(comm_);
-  BasePhysics::setTimestepper(serac::TimestepMethod::ForwardEuler);
-  order_ = 1;
+  order_                         = 1;
 }
 
 BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh, int n, int p) : BasePhysics(mesh)
@@ -55,69 +54,6 @@ void BasePhysics::setState(std::vector<serac::FiniteElementState>&& state)
 }
 
 const std::vector<std::reference_wrapper<serac::FiniteElementState> >& BasePhysics::getState() const { return state_; }
-
-void BasePhysics::setTimestepper(const serac::TimestepMethod timestepper)
-{
-  timestepper_ = timestepper;
-
-  switch (timestepper_) {
-    case serac::TimestepMethod::QuasiStatic:
-      break;
-    case serac::TimestepMethod::BackwardEuler:
-      ode_solver_ = std::make_unique<mfem::BackwardEulerSolver>();
-      break;
-    case serac::TimestepMethod::SDIRK33:
-      ode_solver_ = std::make_unique<mfem::SDIRK33Solver>();
-      break;
-    case serac::TimestepMethod::ForwardEuler:
-      ode_solver_ = std::make_unique<mfem::ForwardEulerSolver>();
-      break;
-    case serac::TimestepMethod::RK2:
-      ode_solver_ = std::make_unique<mfem::RK2Solver>(0.5);
-      break;
-    case serac::TimestepMethod::RK3SSP:
-      ode_solver_ = std::make_unique<mfem::RK3SSPSolver>();
-      break;
-    case serac::TimestepMethod::RK4:
-      ode_solver_ = std::make_unique<mfem::RK4Solver>();
-      break;
-    case serac::TimestepMethod::GeneralizedAlpha:
-      ode_solver_ = std::make_unique<mfem::GeneralizedAlphaSolver>(0.5);
-      break;
-    case serac::TimestepMethod::ImplicitMidpoint:
-      ode_solver_ = std::make_unique<mfem::ImplicitMidpointSolver>();
-      break;
-    case serac::TimestepMethod::SDIRK23:
-      ode_solver_ = std::make_unique<mfem::SDIRK23Solver>();
-      break;
-    case serac::TimestepMethod::SDIRK34:
-      ode_solver_ = std::make_unique<mfem::SDIRK34Solver>();
-      break;
-
-    case serac::TimestepMethod::HHTAlpha:
-      second_order_ode_solver_ = std::make_unique<mfem::HHTAlphaSolver>();
-      break;
-    case serac::TimestepMethod::WBZAlpha:
-      second_order_ode_solver_ = std::make_unique<mfem::WBZAlphaSolver>();
-      break;
-    case serac::TimestepMethod::AverageAcceleration:
-      second_order_ode_solver_ = std::make_unique<mfem::AverageAccelerationSolver>();
-      break;
-    case serac::TimestepMethod::LinearAcceleration:
-      second_order_ode_solver_ = std::make_unique<mfem::LinearAccelerationSolver>();
-      break;
-    case serac::TimestepMethod::CentralDifference:
-      second_order_ode_solver_ = std::make_unique<mfem::CentralDifferenceSolver>();
-      break;
-    case serac::TimestepMethod::FoxGoodwin:
-      second_order_ode_solver_ = std::make_unique<mfem::FoxGoodwinSolver>();
-      break;
-
-    default:
-      SLIC_ERROR_ROOT(mpi_rank_, "Timestep method not recognized!");
-      serac::exitGracefully(true);
-  }
-}
 
 void BasePhysics::setTime(const double time) { time_ = time; }
 

--- a/src/physics/base_physics.hpp
+++ b/src/physics/base_physics.hpp
@@ -81,13 +81,6 @@ public:
   virtual const std::vector<std::reference_wrapper<serac::FiniteElementState> >& getState() const;
 
   /**
-   * @brief Set the time integration method
-   *
-   * @param[in] timestepper The timestepping method for the solver
-   */
-  virtual void setTimestepper(const serac::TimestepMethod timestepper);
-
-  /**
    * @brief Set the current time
    *
    * @param[in] time The time
@@ -174,19 +167,9 @@ protected:
   serac::OutputType output_type_;
 
   /**
-   *@brief Time integration method
+   *@brief Whether the simulation is time-independent
    */
-  serac::TimestepMethod timestepper_ = TimestepMethod::QuasiStatic;
-
-  /**
-   * @brief MFEM solver object for first-order ODEs
-   */
-  std::unique_ptr<mfem::ODESolver> ode_solver_;
-
-  /**
-   * @brief MFEM solver object for second-order ODEs
-   */
-  std::unique_ptr<mfem::SecondOrderODESolver> second_order_ode_solver_;
+  bool is_quasistatic_ = true;
 
   /**
    * @brief Root output name

--- a/src/physics/elasticity.cpp
+++ b/src/physics/elasticity.cpp
@@ -23,8 +23,8 @@ Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const Lin
   // If the user wants the AMG preconditioner with a linear solver, set the pfes to be the displacement
   const auto& augmented_params = augmentAMGForElasticity(params, displacement_.space());
 
-  K_inv_ = EquationSolver(mesh->GetComm(), augmented_params);
-  setTimestepper(TimestepMethod::QuasiStatic);
+  K_inv_          = EquationSolver(mesh->GetComm(), augmented_params);
+  is_quasistatic_ = true;
 }
 
 void Elasticity::setDisplacementBCs(const std::set<int>&                     disp_bdr,
@@ -98,7 +98,7 @@ void Elasticity::advanceTimestep(double&)
   // Initialize the true vector
   displacement_.initializeTrueVec();
 
-  if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
+  if (is_quasistatic_) {
     QuasiStaticSolve();
   } else {
     SLIC_ERROR_ROOT(mpi_rank_, "Only quasistatics implemented for linear elasticity!");

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -46,8 +46,8 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
 
   // Check for dynamic mode
   if (params.dyn_params) {
-    ode2_.setTimestepper(params.dyn_params->timestepper);
-    ode2_.setEnforcementMethod(params.dyn_params->enforcement_method);
+    ode2_.SetTimestepper(params.dyn_params->timestepper);
+    ode2_.SetEnforcementMethod(params.dyn_params->enforcement_method);
     is_quasistatic_ = false;
   } else {
     is_quasistatic_ = true;

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -46,11 +46,11 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
 
   // Check for dynamic mode
   if (params.dyn_params) {
-    setTimestepper(params.dyn_params->timestepper);
     ode2_.setTimestepper(params.dyn_params->timestepper);
     ode2_.setEnforcementMethod(params.dyn_params->enforcement_method);
+    is_quasistatic_ = false;
   } else {
-    setTimestepper(TimestepMethod::QuasiStatic);
+    is_quasistatic_ = true;
   }
 
   int true_size = velocity_.space().TrueVSize();
@@ -117,7 +117,7 @@ void NonlinearSolid::completeSetup()
   H_ = displacement_.createOnSpace<mfem::ParNonlinearForm>();
 
   // Add the hyperelastic integrator
-  if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
+  if (is_quasistatic_) {
     H_->AddDomainIntegrator(new IncrementalHyperelasticIntegrator(model_.get()));
   } else {
     H_->AddDomainIntegrator(new mfem::HyperelasticNLFIntegrator(model_.get()));
@@ -139,7 +139,7 @@ void NonlinearSolid::completeSetup()
   }
 
   // If dynamic, create the mass and viscosity forms
-  if (timestepper_ != serac::TimestepMethod::QuasiStatic) {
+  if (!is_quasistatic_) {
     const double              ref_density = 1.0;  // density in the reference configuration
     mfem::ConstantCoefficient rho0(ref_density);
 
@@ -167,7 +167,7 @@ void NonlinearSolid::completeSetup()
   // the nonlinear solve.
   nonlin_solver_.nonlinearSolver().iterative_mode = true;
 
-  if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
+  if (is_quasistatic_) {
     residual_ = buildQuasistaticOperator();
 
   } else {
@@ -232,7 +232,7 @@ void NonlinearSolid::advanceTimestep(double& dt)
   // Set the mesh nodes to the reference configuration
   mesh_->NewNodes(*reference_nodes_);
 
-  if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
+  if (is_quasistatic_) {
     quasiStaticSolve();
   } else {
     ode2_.Step(displacement_.trueVec(), velocity_.trueVec(), time_, dt);

--- a/src/physics/nonlinear_solid.cpp
+++ b/src/physics/nonlinear_solid.cpp
@@ -47,6 +47,7 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
   // Check for dynamic mode
   if (params.dyn_params) {
     setTimestepper(params.dyn_params->timestepper);
+    ode2_.setTimestepper(params.dyn_params->timestepper);
     ode2_.setEnforcementMethod(params.dyn_params->enforcement_method);
   } else {
     setTimestepper(TimestepMethod::QuasiStatic);
@@ -191,8 +192,6 @@ void NonlinearSolid::completeSetup()
           bcs_.eliminateAllEssentialDofsFromMatrix(*J_mat_);
           return *J_mat_;
         });
-
-    second_order_ode_solver_->Init(ode2_);
   }
 
   nonlin_solver_.SetOperator(*residual_);
@@ -236,7 +235,7 @@ void NonlinearSolid::advanceTimestep(double& dt)
   if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
     quasiStaticSolve();
   } else {
-    second_order_ode_solver_->Step(displacement_.trueVec(), velocity_.trueVec(), time_, dt);
+    ode2_.Step(displacement_.trueVec(), velocity_.trueVec(), time_, dt);
   }
 
   // Distribute the shared DOFs

--- a/src/physics/operators/odes.cpp
+++ b/src/physics/operators/odes.cpp
@@ -20,7 +20,7 @@ SecondOrderODE::SecondOrderODE(int n, State&& state, const EquationSolver& solve
   d2U_dt2_.SetSize(n);
 }
 
-void SecondOrderODE::setTimestepper(const serac::TimestepMethod timestepper)
+void SecondOrderODE::SetTimestepper(const serac::TimestepMethod timestepper)
 {
   switch (timestepper) {
     case serac::TimestepMethod::HHTAlpha:
@@ -134,7 +134,7 @@ FirstOrderODE::FirstOrderODE(int n, State&& state, const EquationSolver& solver,
   dU_dt_.SetSize(n);
 }
 
-void FirstOrderODE::setTimestepper(const serac::TimestepMethod timestepper)
+void FirstOrderODE::SetTimestepper(const serac::TimestepMethod timestepper)
 {
   switch (timestepper) {
     case serac::TimestepMethod::BackwardEuler:

--- a/src/physics/operators/odes.cpp
+++ b/src/physics/operators/odes.cpp
@@ -20,6 +20,33 @@ SecondOrderODE::SecondOrderODE(int n, State&& state, const EquationSolver& solve
   d2U_dt2_.SetSize(n);
 }
 
+void SecondOrderODE::setTimestepper(const serac::TimestepMethod timestepper)
+{
+  switch (timestepper) {
+    case serac::TimestepMethod::HHTAlpha:
+      ode_solver_ = std::make_unique<mfem::HHTAlphaSolver>();
+      break;
+    case serac::TimestepMethod::WBZAlpha:
+      ode_solver_ = std::make_unique<mfem::WBZAlphaSolver>();
+      break;
+    case serac::TimestepMethod::AverageAcceleration:
+      ode_solver_ = std::make_unique<mfem::AverageAccelerationSolver>();
+      break;
+    case serac::TimestepMethod::LinearAcceleration:
+      ode_solver_ = std::make_unique<mfem::LinearAccelerationSolver>();
+      break;
+    case serac::TimestepMethod::CentralDifference:
+      ode_solver_ = std::make_unique<mfem::CentralDifferenceSolver>();
+      break;
+    case serac::TimestepMethod::FoxGoodwin:
+      ode_solver_ = std::make_unique<mfem::FoxGoodwinSolver>();
+      break;
+    default:
+      SLIC_ERROR("Timestep method was not a supported second-order ODE method");
+  }
+  ode_solver_->Init(*this);
+}
+
 void SecondOrderODE::Solve(const double t, const double c0, const double c1, const mfem::Vector& u,
                            const mfem::Vector& du_dt, mfem::Vector& d2u_dt2) const
 {
@@ -105,6 +132,45 @@ FirstOrderODE::FirstOrderODE(int n, State&& state, const EquationSolver& solver,
   U_.SetSize(n);
   U_plus_.SetSize(n);
   dU_dt_.SetSize(n);
+}
+
+void FirstOrderODE::setTimestepper(const serac::TimestepMethod timestepper)
+{
+  switch (timestepper) {
+    case serac::TimestepMethod::BackwardEuler:
+      ode_solver_ = std::make_unique<mfem::BackwardEulerSolver>();
+      break;
+    case serac::TimestepMethod::SDIRK33:
+      ode_solver_ = std::make_unique<mfem::SDIRK33Solver>();
+      break;
+    case serac::TimestepMethod::ForwardEuler:
+      ode_solver_ = std::make_unique<mfem::ForwardEulerSolver>();
+      break;
+    case serac::TimestepMethod::RK2:
+      ode_solver_ = std::make_unique<mfem::RK2Solver>(0.5);
+      break;
+    case serac::TimestepMethod::RK3SSP:
+      ode_solver_ = std::make_unique<mfem::RK3SSPSolver>();
+      break;
+    case serac::TimestepMethod::RK4:
+      ode_solver_ = std::make_unique<mfem::RK4Solver>();
+      break;
+    case serac::TimestepMethod::GeneralizedAlpha:
+      ode_solver_ = std::make_unique<mfem::GeneralizedAlphaSolver>(0.5);
+      break;
+    case serac::TimestepMethod::ImplicitMidpoint:
+      ode_solver_ = std::make_unique<mfem::ImplicitMidpointSolver>();
+      break;
+    case serac::TimestepMethod::SDIRK23:
+      ode_solver_ = std::make_unique<mfem::SDIRK23Solver>();
+      break;
+    case serac::TimestepMethod::SDIRK34:
+      ode_solver_ = std::make_unique<mfem::SDIRK34Solver>();
+      break;
+    default:
+      SLIC_ERROR("Timestep method was not a supported first-order ODE method");
+  }
+  ode_solver_->Init(*this);
 }
 
 void FirstOrderODE::Solve(const double dt, const mfem::Vector& u, mfem::Vector& du_dt) const

--- a/src/physics/operators/odes.hpp
+++ b/src/physics/operators/odes.hpp
@@ -109,14 +109,14 @@ public:
    * @brief Configures the Dirichlet enforcement method to use
    * @param[in] method The selected method
    */
-  void setEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
+  void SetEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
 
   /**
    * @brief Set the time integration method
    *
    * @param[in] timestepper The timestepping method for the solver
    */
-  void setTimestepper(const serac::TimestepMethod timestepper);
+  void SetTimestepper(const serac::TimestepMethod timestepper);
 
   /**
    * @brief Performs a time step
@@ -252,14 +252,14 @@ public:
    * @brief Configures the Dirichlet enforcement method to use
    * @param[in] method The selected method
    */
-  void setEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
+  void SetEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
 
   /**
    * @brief Set the time integration method
    *
    * @param[in] timestepper The timestepping method for the solver
    */
-  void setTimestepper(const serac::TimestepMethod timestepper);
+  void SetTimestepper(const serac::TimestepMethod timestepper);
 
   /**
    * @brief Performs a time step

--- a/src/physics/operators/odes.hpp
+++ b/src/physics/operators/odes.hpp
@@ -111,6 +111,25 @@ public:
    */
   void setEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
 
+  /**
+   * @brief Set the time integration method
+   *
+   * @param[in] timestepper The timestepping method for the solver
+   */
+  void setTimestepper(const serac::TimestepMethod timestepper);
+
+  /**
+   * @brief Performs a time step
+   *
+   * @param[inout] x The predicted solution
+   * @param[inout] dxdt The predicted rate
+   * @param[inout] t The current time
+   * @param[inout] dt The desired time step
+   *
+   * @see mfem::SecondOrderODESolver::Step
+   */
+  void Step(mfem::Vector& x, mfem::Vector& dxdt, double& t, double& dt) { ode_solver_->Step(x, dxdt, t, dt); }
+
 private:
   /**
    * @brief Internal implementation used for mfem::SOTDO::Mult and mfem::SOTDO::ImplicitSolve
@@ -136,6 +155,10 @@ private:
    * @brief Reference to the equationsolver used to solve for d2u_dt2
    */
   const EquationSolver& solver_;
+  /**
+   * @brief MFEM solver object for second-order ODEs
+   */
+  std::unique_ptr<mfem::SecondOrderODESolver> ode_solver_;
   /**
    * @brief Reference to boundary conditions used to constrain the solution
    */
@@ -231,6 +254,24 @@ public:
    */
   void setEnforcementMethod(const DirichletEnforcementMethod method) { enforcement_method_ = method; }
 
+  /**
+   * @brief Set the time integration method
+   *
+   * @param[in] timestepper The timestepping method for the solver
+   */
+  void setTimestepper(const serac::TimestepMethod timestepper);
+
+  /**
+   * @brief Performs a time step
+   *
+   * @param[inout] x The predicted solution
+   * @param[inout] t The current time
+   * @param[inout] dt The desired time step
+   *
+   * @see mfem::ODESolver::Step
+   */
+  void Step(mfem::Vector& x, double& t, double& dt) { ode_solver_->Step(x, t, dt); }
+
 private:
   /**
    * @brief Internal implementation used for mfem::TDO::Mult and mfem::TDO::ImplicitSolve
@@ -252,6 +293,10 @@ private:
    * @brief Reference to the equationsolver used to solve for du_dt
    */
   const EquationSolver& solver_;
+  /**
+   * @brief MFEM solver object for first-order ODEs
+   */
+  std::unique_ptr<mfem::ODESolver> ode_solver_;
   /**
    * @brief Reference to boundary conditions used to constrain the solution
    */

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -29,11 +29,11 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
 
   // Check for dynamic mode
   if (params.dyn_params) {
-    setTimestepper(params.dyn_params->timestepper);
     ode_.setTimestepper(params.dyn_params->timestepper);
     ode_.setEnforcementMethod(params.dyn_params->enforcement_method);
+    is_quasistatic_ = false;
   } else {
-    setTimestepper(TimestepMethod::QuasiStatic);
+    is_quasistatic_ = true;
   }
 
   dt_          = 0.0;
@@ -134,7 +134,7 @@ void ThermalConduction::completeSetup()
   // Initialize the true vector
   temperature_.initializeTrueVec();
 
-  if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
+  if (is_quasistatic_) {
     residual_ = StdFunctionOperator(
         temperature_.space().TrueVSize(),
 
@@ -185,7 +185,7 @@ void ThermalConduction::advanceTimestep(double& dt)
 {
   temperature_.initializeTrueVec();
 
-  if (timestepper_ == serac::TimestepMethod::QuasiStatic) {
+  if (is_quasistatic_) {
     nonlin_solver_.Mult(zero_, temperature_.trueVec());
   } else {
     SLIC_ASSERT_MSG(gf_initialized_[0], "Thermal state not initialized!");

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -30,6 +30,7 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
   // Check for dynamic mode
   if (params.dyn_params) {
     setTimestepper(params.dyn_params->timestepper);
+    ode_.setTimestepper(params.dyn_params->timestepper);
     ode_.setEnforcementMethod(params.dyn_params->enforcement_method);
   } else {
     setTimestepper(TimestepMethod::QuasiStatic);
@@ -177,8 +178,6 @@ void ThermalConduction::completeSetup()
           }
           return *J_;
         });
-
-    ode_solver_->Init(ode_);
   }
 }
 
@@ -192,7 +191,7 @@ void ThermalConduction::advanceTimestep(double& dt)
     SLIC_ASSERT_MSG(gf_initialized_[0], "Thermal state not initialized!");
 
     // Step the time integrator
-    ode_solver_->Step(temperature_.trueVec(), time_, dt);
+    ode_.Step(temperature_.trueVec(), time_, dt);
   }
 
   temperature_.distributeSharedDofs();

--- a/src/physics/thermal_conduction.cpp
+++ b/src/physics/thermal_conduction.cpp
@@ -29,8 +29,8 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
 
   // Check for dynamic mode
   if (params.dyn_params) {
-    ode_.setTimestepper(params.dyn_params->timestepper);
-    ode_.setEnforcementMethod(params.dyn_params->enforcement_method);
+    ode_.SetTimestepper(params.dyn_params->timestepper);
+    ode_.SetEnforcementMethod(params.dyn_params->enforcement_method);
     is_quasistatic_ = false;
   } else {
     is_quasistatic_ = true;

--- a/src/physics/thermal_conduction.hpp
+++ b/src/physics/thermal_conduction.hpp
@@ -67,8 +67,7 @@ public:
 
   static SolverParameters defaultQuasistaticParameters()
   {
-    return {defaultLinearParameters(), defaultNonlinearParameters(),
-            DynamicSolverParameters{TimestepMethod::QuasiStatic, DirichletEnforcementMethod::RateControl}};
+    return {defaultLinearParameters(), defaultNonlinearParameters(), std::nullopt};
   }
 
   static SolverParameters defaultDynamicParameters()

--- a/src/physics/thermal_solid.cpp
+++ b/src/physics/thermal_solid.cpp
@@ -42,13 +42,6 @@ void ThermalSolid::completeSetup()
   solid_solver_.completeSetup();
 }
 
-void ThermalSolid::setTimestepper(const serac::TimestepMethod timestepper)
-{
-  timestepper_ = timestepper;
-  therm_solver_.setTimestepper(timestepper);
-  solid_solver_.setTimestepper(timestepper);
-}
-
 // Advance the timestep
 void ThermalSolid::advanceTimestep(double& dt)
 {

--- a/src/physics/thermal_solid.hpp
+++ b/src/physics/thermal_solid.hpp
@@ -178,14 +178,6 @@ public:
   void SetCouplingScheme(serac::CouplingScheme coupling) { coupling_ = coupling; };
 
   /**
-   * @brief Set the time integration method
-   *
-   * @param[in] timestepper The timestepping method for the solver
-   * @param[in] enforcement_method The method of enforcing time-varying dirichlet boundary conditions
-   */
-  virtual void setTimestepper(const serac::TimestepMethod timestepper) override;
-
-  /**
    * @brief Complete the initialization and allocation of the data structures.
    *
    * This must be called before StaticSolve() or AdvanceTimestep(). If allow_dynamic


### PR DESCRIPTION
After some discussion with @samuelpmishLLNL it was determined that the functionality of `mfem::TimeDependentOperator` and `mfem::ODESolver` (and their second-order counterparts) can be merged into one class for simplicity.

Specifically, there does not appear to be a need to have a serac-wrapped object that conforms to the `mfem::ODESolver` interface (as opposed to `EquationSolver` which needed to implement the `mfem::Solver` interface.

This PR adds a `Step` method to our ODE classes and moves the TimestepMethod -> ODESolver logic into the ODE classes.  `setTimestepper` was removed from the `BaseSolver` and replaced with a `is_quasistatic_` flag.

Resolves #291 