### PR TITLE
Prefix CMake targets with serac_

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -22,4 +22,5 @@ BraceWrapping:
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 DerivePointerAlignment: false
+SortIncludes: false
 PointerAlignment: Left

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,8 +91,17 @@ serac_add_code_checks(PREFIX   serac
 #------------------------------------------------------------------------------
 # Export Targets
 #------------------------------------------------------------------------------
+set(exported_targets
+    serac_coefficients
+    serac_physics
+    serac_infrastructure
+    serac_numerics
+    serac_physics_utilities
+    serac_physics_operators
+    serac_integrators)
+
 add_library(serac INTERFACE)
-target_link_libraries(serac INTERFACE coefficients physics infrastructure numerics physics_utilities physics_operators integrators)
+target_link_libraries(serac INTERFACE ${exported_targets})
 install(TARGETS              serac
         EXPORT               serac-targets
         DESTINATION          lib

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 blt_add_executable( NAME        serac_driver
                     SOURCES     serac.cpp
-                    DEPENDS_ON  numerics infrastructure physics coefficients mfem mpi
+                    DEPENDS_ON  serac_physics serac_coefficients
                     OUTPUT_NAME serac
                     )
 

--- a/src/serac/coefficients/CMakeLists.txt
+++ b/src/serac/coefficients/CMakeLists.txt
@@ -16,20 +16,20 @@ set(coefficients_headers
     )
 
 blt_add_library(
-    NAME        coefficients
+    NAME        serac_coefficients
     SOURCES     ${coefficients_sources}
     HEADERS     ${coefficients_headers}
     DEPENDS_ON  axom mfem mpi
     )
 
-target_include_directories(coefficients PUBLIC 
+target_include_directories(serac_coefficients PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
     )
 
 install(FILES ${coefficients_headers} DESTINATION include/serac/coefficients )
 
-install(TARGETS              coefficients
+install(TARGETS              serac_coefficients
         EXPORT               serac-targets
         DESTINATION          lib
         )

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -28,20 +28,20 @@ set(infrastructure_depends axom fmt mpi cli11 mfem)
 blt_list_append( TO infrastructure_depends ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
 blt_add_library(
-    NAME        infrastructure
+    NAME        serac_infrastructure
     HEADERS     ${infrastructure_headers}
     SOURCES     ${infrastructure_sources}
     DEPENDS_ON  ${infrastructure_depends}
     )
 
-target_include_directories(infrastructure PUBLIC 
+target_include_directories(serac_infrastructure PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<INSTALL_INTERFACE:include>
     )
 
 install(FILES ${infrastructure_headers} DESTINATION include/serac/infrastructure )
 
-install(TARGETS              infrastructure
+install(TARGETS              serac_infrastructure
         EXPORT               serac-targets
         DESTINATION          lib
         )

--- a/src/serac/integrators/CMakeLists.txt
+++ b/src/serac/integrators/CMakeLists.txt
@@ -16,24 +16,18 @@ set(integrators_headers
     wrapper_integrator.hpp
     )
 
-set(integrators_depends infrastructure mfem mpi)
-blt_list_append( TO integrators_depends ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
+set(integrators_depends serac_infrastructure)
 
 blt_add_library(
-    NAME        integrators
+    NAME        serac_integrators
     SOURCES     ${integrators_sources}
     HEADERS     ${integrators_headers}
     DEPENDS_ON  ${integrators_depends}
     )
 
-target_include_directories(integrators PUBLIC 
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-    $<INSTALL_INTERFACE:include>
-    )
-
 install(FILES ${integrators_headers} DESTINATION include/serac/integrators )
 
-install(TARGETS              integrators 
+install(TARGETS              serac_integrators 
         EXPORT               serac-targets
         DESTINATION          lib
         )

--- a/src/serac/numerics/CMakeLists.txt
+++ b/src/serac/numerics/CMakeLists.txt
@@ -15,24 +15,18 @@ set(numerics_sources
     mesh_utils.cpp
     )
 
-set(numerics_depends infrastructure axom mfem mpi fmt)
+set(numerics_depends serac_infrastructure)
 
 blt_add_library(
-    NAME        numerics
+    NAME        serac_numerics
     HEADERS     ${numerics_headers}
     SOURCES     ${numerics_sources}
     DEPENDS_ON  ${numerics_depends}
     )
 
-
-target_include_directories(numerics PUBLIC 
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-    $<INSTALL_INTERFACE:include>
-    )
-
 install(FILES ${numerics_headers} DESTINATION include/serac/numerics )
 
-install(TARGETS              numerics
+install(TARGETS              serac_numerics
         EXPORT               serac-targets
         DESTINATION          lib
         )

--- a/src/serac/physics/CMakeLists.txt
+++ b/src/serac/physics/CMakeLists.txt
@@ -23,16 +23,24 @@ set(physics_headers
     elasticity.hpp
     )
 
+set(physics_dependencies
+    serac_infrastructure
+    serac_integrators
+    serac_numerics
+    serac_physics_utilities
+    serac_physics_operators
+    )
+
 blt_add_library(
-    NAME        physics
+    NAME        serac_physics
     SOURCES     ${physics_sources}
     HEADERS     ${physics_headers}
-    DEPENDS_ON  mfem integrators numerics infrastructure physics_utilities physics_operators axom fmt mpi
+    DEPENDS_ON  ${physics_dependencies}
     )
 
 install(FILES ${physics_headers} DESTINATION include/serac/physics )
 
-install(TARGETS              physics
+install(TARGETS              serac_physics
         EXPORT               serac-targets
         DESTINATION          lib
         )

--- a/src/serac/physics/operators/CMakeLists.txt
+++ b/src/serac/physics/operators/CMakeLists.txt
@@ -4,12 +4,23 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-set(physics_operators_headers odes.hpp stdfunction_operator.hpp)
-set(physics_operators_sources odes.cpp)
-set(physics_operators_depends infrastructure physics_utilities numerics fmt mfem mpi axom)
+set(physics_operators_headers
+    odes.hpp
+    stdfunction_operator.hpp
+    )
+
+set(physics_operators_sources
+    odes.cpp
+    )
+
+set(physics_operators_depends
+    serac_infrastructure
+    serac_physics_utilities
+    serac_numerics
+    )
 
 blt_add_library(
-   NAME        physics_operators
+   NAME        serac_physics_operators
    HEADERS     ${physics_operators_headers}
    SOURCES     ${physics_operators_sources}
    DEPENDS_ON  ${physics_operators_depends}
@@ -17,7 +28,7 @@ blt_add_library(
 
 install(FILES ${physics_operators_headers} DESTINATION include/serac/physics/operators )
 
-install(TARGETS              physics_operators
+install(TARGETS              serac_physics_operators
         EXPORT               serac-targets
         DESTINATION          lib
         )

--- a/src/serac/physics/utilities/CMakeLists.txt
+++ b/src/serac/physics/utilities/CMakeLists.txt
@@ -19,10 +19,10 @@ set(physics_utilities_sources
     finite_element_state.cpp
     )
 
-set(physics_utilities_depends infrastructure mfem mpi axom)
+set(physics_utilities_depends serac_infrastructure)
 
 blt_add_library(
-    NAME        physics_utilities
+    NAME        serac_physics_utilities
     HEADERS     ${physics_utilities_headers}
     SOURCES     ${physics_utilities_sources}
     DEPENDS_ON  ${physics_utilities_depends}
@@ -30,7 +30,7 @@ blt_add_library(
 
 install(FILES ${physics_utilities_headers} DESTINATION include/serac/physics/utilities )
 
-install(TARGETS              physics_utilities
+install(TARGETS              serac_physics_utilities
         EXPORT               serac-targets
         DESTINATION          lib
         )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,13 +10,13 @@
 
 if (ENABLE_GTEST)
 
-    set(test_dependencies physics coefficients axom mpi mfem gtest test_utils)
+    set(test_dependencies serac_physics serac_coefficients gtest test_utils)
 
     blt_add_library(
         NAME        test_utils
         SOURCES     test_utilities.cpp
         HEADERS     test_utilities.hpp
-        DEPENDS_ON  numerics infrastructure physics axom
+        DEPENDS_ON  serac_physics
         )
 
     set(solver_tests
@@ -86,22 +86,22 @@ if (ENABLE_GTEST)
         blt_add_library( NAME       serac_cuda_smoketest_kernel
                          SOURCES    serac_cuda_smoketest_kernel.cpp 
                          DEPENDS_ON cuda)
-        blt_add_executable( NAME       serac_cuda_smoketest
-                            SOURCES    serac_cuda_smoketest.cpp 
-                            OUTPUT_DIR ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON serac_cuda_smoketest_kernel ${test_dependencies} cuda_runtime
+        blt_add_executable( NAME        serac_cuda_smoketest
+                            SOURCES     serac_cuda_smoketest.cpp 
+                            OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
+                            DEPENDS_ON  serac_cuda_smoketest_kernel ${test_dependencies} cuda_runtime
                             FOLDER      serac/tests)
         blt_add_test( NAME          serac_cuda_smoketest
                       COMMAND       serac_cuda_smoketest )
     endif()
 
     if(ENABLE_BENCHMARKS)
-        blt_add_executable( NAME    benchmark_expr_templates
-                            SOURCES benchmark_expr_templates.cpp
-                            DEPENDS_ON gbenchmark ${test_dependencies}
+        blt_add_executable( NAME        benchmark_expr_templates
+                            SOURCES     benchmark_expr_templates.cpp
+                            DEPENDS_ON  gbenchmark ${test_dependencies}
                             FOLDER      serac/tests)
-        blt_add_benchmark(  NAME    benchmark_expr_templates
-                            COMMAND benchmark_expr_templates "--benchmark_min_time=0.0 --v=3 --benchmark_format=console"
+        blt_add_benchmark(  NAME        benchmark_expr_templates
+                            COMMAND     benchmark_expr_templates "--benchmark_min_time=0.0 --v=3 --benchmark_format=console"
                             NUM_MPI_TASKS 4)
     endif()
 


### PR DESCRIPTION
#280

Also limits duplication of targets that are inherited through other CMake targets
Also stops clang-format from sorting includes (didn't fix order in this PR)