### PR TITLE
Remove unnecessary exitGracefullys, add tests for error handling and coefficients

### DIFF
--- a/src/coefficients/coefficient_extensions.cpp
+++ b/src/coefficients/coefficient_extensions.cpp
@@ -93,15 +93,15 @@ double AttributeModifierCoefficient::Eval(mfem::ElementTransformation& Tr, const
   return result;
 }
 
-TransformedVectorCoefficient::TransformedVectorCoefficient(std::shared_ptr<mfem::VectorCoefficient>          v1,
-                                                           std::function<void(mfem::Vector&, mfem::Vector&)> func)
+TransformedVectorCoefficient::TransformedVectorCoefficient(std::shared_ptr<mfem::VectorCoefficient>                v1,
+                                                           std::function<void(const mfem::Vector&, mfem::Vector&)> func)
     : mfem::VectorCoefficient(v1->GetVDim()), v1_(v1), v2_(nullptr), mono_function_(func), bi_function_(nullptr)
 {
 }
 
 TransformedVectorCoefficient::TransformedVectorCoefficient(
     std::shared_ptr<mfem::VectorCoefficient> v1, std::shared_ptr<mfem::VectorCoefficient> v2,
-    std::function<void(mfem::Vector&, mfem::Vector&, mfem::Vector&)> func)
+    std::function<void(const mfem::Vector&, const mfem::Vector&, mfem::Vector&)> func)
     : mfem::VectorCoefficient(v1->GetVDim()), v1_(v1), v2_(v2), mono_function_(nullptr), bi_function_(func)
 {
   SLIC_CHECK_MSG(v1_->GetVDim() == v2_->GetVDim(), "v1 and v2 are not the same size");

--- a/src/coefficients/coefficient_extensions.hpp
+++ b/src/coefficients/coefficient_extensions.hpp
@@ -141,8 +141,8 @@ public:
    * @param[in] func A function that takes in an input vector, and returns the
    * output as the second argument.
    */
-  TransformedVectorCoefficient(std::shared_ptr<mfem::VectorCoefficient>          v1,
-                               std::function<void(mfem::Vector&, mfem::Vector&)> func);
+  TransformedVectorCoefficient(std::shared_ptr<mfem::VectorCoefficient>                v1,
+                               std::function<void(const mfem::Vector&, mfem::Vector&)> func);
 
   /**
    * @brief Apply a vector function, Func, to v1 and v2
@@ -153,7 +153,7 @@ public:
    * output as the third argument.
    */
   TransformedVectorCoefficient(std::shared_ptr<mfem::VectorCoefficient> v1, std::shared_ptr<mfem::VectorCoefficient> v2,
-                               std::function<void(mfem::Vector&, mfem::Vector&, mfem::Vector&)> func);
+                               std::function<void(const mfem::Vector&, const mfem::Vector&, mfem::Vector&)> func);
 
   /**
    * @brief Evaluate the coefficient at a quadrature point
@@ -178,12 +178,12 @@ private:
   /**
    * @brief The one argument function for a transformed coefficient
    */
-  std::function<void(mfem::Vector&, mfem::Vector&)> mono_function_;
+  std::function<void(const mfem::Vector&, mfem::Vector&)> mono_function_;
 
   /**
    * @brief The two argument function for a transformed coefficient
    */
-  std::function<void(mfem::Vector&, mfem::Vector&, mfem::Vector&)> bi_function_;
+  std::function<void(const mfem::Vector&, const mfem::Vector&, mfem::Vector&)> bi_function_;
 };
 
 /**

--- a/src/docs/sphinx/logging.rst
+++ b/src/docs/sphinx/logging.rst
@@ -57,10 +57,6 @@ SLIC has 4 message levels to help indicate the important of messages. Descriptio
  * Warning - message indicating that something has gone wrong but not enough to end the simulation
  * Error - message indicating a non-recoverable error has occurred
 
-Before every warning and error, ``serac::logger::Flush()`` should be called to clarify what happened
-leading up to the message.  After an error has occured ``serac::ExitGracefully(bool error=false)`` should
-be called because we have turned off the abort on errors SLIC functionality.
-
 Logging Macros
 --------------
 

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -51,7 +51,6 @@ void defineInputFileSchema(axom::inlet::Inlet& inlet, int rank)
   // Verify input file
   if (!inlet.verify()) {
     SLIC_ERROR_ROOT(rank, "Input file failed to verify.");
-    serac::exitGracefully(true);
   }
 }
 

--- a/src/infrastructure/cli.cpp
+++ b/src/infrastructure/cli.cpp
@@ -32,11 +32,11 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
     if (e.get_name() == "CallForHelp") {
       auto msg = app.help();
       SLIC_INFO_ROOT(rank, msg);
+      serac::exitGracefully();
     } else {
       auto err_msg = CLI::FailureMessage::simple(&app, e);
       SLIC_ERROR_ROOT(rank, err_msg);
     }
-    serac::exitGracefully();
   }
 
   // Store found values

--- a/src/infrastructure/initialize.cpp
+++ b/src/infrastructure/initialize.cpp
@@ -19,12 +19,10 @@ std::pair<int, int> getMPIInfo(MPI_Comm comm)
   int rank      = 0;
   if (MPI_Comm_size(comm, &num_procs) != MPI_SUCCESS) {
     SLIC_ERROR("Failed to determine number of MPI processes");
-    serac::exitGracefully(true);
   }
 
   if (MPI_Comm_rank(comm, &rank) != MPI_SUCCESS) {
     SLIC_ERROR("Failed to determine MPI rank");
-    serac::exitGracefully(true);
   }
   return {num_procs, rank};
 }

--- a/src/infrastructure/input.cpp
+++ b/src/infrastructure/input.cpp
@@ -51,8 +51,7 @@ std::string findMeshFilePath(const std::string& mesh_path, const std::string& in
   std::string msg = fmt::format("Input file: Given mesh file does not exist: {0}", mesh_path);
   int         rank;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  SLIC_WARNING_ROOT(rank, msg);
-  serac::exitGracefully(true);
+  SLIC_ERROR_ROOT(rank, msg);
   return "";
 }
 
@@ -62,7 +61,6 @@ std::string fullDirectoryFromPath(const std::string& path)
   char* ptr = realpath(path.c_str(), actualpath);
   if (ptr == nullptr) {
     SLIC_ERROR("Failed to find absolute path from input file.");
-    serac::exitGracefully(true);
   }
   std::string dir;
   axom::utilities::filesystem::getDirName(dir, std::string(actualpath));

--- a/src/numerics/mesh_utils.cpp
+++ b/src/numerics/mesh_utils.cpp
@@ -31,7 +31,6 @@ std::shared_ptr<mfem::ParMesh> buildMeshFromFile(const std::string& mesh_file, c
   if (!axom::utilities::filesystem::pathExists(mesh_file)) {
     msg = fmt::format("Given mesh file does not exist: {0}", mesh_file);
     SLIC_ERROR_ROOT(rank, msg);
-    serac::exitGracefully(true);
   }
 
   // This inherits from std::ifstream, and will work the same way as a std::ifstream,
@@ -42,7 +41,6 @@ std::shared_ptr<mfem::ParMesh> buildMeshFromFile(const std::string& mesh_file, c
     serac::logger::flush();
     std::string err_msg = fmt::format("Can not open mesh file: {0}", mesh_file);
     SLIC_ERROR_ROOT(rank, err_msg);
-    serac::exitGracefully();
   }
 
   auto mesh = std::make_unique<mfem::Mesh>(imesh, 1, 1, true);

--- a/src/physics/base_physics.cpp
+++ b/src/physics/base_physics.cpp
@@ -99,7 +99,6 @@ void BasePhysics::initializeOutput(const serac::OutputType output_type, const st
 
     default:
       SLIC_ERROR_ROOT(mpi_rank_, "OutputType not recognized!");
-      serac::exitGracefully(true);
   }
 
   if ((output_type_ == OutputType::VisIt) || (output_type_ == OutputType::SidreVisIt)) {
@@ -141,7 +140,6 @@ void BasePhysics::outputState() const
 
     default:
       SLIC_ERROR_ROOT(mpi_rank_, "OutputType not recognized!");
-      serac::exitGracefully(true);
   }
 }
 

--- a/src/physics/elasticity.cpp
+++ b/src/physics/elasticity.cpp
@@ -102,7 +102,6 @@ void Elasticity::advanceTimestep(double&)
     QuasiStaticSolve();
   } else {
     SLIC_ERROR_ROOT(mpi_rank_, "Only quasistatics implemented for linear elasticity!");
-    serac::exitGracefully(true);
   }
 
   // Distribute the shared DOFs

--- a/src/physics/utilities/equation_solver.cpp
+++ b/src/physics/utilities/equation_solver.cpp
@@ -55,7 +55,6 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
       break;
     default:
       SLIC_ERROR("Linear solver type not recognized.");
-      exitGracefully(true);
   }
 
   iter_lin_solver->SetRelTol(lin_params.rel_tol);

--- a/tests/serac_error_handling.cpp
+++ b/tests/serac_error_handling.cpp
@@ -8,9 +8,13 @@
 
 #include <exception>
 
+#include "infrastructure/cli.hpp"
+#include "infrastructure/initialize.hpp"
 #include "numerics/mesh_utils.hpp"
+#include "physics/thermal_conduction.hpp"
 #include "physics/utilities/boundary_condition.hpp"
 #include "physics/utilities/equation_solver.hpp"
+#include "serac_config.hpp"
 
 class SlicErrorException : public std::exception {
 };
@@ -35,6 +39,17 @@ TEST(serac_error_handling, equationsolver_amgx_not_available)
 }
 #endif
 
+// Only need to test this when KINSOL is **not** available
+#ifndef MFEM_USE_SUNDIALS
+TEST(serac_error_handling, equationsolver_kinsol_not_available)
+{
+  auto lin_params             = ThermalConduction::defaultLinearParameters();
+  auto nonlin_params          = ThermalConduction::defaultNonlinearParameters();
+  nonlin_params.nonlin_solver = NonlinearSolver::KINFullStep;
+  EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, lin_params, nonlin_params), SlicErrorException);
+}
+#endif
+
 TEST(serac_error_handling, bc_project_requires_state)
 {
   auto mesh      = buildDiskMesh(10);
@@ -54,6 +69,71 @@ TEST(serac_error_handling, bc_one_component_vector_coef)
   mfem::Vector vec;
   auto         coef = std::make_shared<mfem::VectorConstantCoefficient>(vec);
   EXPECT_THROW(BoundaryCondition(coef, 0, std::set<int>{1}), SlicErrorException);
+}
+
+TEST(serac_error_handling, bc_one_component_vector_coef_dofs)
+{
+  mfem::Vector     vec;
+  auto             coef = std::make_shared<mfem::VectorConstantCoefficient>(vec);
+  mfem::Array<int> dofs(1);
+  dofs[0] = 1;
+  EXPECT_THROW(BoundaryCondition(coef, 0, dofs), SlicErrorException);
+}
+
+TEST(serac_error_handling, bc_project_no_state)
+{
+  auto              coef = std::make_shared<mfem::ConstantCoefficient>(1.0);
+  BoundaryCondition bc(coef, -1, std::set<int>{});
+  EXPECT_THROW(bc.projectBdr(0.0), SlicErrorException);
+}
+
+TEST(serac_error_handling, bc_retrieve_scalar_coef)
+{
+  auto              coef = std::make_shared<mfem::ConstantCoefficient>(1.0);
+  BoundaryCondition bc(coef, -1, std::set<int>{});
+  EXPECT_NO_THROW(bc.scalarCoefficient());
+  EXPECT_THROW(bc.vectorCoefficient(), SlicErrorException);
+
+  const auto& const_bc = bc;
+  EXPECT_NO_THROW(const_bc.scalarCoefficient());
+  EXPECT_THROW(const_bc.vectorCoefficient(), SlicErrorException);
+}
+
+TEST(serac_error_handling, bc_retrieve_vec_coef)
+{
+  mfem::Vector      vec;
+  auto              coef = std::make_shared<mfem::VectorConstantCoefficient>(vec);
+  BoundaryCondition bc(coef, -1, std::set<int>{});
+  EXPECT_NO_THROW(bc.vectorCoefficient());
+  EXPECT_THROW(bc.scalarCoefficient(), SlicErrorException);
+
+  const auto& const_bc = bc;
+  EXPECT_NO_THROW(const_bc.vectorCoefficient());
+  EXPECT_THROW(const_bc.scalarCoefficient(), SlicErrorException);
+}
+
+TEST(serac_error_handling, invalid_output_type)
+{
+  ThermalConduction physics(1, buildDiskMesh(100), ThermalConduction::defaultQuasistaticParameters());
+  // Try a definitely wrong number to ensure that an invalid output type is detected
+  EXPECT_THROW(physics.initializeOutput(static_cast<OutputType>(-7), ""), SlicErrorException);
+}
+
+TEST(serac_error_handling, invalid_cmdline_arg)
+{
+  // The command is actually --input-file
+  char const* fake_argv[] = {"serac", "--file", "input.lua"};
+  const int   fake_argc   = 3;
+  int         rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  EXPECT_THROW(cli::defineAndParse(fake_argc, const_cast<char**>(fake_argv), rank, ""), SlicErrorException);
+}
+
+TEST(serac_error_handling, nonexistent_mesh_path)
+{
+  std::string mesh_path       = "nonexistent.mesh";
+  std::string input_file_path = std::string(SERAC_REPO_DIR) + "/data/input_files/default.lua";
+  EXPECT_THROW(input::findMeshFilePath(mesh_path, input_file_path), SlicErrorException);
 }
 
 }  // namespace serac

--- a/tests/serac_wrapper_tests.cpp
+++ b/tests/serac_wrapper_tests.cpp
@@ -27,14 +27,15 @@ protected:
     int nez = 4;
 
     Mesh mesh(nex, ney, nez, mfem::Element::HEXAHEDRON, true);
-    pmesh_  = std::shared_ptr<ParMesh>(new ParMesh(MPI_COMM_WORLD, mesh));
-    pfes_   = std::shared_ptr<ParFiniteElementSpace>(new ParFiniteElementSpace(
-        pmesh_.get(), new H1_FECollection(1, dim_, BasisType::GaussLobatto), 1, Ordering::byNODES));
-    pfes_v_ = std::shared_ptr<ParFiniteElementSpace>(new ParFiniteElementSpace(
-        pmesh_.get(), new H1_FECollection(1, dim_, BasisType::GaussLobatto), dim_, Ordering::byNODES));
+    pmesh_ = std::make_shared<ParMesh>(MPI_COMM_WORLD, mesh);
+    fec_   = std::make_unique<H1_FECollection>(1, dim_, BasisType::GaussLobatto);
+    pfes_  = std::make_shared<ParFiniteElementSpace>(pmesh_.get(), fec_.get(), 1, Ordering::byNODES);
 
-    pfes_l2_ = std::shared_ptr<ParFiniteElementSpace>(
-        new ParFiniteElementSpace(pmesh_.get(), new L2_FECollection(0, dim_), 1, Ordering::byNODES));
+    fec_v_  = std::make_unique<H1_FECollection>(1, dim_, BasisType::GaussLobatto);
+    pfes_v_ = std::make_shared<ParFiniteElementSpace>(pmesh_.get(), fec_v_.get(), dim_, Ordering::byNODES);
+
+    fec_l2_  = std::make_unique<L2_FECollection>(0, dim_);
+    pfes_l2_ = std::make_shared<ParFiniteElementSpace>(pmesh_.get(), fec_l2_.get(), 1, Ordering::byNODES);
   }
 
   void TearDown() override {}
@@ -44,6 +45,11 @@ protected:
   std::shared_ptr<ParFiniteElementSpace> pfes_;
   std::shared_ptr<ParFiniteElementSpace> pfes_v_;
   std::shared_ptr<ParFiniteElementSpace> pfes_l2_;
+
+private:
+  std::unique_ptr<FiniteElementCollection> fec_;
+  std::unique_ptr<FiniteElementCollection> fec_v_;
+  std::unique_ptr<FiniteElementCollection> fec_l2_;
 };
 
 void SolveLinear(std::shared_ptr<ParFiniteElementSpace> pfes_, Array<int>& ess_tdof_list, ParGridFunction& temp)
@@ -336,6 +342,65 @@ TEST_F(WrapperTests, Transformed)
   temp.Print();
   std::cout << multiplier << std::endl;
   temp2.Print();
+}
+
+TEST_F(WrapperTests, attribute_modifier_coef)
+{
+  mfem::ConstantCoefficient three_and_a_half(3.5);
+  // All the attributes in the mesh are "1", but for whatever reason the restricted coefficient
+  // operates on attribute "2"
+  mfem::Array<int> restrict_to(2);
+  restrict_to[0] = 0;  // Don't apply if the attr is 1
+  restrict_to[1] = 1;  // But apply if the attr is 0
+  mfem::RestrictedCoefficient restrict_coef(three_and_a_half, restrict_to);
+
+  // Everything gets converted to 2
+  mfem::Array<int> modified_attrs(pmesh_->GetNE());
+  modified_attrs = 2;
+  AttributeModifierCoefficient am_coef(modified_attrs, restrict_coef);
+
+  ParGridFunction gf(pfes_.get());
+  gf.ProjectCoefficient(am_coef);
+  EXPECT_NEAR(gf.ComputeL2Error(three_and_a_half), 0.0, 1.e-8);
+}
+
+TEST_F(WrapperTests, vector_transform_coef)
+{
+  mfem::Vector one_two_three(dim_);
+  one_two_three[0]    = 1;
+  one_two_three[1]    = 2;
+  one_two_three[2]    = 3;
+  auto first_vec_coef = std::make_shared<mfem::VectorConstantCoefficient>(one_two_three);
+
+  mfem::Vector four_five_six(dim_);
+  four_five_six[0]     = 4;
+  four_five_six[1]     = 5;
+  four_five_six[2]     = 6;
+  auto second_vec_coef = std::make_shared<mfem::VectorConstantCoefficient>(four_five_six);
+
+  // Verify the answer using an MFEM VectorSumCoefficient since the transformation is
+  // just an addition
+  mfem::VectorSumCoefficient sum_coef(*first_vec_coef, *second_vec_coef);
+
+  // Both of these do the same thing, but we can test both the single- and dual-vector transformations
+  // by capturing the operand
+  TransformedVectorCoefficient mono_tv_coef(first_vec_coef,
+                                            [&four_five_six](const mfem::Vector& in, mfem::Vector& out) {
+                                              out = in;
+                                              out += four_five_six;
+                                            });
+  ParGridFunction              mono_gf(pfes_v_.get());
+  mono_gf.ProjectCoefficient(mono_tv_coef);
+  EXPECT_NEAR(mono_gf.ComputeL2Error(sum_coef), 0.0, 1.e-8);
+
+  TransformedVectorCoefficient dual_tv_coef(
+      first_vec_coef, second_vec_coef, [](const mfem::Vector& first, const mfem::Vector& second, mfem::Vector& out) {
+        out = first;
+        out += second;
+      });
+  ParGridFunction dual_gf(pfes_v_.get());
+  dual_gf.ProjectCoefficient(dual_tv_coef);
+  EXPECT_NEAR(dual_gf.ComputeL2Error(sum_coef), 0.0, 1.e-8);
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR cleans up the `exitGracefully`s that follow `SLIC_ERROR`s, which now call `exitGracefully` automatically.

It also adds a set of tests that check for proper error handling, and for coefficient extensions that are not tested elsewhere.