### PR TITLE
Doxgyen workaround for getting namespace methods to show up

### DIFF
--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -882,7 +882,7 @@ USE_MDFILE_AS_MAINPAGE =
 # also VERBATIM_HEADERS is set to NO.
 # The default value is: NO.
 
-SOURCE_BROWSER         = NO
+SOURCE_BROWSER         = YES
 
 # Setting the INLINE_SOURCES tag to YES will include the body of functions,
 # classes and enums directly into the documentation.

--- a/src/serac/numerics/mesh_utils.hpp
+++ b/src/serac/numerics/mesh_utils.hpp
@@ -20,7 +20,7 @@
 #include "serac/infrastructure/input.hpp"
 
 /**
-   The Serac namespace
+ * The Serac namespace
  */
 namespace serac {
 /**

--- a/src/serac/numerics/mesh_utils.hpp
+++ b/src/serac/numerics/mesh_utils.hpp
@@ -19,6 +19,9 @@
 #include "mfem.hpp"
 #include "serac/infrastructure/input.hpp"
 
+/**
+   The Serac namespace
+ */
 namespace serac {
 /**
  * @brief Constructs an MFEM parallel mesh from a file and refines it


### PR DESCRIPTION
Certain namespace methods such as `serac::buildMeshFromFile` don't show up in the doxygen search. Apparently the namespace itself needs to be "documented" for doxygen to show the doxygen comments for namespace methods. [stackoverflow](https://stackoverflow.com/questions/25347174/doxygen-no-detailed-description-for-functions-in-namespaces)