### PR TITLE
Doxgyen workaround for getting namespace methods to show up

### DIFF
--- a/src/serac/numerics/mesh_utils.hpp
+++ b/src/serac/numerics/mesh_utils.hpp
@@ -19,6 +19,9 @@
 #include "mfem.hpp"
 #include "serac/infrastructure/input.hpp"
 
+/**
+   The Serac namespace
+ */
 namespace serac {
 /**
  * @brief Constructs an MFEM parallel mesh from a file and refines it


### PR DESCRIPTION
Certain namespace methods such as `serac::buildMeshFromFile` don't show up in the doxygen search. Apparently the namespace itself needs to be "documented" for doxygen to show the doxygen comments for namespace methods. [stackoverflow](
https://stackoverflow.com/questions/25347174/doxygen-no-detailed-description-for-functions-in-namespaces)

