### PR TITLE
Begin adding configuration options to AMGX

### DIFF
--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -114,13 +114,12 @@ std::ostream& operator<<(std::ostream& out, const JSONTable& table)
   char        sep = ' ';                      // Start with empty separator to avoid trailing comma
   for (const auto& [key, val] : table.literals_) {
     out << sep << "\n" << indent << "\"" << key << "\": ";
-    // Strings need to be quoted with escaped strings
+    // Strings need to be wrapped in escaped quotes
     if (auto str_ptr = std::get_if<std::string>(&val)) {
       out << "\"" << *str_ptr << "\"";
     } else {
       std::visit([&out](const auto contained_val) { out << contained_val; }, val);
     }
-
     sep = ',';
   }
 

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -192,7 +192,6 @@ std::unique_ptr<mfem::AmgXSolver> configureAMGX(const MPI_Comm comm, const AMGXP
 
   std::ostringstream oss;
   oss << options_table;
-  SLIC_INFO(options_table);
   // Treat the string as the config (not a filename)
   amgx->ReadParameters(oss.str(), mfem::AmgXSolver::INTERNAL);
   amgx->InitExclusiveGPU(comm);

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -245,10 +245,11 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
       prec_smoother->SetType(smoother_params->type);
       prec_smoother->SetPositiveDiagonal(true);
       prec_ = std::move(prec_smoother);
-    } else if (auto amgx_options = std::get_if<AMGXPrec>(prec_ptr)) {
 #ifdef MFEM_USE_AMGX
+    } else if (auto amgx_options = std::get_if<AMGXPrec>(prec_ptr)) {
       prec_ = detail::configureAMGX(comm, *amgx_options);
 #else
+    } else if (std::get_if<AMGXPrec>(prec_ptr)) {
       SLIC_ERROR("AMGX was not enabled when MFEM was built");
 #endif
     } else if (auto ilu_params = std::get_if<BlockILUPrec>(prec_ptr)) {

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -167,6 +167,29 @@ std::unique_ptr<mfem::AmgXSolver> configureAMGX(const MPI_Comm comm, const AMGXP
     options_table["solver"].add(default_verbose_options);
   }
 
+  // FIXME: magic_enum?
+  static const auto solver_names = []() {
+    std::unordered_map<AMGXSolver, std::string> names;
+    names[AMGXSolver::AMG]             = "AMG";
+    names[AMGXSolver::PCGF]            = "PCGF";
+    names[AMGXSolver::CG]              = "CG";
+    names[AMGXSolver::PCG]             = "PCG";
+    names[AMGXSolver::PBICGSTAB]       = "PBICGSTAB";
+    names[AMGXSolver::BICGSTAB]        = "BICGSTAB";
+    names[AMGXSolver::FGMRES]          = "FGMRES";
+    names[AMGXSolver::JACOBI_L1]       = "JACOBI_L1";
+    names[AMGXSolver::GS]              = "GS";
+    names[AMGXSolver::POLYNOMIAL]      = "POLYNOMIAL";
+    names[AMGXSolver::KPZ_POLYNOMIAL]  = "KPZ_POLYNOMIAL";
+    names[AMGXSolver::BLOCK_JACOBI]    = "BLOCK_JACOBI";
+    names[AMGXSolver::MULTICOLOR_GS]   = "MULTICOLOR_GS";
+    names[AMGXSolver::MULTICOLOR_DILU] = "MULTICOLOR_DILU";
+    return names;
+  }();
+
+  options_table["solver"].literal("solver")   = solver_names.at(options.solver);
+  options_table["solver"].literal("smoother") = solver_names.at(options.smoother);
+
   std::ostringstream oss;
   oss << options_table;
   SLIC_INFO(options_table);

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -38,6 +38,65 @@ EquationSolver::EquationSolver(MPI_Comm comm, const LinearSolverParameters& lin_
   }
 }
 
+namespace detail {
+#ifdef MFEM_USE_AMGX
+std::unique_ptr<mfem::AmgXSolver> configureAMGX(const MPI_Comm comm, const AMGXPrec& options)
+{
+  auto amgx                              = std::make_unique<mfem::AmgXSolver>();
+  using JSONType                         = std::variant<std::string, double, int>;
+  static const auto default_prec_options = []() {
+    std::unordered_map<std::string, JSONType> result;
+    result["solver"]       = "AMG";
+    result["presweeps"]    = 1;
+    result["postsweeps"]   = 2;
+    result["interpolator"] = "D2";
+    result["max_iters"]    = 2;
+    result["convergence"]  = "ABSOLUTE";
+    result["cycle"]        = "V";
+    return result;
+  }();
+
+  auto options_table = default_prec_options;
+  if (options.verbose) {
+    static const auto default_verbose_options = []() {
+      std::unordered_map<std::string, JSONType> result;
+      result["obtain_timings"]    = 1;
+      result["monitor_residual"]  = 1;
+      result["print_solve_stats"] = 1;
+      result["print_solve_stats"] = 1;
+      return result;
+    }();
+    options_table.insert(default_verbose_options.begin(), default_verbose_options.end());
+  }
+
+  std::string amgx_config =
+      "{\n"
+      " \"config_version\": 2, \n"
+      " \"solver\": { \n";
+  std::ostringstream oss;
+  char               sep = ' ';
+  for (const auto& [key, val] : options_table) {
+    oss << sep << "\n   \"" << key << "\": ";
+    if (auto str_ptr = std::get_if<std::string>(&val)) {
+      oss << "\"" << *str_ptr << "\"";
+    } else {
+      std::visit([&oss](const auto contained_val) { oss << contained_val; }, val);
+    }
+
+    sep = ',';
+  }
+
+  amgx_config = amgx_config + oss.str() + "\n }\n" + "}\n";
+
+  amgx->ReadParameters(amgx_config, mfem::AmgXSolver::INTERNAL);
+  amgx->InitExclusiveGPU(comm);
+
+  return amgx;
+}
+
+#endif
+}  // namespace detail
+
 std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolver(
     MPI_Comm comm, const IterativeSolverParameters& lin_params)
 {
@@ -81,9 +140,9 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
       prec_smoother->SetType(smoother_params->type);
       prec_smoother->SetPositiveDiagonal(true);
       prec_ = std::move(prec_smoother);
-    } else if (std::holds_alternative<AMGXPrec>(*lin_params.prec)) {
+    } else if (auto amgx_options = std::get_if<AMGXPrec>(prec_ptr)) {
 #ifdef MFEM_USE_AMGX
-      prec_ = std::make_unique<mfem::AmgXSolver>(comm, mfem::AmgXSolver::PRECONDITIONER, true);
+      prec_ = detail::configureAMGX(comm, *amgx_options);
 #else
       SLIC_ERROR("AMGX was not enabled when MFEM was built");
 #endif

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -137,18 +137,18 @@ std::unique_ptr<mfem::AmgXSolver> configureAMGX(const MPI_Comm comm, const AMGXP
 {
   auto              amgx                 = std::make_unique<mfem::AmgXSolver>();
   static const auto default_prec_options = []() {
-    JSONTable result;
-    result.literal("solver")       = "AMG";
-    result.literal("presweeps")    = 1;
-    result.literal("postsweeps")   = 2;
-    result.literal("interpolator") = "D2";
-    result.literal("max_iters")    = 2;
-    result.literal("convergence")  = "ABSOLUTE";
-    result.literal("cycle")        = "V";
+    JSONTable solver_table;
+    solver_table.literal("solver")       = "AMG";
+    solver_table.literal("presweeps")    = 1;
+    solver_table.literal("postsweeps")   = 2;
+    solver_table.literal("interpolator") = "D2";
+    solver_table.literal("max_iters")    = 2;
+    solver_table.literal("convergence")  = "ABSOLUTE";
+    solver_table.literal("cycle")        = "V";
 
     JSONTable top_level;
     top_level.literal("config_version") = 2;
-    top_level["solver"].add(result);
+    top_level["solver"].add(solver_table);
     return top_level;
   }();
 
@@ -218,6 +218,7 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
       break;
     default:
       SLIC_ERROR("Linear solver type not recognized.");
+      exitGracefully(true);
   }
 
   iter_lin_solver->SetRelTol(lin_params.rel_tol);

--- a/src/physics/utilities/solver_config.hpp
+++ b/src/physics/utilities/solver_config.hpp
@@ -122,9 +122,38 @@ struct HypreBoomerAMGPrec {
 };
 
 /**
+ * @brief Solver types supported by AMGX
+ */
+enum class AMGXSolver
+{
+  AMG,
+  PCGF,
+  CG,
+  PCG,
+  PBICGSTAB,
+  BICGSTAB,
+  FGMRES,
+  JACOBI_L1,
+  GS,
+  POLYNOMIAL,
+  KPZ_POLYNOMIAL,
+  BLOCK_JACOBI,
+  MULTICOLOR_GS,
+  MULTICOLOR_DILU
+};
+
+/**
  * @brief Stores the information required to configure a NVIDIA AMGX preconditioner
  */
 struct AMGXPrec {
+  /**
+   * @brief The solver algorithm
+   */
+  AMGXSolver solver = AMGXSolver::AMG;
+  /**
+   * @brief The smoother algorithm
+   */
+  AMGXSolver smoother = AMGXSolver::BLOCK_JACOBI;
   /**
    * @brief Whether to display statistics from AMGX
    */

--- a/src/physics/utilities/solver_config.hpp
+++ b/src/physics/utilities/solver_config.hpp
@@ -125,6 +125,10 @@ struct HypreBoomerAMGPrec {
  * @brief Stores the information required to configure a NVIDIA AMGX preconditioner
  */
 struct AMGXPrec {
+  /**
+   * @brief Whether to display statistics from AMGX
+   */
+  bool verbose = false;
 };
 
 /**


### PR DESCRIPTION
This PR adds configuration options to what was just a placeholder `AMGXPrec` structure.  The default options were insufficient for an AMGX version of the static thermal solve test (see #289), which is added in this PR.

AMGX uses a JSON string for configuration but I did not think it was necessary to pull in a full JSON library - I was able to implement the required functionality in < 35 LLOC.

Thanks to @jonwong12 and @artv3 for tracking down the required configuration changes - AMGX has a [fair number of options](https://github.com/NVIDIA/AMGX/blob/919fb92a2c02ea3d8d3d0f0660e3b507d84705bc/core/src/core.cu#L331-L560), so we can look into exposing more of them in future PRs, or possibly exposing my minimal `JSONTable` interface which is a little friendlier than having the user pass a full JSON string.  I'm not sure if any of these changes might be worth propagating upstream to MFEM.

Resolves #300 