### PR TITLE
Switch to pragma once, conform to google style guide for header ordering

### DIFF
--- a/src/serac/coefficients/coefficient_extensions.hpp
+++ b/src/serac/coefficients/coefficient_extensions.hpp
@@ -10,13 +10,13 @@
  * @brief Extensions of MFEM's coefficient interface and helper functions
  */
 
-#ifndef COEFFICIENT_EXTENSIONS_HPP
-#define COEFFICIENT_EXTENSIONS_HPP
+#pragma once
 
 #include <functional>
 #include <memory>
 
 #include "mfem.hpp"
+
 #include "serac/numerics/expr_template_ops.hpp"
 
 namespace serac {
@@ -244,5 +244,3 @@ private:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/coefficients/loading_functions.hpp
+++ b/src/serac/coefficients/loading_functions.hpp
@@ -10,8 +10,7 @@
  * @brief Some simple default loading functions for the Serac driver
  */
 
-#ifndef LOADING_FUNCTIONS
-#define LOADING_FUNCTIONS
+#pragma once
 
 #include "mfem.hpp"
 
@@ -34,5 +33,3 @@ void referenceConfiguration(const mfem::Vector& x, mfem::Vector& y);
 void initialDeformation(const mfem::Vector& x, mfem::Vector& y);
 
 }  // namespace serac
-
-#endif

--- a/src/serac/coefficients/traction_coefficient.hpp
+++ b/src/serac/coefficients/traction_coefficient.hpp
@@ -10,8 +10,7 @@
  * @brief MFEM coefficients for handling traction boundaries
  */
 
-#ifndef TRACTION_COEF
-#define TRACTION_COEF
+#pragma once
 
 #include "mfem.hpp"
 
@@ -61,5 +60,3 @@ private:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/infrastructure/accelerator.cpp
+++ b/src/serac/infrastructure/accelerator.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 
 #include "mfem.hpp"
+
 #include "serac/infrastructure/logger.hpp"
 
 namespace serac {

--- a/src/serac/infrastructure/accelerator.hpp
+++ b/src/serac/infrastructure/accelerator.hpp
@@ -11,12 +11,9 @@
  * any hardware accelerator-related functionality
  */
 
-#ifndef SERAC_ACCELERATOR
-#define SERAC_ACCELERATOR
+#pragma once
 
-namespace serac {
-
-namespace accelerator {
+namespace serac::accelerator {
 
 /**
  * @brief Initializes the device (GPU)
@@ -30,8 +27,4 @@ void initializeDevice();
  */
 void terminateDevice();
 
-}  // namespace accelerator
-
-}  // namespace serac
-
-#endif  // SERAC_ACCELERATOR
+}  // namespace serac::accelerator

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -7,12 +7,11 @@
 #include "serac/infrastructure/cli.hpp"
 
 #include "CLI11/CLI11.hpp"
+
 #include "serac/infrastructure/logger.hpp"
 #include "serac/infrastructure/terminator.hpp"
 
-namespace serac {
-
-namespace cli {
+namespace serac::cli {
 
 //------- Command Line Interface -------
 
@@ -62,5 +61,4 @@ void printGiven(std::unordered_map<std::string, std::string>& cli_opts, int rank
   serac::logger::flush();
 }
 
-}  // namespace cli
-}  // namespace serac
+}  // namespace serac::cli

--- a/src/serac/infrastructure/cli.hpp
+++ b/src/serac/infrastructure/cli.hpp
@@ -11,16 +11,13 @@
  *        for interacting with the command line interface.
  */
 
-#ifndef SERAC_CLI
-#define SERAC_CLI
+#pragma once
 
 #include <string>
 #include <unordered_map>
 
-namespace serac {
-
 // Command line functionality
-namespace cli {
+namespace serac::cli {
 
 /**
  * @brief Defines command line options and parses the found values.
@@ -42,7 +39,4 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
  */
 void printGiven(std::unordered_map<std::string, std::string>& cli_opts, int rank);
 
-}  // namespace cli
-}  // namespace serac
-
-#endif
+}  // namespace serac::cli

--- a/src/serac/infrastructure/initialize.hpp
+++ b/src/serac/infrastructure/initialize.hpp
@@ -9,8 +9,7 @@
  *
  * @brief A function intended to be used as part of a driver to initialize common libraries
  */
-#ifndef INITIALIZE
-#define INITIALIZE
+#pragma once
 
 #include <utility>
 
@@ -34,6 +33,5 @@ std::pair<int, int> getMPIInfo(MPI_Comm comm = MPI_COMM_WORLD);
  * @return A pair containing the size and rank relative to the provided MPI communicator
  */
 std::pair<int, int> initialize(int argc, char* argv[], MPI_Comm comm = MPI_COMM_WORLD);
-}  // namespace serac
 
-#endif
+}  // namespace serac

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -9,12 +9,11 @@
 #include <stdlib.h>
 
 #include "axom/core.hpp"
+
 #include "serac/infrastructure/logger.hpp"
 #include "serac/infrastructure/terminator.hpp"
 
-namespace serac {
-
-namespace input {
+namespace serac::input {
 
 axom::inlet::Inlet initialize(axom::sidre::DataStore& datastore, const std::string& input_file_path)
 {
@@ -110,8 +109,7 @@ void CoefficientInputOptions::defineInputFileSchema(axom::inlet::Table& table)
   table.addInt("component", "The vector component to which the scalar coefficient should be applied");
 }
 
-}  // namespace input
-}  // namespace serac
+}  // namespace serac::input
 
 mfem::Vector FromInlet<mfem::Vector>::operator()(const axom::inlet::Table& base)
 {

--- a/src/serac/infrastructure/input.hpp
+++ b/src/serac/infrastructure/input.hpp
@@ -5,25 +5,21 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /**
- * @file cli.hpp
+ * @file input.hpp
  *
- * @brief This file contains the all the necessary functions and macros required
- *        for interacting with the command line interface.
+ * @brief This file contains the all the necessary functions for reading input files
  */
 
-#ifndef SERAC_INPUT
-#define SERAC_INPUT
+#pragma once
 
 #include <string>
 #include <variant>
 
+#include "mfem.hpp"
 #include "axom/inlet.hpp"
 #include "axom/sidre.hpp"
-#include "mfem.hpp"
 
-namespace serac {
-
-namespace input {
+namespace serac::input {
 
 /**
  * @brief Initializes Inlet with the given datastore and input file.
@@ -110,8 +106,7 @@ struct BoundaryConditionInputOptions {
   static void defineInputFileSchema(axom::inlet::Table& table);
 };
 
-}  // namespace input
-}  // namespace serac
+}  // namespace serac::input
 
 // Template specializations
 template <>
@@ -128,5 +123,3 @@ template <>
 struct FromInlet<serac::input::BoundaryConditionInputOptions> {
   serac::input::BoundaryConditionInputOptions operator()(const axom::inlet::Table& base);
 };
-
-#endif

--- a/src/serac/infrastructure/logger.cpp
+++ b/src/serac/infrastructure/logger.cpp
@@ -9,9 +9,7 @@
 #include "serac/infrastructure/initialize.hpp"
 #include "serac/infrastructure/terminator.hpp"
 
-namespace serac {
-
-namespace logger {
+namespace serac::logger {
 
 bool initialize(MPI_Comm comm)
 {
@@ -86,5 +84,4 @@ void finalize() { axom::slic::finalize(); }
 
 void flush() { axom::slic::flushStreams(); }
 
-}  // namespace logger
-}  // namespace serac
+}  // namespace serac::logger

--- a/src/serac/infrastructure/logger.hpp
+++ b/src/serac/infrastructure/logger.hpp
@@ -11,17 +11,14 @@
  *        for logging as well as a helper function to exit the program gracefully.
  */
 
-#ifndef SERAC_LOGGER
-#define SERAC_LOGGER
+#pragma once
 
 #include "axom/slic.hpp"
 #include "fmt/fmt.hpp"
 #include "mpi.h"
 
-namespace serac {
-
 // Logger functionality
-namespace logger {
+namespace serac::logger {
 /**
  * @brief Initializes and setups the logger.
  *
@@ -50,8 +47,7 @@ void finalize();
  */
 void flush();
 
-}  // namespace logger
-}  // namespace serac
+}  // namespace serac::logger
 
 // Utility SLIC macros
 
@@ -94,5 +90,3 @@ void flush();
  * @brief Macro that logs given debug message only on rank 0 if EXP is true.
  */
 #define SLIC_DEBUG_ROOT_IF(EXP, rank, msg) SLIC_DEBUG_IF((EXP) && (rank == 0), msg)
-
-#endif

--- a/src/serac/infrastructure/profiling.cpp
+++ b/src/serac/infrastructure/profiling.cpp
@@ -10,13 +10,15 @@
 
 #ifdef SERAC_USE_CALIPER
 #include <optional>
+#endif
 
+namespace serac::profiling {
+
+#ifdef SERAC_USE_CALIPER
 namespace {
 std::optional<cali::ConfigManager> mgr;
 }  // namespace
 #endif
-
-namespace serac::profiling {
 
 void initializeCaliper(const std::string& options)
 {
@@ -44,6 +46,7 @@ void terminateCaliper()
     mgr->stop();
     mgr->flush();
   }
+  mgr.reset();
 #endif
 }
 

--- a/src/serac/infrastructure/profiling.hpp
+++ b/src/serac/infrastructure/profiling.hpp
@@ -10,12 +10,16 @@
  * @brief Various helper functions and macros for profiling using Caliper
  */
 
-#ifndef PROFILING_CALIPER
-#define PROFILING_CALIPER
+#pragma once
 
 #include <string>
 
 #include "serac/serac_config.hpp"
+
+#ifdef SERAC_USE_CALIPER
+#include "caliper/cali-manager.h"
+#include "caliper/cali.h"
+#endif
 
 /**
  * @def SERAC_MARK_FUNCTION
@@ -38,9 +42,6 @@
  */
 
 #ifdef SERAC_USE_CALIPER
-
-#include "caliper/cali-manager.h"
-#include "caliper/cali.h"
 
 #define SERAC_MARK_FUNCTION CALI_CXX_MARK_FUNCTION
 #define SERAC_MARK_LOOP_START(id, name) CALI_CXX_MARK_LOOP_BEGIN(id, name)
@@ -71,5 +72,3 @@ void initializeCaliper(const std::string& options = "");
 void terminateCaliper();
 
 }  // namespace serac::profiling
-
-#endif

--- a/src/serac/infrastructure/terminator.hpp
+++ b/src/serac/infrastructure/terminator.hpp
@@ -4,8 +4,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef TERMINATOR
-#define TERMINATOR
+#pragma once
 
 namespace serac {
 
@@ -36,5 +35,3 @@ void registerSignals();
 void exitGracefully(bool error = false);
 
 }  // namespace serac
-
-#endif

--- a/src/serac/integrators/hyperelastic_traction_integrator.hpp
+++ b/src/serac/integrators/hyperelastic_traction_integrator.hpp
@@ -10,6 +10,8 @@
  * @brief Custom MFEM integrator for nonlinear finite deformation traction loads
  */
 
+#pragma once
+
 #include "mfem.hpp"
 
 namespace serac {

--- a/src/serac/integrators/inc_hyperelastic_integrator.hpp
+++ b/src/serac/integrators/inc_hyperelastic_integrator.hpp
@@ -10,6 +10,8 @@
  * @brief The MFEM integrators for the incremental hyperelastic formulation
  */
 
+#pragma once
+
 #include "mfem.hpp"
 
 namespace serac {

--- a/src/serac/integrators/wrapper_integrator.hpp
+++ b/src/serac/integrators/wrapper_integrator.hpp
@@ -10,8 +10,7 @@
  * @brief Wrappers to turn bilinear and linear integrators into nonlinear ones
  */
 
-#ifndef WRAPPER_INTEGRATOR_HPP
-#define WRAPPER_INTEGRATOR_HPP
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -223,5 +222,3 @@ private:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/numerics/CMakeLists.txt
+++ b/src/serac/numerics/CMakeLists.txt
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: (BSD-3-Clause)
 
 set(numerics_headers
-    expr_template_internal.hpp
+    expr_template_impl.hpp
     expr_template_ops.hpp
     mesh_utils.hpp
     vector_expression.hpp

--- a/src/serac/numerics/expr_template_impl.hpp
+++ b/src/serac/numerics/expr_template_impl.hpp
@@ -5,14 +5,13 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /**
- * \@file expr_templates_internal.hpp
+ * \@file expr_templates_impl.hpp
  *
  * @brief The internal implementation for a set of template classes used to
  * represent the evaluation of unary and binary operations on vectors
  */
 
-#ifndef EXPR_TEMPLATES_INTERNAL
-#define EXPR_TEMPLATES_INTERNAL
+#pragma once
 
 #include <functional>
 #include <type_traits>
@@ -21,7 +20,7 @@
 #include "serac/infrastructure/logger.hpp"
 #include "serac/numerics/vector_expression.hpp"
 
-namespace serac::internal {
+namespace detail {
 
 /**
  * @brief Determines whether a given type should be owned by a vector expression
@@ -54,6 +53,13 @@ template <typename vec>
 using vec_arg_t = typename std::conditional_t<owns_v<vec>, std::decay_t<vec>&&, const vec&>;
 
 /**
+ * @brief A utility for conditionally enabling templates if a given type
+ * is an mfem::Vector (including by inheritance)
+ */
+template <typename MFEMVec>
+using enable_if_mfem_vec = std::enable_if_t<std::is_base_of_v<mfem::Vector, std::decay_t<MFEMVec>>>;
+
+/**
  * @brief Wraps the indexing of a vector type
  * @param[in] v The vector to index
  * @param[in] idx The offset of the indexing
@@ -72,6 +78,8 @@ auto index(vec&& v, const std::size_t idx)
     return v[idx];
   }
 }
+
+using serac::VectorExpr;
 
 /**
  * @brief Derived VectorExpr class for representing the application of a unary
@@ -251,6 +259,4 @@ private:
   mfem::Vector result_;
 };
 
-}  // namespace serac::internal
-
-#endif
+}  // namespace detail

--- a/src/serac/numerics/expr_template_impl.hpp
+++ b/src/serac/numerics/expr_template_impl.hpp
@@ -20,7 +20,7 @@
 #include "serac/infrastructure/logger.hpp"
 #include "serac/numerics/vector_expression.hpp"
 
-namespace detail {
+namespace serac::detail {
 
 /**
  * @brief Determines whether a given type should be owned by a vector expression
@@ -259,4 +259,4 @@ private:
   mfem::Vector result_;
 };
 
-}  // namespace detail
+}  // namespace serac::detail

--- a/src/serac/numerics/expr_template_ops.hpp
+++ b/src/serac/numerics/expr_template_ops.hpp
@@ -10,35 +10,27 @@
  * @brief The operator overloads for mfem::Vector
  */
 
-#ifndef EXPR_TEMPLATE_OPS
-#define EXPR_TEMPLATE_OPS
+#pragma once
 
-#include "serac/numerics/expr_template_internal.hpp"
-
-/**
- * @brief A utility for conditionally enabling templates if a given type
- * is an mfem::Vector (including by inheritance)
- */
-template <typename MFEMVec>
-using enable_if_mfem_vec = std::enable_if_t<std::is_base_of_v<mfem::Vector, std::decay_t<MFEMVec>>>;
+#include "serac/numerics/expr_template_impl.hpp"
 
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u)
 {
-  return serac::internal::UnaryNegation<T>(std::move(u.asDerived()));
+  return detail::UnaryNegation<T>(std::move(u.asDerived()));
 }
 
-template <typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator-(MFEMVec&& u)
 {
-  return serac::internal::UnaryNegation<MFEMVec>(std::forward<MFEMVec>(u));
+  return detail::UnaryNegation<MFEMVec>(std::forward<MFEMVec>(u));
 }
 
 template <typename T>
 auto operator*(serac::VectorExpr<T>&& u, const double a)
 {
-  using serac::internal::ScalarMultOp;
-  return serac::internal::UnaryVectorExpr<T, ScalarMultOp>(std::move(u.asDerived()), ScalarMultOp{a});
+  using detail::ScalarMultOp;
+  return detail::UnaryVectorExpr<T, ScalarMultOp>(std::move(u.asDerived()), ScalarMultOp{a});
 }
 
 template <typename T>
@@ -47,14 +39,14 @@ auto operator*(const double a, serac::VectorExpr<T>&& u)
   return operator*(std::move(u), a);
 }
 
-template <typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator*(const double a, MFEMVec&& u)
 {
-  using serac::internal::ScalarMultOp;
-  return serac::internal::UnaryVectorExpr<MFEMVec, ScalarMultOp>(std::forward<MFEMVec>(u), ScalarMultOp{a});
+  using detail::ScalarMultOp;
+  return detail::UnaryVectorExpr<MFEMVec, ScalarMultOp>(std::forward<MFEMVec>(u), ScalarMultOp{a});
 }
 
-template <typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator*(MFEMVec&& u, const double a)
 {
   return operator*(a, std::forward<MFEMVec>(u));
@@ -63,90 +55,88 @@ auto operator*(MFEMVec&& u, const double a)
 template <typename T>
 auto operator/(serac::VectorExpr<T>&& u, const double a)
 {
-  using serac::internal::ScalarDivOp;
-  return serac::internal::UnaryVectorExpr<T, ScalarDivOp<true>>(std::move(u.asDerived()), ScalarDivOp{a});
+  using detail::ScalarDivOp;
+  return detail::UnaryVectorExpr<T, ScalarDivOp<true>>(std::move(u.asDerived()), ScalarDivOp{a});
 }
 
-template <typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator/(MFEMVec&& u, const double a)
 {
-  using serac::internal::ScalarDivOp;
-  return serac::internal::UnaryVectorExpr<MFEMVec, ScalarDivOp<true>>(std::forward<MFEMVec>(u), ScalarDivOp{a});
+  using detail::ScalarDivOp;
+  return detail::UnaryVectorExpr<MFEMVec, ScalarDivOp<true>>(std::forward<MFEMVec>(u), ScalarDivOp{a});
 }
 
 template <typename T>
 auto operator/(const double a, serac::VectorExpr<T>&& u)
 {
-  using serac::internal::ScalarDivOp;
-  return serac::internal::UnaryVectorExpr<T, ScalarDivOp<false>>(std::move(u.asDerived()), ScalarDivOp<false>{a});
+  using detail::ScalarDivOp;
+  return detail::UnaryVectorExpr<T, ScalarDivOp<false>>(std::move(u.asDerived()), ScalarDivOp<false>{a});
 }
 
-template <typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator/(const double a, MFEMVec&& u)
 {
-  using serac::internal::ScalarDivOp;
-  return serac::internal::UnaryVectorExpr<MFEMVec, ScalarDivOp<false>>(std::forward<MFEMVec>(u), ScalarDivOp<false>{a});
+  using detail::ScalarDivOp;
+  return detail::UnaryVectorExpr<MFEMVec, ScalarDivOp<false>>(std::forward<MFEMVec>(u), ScalarDivOp<false>{a});
 }
 
 template <typename S, typename T>
 auto operator+(serac::VectorExpr<S>&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorAddition<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
+  return detail::VectorAddition<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator+(MFEMVec&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorAddition<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
+  return detail::VectorAddition<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator+(serac::VectorExpr<T>&& u, MFEMVec&& v)
 {
   return operator+(std::forward<MFEMVec>(v), std::move(u));
 }
 
-template <typename MFEMVecL, typename MFEMVecR, typename = enable_if_mfem_vec<MFEMVecL>,
-          typename = enable_if_mfem_vec<MFEMVecR>>
+template <typename MFEMVecL, typename MFEMVecR, typename = detail::enable_if_mfem_vec<MFEMVecL>,
+          typename = detail::enable_if_mfem_vec<MFEMVecR>>
 auto operator+(MFEMVecL&& u, MFEMVecR&& v)
 {
-  return serac::internal::VectorAddition<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
+  return detail::VectorAddition<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
 }
 
 template <typename S, typename T>
 auto operator-(serac::VectorExpr<S>&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorSubtraction<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
+  return detail::VectorSubtraction<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator-(MFEMVec&& u, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::VectorSubtraction<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
+  return detail::VectorSubtraction<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
 auto operator-(serac::VectorExpr<T>&& u, MFEMVec&& v)
 {
-  return serac::internal::VectorSubtraction<T, MFEMVec>(std::move(u.asDerived()), std::forward<MFEMVec>(v));
+  return detail::VectorSubtraction<T, MFEMVec>(std::move(u.asDerived()), std::forward<MFEMVec>(v));
 }
 
-template <typename MFEMVecL, typename MFEMVecR, typename = enable_if_mfem_vec<MFEMVecL>,
-          typename = enable_if_mfem_vec<MFEMVecR>>
+template <typename MFEMVecL, typename MFEMVecR, typename = detail::enable_if_mfem_vec<MFEMVecL>,
+          typename = detail::enable_if_mfem_vec<MFEMVecR>>
 auto operator-(MFEMVecL&& u, MFEMVecR&& v)
 {
-  return serac::internal::VectorSubtraction<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
+  return detail::VectorSubtraction<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
 }
 
 template <typename T>
 auto operator*(const mfem::Operator& A, serac::VectorExpr<T>&& v)
 {
-  return serac::internal::OperatorExpr<T>(A, std::move(v.asDerived()));
+  return detail::OperatorExpr<T>(A, std::move(v.asDerived()));
 }
 
 inline auto operator*(const mfem::Operator& A, const mfem::Vector& v)
 {
-  return serac::internal::OperatorExpr<mfem::Vector>(A, v);
+  return detail::OperatorExpr<mfem::Vector>(A, v);
 }
-
-#endif

--- a/src/serac/numerics/expr_template_ops.hpp
+++ b/src/serac/numerics/expr_template_ops.hpp
@@ -17,20 +17,20 @@
 template <typename T>
 auto operator-(serac::VectorExpr<T>&& u)
 {
-  return detail::UnaryNegation<T>(std::move(u.asDerived()));
+  return serac::detail::UnaryNegation<T>(std::move(u.asDerived()));
 }
 
-template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator-(MFEMVec&& u)
 {
-  return detail::UnaryNegation<MFEMVec>(std::forward<MFEMVec>(u));
+  return serac::detail::UnaryNegation<MFEMVec>(std::forward<MFEMVec>(u));
 }
 
 template <typename T>
 auto operator*(serac::VectorExpr<T>&& u, const double a)
 {
-  using detail::ScalarMultOp;
-  return detail::UnaryVectorExpr<T, ScalarMultOp>(std::move(u.asDerived()), ScalarMultOp{a});
+  using serac::detail::ScalarMultOp;
+  return serac::detail::UnaryVectorExpr<T, ScalarMultOp>(std::move(u.asDerived()), ScalarMultOp{a});
 }
 
 template <typename T>
@@ -39,14 +39,14 @@ auto operator*(const double a, serac::VectorExpr<T>&& u)
   return operator*(std::move(u), a);
 }
 
-template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator*(const double a, MFEMVec&& u)
 {
-  using detail::ScalarMultOp;
-  return detail::UnaryVectorExpr<MFEMVec, ScalarMultOp>(std::forward<MFEMVec>(u), ScalarMultOp{a});
+  using serac::detail::ScalarMultOp;
+  return serac::detail::UnaryVectorExpr<MFEMVec, ScalarMultOp>(std::forward<MFEMVec>(u), ScalarMultOp{a});
 }
 
-template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator*(MFEMVec&& u, const double a)
 {
   return operator*(a, std::forward<MFEMVec>(u));
@@ -55,88 +55,88 @@ auto operator*(MFEMVec&& u, const double a)
 template <typename T>
 auto operator/(serac::VectorExpr<T>&& u, const double a)
 {
-  using detail::ScalarDivOp;
-  return detail::UnaryVectorExpr<T, ScalarDivOp<true>>(std::move(u.asDerived()), ScalarDivOp{a});
+  using serac::detail::ScalarDivOp;
+  return serac::detail::UnaryVectorExpr<T, ScalarDivOp<true>>(std::move(u.asDerived()), ScalarDivOp{a});
 }
 
-template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator/(MFEMVec&& u, const double a)
 {
-  using detail::ScalarDivOp;
-  return detail::UnaryVectorExpr<MFEMVec, ScalarDivOp<true>>(std::forward<MFEMVec>(u), ScalarDivOp{a});
+  using serac::detail::ScalarDivOp;
+  return serac::detail::UnaryVectorExpr<MFEMVec, ScalarDivOp<true>>(std::forward<MFEMVec>(u), ScalarDivOp{a});
 }
 
 template <typename T>
 auto operator/(const double a, serac::VectorExpr<T>&& u)
 {
-  using detail::ScalarDivOp;
-  return detail::UnaryVectorExpr<T, ScalarDivOp<false>>(std::move(u.asDerived()), ScalarDivOp<false>{a});
+  using serac::detail::ScalarDivOp;
+  return serac::detail::UnaryVectorExpr<T, ScalarDivOp<false>>(std::move(u.asDerived()), ScalarDivOp<false>{a});
 }
 
-template <typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator/(const double a, MFEMVec&& u)
 {
-  using detail::ScalarDivOp;
-  return detail::UnaryVectorExpr<MFEMVec, ScalarDivOp<false>>(std::forward<MFEMVec>(u), ScalarDivOp<false>{a});
+  using serac::detail::ScalarDivOp;
+  return serac::detail::UnaryVectorExpr<MFEMVec, ScalarDivOp<false>>(std::forward<MFEMVec>(u), ScalarDivOp<false>{a});
 }
 
 template <typename S, typename T>
 auto operator+(serac::VectorExpr<S>&& u, serac::VectorExpr<T>&& v)
 {
-  return detail::VectorAddition<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
+  return serac::detail::VectorAddition<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator+(MFEMVec&& u, serac::VectorExpr<T>&& v)
 {
-  return detail::VectorAddition<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
+  return serac::detail::VectorAddition<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator+(serac::VectorExpr<T>&& u, MFEMVec&& v)
 {
   return operator+(std::forward<MFEMVec>(v), std::move(u));
 }
 
-template <typename MFEMVecL, typename MFEMVecR, typename = detail::enable_if_mfem_vec<MFEMVecL>,
-          typename = detail::enable_if_mfem_vec<MFEMVecR>>
+template <typename MFEMVecL, typename MFEMVecR, typename = serac::detail::enable_if_mfem_vec<MFEMVecL>,
+          typename = serac::detail::enable_if_mfem_vec<MFEMVecR>>
 auto operator+(MFEMVecL&& u, MFEMVecR&& v)
 {
-  return detail::VectorAddition<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
+  return serac::detail::VectorAddition<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
 }
 
 template <typename S, typename T>
 auto operator-(serac::VectorExpr<S>&& u, serac::VectorExpr<T>&& v)
 {
-  return detail::VectorSubtraction<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
+  return serac::detail::VectorSubtraction<S, T>(std::move(u.asDerived()), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator-(MFEMVec&& u, serac::VectorExpr<T>&& v)
 {
-  return detail::VectorSubtraction<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
+  return serac::detail::VectorSubtraction<MFEMVec, T>(std::forward<MFEMVec>(u), std::move(v.asDerived()));
 }
 
-template <typename T, typename MFEMVec, typename = detail::enable_if_mfem_vec<MFEMVec>>
+template <typename T, typename MFEMVec, typename = serac::detail::enable_if_mfem_vec<MFEMVec>>
 auto operator-(serac::VectorExpr<T>&& u, MFEMVec&& v)
 {
-  return detail::VectorSubtraction<T, MFEMVec>(std::move(u.asDerived()), std::forward<MFEMVec>(v));
+  return serac::detail::VectorSubtraction<T, MFEMVec>(std::move(u.asDerived()), std::forward<MFEMVec>(v));
 }
 
-template <typename MFEMVecL, typename MFEMVecR, typename = detail::enable_if_mfem_vec<MFEMVecL>,
-          typename = detail::enable_if_mfem_vec<MFEMVecR>>
+template <typename MFEMVecL, typename MFEMVecR, typename = serac::detail::enable_if_mfem_vec<MFEMVecL>,
+          typename = serac::detail::enable_if_mfem_vec<MFEMVecR>>
 auto operator-(MFEMVecL&& u, MFEMVecR&& v)
 {
-  return detail::VectorSubtraction<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
+  return serac::detail::VectorSubtraction<MFEMVecL, MFEMVecR>(std::forward<MFEMVecL>(u), std::forward<MFEMVecR>(v));
 }
 
 template <typename T>
 auto operator*(const mfem::Operator& A, serac::VectorExpr<T>&& v)
 {
-  return detail::OperatorExpr<T>(A, std::move(v.asDerived()));
+  return serac::detail::OperatorExpr<T>(A, std::move(v.asDerived()));
 }
 
 inline auto operator*(const mfem::Operator& A, const mfem::Vector& v)
 {
-  return detail::OperatorExpr<mfem::Vector>(A, v);
+  return serac::detail::OperatorExpr<mfem::Vector>(A, v);
 }

--- a/src/serac/numerics/mesh_utils.cpp
+++ b/src/serac/numerics/mesh_utils.cpp
@@ -10,6 +10,7 @@
 
 #include "axom/core.hpp"
 #include "fmt/fmt.hpp"
+
 #include "serac/infrastructure/logger.hpp"
 #include "serac/infrastructure/terminator.hpp"
 

--- a/src/serac/numerics/mesh_utils.hpp
+++ b/src/serac/numerics/mesh_utils.hpp
@@ -11,12 +11,12 @@
  *        various mesh objects.
  */
 
-#ifndef MESH_UTILS
-#define MESH_UTILS
+#pragma once
 
 #include <memory>
 
 #include "mfem.hpp"
+
 #include "serac/infrastructure/input.hpp"
 
 namespace serac {
@@ -103,5 +103,3 @@ template <>
 struct FromInlet<serac::mesh::InputOptions> {
   serac::mesh::InputOptions operator()(const axom::inlet::Table& base);
 };
-
-#endif

--- a/src/serac/numerics/vector_expression.hpp
+++ b/src/serac/numerics/vector_expression.hpp
@@ -11,8 +11,7 @@
  * on vectors
  */
 
-#ifndef VECTOR_EXPRESSION
-#define VECTOR_EXPRESSION
+#pragma once
 
 #include "mfem.hpp"
 
@@ -136,5 +135,3 @@ void evaluate(const VectorExpr<T>& expr, mfem::Vector& result, MPI_Comm comm)
 }
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -9,6 +9,7 @@
 #include <fstream>
 
 #include "fmt/fmt.hpp"
+
 #include "serac/infrastructure/initialize.hpp"
 #include "serac/infrastructure/logger.hpp"
 #include "serac/infrastructure/terminator.hpp"

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -10,13 +10,13 @@
  * @brief The base interface class for a generic PDE solver
  */
 
-#ifndef BASE_PHYSICS
-#define BASE_PHYSICS
+#pragma once
 
 #include <functional>
 #include <memory>
 
 #include "mfem.hpp"
+
 #include "serac/physics/utilities/boundary_condition_manager.hpp"
 #include "serac/physics/utilities/equation_solver.hpp"
 #include "serac/physics/utilities/finite_element_state.hpp"
@@ -223,5 +223,3 @@ protected:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/elasticity.hpp
+++ b/src/serac/physics/elasticity.hpp
@@ -10,10 +10,10 @@
  * @brief A solver for the steady state solution of a linear elasticity PDE
  */
 
-#ifndef LINEAR_ELASTICITY
-#define LINEAR_ELASTICITY
+#pragma once
 
 #include "mfem.hpp"
+
 #include "serac/physics/base_physics.hpp"
 
 namespace serac {
@@ -150,5 +150,3 @@ protected:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -10,12 +10,12 @@
  * @brief The solver object for finite deformation hyperelasticity
  */
 
-#ifndef NONLIN_SOLID
-#define NONLIN_SOLID
+#pragma once
 
 #include <optional>
 
 #include "mfem.hpp"
+
 #include "serac/infrastructure/input.hpp"
 #include "serac/physics/base_physics.hpp"
 #include "serac/physics/operators/odes.hpp"
@@ -316,5 +316,3 @@ template <>
 struct FromInlet<serac::NonlinearSolid::InputOptions> {
   serac::NonlinearSolid::InputOptions operator()(const axom::inlet::Table& base);
 };
-
-#endif

--- a/src/serac/physics/operators/odes.hpp
+++ b/src/serac/physics/operators/odes.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 
 #include "mfem.hpp"
+
 #include "serac/physics/utilities/boundary_condition_manager.hpp"
 #include "serac/physics/utilities/equation_solver.hpp"
 

--- a/src/serac/physics/thermal_conduction.hpp
+++ b/src/serac/physics/thermal_conduction.hpp
@@ -10,10 +10,10 @@
  * @brief An object containing the solver for a thermal conduction PDE
  */
 
-#ifndef THERMAL_CONDUCTION
-#define THERMAL_CONDUCTION
+#pragma once
 
 #include "mfem.hpp"
+
 #include "serac/physics/base_physics.hpp"
 #include "serac/physics/operators/odes.hpp"
 #include "serac/physics/operators/stdfunction_operator.hpp"
@@ -274,5 +274,3 @@ protected:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/thermal_solid.hpp
+++ b/src/serac/physics/thermal_solid.hpp
@@ -10,10 +10,10 @@
  * @brief An object containing an operator-split thermal structural solver
  */
 
-#ifndef THERMAL_SOLID
-#define THERMAL_SOLID
+#pragma once
 
 #include "mfem.hpp"
+
 #include "serac/physics/base_physics.hpp"
 #include "serac/physics/nonlinear_solid.hpp"
 #include "serac/physics/thermal_conduction.hpp"
@@ -251,5 +251,3 @@ protected:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/utilities/boundary_condition.hpp
+++ b/src/serac/physics/utilities/boundary_condition.hpp
@@ -10,8 +10,7 @@
  * @brief This file contains the declaration of the boundary condition class
  */
 
-#ifndef BOUNDARY_CONDITION
-#define BOUNDARY_CONDITION
+#pragma once
 
 #include <memory>
 #include <optional>
@@ -267,5 +266,3 @@ private:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/utilities/boundary_condition_manager.hpp
+++ b/src/serac/physics/utilities/boundary_condition_manager.hpp
@@ -10,8 +10,7 @@
  * @brief This file contains the declaration of the boundary condition manager class
  */
 
-#ifndef BOUNDARY_CONDITION_MANAGER
-#define BOUNDARY_CONDITION_MANAGER
+#pragma once
 
 #include <memory>
 #include <set>
@@ -296,5 +295,3 @@ private:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/utilities/equation_solver.hpp
+++ b/src/serac/physics/utilities/equation_solver.hpp
@@ -10,14 +10,14 @@
  * @brief This file contains the declaration of an equation solver wrapper
  */
 
-#ifndef EQUATION_SOLVER
-#define EQUATION_SOLVER
+#pragma once
 
 #include <memory>
 #include <optional>
 #include <variant>
 
 #include "mfem.hpp"
+
 #include "serac/infrastructure/input.hpp"
 #include "serac/physics/utilities/solver_config.hpp"
 
@@ -225,5 +225,3 @@ template <>
 struct FromInlet<serac::EquationSolver> {
   serac::EquationSolver operator()(const axom::inlet::Table& base);
 };
-
-#endif

--- a/src/serac/physics/utilities/finite_element_state.hpp
+++ b/src/serac/physics/utilities/finite_element_state.hpp
@@ -5,13 +5,13 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /**
- * @file boundary_condition.hpp
+ * @file finite_element_state.hpp
  *
- * @brief This file contains the declaration of the boundary condition class
+ * @brief This file contains the declaration of structure that manages the MFEM objects
+ * that make up the state for a given field
  */
 
-#ifndef FINITE_ELEMENT_STATE
-#define FINITE_ELEMENT_STATE
+#pragma once
 
 #include <functional>
 #include <memory>
@@ -186,5 +186,3 @@ private:
 };
 
 }  // namespace serac
-
-#endif

--- a/src/serac/physics/utilities/solver_config.hpp
+++ b/src/serac/physics/utilities/solver_config.hpp
@@ -10,8 +10,7 @@
  * @brief This file contains enumerations and record types for physics solver configuration
  */
 
-#ifndef SOLVER_CONFIG
-#define SOLVER_CONFIG
+#pragma once
 
 #include <variant>
 
@@ -272,5 +271,3 @@ struct NonlinearSolverOptions {
 };
 
 }  // namespace serac
-
-#endif

--- a/tests/benchmark_expr_templates.cpp
+++ b/tests/benchmark_expr_templates.cpp
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <benchmark/benchmark.h>
+#include "numerics/expr_template_ops.hpp"
 
 #include <utility>
 
-#include "numerics/expr_template_ops.hpp"
+#include <benchmark/benchmark.h>
 
 static std::pair<mfem::Vector, mfem::Vector> sample_vectors(const int entries)
 {

--- a/tests/copy_elision.cpp
+++ b/tests/copy_elision.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include <gtest/gtest.h>
-
 #include "mfem.hpp"
 
 class ArrayCtr {

--- a/tests/expr_templates.cpp
+++ b/tests/expr_templates.cpp
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
-
 #include "serac/numerics/expr_template_ops.hpp"
+
+#include <gtest/gtest.h>
 
 static std::pair<mfem::Vector, mfem::Vector> sample_vectors(const int entries)
 {

--- a/tests/mesh_generation.cpp
+++ b/tests/mesh_generation.cpp
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
-
 #include "serac/numerics/mesh_utils.hpp"
+
+#include <gtest/gtest.h>
 
 TEST(meshgen, successful_creation)
 {

--- a/tests/mfem_array_std_algo.cpp
+++ b/tests/mfem_array_std_algo.cpp
@@ -4,11 +4,10 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
-
 #include <algorithm>
 #include <numeric>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
 
 // In these tests std::algorithms should only be used once -

--- a/tests/serac_boundary_cond.cpp
+++ b/tests/serac_boundary_cond.cpp
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
+#include "serac/physics/utilities/boundary_condition_manager.hpp"
 
 #include <memory>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
-#include "serac/physics/utilities/boundary_condition_manager.hpp"
 
 namespace serac {
 

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -7,8 +7,8 @@
 #include "serac/physics/nonlinear_solid.hpp"
 
 #include <fstream>
-#include <gtest/gtest.h>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
 
 #include "serac/coefficients/coefficient_extensions.hpp"

--- a/tests/serac_cuda_smoketest.cpp
+++ b/tests/serac_cuda_smoketest.cpp
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include <algorithm>
+
 #include <cuda_runtime.h>
 #include <gtest/gtest.h>
-
-#include <algorithm>
 
 void vector_add(float* out, float* a, float* b, int n);
 

--- a/tests/serac_cuda_smoketest_kernel.cpp
+++ b/tests/serac_cuda_smoketest_kernel.cpp
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include <cstdio>
+
 #include <cuda.h>
 #include <cuda_runtime.h>
-
-#include <cstdio>
 
 __global__ void vector_add_kernel(float* out, float* a, float* b, int n)
 {

--- a/tests/serac_dtor.cpp
+++ b/tests/serac_dtor.cpp
@@ -4,15 +4,17 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
+#include "serac/physics/thermal_conduction.hpp"
+
 #include <sys/stat.h>
 
 #include <fstream>
 #include <memory>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
+
 #include "serac/numerics/mesh_utils.hpp"
-#include "serac/physics/thermal_conduction.hpp"
 #include "serac/serac_config.hpp"
 
 namespace serac {

--- a/tests/serac_error_handling.cpp
+++ b/tests/serac_error_handling.cpp
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
-
 #include <exception>
+
+#include <gtest/gtest.h>
 
 #include "serac/infrastructure/cli.hpp"
 #include "serac/infrastructure/initialize.hpp"

--- a/tests/serac_input.cpp
+++ b/tests/serac_input.cpp
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
-
 #include "serac/infrastructure/input.hpp"
+
+#include <gtest/gtest.h>
 #include "mfem.hpp"
 
 class SlicErrorException : public std::exception {

--- a/tests/serac_linelastic_solver.cpp
+++ b/tests/serac_linelastic_solver.cpp
@@ -4,13 +4,14 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
+#include "serac/physics/elasticity.hpp"
 
 #include <fstream>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
+
 #include "serac/numerics/mesh_utils.hpp"
-#include "serac/physics/elasticity.hpp"
 #include "serac/serac_config.hpp"
 
 namespace serac {

--- a/tests/serac_mesh.cpp
+++ b/tests/serac_mesh.cpp
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
+#include "serac/numerics/mesh_utils.hpp"
 
 #include <fstream>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
-#include "serac/numerics/mesh_utils.hpp"
-#include "serac/physics/elasticity.hpp"
+
 #include "serac/serac_config.hpp"
 
 namespace serac {

--- a/tests/serac_nonlinear_solid.cpp
+++ b/tests/serac_nonlinear_solid.cpp
@@ -7,8 +7,8 @@
 #include "serac/physics/nonlinear_solid.hpp"
 
 #include <fstream>
-#include <gtest/gtest.h>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
 
 #include "serac/coefficients/coefficient_extensions.hpp"

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -4,14 +4,16 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
+#include "serac/physics/thermal_conduction.hpp"
+
 #include <sys/stat.h>
 
 #include <fstream>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
+
 #include "serac/numerics/mesh_utils.hpp"
-#include "serac/physics/thermal_conduction.hpp"
 #include "serac/serac_config.hpp"
 
 namespace serac {

--- a/tests/serac_thermal_structural_solver.cpp
+++ b/tests/serac_thermal_structural_solver.cpp
@@ -4,14 +4,15 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#include <gtest/gtest.h>
+#include "serac/physics/thermal_solid.hpp"
 
 #include <fstream>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
+
 #include "serac/coefficients/coefficient_extensions.hpp"
 #include "serac/numerics/mesh_utils.hpp"
-#include "serac/physics/thermal_solid.hpp"
 #include "serac/serac_config.hpp"
 
 namespace serac {

--- a/tests/serac_wrapper_tests.cpp
+++ b/tests/serac_wrapper_tests.cpp
@@ -5,12 +5,13 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 // # Author: Jonathan Wong @ LLNL.
 
-#include <gtest/gtest.h>
+#include "serac/coefficients/coefficient_extensions.hpp"
 
 #include <memory>
 
+#include <gtest/gtest.h>
 #include "mfem.hpp"
-#include "serac/coefficients/coefficient_extensions.hpp"
+
 #include "serac/integrators/wrapper_integrator.hpp"
 
 using namespace mfem;

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -3,17 +3,14 @@
 // details.
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
+#pragma once
 
 #include "serac/infrastructure/input.hpp"
 
-namespace serac {
-
-namespace test_utils {
+namespace serac::test_utils {
 
 void defineNonlinSolidInputFileSchema(axom::inlet::Inlet& inlet);
 
 void runNonlinSolidTest(const std::string& input_file);
 
-}  // end namespace test_utils
-
-}  // end namespace serac
+}  // end namespace serac::test_utils


### PR DESCRIPTION
Also switches to nested namespaces (e.g. `namespace serac::logger` instead of `namespace serac` then `namespace logger`).

Resolves #161 
Resolves #306 