### PR TITLE
Unify option struct naming scheme

### DIFF
--- a/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_amgx_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_amgx_solve.lua
@@ -35,7 +35,7 @@ nonlinear_solid = {
         },
     },
 
-    mass_solver = {
+    dynamics = {
         timestepper = "AverageAcceleration",
         enforcement_method = "RateControl",
     },

--- a/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_direct_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_direct_solve.lua
@@ -35,7 +35,7 @@ nonlinear_solid = {
         },
     },
 
-    mass_solver = {
+    dynamics = {
         timestepper = "AverageAcceleration",
         enforcement_method = "RateControl",
     },

--- a/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_linesearch_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_linesearch_solve.lua
@@ -36,7 +36,7 @@ nonlinear_solid = {
         },
     },
 
-    mass_solver = {
+    dynamics = {
         timestepper = "AverageAcceleration",
         enforcement_method = "RateControl",
     },

--- a/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/serac_dynamic_solver/dyn_solve.lua
@@ -35,7 +35,7 @@ nonlinear_solid = {
         },
     },
 
-    mass_solver = {
+    dynamics = {
         timestepper = "AverageAcceleration",
         enforcement_method = "RateControl",
     },

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -83,13 +83,13 @@ int main(int argc, char* argv[])
   datastore.getRoot()->save("serac_input.json", "json");
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
+  auto                  solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  serac::NonlinearSolid solid_solver(mesh, solid_solver_options);
 
   // Project the initial and reference configuration functions onto the
   // appropriate grid functions
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
   auto traction_coef = std::make_shared<serac::VectorScaledConstantCoefficient>(traction);
 
   // Set the boundary condition information
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       solid_solver.setDisplacementBCs(bc.attrs, disp_coef);
     } else if (bc.name == "traction") {

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -42,11 +42,11 @@ void defineInputFileSchema(axom::inlet::Inlet& inlet, int rank)
   inlet.addDouble("dt", "Time step.").defaultValue(0.25);
 
   auto& mesh_table = inlet.addTable("main_mesh", "The main mesh for the problem");
-  serac::mesh::InputInfo::defineInputFileSchema(mesh_table);
+  serac::mesh::InputOptions::defineInputFileSchema(mesh_table);
 
   // Physics
   auto& solid_solver_table = inlet.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
-  serac::NonlinearSolid::InputInfo::defineInputFileSchema(solid_solver_table);
+  serac::NonlinearSolid::InputOptions::defineInputFileSchema(solid_solver_table);
 
   // Verify input file
   if (!inlet.verify()) {
@@ -83,12 +83,12 @@ int main(int argc, char* argv[])
   datastore.getRoot()->save("serac_input.json", "json");
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   // Project the initial and reference configuration functions onto the

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -81,7 +81,7 @@ void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension)
   }
 }
 
-void BoundaryConditionInputInfo::defineInputFileSchema(axom::inlet::Table& table)
+void BoundaryConditionInputOptions::defineInputFileSchema(axom::inlet::Table& table)
 {
   table.addString("name", "Name used to identify the boundary condition").required();
   table.addIntArray("attrs", "Boundary attributes to which the BC should be applied").required();
@@ -107,10 +107,10 @@ mfem::Vector FromInlet<mfem::Vector>::operator()(const axom::inlet::Table& base)
   return result;
 }
 
-serac::input::BoundaryConditionInputInfo FromInlet<serac::input::BoundaryConditionInputInfo>::operator()(
+serac::input::BoundaryConditionInputOptions FromInlet<serac::input::BoundaryConditionInputOptions>::operator()(
     const axom::inlet::Table& base)
 {
-  serac::input::BoundaryConditionInputInfo result;
+  serac::input::BoundaryConditionInputOptions result;
   // Build a set with just the values of the map
   auto bdr_attr_map = base["attrs"].get<std::unordered_map<int, int>>();
   for (const auto& [_, val] : bdr_attr_map) {

--- a/src/serac/infrastructure/input.hpp
+++ b/src/serac/infrastructure/input.hpp
@@ -61,7 +61,7 @@ void defineVectorInputFileSchema(axom::inlet::Table& table, const int dimension 
 /**
  * @brief The information required from the input deck for a boundary condition
  */
-struct BoundaryConditionInputInfo {
+struct BoundaryConditionInputOptions {
   // Just store the attributes and a name for now
   std::string   name;
   std::set<int> attrs;
@@ -83,8 +83,8 @@ struct FromInlet<mfem::Vector> {
 };
 
 template <>
-struct FromInlet<serac::input::BoundaryConditionInputInfo> {
-  serac::input::BoundaryConditionInputInfo operator()(const axom::inlet::Table& base);
+struct FromInlet<serac::input::BoundaryConditionInputOptions> {
+  serac::input::BoundaryConditionInputOptions operator()(const axom::inlet::Table& base);
 };
 
 #endif

--- a/src/serac/numerics/mesh_utils.cpp
+++ b/src/serac/numerics/mesh_utils.cpp
@@ -168,7 +168,7 @@ std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_i
 
 namespace mesh {
 
-void InputInfo::defineInputFileSchema(axom::inlet::Table& table)
+void InputOptions::defineInputFileSchema(axom::inlet::Table& table)
 {
   // mesh path
   table.addString("mesh", "Path to Mesh file").required();
@@ -181,7 +181,7 @@ void InputInfo::defineInputFileSchema(axom::inlet::Table& table)
 }  // namespace mesh
 }  // namespace serac
 
-serac::mesh::InputInfo FromInlet<serac::mesh::InputInfo>::operator()(const axom::inlet::Table& base)
+serac::mesh::InputOptions FromInlet<serac::mesh::InputOptions>::operator()(const axom::inlet::Table& base)
 {
   std::string mesh_path = base["mesh"];
   int         ser_ref   = base["ser_ref_levels"];

--- a/src/serac/numerics/mesh_utils.hpp
+++ b/src/serac/numerics/mesh_utils.hpp
@@ -81,7 +81,7 @@ std::shared_ptr<mfem::ParMesh> buildCuboidMesh(int elements_in_x, int elements_i
 
 namespace mesh {
 
-struct InputInfo {
+struct InputOptions {
   /**
    * @brief Input file parameters specific to this class
    *
@@ -100,8 +100,8 @@ struct InputInfo {
 
 // Prototype the specialization
 template <>
-struct FromInlet<serac::mesh::InputInfo> {
-  serac::mesh::InputInfo operator()(const axom::inlet::Table& base);
+struct FromInlet<serac::mesh::InputOptions> {
+  serac::mesh::InputOptions operator()(const axom::inlet::Table& base);
 };
 
 #endif

--- a/src/serac/physics/elasticity.cpp
+++ b/src/serac/physics/elasticity.cpp
@@ -13,7 +13,7 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 1;
 
-Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverParameters& params)
+Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverOptions& params)
     : BasePhysics(mesh, NUM_FIELDS, order),
       displacement_(*mesh, FiniteElementState::Options{.order = order, .name = "displacement"})
 {

--- a/src/serac/physics/elasticity.cpp
+++ b/src/serac/physics/elasticity.cpp
@@ -13,7 +13,7 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 1;
 
-Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverOptions& params)
+Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverOptions& options)
     : BasePhysics(mesh, NUM_FIELDS, order),
       displacement_(*mesh, FiniteElementState::Options{.order = order, .name = "displacement"})
 {
@@ -21,9 +21,9 @@ Elasticity::Elasticity(int order, std::shared_ptr<mfem::ParMesh> mesh, const Lin
   state_.push_back(displacement_);
 
   // If the user wants the AMG preconditioner with a linear solver, set the pfes to be the displacement
-  const auto& augmented_params = augmentAMGForElasticity(params, displacement_.space());
+  const auto& augmented_options = augmentAMGForElasticity(options, displacement_.space());
 
-  K_inv_          = EquationSolver(mesh->GetComm(), augmented_params);
+  K_inv_          = EquationSolver(mesh->GetComm(), augmented_options);
   is_quasistatic_ = true;
 }
 

--- a/src/serac/physics/elasticity.hpp
+++ b/src/serac/physics/elasticity.hpp
@@ -36,9 +36,9 @@ public:
    *
    * @param[in] order The polynomial order of the solver
    * @param[in] mesh The parallel MFEM mesh
-   * @param[in] params The system solver parameters
+   * @param[in] options The system solver parameters
    */
-  Elasticity(const int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverOptions& params);
+  Elasticity(const int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverOptions& options);
 
   /**
    * @brief Set the vector-valued essential displacement boundary conditions

--- a/src/serac/physics/elasticity.hpp
+++ b/src/serac/physics/elasticity.hpp
@@ -38,7 +38,7 @@ public:
    * @param[in] mesh The parallel MFEM mesh
    * @param[in] params The system solver parameters
    */
-  Elasticity(const int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverParameters& params);
+  Elasticity(const int order, std::shared_ptr<mfem::ParMesh> mesh, const LinearSolverOptions& params);
 
   /**
    * @brief Set the vector-valued essential displacement boundary conditions

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -278,9 +278,9 @@ void NonlinearSolid::InputOptions::defineInputFileSchema(axom::inlet::Table& tab
   // See comment in header - schema definitions should never be guarded by a conditional.
   // This is a short-term patch.
   if (dynamic) {
-    auto& mass_solver_table = table.addTable("mass_solver", "Parameters for mass matrix inversion");
-    mass_solver_table.addString("timestepper", "Timestepper (ODE) method to use");
-    mass_solver_table.addString("enforcement_method", "Time-varying constraint enforcement method to use");
+    auto& dynamics_table = table.addTable("dynamics", "Parameters for mass matrix inversion");
+    dynamics_table.addString("timestepper", "Timestepper (ODE) method to use");
+    dynamics_table.addString("enforcement_method", "Time-varying constraint enforcement method to use");
   }
 
   auto& bc_table = table.addGenericArray("boundary_conds", "Boundary condition information");
@@ -304,21 +304,21 @@ NonlinearSolid::InputOptions FromInlet<NonlinearSolid::InputOptions>::operator()
   result.solver_params.H_lin_params    = stiffness_solver["linear"].get<serac::IterativeSolverOptions>();
   result.solver_params.H_nonlin_params = stiffness_solver["nonlinear"].get<serac::NonlinearSolverOptions>();
 
-  if (base.contains("mass_solver")) {
+  if (base.contains("dynamics")) {
     NonlinearSolid::TimesteppingOptions dyn_params;
-    auto                                mass_solver = base["mass_solver"];
+    auto                                dynamics = base["dynamics"];
 
     // FIXME: Implement all supported methods as part of an ODE schema
     const static std::map<std::string, TimestepMethod> timestep_methods = {
         {"AverageAcceleration", TimestepMethod::AverageAcceleration}};
-    std::string timestep_method = mass_solver["timestepper"];
+    std::string timestep_method = dynamics["timestepper"];
     SLIC_ERROR_IF(timestep_methods.count(timestep_method) == 0, "Unrecognized timestep method: " << timestep_method);
     dyn_params.timestepper = timestep_methods.at(timestep_method);
 
     // FIXME: Implement all supported methods as part of an ODE schema
     const static std::map<std::string, DirichletEnforcementMethod> enforcement_methods = {
         {"RateControl", DirichletEnforcementMethod::RateControl}};
-    std::string enforcement_method = mass_solver["enforcement_method"];
+    std::string enforcement_method = dynamics["enforcement_method"];
     SLIC_ERROR_IF(enforcement_methods.count(enforcement_method) == 0,
                   "Unrecognized enforcement method: " << enforcement_method);
     dyn_params.enforcement_method = enforcement_methods.at(enforcement_method);

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -65,7 +65,7 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
 }
 
 NonlinearSolid::NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const NonlinearSolid::InputOptions& info)
-    : NonlinearSolid(info.order, mesh, info.solver_params)
+    : NonlinearSolid(info.order, mesh, info.solver_options)
 {
   // This is the only other info stored in the input file that we can use
   // in the initialization stage
@@ -300,9 +300,9 @@ NonlinearSolid::InputOptions FromInlet<NonlinearSolid::InputOptions>::operator()
   result.order = base["order"];
 
   // Solver parameters
-  auto stiffness_solver                = base["stiffness_solver"];
-  result.solver_params.H_lin_params    = stiffness_solver["linear"].get<serac::IterativeSolverOptions>();
-  result.solver_params.H_nonlin_params = stiffness_solver["nonlinear"].get<serac::NonlinearSolverOptions>();
+  auto stiffness_solver                 = base["stiffness_solver"];
+  result.solver_options.H_lin_params    = stiffness_solver["linear"].get<serac::IterativeSolverOptions>();
+  result.solver_options.H_nonlin_params = stiffness_solver["nonlinear"].get<serac::NonlinearSolverOptions>();
 
   if (base.contains("dynamics")) {
     NonlinearSolid::TimesteppingOptions dyn_params;
@@ -323,7 +323,7 @@ NonlinearSolid::InputOptions FromInlet<NonlinearSolid::InputOptions>::operator()
                   "Unrecognized enforcement method: " << enforcement_method);
     dyn_params.enforcement_method = enforcement_methods.at(enforcement_method);
 
-    result.solver_params.dyn_params = std::move(dyn_params);
+    result.solver_options.dyn_params = std::move(dyn_params);
   }
 
   // Set the material parameters

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -306,7 +306,7 @@ NonlinearSolid::InputOptions FromInlet<NonlinearSolid::InputOptions>::operator()
 
   if (base.contains("mass_solver")) {
     NonlinearSolid::TimesteppingOptions dyn_params;
-    auto                                    mass_solver = base["mass_solver"];
+    auto                                mass_solver = base["mass_solver"];
 
     // FIXME: Implement all supported methods as part of an ODE schema
     const static std::map<std::string, TimestepMethod> timestep_methods = {

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -16,7 +16,7 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 2;
 
-NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& params)
+NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& options)
     : BasePhysics(mesh, NUM_FIELDS, order),
       velocity_(*mesh, FiniteElementState::Options{.order = order, .name = "velocity"}),
       displacement_(*mesh, FiniteElementState::Options{.order = order, .name = "displacement"}),
@@ -37,17 +37,17 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
   displacement_.trueVec() = 0.0;
   velocity_.trueVec()     = 0.0;
 
-  const auto& lin_params = params.H_lin_options;
+  const auto& lin_options = options.H_lin_options;
   // If the user wants the AMG preconditioner with a linear solver, set the pfes
   // to be the displacement
-  const auto& augmented_params = augmentAMGForElasticity(lin_params, displacement_.space());
+  const auto& augmented_options = augmentAMGForElasticity(lin_options, displacement_.space());
 
-  nonlin_solver_ = EquationSolver(mesh->GetComm(), augmented_params, params.H_nonlin_options);
+  nonlin_solver_ = EquationSolver(mesh->GetComm(), augmented_options, options.H_nonlin_options);
 
   // Check for dynamic mode
-  if (params.dyn_options) {
-    ode2_.SetTimestepper(params.dyn_options->timestepper);
-    ode2_.SetEnforcementMethod(params.dyn_options->enforcement_method);
+  if (options.dyn_options) {
+    ode2_.SetTimestepper(options.dyn_options->timestepper);
+    ode2_.SetEnforcementMethod(options.dyn_options->enforcement_method);
     is_quasistatic_ = false;
   } else {
     is_quasistatic_ = true;

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -64,12 +64,12 @@ NonlinearSolid::NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, c
   zero_ = 0.0;
 }
 
-NonlinearSolid::NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const NonlinearSolid::InputOptions& info)
-    : NonlinearSolid(info.order, mesh, info.solver_options)
+NonlinearSolid::NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const NonlinearSolid::InputOptions& options)
+    : NonlinearSolid(options.order, mesh, options.solver_options)
 {
-  // This is the only other info stored in the input file that we can use
+  // This is the only other options stored in the input file that we can use
   // in the initialization stage
-  setHyperelasticMaterialParameters(info.mu, info.K);
+  setHyperelasticMaterialParameters(options.mu, options.K);
 }
 
 void NonlinearSolid::setDisplacementBCs(const std::set<int>&                     disp_bdr,

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -86,9 +86,9 @@ public:
    * @brief Construct a new Nonlinear Solid Solver object
    *
    * @param[in] mesh The MFEM parallel mesh to solve on
-   * @param[in] info The solver information parsed from the input file
+   * @param[in] options The solver information parsed from the input file
    */
-  NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const InputOptions& info);
+  NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const InputOptions& options);
 
   /**
    * @brief Set displacement boundary conditions

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -42,8 +42,8 @@ public:
    * Either quasistatic, or time-dependent with timestep and M params
    */
   struct SolverOptions {
-    LinearSolverOptions                 H_lin_params;
-    NonlinearSolverOptions              H_nonlin_params;
+    LinearSolverOptions                H_lin_params;
+    NonlinearSolverOptions             H_nonlin_params;
     std::optional<TimesteppingOptions> dyn_params = std::nullopt;
   };
 
@@ -63,7 +63,7 @@ public:
     static void defineInputFileSchema(axom::inlet::Table& table, const bool dynamic = false);
 
     // The order of the field
-    int              order;
+    int           order;
     SolverOptions solver_params;
     // Lame parameters
     double mu;

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -33,7 +33,7 @@ public:
   /**
    * @brief A timestep method and config for the M solver
    */
-  struct DynamicSolverParameters {
+  struct TimesteppingOptions {
     TimestepMethod             timestepper;
     DirichletEnforcementMethod enforcement_method;
   };
@@ -41,17 +41,17 @@ public:
    * @brief A configuration variant for the various solves
    * Either quasistatic, or time-dependent with timestep and M params
    */
-  struct SolverParameters {
-    LinearSolverParameters                 H_lin_params;
-    NonlinearSolverParameters              H_nonlin_params;
-    std::optional<DynamicSolverParameters> dyn_params = std::nullopt;
+  struct SolverOptions {
+    LinearSolverOptions                 H_lin_params;
+    NonlinearSolverOptions              H_nonlin_params;
+    std::optional<TimesteppingOptions> dyn_params = std::nullopt;
   };
 
   /**
    * @brief Stores all information held in the input file that
    * is used to configure the solver
    */
-  struct InputInfo {
+  struct InputOptions {
     /**
      * @brief Input file parameters specific to this class
      *
@@ -64,13 +64,13 @@ public:
 
     // The order of the field
     int              order;
-    SolverParameters solver_params;
+    SolverOptions solver_params;
     // Lame parameters
     double mu;
     double K;
 
     // Boundary condition information
-    std::vector<input::BoundaryConditionInputInfo> boundary_conditions;
+    std::vector<input::BoundaryConditionInputOptions> boundary_conditions;
   };
 
   /**
@@ -80,7 +80,7 @@ public:
    * @param[in] mesh The MFEM parallel mesh to solve on
    * @param[in] solver The system solver parameters
    */
-  NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverParameters& params);
+  NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& params);
 
   /**
    * @brief Construct a new Nonlinear Solid Solver object
@@ -88,7 +88,7 @@ public:
    * @param[in] mesh The MFEM parallel mesh to solve on
    * @param[in] info The solver information parsed from the input file
    */
-  NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const InputInfo& info);
+  NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const InputOptions& info);
 
   /**
    * @brief Set displacement boundary conditions
@@ -213,7 +213,7 @@ protected:
   /**
    * @brief Configuration for dynamic equation solver
    */
-  std::optional<LinearSolverParameters> timedep_oper_params_;
+  std::optional<LinearSolverOptions> timedep_oper_params_;
 
   /**
    * @brief The time dependent operator for use with the MFEM ODE solvers
@@ -315,8 +315,8 @@ protected:
 }  // namespace serac
 
 template <>
-struct FromInlet<serac::NonlinearSolid::InputInfo> {
-  serac::NonlinearSolid::InputInfo operator()(const axom::inlet::Table& base);
+struct FromInlet<serac::NonlinearSolid::InputOptions> {
+  serac::NonlinearSolid::InputOptions operator()(const axom::inlet::Table& base);
 };
 
 #endif

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -80,7 +80,7 @@ public:
    * @param[in] mesh The MFEM parallel mesh to solve on
    * @param[in] solver The system solver parameters
    */
-  NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& params);
+  NonlinearSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& options);
 
   /**
    * @brief Construct a new Nonlinear Solid Solver object

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -39,12 +39,12 @@ public:
   };
   /**
    * @brief A configuration variant for the various solves
-   * Either quasistatic, or time-dependent with timestep and M params
+   * Either quasistatic, or time-dependent with timestep and M options
    */
   struct SolverOptions {
-    LinearSolverOptions                H_lin_params;
-    NonlinearSolverOptions             H_nonlin_params;
-    std::optional<TimesteppingOptions> dyn_params = std::nullopt;
+    LinearSolverOptions                H_lin_options;
+    NonlinearSolverOptions             H_nonlin_options;
+    std::optional<TimesteppingOptions> dyn_options = std::nullopt;
   };
 
   /**

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -211,11 +211,6 @@ protected:
   std::unique_ptr<mfem::Operator> residual_;
 
   /**
-   * @brief Configuration for dynamic equation solver
-   */
-  std::optional<LinearSolverOptions> timedep_oper_params_;
-
-  /**
    * @brief The time dependent operator for use with the MFEM ODE solvers
    */
   std::unique_ptr<mfem::TimeDependentOperator> timedep_oper_;

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -64,7 +64,7 @@ public:
 
     // The order of the field
     int           order;
-    SolverOptions solver_params;
+    SolverOptions solver_options;
     // Lame parameters
     double mu;
     double K;

--- a/src/serac/physics/thermal_conduction.cpp
+++ b/src/serac/physics/thermal_conduction.cpp
@@ -13,7 +13,7 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 1;
 
-ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& params)
+ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& options)
     : BasePhysics(mesh, NUM_FIELDS, order),
       temperature_(*mesh,
                    FiniteElementState::Options{
@@ -24,13 +24,13 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
 {
   state_.push_back(temperature_);
 
-  nonlin_solver_ = EquationSolver(mesh->GetComm(), params.T_lin_options, params.T_nonlin_options);
+  nonlin_solver_ = EquationSolver(mesh->GetComm(), options.T_lin_options, options.T_nonlin_options);
   nonlin_solver_.SetOperator(residual_);
 
   // Check for dynamic mode
-  if (params.dyn_options) {
-    ode_.SetTimestepper(params.dyn_options->timestepper);
-    ode_.SetEnforcementMethod(params.dyn_options->enforcement_method);
+  if (options.dyn_options) {
+    ode_.SetTimestepper(options.dyn_options->timestepper);
+    ode_.SetEnforcementMethod(options.dyn_options->enforcement_method);
     is_quasistatic_ = false;
   } else {
     is_quasistatic_ = true;

--- a/src/serac/physics/thermal_conduction.cpp
+++ b/src/serac/physics/thermal_conduction.cpp
@@ -13,7 +13,7 @@ namespace serac {
 
 constexpr int NUM_FIELDS = 1;
 
-ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverParameters& params)
+ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& params)
     : BasePhysics(mesh, NUM_FIELDS, order),
       temperature_(*mesh,
                    FiniteElementState::Options{

--- a/src/serac/physics/thermal_conduction.cpp
+++ b/src/serac/physics/thermal_conduction.cpp
@@ -24,13 +24,13 @@ ThermalConduction::ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> m
 {
   state_.push_back(temperature_);
 
-  nonlin_solver_ = EquationSolver(mesh->GetComm(), params.T_lin_params, params.T_nonlin_params);
+  nonlin_solver_ = EquationSolver(mesh->GetComm(), params.T_lin_options, params.T_nonlin_options);
   nonlin_solver_.SetOperator(residual_);
 
   // Check for dynamic mode
-  if (params.dyn_params) {
-    ode_.SetTimestepper(params.dyn_params->timestepper);
-    ode_.SetEnforcementMethod(params.dyn_params->enforcement_method);
+  if (params.dyn_options) {
+    ode_.SetTimestepper(params.dyn_options->timestepper);
+    ode_.SetEnforcementMethod(params.dyn_options->enforcement_method);
     is_quasistatic_ = false;
   } else {
     is_quasistatic_ = true;

--- a/src/serac/physics/thermal_conduction.hpp
+++ b/src/serac/physics/thermal_conduction.hpp
@@ -45,8 +45,8 @@ public:
    * Either quasistatic, or time-dependent with timestep and M params
    */
   struct SolverOptions {
-    LinearSolverOptions                 T_lin_params;
-    NonlinearSolverOptions              T_nonlin_params;
+    LinearSolverOptions                T_lin_params;
+    NonlinearSolverOptions             T_nonlin_params;
     std::optional<TimesteppingOptions> dyn_params = std::nullopt;
   };
 

--- a/src/serac/physics/thermal_conduction.hpp
+++ b/src/serac/physics/thermal_conduction.hpp
@@ -35,7 +35,7 @@ public:
   /**
    * @brief A timestep method and config for the M solver
    */
-  struct DynamicSolverParameters {
+  struct TimesteppingOptions {
     TimestepMethod             timestepper;
     DirichletEnforcementMethod enforcement_method;
   };
@@ -44,13 +44,13 @@ public:
    * @brief A configuration variant for the various solves
    * Either quasistatic, or time-dependent with timestep and M params
    */
-  struct SolverParameters {
-    LinearSolverParameters                 T_lin_params;
-    NonlinearSolverParameters              T_nonlin_params;
-    std::optional<DynamicSolverParameters> dyn_params = std::nullopt;
+  struct SolverOptions {
+    LinearSolverOptions                 T_lin_params;
+    NonlinearSolverOptions              T_nonlin_params;
+    std::optional<TimesteppingOptions> dyn_params = std::nullopt;
   };
 
-  static IterativeSolverParameters defaultLinearParameters()
+  static IterativeSolverOptions defaultLinearParameters()
   {
     return {.rel_tol     = 1.0e-6,
             .abs_tol     = 1.0e-12,
@@ -60,20 +60,20 @@ public:
             .prec        = HypreSmootherPrec{mfem::HypreSmoother::Jacobi}};
   }
 
-  static NonlinearSolverParameters defaultNonlinearParameters()
+  static NonlinearSolverOptions defaultNonlinearParameters()
   {
     return {.rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 500, .print_level = 1};
   }
 
-  static SolverParameters defaultQuasistaticParameters()
+  static SolverOptions defaultQuasistaticParameters()
   {
     return {defaultLinearParameters(), defaultNonlinearParameters(), std::nullopt};
   }
 
-  static SolverParameters defaultDynamicParameters()
+  static SolverOptions defaultDynamicParameters()
   {
     return {defaultLinearParameters(), defaultNonlinearParameters(),
-            DynamicSolverParameters{TimestepMethod::BackwardEuler, DirichletEnforcementMethod::RateControl}};
+            TimesteppingOptions{TimestepMethod::BackwardEuler, DirichletEnforcementMethod::RateControl}};
   }
 
   /**
@@ -83,7 +83,7 @@ public:
    * @param[in] mesh The MFEM parallel mesh to solve the PDE on
    * @param[in] params The system solver parameters
    */
-  ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverParameters& params);
+  ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& params);
 
   /**
    * @brief Set essential temperature boundary conditions (strongly enforced)

--- a/src/serac/physics/thermal_conduction.hpp
+++ b/src/serac/physics/thermal_conduction.hpp
@@ -45,12 +45,12 @@ public:
    * Either quasistatic, or time-dependent with timestep and M params
    */
   struct SolverOptions {
-    LinearSolverOptions                T_lin_params;
-    NonlinearSolverOptions             T_nonlin_params;
-    std::optional<TimesteppingOptions> dyn_params = std::nullopt;
+    LinearSolverOptions                T_lin_options;
+    NonlinearSolverOptions             T_nonlin_options;
+    std::optional<TimesteppingOptions> dyn_options = std::nullopt;
   };
 
-  static IterativeSolverOptions defaultLinearParameters()
+  static IterativeSolverOptions defaultLinearOptions()
   {
     return {.rel_tol     = 1.0e-6,
             .abs_tol     = 1.0e-12,
@@ -60,19 +60,19 @@ public:
             .prec        = HypreSmootherPrec{mfem::HypreSmoother::Jacobi}};
   }
 
-  static NonlinearSolverOptions defaultNonlinearParameters()
+  static NonlinearSolverOptions defaultNonlinearOptions()
   {
     return {.rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 500, .print_level = 1};
   }
 
-  static SolverOptions defaultQuasistaticParameters()
+  static SolverOptions defaultQuasistaticOptions()
   {
-    return {defaultLinearParameters(), defaultNonlinearParameters(), std::nullopt};
+    return {defaultLinearOptions(), defaultNonlinearOptions(), std::nullopt};
   }
 
-  static SolverOptions defaultDynamicParameters()
+  static SolverOptions defaultDynamicOptions()
   {
-    return {defaultLinearParameters(), defaultNonlinearParameters(),
+    return {defaultLinearOptions(), defaultNonlinearOptions(),
             TimesteppingOptions{TimestepMethod::BackwardEuler, DirichletEnforcementMethod::RateControl}};
   }
 

--- a/src/serac/physics/thermal_conduction.hpp
+++ b/src/serac/physics/thermal_conduction.hpp
@@ -42,7 +42,7 @@ public:
 
   /**
    * @brief A configuration variant for the various solves
-   * Either quasistatic, or time-dependent with timestep and M params
+   * Either quasistatic, or time-dependent with timestep and M options
    */
   struct SolverOptions {
     LinearSolverOptions                T_lin_options;
@@ -81,9 +81,9 @@ public:
    *
    * @param[in] order The order of the thermal field discretization
    * @param[in] mesh The MFEM parallel mesh to solve the PDE on
-   * @param[in] params The system solver parameters
+   * @param[in] options The system solver parameters
    */
-  ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& params);
+  ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& options);
 
   /**
    * @brief Set essential temperature boundary conditions (strongly enforced)

--- a/src/serac/physics/thermal_solid.cpp
+++ b/src/serac/physics/thermal_solid.cpp
@@ -14,11 +14,11 @@ namespace serac {
 constexpr int NUM_FIELDS = 3;
 
 ThermalSolid::ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh,
-                           const ThermalConduction::SolverOptions& therm_params,
-                           const NonlinearSolid::SolverOptions&    solid_params)
+                           const ThermalConduction::SolverOptions& therm_options,
+                           const NonlinearSolid::SolverOptions&    solid_options)
     : BasePhysics(mesh, NUM_FIELDS, order),
-      therm_solver_(order, mesh, therm_params),
-      solid_solver_(order, mesh, solid_params),
+      therm_solver_(order, mesh, therm_options),
+      solid_solver_(order, mesh, solid_options),
       temperature_(therm_solver_.temperature()),
       velocity_(solid_solver_.velocity()),
       displacement_(solid_solver_.displacement())

--- a/src/serac/physics/thermal_solid.cpp
+++ b/src/serac/physics/thermal_solid.cpp
@@ -14,8 +14,8 @@ namespace serac {
 constexpr int NUM_FIELDS = 3;
 
 ThermalSolid::ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh,
-                           const ThermalConduction::SolverParameters& therm_params,
-                           const NonlinearSolid::SolverParameters&    solid_params)
+                           const ThermalConduction::SolverOptions& therm_params,
+                           const NonlinearSolid::SolverOptions&    solid_params)
     : BasePhysics(mesh, NUM_FIELDS, order),
       therm_solver_(order, mesh, therm_params),
       solid_solver_(order, mesh, solid_params),

--- a/src/serac/physics/thermal_solid.hpp
+++ b/src/serac/physics/thermal_solid.hpp
@@ -30,11 +30,11 @@ public:
    *
    * @param[in] order The order of the temperature and displacement discretizations
    * @param[in] mesh The parallel mesh object on which to solve
-   * @param[in] therm_params The equation solver params for the conduction physics
-   * @param[in] solid_params The equation solver params for the solid physics
+   * @param[in] therm_options The equation solver options for the conduction physics
+   * @param[in] solid_options The equation solver options for the solid physics
    */
-  ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const ThermalConduction::SolverOptions& therm_params,
-               const NonlinearSolid::SolverOptions& solid_params);
+  ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const ThermalConduction::SolverOptions& therm_options,
+               const NonlinearSolid::SolverOptions& solid_options);
 
   /**
    * @brief Set essential temperature boundary conditions (strongly enforced)

--- a/src/serac/physics/thermal_solid.hpp
+++ b/src/serac/physics/thermal_solid.hpp
@@ -33,8 +33,8 @@ public:
    * @param[in] therm_params The equation solver params for the conduction physics
    * @param[in] solid_params The equation solver params for the solid physics
    */
-  ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const ThermalConduction::SolverParameters& therm_params,
-               const NonlinearSolid::SolverParameters& solid_params);
+  ThermalSolid(int order, std::shared_ptr<mfem::ParMesh> mesh, const ThermalConduction::SolverOptions& therm_params,
+               const NonlinearSolid::SolverOptions& solid_params);
 
   /**
    * @brief Set essential temperature boundary conditions (strongly enforced)

--- a/src/serac/physics/utilities/equation_solver.cpp
+++ b/src/serac/physics/utilities/equation_solver.cpp
@@ -11,30 +11,30 @@
 
 namespace serac {
 
-EquationSolver::EquationSolver(MPI_Comm comm, const LinearSolverOptions& lin_params,
-                               const std::optional<NonlinearSolverOptions>& nonlin_params)
+EquationSolver::EquationSolver(MPI_Comm comm, const LinearSolverOptions& lin_options,
+                               const std::optional<NonlinearSolverOptions>& nonlin_options)
 {
   // If it's an iterative solver, build it and set the preconditioner
-  if (auto iter_params = std::get_if<IterativeSolverOptions>(&lin_params)) {
-    lin_solver_ = buildIterativeLinearSolver(comm, *iter_params);
+  if (auto iter_options = std::get_if<IterativeSolverOptions>(&lin_options)) {
+    lin_solver_ = buildIterativeLinearSolver(comm, *iter_options);
   }
   // If it's a custom solver, check that the mfem::Solver* is not null
-  else if (auto custom = std::get_if<CustomSolverOptions>(&lin_params)) {
+  else if (auto custom = std::get_if<CustomSolverOptions>(&lin_options)) {
     SLIC_ERROR_IF(custom->solver == nullptr, "Custom solver pointer must be initialized.");
     lin_solver_ = custom->solver;
   }
   // If it's a direct solver (currently SuperLU only)
-  else if (auto direct_params = std::get_if<DirectSolverOptions>(&lin_params)) {
+  else if (auto direct_options = std::get_if<DirectSolverOptions>(&lin_options)) {
     auto direct_solver = std::make_unique<mfem::SuperLUSolver>(comm);
     direct_solver->SetColumnPermutation(mfem::superlu::PARMETIS);
-    if (direct_params->print_level == 0) {
+    if (direct_options->print_level == 0) {
       direct_solver->SetPrintStatistics(false);
     }
     lin_solver_ = std::move(direct_solver);
   }
 
-  if (nonlin_params) {
-    nonlin_solver_ = buildNewtonSolver(comm, *nonlin_params);
+  if (nonlin_options) {
+    nonlin_solver_ = buildNewtonSolver(comm, *nonlin_options);
   }
 }
 
@@ -202,11 +202,11 @@ std::unique_ptr<mfem::AmgXSolver> configureAMGX(const MPI_Comm comm, const AMGXP
 }  // namespace detail
 
 std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolver(
-    MPI_Comm comm, const IterativeSolverOptions& lin_params)
+    MPI_Comm comm, const IterativeSolverOptions& lin_options)
 {
   std::unique_ptr<mfem::IterativeSolver> iter_lin_solver;
 
-  switch (lin_params.lin_solver) {
+  switch (lin_options.lin_solver) {
     case LinearSolver::CG:
       iter_lin_solver = std::make_unique<mfem::CGSolver>(comm);
       break;
@@ -221,27 +221,27 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
       exitGracefully(true);
   }
 
-  iter_lin_solver->SetRelTol(lin_params.rel_tol);
-  iter_lin_solver->SetAbsTol(lin_params.abs_tol);
-  iter_lin_solver->SetMaxIter(lin_params.max_iter);
-  iter_lin_solver->SetPrintLevel(lin_params.print_level);
+  iter_lin_solver->SetRelTol(lin_options.rel_tol);
+  iter_lin_solver->SetAbsTol(lin_options.abs_tol);
+  iter_lin_solver->SetMaxIter(lin_options.max_iter);
+  iter_lin_solver->SetPrintLevel(lin_options.print_level);
 
   // Handle the preconditioner - currently just BoomerAMG and HypreSmoother are supported
-  if (lin_params.prec) {
-    const auto prec_ptr = &lin_params.prec.value();
-    if (auto amg_params = std::get_if<HypreBoomerAMGPrec>(prec_ptr)) {
+  if (lin_options.prec) {
+    const auto prec_ptr = &lin_options.prec.value();
+    if (auto amg_options = std::get_if<HypreBoomerAMGPrec>(prec_ptr)) {
       auto prec_amg = std::make_unique<mfem::HypreBoomerAMG>();
-      auto par_fes  = amg_params->pfes;
+      auto par_fes  = amg_options->pfes;
       if (par_fes != nullptr) {
         SLIC_WARNING_IF(par_fes->GetOrdering() == mfem::Ordering::byNODES,
                         "Attempting to use BoomerAMG with nodal ordering on an elasticity problem.");
         prec_amg->SetElasticityOptions(par_fes);
       }
-      prec_amg->SetPrintLevel(lin_params.print_level);
+      prec_amg->SetPrintLevel(lin_options.print_level);
       prec_ = std::move(prec_amg);
-    } else if (auto smoother_params = std::get_if<HypreSmootherPrec>(prec_ptr)) {
+    } else if (auto smoother_options = std::get_if<HypreSmootherPrec>(prec_ptr)) {
       auto prec_smoother = std::make_unique<mfem::HypreSmoother>();
-      prec_smoother->SetType(smoother_params->type);
+      prec_smoother->SetType(smoother_options->type);
       prec_smoother->SetPositiveDiagonal(true);
       prec_ = std::move(prec_smoother);
 #ifdef MFEM_USE_AMGX
@@ -251,8 +251,8 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
     } else if (std::get_if<AMGXPrec>(prec_ptr)) {
       SLIC_ERROR("AMGX was not enabled when MFEM was built");
 #endif
-    } else if (auto ilu_params = std::get_if<BlockILUPrec>(prec_ptr)) {
-      prec_ = std::make_unique<mfem::BlockILU>(ilu_params->block_size);
+    } else if (auto ilu_options = std::get_if<BlockILUPrec>(prec_ptr)) {
+      prec_ = std::make_unique<mfem::BlockILU>(ilu_options->block_size);
     }
     iter_lin_solver->SetPreconditioner(*prec_);
   }
@@ -260,28 +260,28 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
 }
 
 std::unique_ptr<mfem::NewtonSolver> EquationSolver::buildNewtonSolver(MPI_Comm                      comm,
-                                                                      const NonlinearSolverOptions& nonlin_params)
+                                                                      const NonlinearSolverOptions& nonlin_options)
 {
   std::unique_ptr<mfem::NewtonSolver> newton_solver;
 
-  if (nonlin_params.nonlin_solver == NonlinearSolver::MFEMNewton) {
+  if (nonlin_options.nonlin_solver == NonlinearSolver::MFEMNewton) {
     newton_solver = std::make_unique<mfem::NewtonSolver>(comm);
   }
   // KINSOL
   else {
 #ifdef MFEM_USE_SUNDIALS
     auto kinsol_strat =
-        (nonlin_params.nonlin_solver == NonlinearSolver::KINBacktrackingLineSearch) ? KIN_LINESEARCH : KIN_NONE;
+        (nonlin_options.nonlin_solver == NonlinearSolver::KINBacktrackingLineSearch) ? KIN_LINESEARCH : KIN_NONE;
     newton_solver = std::make_unique<mfem::KINSolver>(comm, kinsol_strat, true);
 #else
     SLIC_ERROR("KINSOL was not enabled when MFEM was built");
 #endif
   }
 
-  newton_solver->SetRelTol(nonlin_params.rel_tol);
-  newton_solver->SetAbsTol(nonlin_params.abs_tol);
-  newton_solver->SetMaxIter(nonlin_params.max_iter);
-  newton_solver->SetPrintLevel(nonlin_params.print_level);
+  newton_solver->SetRelTol(nonlin_options.rel_tol);
+  newton_solver->SetAbsTol(nonlin_options.abs_tol);
+  newton_solver->SetMaxIter(nonlin_options.max_iter);
+  newton_solver->SetPrintLevel(nonlin_options.print_level);
   return newton_solver;
 }
 
@@ -366,56 +366,56 @@ using serac::NonlinearSolverOptions;
 
 IterativeSolverOptions FromInlet<IterativeSolverOptions>::operator()(const axom::inlet::Table& base)
 {
-  IterativeSolverOptions params;
-  params.rel_tol          = base["rel_tol"];
-  params.abs_tol          = base["abs_tol"];
-  params.max_iter         = base["max_iter"];
-  params.print_level      = base["print_level"];
+  IterativeSolverOptions options;
+  options.rel_tol         = base["rel_tol"];
+  options.abs_tol         = base["abs_tol"];
+  options.max_iter        = base["max_iter"];
+  options.print_level     = base["print_level"];
   std::string solver_type = base["solver_type"];
   if (solver_type == "gmres") {
-    params.lin_solver = serac::LinearSolver::GMRES;
+    options.lin_solver = serac::LinearSolver::GMRES;
   } else if (solver_type == "minres") {
-    params.lin_solver = serac::LinearSolver::MINRES;
+    options.lin_solver = serac::LinearSolver::MINRES;
   } else {
     std::string msg = fmt::format("Unknown Linear solver type given: {0}", solver_type);
     SLIC_ERROR(msg);
   }
   const std::string prec_type = base["prec_type"];
   if (prec_type == "JacobiSmoother") {
-    params.prec = serac::HypreSmootherPrec{mfem::HypreSmoother::Jacobi};
+    options.prec = serac::HypreSmootherPrec{mfem::HypreSmoother::Jacobi};
   } else if (prec_type == "L1JacobiSmoother") {
-    params.prec = serac::HypreSmootherPrec{mfem::HypreSmoother::l1Jacobi};
+    options.prec = serac::HypreSmootherPrec{mfem::HypreSmoother::l1Jacobi};
   } else if (prec_type == "HypreAMG") {
-    params.prec = serac::HypreBoomerAMGPrec{};
+    options.prec = serac::HypreBoomerAMGPrec{};
   } else if (prec_type == "AMGX") {
-    params.prec = serac::AMGXPrec{};
+    options.prec = serac::AMGXPrec{};
   } else if (prec_type == "BlockILU") {
-    params.prec = serac::BlockILUPrec{};
+    options.prec = serac::BlockILUPrec{};
   } else {
     std::string msg = fmt::format("Unknown preconditioner type given: {0}", prec_type);
     SLIC_ERROR(msg);
   }
-  return params;
+  return options;
 }
 
 NonlinearSolverOptions FromInlet<NonlinearSolverOptions>::operator()(const axom::inlet::Table& base)
 {
-  NonlinearSolverOptions params;
-  params.rel_tol                = base["rel_tol"];
-  params.abs_tol                = base["abs_tol"];
-  params.max_iter               = base["max_iter"];
-  params.print_level            = base["print_level"];
+  NonlinearSolverOptions options;
+  options.rel_tol               = base["rel_tol"];
+  options.abs_tol               = base["abs_tol"];
+  options.max_iter              = base["max_iter"];
+  options.print_level           = base["print_level"];
   const std::string solver_type = base["solver_type"];
   if (solver_type == "MFEMNewton") {
-    params.nonlin_solver = serac::NonlinearSolver::MFEMNewton;
+    options.nonlin_solver = serac::NonlinearSolver::MFEMNewton;
   } else if (solver_type == "KINFullStep") {
-    params.nonlin_solver = serac::NonlinearSolver::KINFullStep;
+    options.nonlin_solver = serac::NonlinearSolver::KINFullStep;
   } else if (solver_type == "KINLineSearch") {
-    params.nonlin_solver = serac::NonlinearSolver::KINBacktrackingLineSearch;
+    options.nonlin_solver = serac::NonlinearSolver::KINBacktrackingLineSearch;
   } else {
     SLIC_ERROR(fmt::format("Unknown nonlinear solver type given: {0}", solver_type));
   }
-  return params;
+  return options;
 }
 
 EquationSolver FromInlet<EquationSolver>::operator()(const axom::inlet::Table& base)

--- a/src/serac/physics/utilities/equation_solver.cpp
+++ b/src/serac/physics/utilities/equation_solver.cpp
@@ -259,7 +259,7 @@ std::unique_ptr<mfem::IterativeSolver> EquationSolver::buildIterativeLinearSolve
   return iter_lin_solver;
 }
 
-std::unique_ptr<mfem::NewtonSolver> EquationSolver::buildNewtonSolver(MPI_Comm                         comm,
+std::unique_ptr<mfem::NewtonSolver> EquationSolver::buildNewtonSolver(MPI_Comm                      comm,
                                                                       const NonlinearSolverOptions& nonlin_params)
 {
   std::unique_ptr<mfem::NewtonSolver> newton_solver;

--- a/src/serac/physics/utilities/equation_solver.hpp
+++ b/src/serac/physics/utilities/equation_solver.hpp
@@ -36,11 +36,11 @@ public:
    * @param[in] comm The MPI communicator object
    * @param[in] lin_params The parameters for the linear solver
    * @param[in] nonlin_params The optional parameters for the optional nonlinear solver
-   * @see serac::LinearSolverParameters
-   * @see serac::NonlinearSolverParameters
+   * @see serac::LinearSolverOptions
+   * @see serac::NonlinearSolverOptions
    */
-  EquationSolver(MPI_Comm comm, const LinearSolverParameters& lin_params,
-                 const std::optional<NonlinearSolverParameters>& nonlin_params = std::nullopt);
+  EquationSolver(MPI_Comm comm, const LinearSolverOptions& lin_params,
+                 const std::optional<NonlinearSolverOptions>& nonlin_params = std::nullopt);
 
   /**
    * Updates the solver with the provided operator
@@ -97,7 +97,7 @@ private:
    * @param[in] lin_params The parameters for the linear solver
    */
   std::unique_ptr<mfem::IterativeSolver> buildIterativeLinearSolver(MPI_Comm                         comm,
-                                                                    const IterativeSolverParameters& lin_params);
+                                                                    const IterativeSolverOptions& lin_params);
 
   /**
    * @brief Builds an Newton-Raphson solver given a set of nonlinear solver parameters
@@ -105,7 +105,7 @@ private:
    * @param[in] nonlin_params The parameters for the nonlinear solver
    */
   static std::unique_ptr<mfem::NewtonSolver> buildNewtonSolver(MPI_Comm                         comm,
-                                                               const NonlinearSolverParameters& nonlin_params);
+                                                               const NonlinearSolverOptions& nonlin_params);
 
   /**
    * @brief A wrapper class for combining a nonlinear solver with a SuperLU direct solver
@@ -191,15 +191,15 @@ private:
  * @param[in] pfes The FiniteElementSpace to configure the preconditioner with
  * @note A full copy of the object is made, pending C++20 relaxation of "mutable"
  */
-inline LinearSolverParameters augmentAMGForElasticity(const LinearSolverParameters& init_params,
+inline LinearSolverOptions augmentAMGForElasticity(const LinearSolverOptions& init_params,
                                                       mfem::ParFiniteElementSpace&  pfes)
 {
   auto augmented_params = init_params;
-  if (auto iter_params = std::get_if<IterativeSolverParameters>(&init_params)) {
+  if (auto iter_params = std::get_if<IterativeSolverOptions>(&init_params)) {
     if (iter_params->prec) {
       if (std::holds_alternative<HypreBoomerAMGPrec>(iter_params->prec.value())) {
         // It's a copy, but at least it's on the stack
-        std::get<HypreBoomerAMGPrec>(*std::get<IterativeSolverParameters>(augmented_params).prec).pfes = &pfes;
+        std::get<HypreBoomerAMGPrec>(*std::get<IterativeSolverOptions>(augmented_params).prec).pfes = &pfes;
       }
     }
   }
@@ -212,13 +212,13 @@ inline LinearSolverParameters augmentAMGForElasticity(const LinearSolverParamete
 // Prototype the specialization
 
 template <>
-struct FromInlet<serac::IterativeSolverParameters> {
-  serac::IterativeSolverParameters operator()(const axom::inlet::Table& base);
+struct FromInlet<serac::IterativeSolverOptions> {
+  serac::IterativeSolverOptions operator()(const axom::inlet::Table& base);
 };
 
 template <>
-struct FromInlet<serac::NonlinearSolverParameters> {
-  serac::NonlinearSolverParameters operator()(const axom::inlet::Table& base);
+struct FromInlet<serac::NonlinearSolverOptions> {
+  serac::NonlinearSolverOptions operator()(const axom::inlet::Table& base);
 };
 
 template <>

--- a/src/serac/physics/utilities/equation_solver.hpp
+++ b/src/serac/physics/utilities/equation_solver.hpp
@@ -96,7 +96,7 @@ private:
    * @param[in] comm The MPI communicator object
    * @param[in] lin_params The parameters for the linear solver
    */
-  std::unique_ptr<mfem::IterativeSolver> buildIterativeLinearSolver(MPI_Comm                         comm,
+  std::unique_ptr<mfem::IterativeSolver> buildIterativeLinearSolver(MPI_Comm                      comm,
                                                                     const IterativeSolverOptions& lin_params);
 
   /**
@@ -104,7 +104,7 @@ private:
    * @param[in] comm The MPI communicator object
    * @param[in] nonlin_params The parameters for the nonlinear solver
    */
-  static std::unique_ptr<mfem::NewtonSolver> buildNewtonSolver(MPI_Comm                         comm,
+  static std::unique_ptr<mfem::NewtonSolver> buildNewtonSolver(MPI_Comm                      comm,
                                                                const NonlinearSolverOptions& nonlin_params);
 
   /**
@@ -191,8 +191,8 @@ private:
  * @param[in] pfes The FiniteElementSpace to configure the preconditioner with
  * @note A full copy of the object is made, pending C++20 relaxation of "mutable"
  */
-inline LinearSolverOptions augmentAMGForElasticity(const LinearSolverOptions& init_params,
-                                                      mfem::ParFiniteElementSpace&  pfes)
+inline LinearSolverOptions augmentAMGForElasticity(const LinearSolverOptions&   init_params,
+                                                   mfem::ParFiniteElementSpace& pfes)
 {
   auto augmented_params = init_params;
   if (auto iter_params = std::get_if<IterativeSolverOptions>(&init_params)) {

--- a/src/serac/physics/utilities/equation_solver.hpp
+++ b/src/serac/physics/utilities/equation_solver.hpp
@@ -34,13 +34,13 @@ public:
   /**
    * Constructs a new solver wrapper
    * @param[in] comm The MPI communicator object
-   * @param[in] lin_params The parameters for the linear solver
-   * @param[in] nonlin_params The optional parameters for the optional nonlinear solver
+   * @param[in] lin_options The parameters for the linear solver
+   * @param[in] nonlin_options The optional parameters for the optional nonlinear solver
    * @see serac::LinearSolverOptions
    * @see serac::NonlinearSolverOptions
    */
-  EquationSolver(MPI_Comm comm, const LinearSolverOptions& lin_params,
-                 const std::optional<NonlinearSolverOptions>& nonlin_params = std::nullopt);
+  EquationSolver(MPI_Comm comm, const LinearSolverOptions& lin_options,
+                 const std::optional<NonlinearSolverOptions>& nonlin_options = std::nullopt);
 
   /**
    * Updates the solver with the provided operator
@@ -94,18 +94,18 @@ private:
   /**
    * @brief Builds an iterative solver given a set of linear solver parameters
    * @param[in] comm The MPI communicator object
-   * @param[in] lin_params The parameters for the linear solver
+   * @param[in] lin_options The parameters for the linear solver
    */
   std::unique_ptr<mfem::IterativeSolver> buildIterativeLinearSolver(MPI_Comm                      comm,
-                                                                    const IterativeSolverOptions& lin_params);
+                                                                    const IterativeSolverOptions& lin_options);
 
   /**
    * @brief Builds an Newton-Raphson solver given a set of nonlinear solver parameters
    * @param[in] comm The MPI communicator object
-   * @param[in] nonlin_params The parameters for the nonlinear solver
+   * @param[in] nonlin_options The parameters for the nonlinear solver
    */
   static std::unique_ptr<mfem::NewtonSolver> buildNewtonSolver(MPI_Comm                      comm,
-                                                               const NonlinearSolverOptions& nonlin_params);
+                                                               const NonlinearSolverOptions& nonlin_options);
 
   /**
    * @brief A wrapper class for combining a nonlinear solver with a SuperLU direct solver
@@ -187,24 +187,24 @@ private:
 /**
  * @brief A helper method intended to be called by physics modules to configure the AMG preconditioner for elasticity
  * problems
- * @param[in] init_params The user-provided solver parameters to possibly modify
+ * @param[in] init_options The user-provided solver parameters to possibly modify
  * @param[in] pfes The FiniteElementSpace to configure the preconditioner with
  * @note A full copy of the object is made, pending C++20 relaxation of "mutable"
  */
-inline LinearSolverOptions augmentAMGForElasticity(const LinearSolverOptions&   init_params,
+inline LinearSolverOptions augmentAMGForElasticity(const LinearSolverOptions&   init_options,
                                                    mfem::ParFiniteElementSpace& pfes)
 {
-  auto augmented_params = init_params;
-  if (auto iter_params = std::get_if<IterativeSolverOptions>(&init_params)) {
-    if (iter_params->prec) {
-      if (std::holds_alternative<HypreBoomerAMGPrec>(iter_params->prec.value())) {
+  auto augmented_options = init_options;
+  if (auto iter_options = std::get_if<IterativeSolverOptions>(&init_options)) {
+    if (iter_options->prec) {
+      if (std::holds_alternative<HypreBoomerAMGPrec>(iter_options->prec.value())) {
         // It's a copy, but at least it's on the stack
-        std::get<HypreBoomerAMGPrec>(*std::get<IterativeSolverOptions>(augmented_params).prec).pfes = &pfes;
+        std::get<HypreBoomerAMGPrec>(*std::get<IterativeSolverOptions>(augmented_options).prec).pfes = &pfes;
       }
     }
   }
   // NRVO will kick in here
-  return augmented_params;
+  return augmented_options;
 }
 
 }  // namespace serac

--- a/src/serac/physics/utilities/solver_config.hpp
+++ b/src/serac/physics/utilities/solver_config.hpp
@@ -185,7 +185,7 @@ enum class CouplingScheme
 /**
  * @brief Parameters for an iterative linear solution scheme
  */
-struct IterativeSolverParameters {
+struct IterativeSolverOptions {
   /**
    * @brief Relative tolerance
    */
@@ -222,14 +222,14 @@ struct IterativeSolverParameters {
  * @note This is preferable to unique_ptr or even references because non-trivial copy constructors
  * and destructors are a nightmare in this context
  */
-struct CustomSolverParameters {
+struct CustomSolverOptions {
   mfem::Solver* solver = nullptr;
 };
 
 /**
  * @brief Parameters for a direct solver (PARDISO, MUMPS, SuperLU, etc)
  */
-struct DirectSolverParameters {
+struct DirectSolverOptions {
   /**
    * @brief Debugging print level
    */
@@ -239,12 +239,12 @@ struct DirectSolverParameters {
 /**
  * @brief Parameters for a linear solver
  */
-using LinearSolverParameters = std::variant<IterativeSolverParameters, CustomSolverParameters, DirectSolverParameters>;
+using LinearSolverOptions = std::variant<IterativeSolverOptions, CustomSolverOptions, DirectSolverOptions>;
 
 /**
  * @brief Nonlinear solution scheme parameters
  */
-struct NonlinearSolverParameters {
+struct NonlinearSolverOptions {
   /**
    * @brief Relative tolerance
    */

--- a/tests/mfem_ex9p_blockilu.cpp
+++ b/tests/mfem_ex9p_blockilu.cpp
@@ -117,7 +117,7 @@ public:
         K(K_),
         A(NULL),
         linear_solver(M.GetComm(),
-                      serac::IterativeSolverParameters{.rel_tol     = 1e-9,
+                      serac::IterativeSolverOptions{.rel_tol     = 1e-9,
                                                        .abs_tol     = 0.0,
                                                        .print_level = 0,
                                                        .max_iter    = 100,

--- a/tests/mfem_ex9p_blockilu.cpp
+++ b/tests/mfem_ex9p_blockilu.cpp
@@ -116,13 +116,12 @@ public:
       : M(M_),
         K(K_),
         A(NULL),
-        linear_solver(M.GetComm(),
-                      serac::IterativeSolverOptions{.rel_tol     = 1e-9,
-                                                       .abs_tol     = 0.0,
-                                                       .print_level = 0,
-                                                       .max_iter    = 100,
-                                                       .lin_solver  = serac::LinearSolver::GMRES,
-                                                       .prec        = serac::BlockILUPrec{fes.GetFE(0)->GetDof()}}),
+        linear_solver(M.GetComm(), serac::IterativeSolverOptions{.rel_tol     = 1e-9,
+                                                                 .abs_tol     = 0.0,
+                                                                 .print_level = 0,
+                                                                 .max_iter    = 100,
+                                                                 .lin_solver  = serac::LinearSolver::GMRES,
+                                                                 .prec = serac::BlockILUPrec{fes.GetFE(0)->GetDof()}}),
         dt(-1.0)
   {
     linear_solver.linearSolver().iterative_mode = false;

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -34,12 +34,12 @@ TEST(component_bc, qs_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -110,12 +110,12 @@ TEST(component_bc, qs_attribute_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -34,13 +34,13 @@ TEST(component_bc, qs_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
+  auto                  solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  serac::NonlinearSolid solid_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -48,7 +48,7 @@ TEST(component_bc, qs_solve)
   auto disp_coef = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector& x) { return x[0] * -1.0e-1; });
 
   // Pass the BC information to the solver object setting only the z direction
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       solid_solver.setDisplacementBCs(bc.attrs, disp_coef, 0);
     } else {
@@ -110,13 +110,13 @@ TEST(component_bc, qs_attribute_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto                  solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  serac::NonlinearSolid solid_solver(mesh, solid_solver_info);
+  auto                  solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  serac::NonlinearSolid solid_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -125,7 +125,7 @@ TEST(component_bc, qs_attribute_solve)
   auto disp_y_coef = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector& x) { return x[1] * -5.0e-2; });
 
   // Pass the BC information to the solver object setting only the z direction
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement_x") {
       solid_solver.setDisplacementBCs(bc.attrs, disp_x_coef, 0);
     } else if (bc.name == "displacement_y") {

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -27,7 +27,7 @@ TEST(serac_dtor, test1)
   auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   // Initialize the second order thermal solver on the parallel mesh
-  auto therm_solver = std::make_unique<ThermalConduction>(2, pmesh, ThermalConduction::defaultQuasistaticParameters());
+  auto therm_solver = std::make_unique<ThermalConduction>(2, pmesh, ThermalConduction::defaultQuasistaticOptions());
 
   // Initialize the temperature boundary condition
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector& x) { return x.Norml2(); });
@@ -45,7 +45,7 @@ TEST(serac_dtor, test1)
   therm_solver->completeSetup();
 
   // Destruct the old thermal solver and build a new one
-  therm_solver.reset(new ThermalConduction(1, pmesh, ThermalConduction::defaultQuasistaticParameters()));
+  therm_solver.reset(new ThermalConduction(1, pmesh, ThermalConduction::defaultQuasistaticOptions()));
 
   // Destruct the second thermal solver and leave the pointer empty
   therm_solver.reset(nullptr);

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -37,13 +37,13 @@ TEST(dynamic_solver, dyn_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, /* dynamic = */ true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  NonlinearSolid dyn_solver(mesh, solid_solver_info);
+  auto           solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  NonlinearSolid dyn_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -52,7 +52,7 @@ TEST(dynamic_solver, dyn_solve)
   auto velo   = std::make_shared<mfem::VectorFunctionCoefficient>(dim, initialVelocity);
 
   // Pass the BC information to the solver object setting only the z direction
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       dyn_solver.setDisplacementBCs(bc.attrs, deform);
     } else {
@@ -122,15 +122,15 @@ TEST(dynamic_solver, dyn_direct_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  auto solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_options.H_lin_options = DirectSolverOptions{0};
-  NonlinearSolid dyn_solver(mesh, solid_solver_info);
+  solid_solver_options.solver_options.H_lin_options = DirectSolverOptions{0};
+  NonlinearSolid dyn_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -139,7 +139,7 @@ TEST(dynamic_solver, dyn_direct_solve)
   auto velo   = std::make_shared<mfem::VectorFunctionCoefficient>(dim, initialVelocity);
 
   // Pass the BC information to the solver object setting only the z direction
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       dyn_solver.setDisplacementBCs(bc.attrs, deform);
     } else {
@@ -210,13 +210,13 @@ TEST(dynamic_solver, dyn_linesearch_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  NonlinearSolid dyn_solver(mesh, solid_solver_info);
+  auto           solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  NonlinearSolid dyn_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -225,7 +225,7 @@ TEST(dynamic_solver, dyn_linesearch_solve)
   auto velo   = std::make_shared<mfem::VectorFunctionCoefficient>(dim, initialVelocity);
 
   // Pass the BC information to the solver object setting only the z direction
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       dyn_solver.setDisplacementBCs(bc.attrs, deform);
     } else {
@@ -297,13 +297,13 @@ TEST(dynamic_solver, dyn_amgx_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, /* dynamic = */ true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  NonlinearSolid dyn_solver(mesh, solid_solver_info);
+  auto           solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  NonlinearSolid dyn_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -312,7 +312,7 @@ TEST(dynamic_solver, dyn_amgx_solve)
   auto velo   = std::make_shared<mfem::VectorFunctionCoefficient>(dim, initialVelocity);
 
   // Pass the BC information to the solver object setting only the z direction
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       dyn_solver.setDisplacementBCs(bc.attrs, deform);
     } else {

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -129,7 +129,7 @@ TEST(dynamic_solver, dyn_direct_solve)
   // Define the solid solver object
   auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_params.H_lin_params = DirectSolverOptions{0};
+  solid_solver_info.solver_options.H_lin_params = DirectSolverOptions{0};
   NonlinearSolid dyn_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -37,12 +37,12 @@ TEST(dynamic_solver, dyn_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, /* dynamic = */ true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   NonlinearSolid dyn_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -122,14 +122,14 @@ TEST(dynamic_solver, dyn_direct_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_params.H_lin_params = DirectSolverParameters{0};
+  solid_solver_info.solver_params.H_lin_params = DirectSolverOptions{0};
   NonlinearSolid dyn_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -210,12 +210,12 @@ TEST(dynamic_solver, dyn_linesearch_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   NonlinearSolid dyn_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -297,12 +297,12 @@ TEST(dynamic_solver, dyn_amgx_solve)
   testing::defineNonlinSolidInputFileSchema(inlet, /* dynamic = */ true);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   NonlinearSolid dyn_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();

--- a/tests/serac_dynamic_solver.cpp
+++ b/tests/serac_dynamic_solver.cpp
@@ -129,7 +129,7 @@ TEST(dynamic_solver, dyn_direct_solve)
   // Define the solid solver object
   auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_options.H_lin_params = DirectSolverOptions{0};
+  solid_solver_info.solver_options.H_lin_options = DirectSolverOptions{0};
   NonlinearSolid dyn_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();

--- a/tests/serac_error_handling.cpp
+++ b/tests/serac_error_handling.cpp
@@ -43,8 +43,8 @@ TEST(serac_error_handling, equationsolver_amgx_not_available)
 #ifndef MFEM_USE_SUNDIALS
 TEST(serac_error_handling, equationsolver_kinsol_not_available)
 {
-  auto lin_params             = ThermalConduction::defaultLinearParameters();
-  auto nonlin_params          = ThermalConduction::defaultNonlinearParameters();
+  auto lin_params             = ThermalConduction::defaultLinearOptions();
+  auto nonlin_params          = ThermalConduction::defaultNonlinearOptions();
   nonlin_params.nonlin_solver = NonlinearSolver::KINFullStep;
   EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, lin_params, nonlin_params), SlicErrorException);
 }
@@ -114,7 +114,7 @@ TEST(serac_error_handling, bc_retrieve_vec_coef)
 
 TEST(serac_error_handling, invalid_output_type)
 {
-  ThermalConduction physics(1, buildDiskMesh(100), ThermalConduction::defaultQuasistaticParameters());
+  ThermalConduction physics(1, buildDiskMesh(100), ThermalConduction::defaultQuasistaticOptions());
   // Try a definitely wrong number to ensure that an invalid output type is detected
   EXPECT_THROW(physics.initializeOutput(static_cast<OutputType>(-7), ""), SlicErrorException);
 }

--- a/tests/serac_error_handling.cpp
+++ b/tests/serac_error_handling.cpp
@@ -23,19 +23,19 @@ namespace serac {
 
 TEST(serac_error_handling, equationsolver_bad_lin_solver)
 {
-  IterativeSolverOptions params;
+  IterativeSolverOptions options;
   // Try a definitely wrong number to ensure that an invalid linear solver is detected
-  params.lin_solver = static_cast<LinearSolver>(-7);
-  EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, params), SlicErrorException);
+  options.lin_solver = static_cast<LinearSolver>(-7);
+  EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, options), SlicErrorException);
 }
 
 // Only need to test this when AmgX is **not** available
 #ifndef MFEM_USE_AMGX
 TEST(serac_error_handling, equationsolver_amgx_not_available)
 {
-  IterativeSolverOptions params;
-  params.prec = AMGXPrec{};
-  EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, params), SlicErrorException);
+  IterativeSolverOptions options;
+  options.prec = AMGXPrec{};
+  EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, options), SlicErrorException);
 }
 #endif
 
@@ -43,10 +43,10 @@ TEST(serac_error_handling, equationsolver_amgx_not_available)
 #ifndef MFEM_USE_SUNDIALS
 TEST(serac_error_handling, equationsolver_kinsol_not_available)
 {
-  auto lin_params             = ThermalConduction::defaultLinearOptions();
-  auto nonlin_params          = ThermalConduction::defaultNonlinearOptions();
-  nonlin_params.nonlin_solver = NonlinearSolver::KINFullStep;
-  EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, lin_params, nonlin_params), SlicErrorException);
+  auto lin_options             = ThermalConduction::defaultLinearOptions();
+  auto nonlin_options          = ThermalConduction::defaultNonlinearOptions();
+  nonlin_options.nonlin_solver = NonlinearSolver::KINFullStep;
+  EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, lin_options, nonlin_options), SlicErrorException);
 }
 #endif
 

--- a/tests/serac_error_handling.cpp
+++ b/tests/serac_error_handling.cpp
@@ -23,7 +23,7 @@ namespace serac {
 
 TEST(serac_error_handling, equationsolver_bad_lin_solver)
 {
-  IterativeSolverParameters params;
+  IterativeSolverOptions params;
   // Try a definitely wrong number to ensure that an invalid linear solver is detected
   params.lin_solver = static_cast<LinearSolver>(-7);
   EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, params), SlicErrorException);
@@ -33,7 +33,7 @@ TEST(serac_error_handling, equationsolver_bad_lin_solver)
 #ifndef MFEM_USE_AMGX
 TEST(serac_error_handling, equationsolver_amgx_not_available)
 {
-  IterativeSolverParameters params;
+  IterativeSolverOptions params;
   params.prec = AMGXPrec{};
   EXPECT_THROW(EquationSolver(MPI_COMM_WORLD, params), SlicErrorException);
 }

--- a/tests/serac_linelastic_solver.cpp
+++ b/tests/serac_linelastic_solver.cpp
@@ -25,11 +25,11 @@ TEST(elastic_solver, static_solve)
   auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
   IterativeSolverOptions default_quasistatic = {.rel_tol     = 1.0e-4,
-                                                   .abs_tol     = 1.0e-10,
-                                                   .print_level = 0,
-                                                   .max_iter    = 500,
-                                                   .lin_solver  = LinearSolver::MINRES,
-                                                   .prec        = HypreSmootherPrec{mfem::HypreSmoother::l1Jacobi}};
+                                                .abs_tol     = 1.0e-10,
+                                                .print_level = 0,
+                                                .max_iter    = 500,
+                                                .lin_solver  = LinearSolver::MINRES,
+                                                .prec        = HypreSmootherPrec{mfem::HypreSmoother::l1Jacobi}};
 
   Elasticity elas_solver(1, pmesh, default_quasistatic);
 

--- a/tests/serac_linelastic_solver.cpp
+++ b/tests/serac_linelastic_solver.cpp
@@ -24,7 +24,7 @@ TEST(elastic_solver, static_solve)
 
   auto pmesh = buildMeshFromFile(mesh_file, 1, 0);
 
-  IterativeSolverParameters default_quasistatic = {.rel_tol     = 1.0e-4,
+  IterativeSolverOptions default_quasistatic = {.rel_tol     = 1.0e-4,
                                                    .abs_tol     = 1.0e-10,
                                                    .print_level = 0,
                                                    .max_iter    = 500,

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -111,7 +111,7 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   // Define the solid solver object
   auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_params.H_lin_params = DirectSolverOptions{0};
+  solid_solver_info.solver_options.H_lin_params = DirectSolverOptions{0};
   NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -193,7 +193,7 @@ TEST(nonlinear_solid_solver, qs_custom_solve)
   custom_solver->SetMaxIter(custom_params.max_iter);
   custom_solver->SetPrintLevel(custom_params.print_level);
 
-  solid_solver_info.solver_params.H_lin_params = CustomSolverOptions{custom_solver.get()};
+  solid_solver_info.solver_options.H_lin_params = CustomSolverOptions{custom_solver.get()};
   NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -111,7 +111,7 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   // Define the solid solver object
   auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_options.H_lin_params = DirectSolverOptions{0};
+  solid_solver_info.solver_options.H_lin_options = DirectSolverOptions{0};
   NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -193,7 +193,7 @@ TEST(nonlinear_solid_solver, qs_custom_solve)
   custom_solver->SetMaxIter(custom_params.max_iter);
   custom_solver->SetPrintLevel(custom_params.print_level);
 
-  solid_solver_info.solver_options.H_lin_params = CustomSolverOptions{custom_solver.get()};
+  solid_solver_info.solver_options.H_lin_options = CustomSolverOptions{custom_solver.get()};
   NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -34,12 +34,12 @@ TEST(nonlinear_solid_solver, qs_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -104,14 +104,14 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_params.H_lin_params = DirectSolverParameters{0};
+  solid_solver_info.solver_params.H_lin_params = DirectSolverOptions{0};
   NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();
@@ -176,24 +176,24 @@ TEST(nonlinear_solid_solver, qs_custom_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputInfo>();
+  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
   auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
   auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
 
   // Define the solid solver object
-  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputInfo>();
+  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
 
   // Simulate a custom solver by manually building the linear solver and passing it in
   // The custom solver built here should be identical to what is internally built in the
   // qs_solve test
-  auto custom_params = inlet["nonlinear_solid/stiffness_solver/linear"].get<serac::IterativeSolverParameters>();
+  auto custom_params = inlet["nonlinear_solid/stiffness_solver/linear"].get<serac::IterativeSolverOptions>();
   auto custom_solver = std::make_unique<mfem::MINRESSolver>(MPI_COMM_WORLD);
   custom_solver->SetRelTol(custom_params.rel_tol);
   custom_solver->SetAbsTol(custom_params.abs_tol);
   custom_solver->SetMaxIter(custom_params.max_iter);
   custom_solver->SetPrintLevel(custom_params.print_level);
 
-  solid_solver_info.solver_params.H_lin_params = CustomSolverParameters{custom_solver.get()};
+  solid_solver_info.solver_params.H_lin_params = CustomSolverOptions{custom_solver.get()};
   NonlinearSolid solid_solver(mesh, solid_solver_info);
 
   int dim = mesh->Dimension();

--- a/tests/serac_quasistatic_solver.cpp
+++ b/tests/serac_quasistatic_solver.cpp
@@ -34,13 +34,13 @@ TEST(nonlinear_solid_solver, qs_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto           solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  NonlinearSolid solid_solver(mesh, solid_solver_info);
+  auto           solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  NonlinearSolid solid_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -56,7 +56,7 @@ TEST(nonlinear_solid_solver, qs_solve)
   auto traction_coef = std::make_shared<mfem::VectorConstantCoefficient>(traction);
 
   // Pass the BC information to the solver object
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       solid_solver.setDisplacementBCs(bc.attrs, disp_coef);
     } else if (bc.name == "traction") {
@@ -104,15 +104,15 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  auto solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
   // FIXME: These should be moved to part of the schema once the contains() logic is updated in Inlet
-  solid_solver_info.solver_options.H_lin_options = DirectSolverOptions{0};
-  NonlinearSolid solid_solver(mesh, solid_solver_info);
+  solid_solver_options.solver_options.H_lin_options = DirectSolverOptions{0};
+  NonlinearSolid solid_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -128,7 +128,7 @@ TEST(nonlinear_solid_solver, qs_direct_solve)
   auto traction_coef = std::make_shared<mfem::VectorConstantCoefficient>(traction);
 
   // Pass the BC information to the solver object
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       solid_solver.setDisplacementBCs(bc.attrs, disp_coef);
     } else if (bc.name == "traction") {
@@ -176,25 +176,25 @@ TEST(nonlinear_solid_solver, qs_custom_solve)
   testing::defineNonlinSolidInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_info      = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_info.relative_mesh_file_name, input_file_path);
-  auto mesh           = serac::buildMeshFromFile(full_mesh_path, mesh_info.ser_ref_levels, mesh_info.par_ref_levels);
+  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file_path);
+  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
 
   // Define the solid solver object
-  auto solid_solver_info = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
+  auto solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
 
   // Simulate a custom solver by manually building the linear solver and passing it in
   // The custom solver built here should be identical to what is internally built in the
   // qs_solve test
-  auto custom_params = inlet["nonlinear_solid/stiffness_solver/linear"].get<serac::IterativeSolverOptions>();
-  auto custom_solver = std::make_unique<mfem::MINRESSolver>(MPI_COMM_WORLD);
-  custom_solver->SetRelTol(custom_params.rel_tol);
-  custom_solver->SetAbsTol(custom_params.abs_tol);
-  custom_solver->SetMaxIter(custom_params.max_iter);
-  custom_solver->SetPrintLevel(custom_params.print_level);
+  auto custom_options = inlet["nonlinear_solid/stiffness_solver/linear"].get<serac::IterativeSolverOptions>();
+  auto custom_solver  = std::make_unique<mfem::MINRESSolver>(MPI_COMM_WORLD);
+  custom_solver->SetRelTol(custom_options.rel_tol);
+  custom_solver->SetAbsTol(custom_options.abs_tol);
+  custom_solver->SetMaxIter(custom_options.max_iter);
+  custom_solver->SetPrintLevel(custom_options.print_level);
 
-  solid_solver_info.solver_options.H_lin_options = CustomSolverOptions{custom_solver.get()};
-  NonlinearSolid solid_solver(mesh, solid_solver_info);
+  solid_solver_options.solver_options.H_lin_options = CustomSolverOptions{custom_solver.get()};
+  NonlinearSolid solid_solver(mesh, solid_solver_options);
 
   int dim = mesh->Dimension();
 
@@ -210,7 +210,7 @@ TEST(nonlinear_solid_solver, qs_custom_solve)
   auto traction_coef = std::make_shared<mfem::VectorConstantCoefficient>(traction);
 
   // Pass the BC information to the solver object
-  for (const auto& bc : solid_solver_info.boundary_conditions) {
+  for (const auto& bc : solid_solver_options.boundary_conditions) {
     if (bc.name == "displacement") {
       solid_solver.setDisplacementBCs(bc.attrs, disp_coef);
     } else if (bc.name == "traction") {

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -36,7 +36,7 @@ TEST(thermal_solver, static_solve)
   auto pmesh = buildBallMesh(10000);
 
   // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticParameters());
+  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticOptions());
 
   // Initialize the temperature boundary condition
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(One);
@@ -76,7 +76,7 @@ TEST(thermal_solver, static_solve_multiple_bcs)
   auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticParameters());
+  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticOptions());
 
   // Initialize the temperature boundary condition
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(BoundaryTemperature);
@@ -126,7 +126,7 @@ TEST(thermal_solver, static_solve_repeated_bcs)
   auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticParameters());
+  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticOptions());
 
   // Initialize the temperature boundary condition
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(BoundaryTemperature);
@@ -167,8 +167,8 @@ TEST(thermal_solver, dyn_exp_solve)
 
   auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
-  auto params                    = ThermalConduction::defaultDynamicParameters();
-  params.dyn_params->timestepper = TimestepMethod::ForwardEuler;
+  auto params                     = ThermalConduction::defaultDynamicOptions();
+  params.dyn_options->timestepper = TimestepMethod::ForwardEuler;
 
   // Initialize the second order thermal solver on the parallel mesh
   ThermalConduction therm_solver(2, pmesh, params);
@@ -229,7 +229,7 @@ TEST(thermal_solver, dyn_imp_solve)
   auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultDynamicParameters());
+  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultDynamicOptions());
 
   // Initialize the state grid function
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(InitialTemperature);
@@ -295,7 +295,7 @@ TEST(thermal_solver_rework, dyn_imp_solve_time_varying)
   auto pmesh = buildMeshFromFile(mesh_file, 2, 1);
 
   // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultDynamicParameters());
+  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultDynamicOptions());
 
   // by construction, f(x, y, t) satisfies df_dt == d2f_dx2 + d2f_dy2
   auto f = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector& x, double t) {
@@ -352,8 +352,8 @@ TEST(thermal_solver, static_amgx_solve)
 
   auto pmesh = buildBallMesh(10000);
 
-  auto params                                                = ThermalConduction::defaultQuasistaticParameters();
-  std::get<IterativeSolverOptions>(params.T_lin_params).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
+  auto params                                                 = ThermalConduction::defaultQuasistaticOptions();
+  std::get<IterativeSolverOptions>(params.T_lin_options).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
   // Initialize the second order thermal solver on the parallel mesh
   ThermalConduction therm_solver(2, pmesh, params);
 

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -167,11 +167,11 @@ TEST(thermal_solver, dyn_exp_solve)
 
   auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
 
-  auto params                     = ThermalConduction::defaultDynamicOptions();
-  params.dyn_options->timestepper = TimestepMethod::ForwardEuler;
+  auto options                     = ThermalConduction::defaultDynamicOptions();
+  options.dyn_options->timestepper = TimestepMethod::ForwardEuler;
 
   // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, params);
+  ThermalConduction therm_solver(2, pmesh, options);
 
   // Initialize the state grid function
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(InitialTemperature);
@@ -352,10 +352,10 @@ TEST(thermal_solver, static_amgx_solve)
 
   auto pmesh = buildBallMesh(10000);
 
-  auto params                                                 = ThermalConduction::defaultQuasistaticOptions();
-  std::get<IterativeSolverOptions>(params.T_lin_options).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
+  auto options                                                 = ThermalConduction::defaultQuasistaticOptions();
+  std::get<IterativeSolverOptions>(options.T_lin_options).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
   // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, params);
+  ThermalConduction therm_solver(2, pmesh, options);
 
   // Initialize the temperature boundary condition
   auto u_0 = std::make_shared<mfem::FunctionCoefficient>(One);

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -352,7 +352,7 @@ TEST(thermal_solver, static_amgx_solve)
 
   auto pmesh = buildBallMesh(10000);
 
-  auto params                                                   = ThermalConduction::defaultQuasistaticParameters();
+  auto params                                                = ThermalConduction::defaultQuasistaticParameters();
   std::get<IterativeSolverOptions>(params.T_lin_params).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
   // Initialize the second order thermal solver on the parallel mesh
   ThermalConduction therm_solver(2, pmesh, params);

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -353,7 +353,7 @@ TEST(thermal_solver, static_amgx_solve)
   auto pmesh = buildBallMesh(10000);
 
   auto params                                                   = ThermalConduction::defaultQuasistaticParameters();
-  std::get<IterativeSolverParameters>(params.T_lin_params).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
+  std::get<IterativeSolverOptions>(params.T_lin_params).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
   // Initialize the second order thermal solver on the parallel mesh
   ThermalConduction therm_solver(2, pmesh, params);
 

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -58,30 +58,30 @@ TEST(dynamic_solver, dyn_solve)
   auto traction_coef = std::make_shared<mfem::VectorConstantCoefficient>(traction);
 
   // Use the same configuration as the solid solver
-  const IterativeSolverOptions default_dyn_linear_params = {.rel_tol     = 1.0e-4,
-                                                            .abs_tol     = 1.0e-8,
-                                                            .print_level = 0,
-                                                            .max_iter    = 500,
-                                                            .lin_solver  = LinearSolver::GMRES,
-                                                            .prec        = HypreBoomerAMGPrec{}};
+  const IterativeSolverOptions default_dyn_linear_options = {.rel_tol     = 1.0e-4,
+                                                             .abs_tol     = 1.0e-8,
+                                                             .print_level = 0,
+                                                             .max_iter    = 500,
+                                                             .lin_solver  = LinearSolver::GMRES,
+                                                             .prec        = HypreBoomerAMGPrec{}};
 
-  auto therm_M_params = default_dyn_linear_params;
-  auto therm_T_params = default_dyn_linear_params;
-  therm_M_params.prec = HypreSmootherPrec{};
-  therm_T_params.prec = HypreSmootherPrec{};
+  auto therm_M_options = default_dyn_linear_options;
+  auto therm_T_options = default_dyn_linear_options;
+  therm_M_options.prec = HypreSmootherPrec{};
+  therm_T_options.prec = HypreSmootherPrec{};
 
-  auto therm_params = ThermalConduction::defaultDynamicOptions();
+  auto therm_options = ThermalConduction::defaultDynamicOptions();
 
-  const NonlinearSolverOptions default_dyn_nonlinear_params = {
+  const NonlinearSolverOptions default_dyn_nonlinear_options = {
       .rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 500, .print_level = 1};
 
   const NonlinearSolid::SolverOptions default_dynamic = {
-      default_dyn_linear_params, default_dyn_nonlinear_params,
+      default_dyn_linear_options, default_dyn_nonlinear_options,
       NonlinearSolid::TimesteppingOptions{TimestepMethod::AverageAcceleration,
                                           DirichletEnforcementMethod::RateControl}};
 
   // initialize the dynamic solver object
-  ThermalSolid ts_solver(1, pmesh, therm_params, default_dynamic);
+  ThermalSolid ts_solver(1, pmesh, therm_options, default_dynamic);
   ts_solver.SetDisplacementBCs(ess_bdr, deform);
   ts_solver.SetTractionBCs(trac_bdr, traction_coef);
   ts_solver.SetHyperelasticMaterialParameters(0.25, 5.0);

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -59,11 +59,11 @@ TEST(dynamic_solver, dyn_solve)
 
   // Use the same configuration as the solid solver
   const IterativeSolverOptions default_dyn_linear_params = {.rel_tol     = 1.0e-4,
-                                                               .abs_tol     = 1.0e-8,
-                                                               .print_level = 0,
-                                                               .max_iter    = 500,
-                                                               .lin_solver  = LinearSolver::GMRES,
-                                                               .prec        = HypreBoomerAMGPrec{}};
+                                                            .abs_tol     = 1.0e-8,
+                                                            .print_level = 0,
+                                                            .max_iter    = 500,
+                                                            .lin_solver  = LinearSolver::GMRES,
+                                                            .prec        = HypreBoomerAMGPrec{}};
 
   auto therm_M_params = default_dyn_linear_params;
   auto therm_T_params = default_dyn_linear_params;
@@ -78,7 +78,7 @@ TEST(dynamic_solver, dyn_solve)
   const NonlinearSolid::SolverOptions default_dynamic = {
       default_dyn_linear_params, default_dyn_nonlinear_params,
       NonlinearSolid::TimesteppingOptions{TimestepMethod::AverageAcceleration,
-                                              DirichletEnforcementMethod::RateControl}};
+                                          DirichletEnforcementMethod::RateControl}};
 
   // initialize the dynamic solver object
   ThermalSolid ts_solver(1, pmesh, therm_params, default_dynamic);

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -58,7 +58,7 @@ TEST(dynamic_solver, dyn_solve)
   auto traction_coef = std::make_shared<mfem::VectorConstantCoefficient>(traction);
 
   // Use the same configuration as the solid solver
-  const IterativeSolverParameters default_dyn_linear_params = {.rel_tol     = 1.0e-4,
+  const IterativeSolverOptions default_dyn_linear_params = {.rel_tol     = 1.0e-4,
                                                                .abs_tol     = 1.0e-8,
                                                                .print_level = 0,
                                                                .max_iter    = 500,
@@ -72,12 +72,12 @@ TEST(dynamic_solver, dyn_solve)
 
   auto therm_params = ThermalConduction::defaultDynamicParameters();
 
-  const NonlinearSolverParameters default_dyn_nonlinear_params = {
+  const NonlinearSolverOptions default_dyn_nonlinear_params = {
       .rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 500, .print_level = 1};
 
-  const NonlinearSolid::SolverParameters default_dynamic = {
+  const NonlinearSolid::SolverOptions default_dynamic = {
       default_dyn_linear_params, default_dyn_nonlinear_params,
-      NonlinearSolid::DynamicSolverParameters{TimestepMethod::AverageAcceleration,
+      NonlinearSolid::TimesteppingOptions{TimestepMethod::AverageAcceleration,
                                               DirichletEnforcementMethod::RateControl}};
 
   // initialize the dynamic solver object

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -70,7 +70,7 @@ TEST(dynamic_solver, dyn_solve)
   therm_M_params.prec = HypreSmootherPrec{};
   therm_T_params.prec = HypreSmootherPrec{};
 
-  auto therm_params = ThermalConduction::defaultDynamicParameters();
+  auto therm_params = ThermalConduction::defaultDynamicOptions();
 
   const NonlinearSolverOptions default_dyn_nonlinear_params = {
       .rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 500, .print_level = 1};

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -25,12 +25,12 @@ void defineNonlinSolidInputFileSchema(axom::inlet::Inlet& inlet, const bool dyna
   inlet.addDouble("epsilon", "Threshold to be used in the comparison");
 
   auto& mesh_table = inlet.addTable("main_mesh", "The main mesh for the problem");
-  serac::mesh::InputInfo::defineInputFileSchema(mesh_table);
+  serac::mesh::InputOptions::defineInputFileSchema(mesh_table);
 
   // Physics
   auto& solid_solver_table = inlet.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
   // FIXME: Remove once Inlet's "contains" logic improvements are merged
-  serac::NonlinearSolid::InputInfo::defineInputFileSchema(solid_solver_table, dynamic);
+  serac::NonlinearSolid::InputOptions::defineInputFileSchema(solid_solver_table, dynamic);
 
   // Verify input file
   if (!inlet.verify()) {


### PR DESCRIPTION
This unifies the `InputInfo` and `Parameter` structs in the code to use a consistent `Option` naming scheme.

Resolves https://github.com/LLNL/serac/issues/288