### PR TITLE
Add input schemas/test files for thermal solver

### DIFF
--- a/data/input_files/tests/nonlinear_solid/dyn_amgx_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_amgx_solve.lua
@@ -15,6 +15,9 @@ main_mesh = {
     par_ref_levels = 0,
 }
 
+-- Simulation output format
+output_type = "VisIt"
+
 -- Solver parameters
 nonlinear_solid = {
     stiffness_solver = {

--- a/data/input_files/tests/nonlinear_solid/dyn_amgx_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_amgx_solve.lua
@@ -50,6 +50,8 @@ nonlinear_solid = {
     mu = 0.25,
     K  = 5.0,
 
+    viscosity = 0.0,
+
     -- initial conditions
     initial_displacement = {
         vec_coef = function (x, y, z)

--- a/data/input_files/tests/nonlinear_solid/dyn_direct_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_direct_solve.lua
@@ -45,6 +45,8 @@ nonlinear_solid = {
     mu = 0.25,
     K  = 5.0,
 
+    viscosity = 0.0,
+
     -- initial conditions
     initial_displacement = {
         vec_coef = function (x, y, z)

--- a/data/input_files/tests/nonlinear_solid/dyn_direct_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_direct_solve.lua
@@ -15,6 +15,9 @@ main_mesh = {
     par_ref_levels = 0,
 }
 
+-- Simulation output format
+output_type = "VisIt"
+
 -- Solver parameters
 nonlinear_solid = {
     stiffness_solver = {

--- a/data/input_files/tests/nonlinear_solid/dyn_linesearch_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_linesearch_solve.lua
@@ -51,6 +51,8 @@ nonlinear_solid = {
     mu = 0.25,
     K  = 5.0,
 
+    viscosity = 0.0,
+
     -- initial conditions
     initial_displacement = {
         vec_coef = function (x, y, z)

--- a/data/input_files/tests/nonlinear_solid/dyn_linesearch_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_linesearch_solve.lua
@@ -15,6 +15,9 @@ main_mesh = {
     par_ref_levels = 0,
 }
 
+-- Simulation output format
+output_type = "VisIt"
+
 -- Solver parameters
 nonlinear_solid = {
     stiffness_solver = {

--- a/data/input_files/tests/nonlinear_solid/dyn_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_solve.lua
@@ -7,6 +7,9 @@ epsilon = 0.0001
 dt      = 1.0
 t_final = 6.0
 
+-- Simulation output format
+output_type = "VisIt"
+
 main_mesh = {
     -- mesh file
     mesh = "../../../meshes/beam-hex.mesh",

--- a/data/input_files/tests/nonlinear_solid/dyn_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/dyn_solve.lua
@@ -50,6 +50,8 @@ nonlinear_solid = {
     mu = 0.25,
     K  = 5.0,
 
+    viscosity = 0.0,
+
     -- initial conditions
     initial_displacement = {
         vec_coef = function (x, y, z)

--- a/data/input_files/tests/nonlinear_solid/qs_attribute_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/qs_attribute_solve.lua
@@ -13,6 +13,9 @@ main_mesh = {
     par_ref_levels = 0,
 }
 
+-- Simulation output format
+output_type = "GLVis"
+
 -- Solver parameters
 nonlinear_solid = {
     stiffness_solver = {

--- a/data/input_files/tests/nonlinear_solid/qs_component_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/qs_component_solve.lua
@@ -13,6 +13,9 @@ main_mesh = {
     par_ref_levels = 0,
 }
 
+-- Simulation output format
+output_type = "VisIt"
+
 -- Solver parameters
 nonlinear_solid = {
     stiffness_solver = {

--- a/data/input_files/tests/nonlinear_solid/qs_direct_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/qs_direct_solve.lua
@@ -13,6 +13,9 @@ main_mesh = {
     par_ref_levels = 0,
 }
 
+-- Simulation output format
+output_type = "VisIt"
+
 -- Solver parameters
 nonlinear_solid = {
     stiffness_solver = {

--- a/data/input_files/tests/nonlinear_solid/qs_solve.lua
+++ b/data/input_files/tests/nonlinear_solid/qs_solve.lua
@@ -13,6 +13,9 @@ main_mesh = {
     par_ref_levels = 0,
 }
 
+-- Simulation output format
+output_type = "VisIt"
+
 -- Solver parameters
 nonlinear_solid = {
     stiffness_solver = {

--- a/data/input_files/tests/thermal_conduction/dyn_exp_solve.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_exp_solve.lua
@@ -6,6 +6,9 @@ epsilon = 0.00001
 dt      = 0.0001
 t_final = 0.001
 
+-- Simulation output format
+output_type = "ParaView"
+
 main_mesh = {
     -- mesh file
     mesh = "../../../meshes/star.mesh",

--- a/data/input_files/tests/thermal_conduction/dyn_exp_solve.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_exp_solve.lua
@@ -17,6 +17,11 @@ main_mesh = {
     par_ref_levels = 1,
 }
 
+temp_func = function (x, y, z)
+    local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+    if norm < 0.5 then return 2.0 else return 1.0 end
+end
+
 -- Solver parameters
 thermal_conduction = {
     stiffness_solver = {
@@ -53,20 +58,14 @@ thermal_conduction = {
 
     -- initial conditions
     initial_temperature = {
-        coef = function (x, y, z)
-            local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-            if norm < 0.5 then return 2.0 else return 1.0 end
-        end
+        coef = temp_func
     },
 
     -- boundary condition parameters
     boundary_conds = {
         ['temperature'] = {
             attrs = {1},
-            coef = function (x, y, z)
-                local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-                if norm < 0.5 then return 2.0 else return 1.0 end
-            end
+            coef = temp_func
         },
     },
 }

--- a/data/input_files/tests/thermal_conduction/dyn_exp_solve.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_exp_solve.lua
@@ -1,13 +1,14 @@
 -- Comparison information
-expected_t_l2norm = 2.56980679
+expected_t_l2norm = 2.6493029
 epsilon = 0.00001
 
 -- Simulation time parameters
-dt      = 1.0
+dt      = 0.0001
+t_final = 0.001
 
 main_mesh = {
     -- mesh file
-    mesh = "../../../meshes/star_with_2_bdr_attributes.mesh",
+    mesh = "../../../meshes/star.mesh",
     -- serial and parallel refinement levels
     ser_ref_levels = 1,
     par_ref_levels = 1,
@@ -36,24 +37,32 @@ thermal_conduction = {
         },
     },
 
+    dynamics = {
+        timestepper = "ForwardEuler",
+        enforcement_method = "RateControl",
+    },
+
     -- polynomial interpolation order
     order = 2,
 
     -- material parameters
     kappa = 0.5,
 
+    -- initial conditions
+    initial_temperature = {
+        coef = function (x, y, z)
+            local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+            if norm < 0.5 then return 2.0 else return 1.0 end
+        end
+    },
+
     -- boundary condition parameters
     boundary_conds = {
-        ['temperature_1'] = {
+        ['temperature'] = {
             attrs = {1},
             coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-            end
-        },
-        ['temperature_2'] = {
-            attrs = {2},
-            coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+                local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+                if norm < 0.5 then return 2.0 else return 1.0 end
             end
         },
     },

--- a/data/input_files/tests/thermal_conduction/dyn_imp_solve.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_imp_solve.lua
@@ -17,6 +17,11 @@ main_mesh = {
     par_ref_levels = 1,
 }
 
+temp_func = function (x, y, z)
+    local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+    if norm < 0.5 then return 2.0 else return 1.0 end
+end
+
 -- Solver parameters
 thermal_conduction = {
     stiffness_solver = {
@@ -55,20 +60,14 @@ thermal_conduction = {
 
     -- initial conditions
     initial_temperature = {
-        coef = function (x, y, z)
-            local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-            if norm < 0.5 then return 2.0 else return 1.0 end
-        end
+        coef = temp_func
     },
 
     -- boundary condition parameters
     boundary_conds = {
         ['temperature'] = {
             attrs = {1},
-            coef = function (x, y, z)
-                local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-                if norm < 0.5 then return 2.0 else return 1.0 end
-            end
+            coef = temp_func
         },
     },
 }

--- a/data/input_files/tests/thermal_conduction/dyn_imp_solve.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_imp_solve.lua
@@ -6,6 +6,9 @@ epsilon = 0.00001
 dt      = 1.0
 t_final = 5.0
 
+-- Simulation output format
+output_type = "VisIt"
+
 main_mesh = {
     -- mesh file
     mesh = "../../../meshes/star.mesh",

--- a/data/input_files/tests/thermal_conduction/dyn_imp_solve.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_imp_solve.lua
@@ -1,13 +1,14 @@
 -- Comparison information
-expected_t_l2norm = 2.56980679
+expected_t_l2norm = 2.1806652643
 epsilon = 0.00001
 
 -- Simulation time parameters
 dt      = 1.0
+t_final = 5.0
 
 main_mesh = {
     -- mesh file
-    mesh = "../../../meshes/star_with_2_bdr_attributes.mesh",
+    mesh = "../../../meshes/star.mesh",
     -- serial and parallel refinement levels
     ser_ref_levels = 1,
     par_ref_levels = 1,
@@ -36,24 +37,34 @@ thermal_conduction = {
         },
     },
 
+    dynamics = {
+        timestepper = "BackwardEuler",
+        enforcement_method = "RateControl",
+    },
+
     -- polynomial interpolation order
     order = 2,
 
     -- material parameters
     kappa = 0.5,
+    rho = 0.5,
+    cp = 0.5,
+
+    -- initial conditions
+    initial_temperature = {
+        coef = function (x, y, z)
+            local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+            if norm < 0.5 then return 2.0 else return 1.0 end
+        end
+    },
 
     -- boundary condition parameters
     boundary_conds = {
-        ['temperature_1'] = {
+        ['temperature'] = {
             attrs = {1},
             coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-            end
-        },
-        ['temperature_2'] = {
-            attrs = {2},
-            coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+                local norm = math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+                if norm < 0.5 then return 2.0 else return 1.0 end
             end
         },
     },

--- a/data/input_files/tests/thermal_conduction/static_amgx_solve.lua
+++ b/data/input_files/tests/thermal_conduction/static_amgx_solve.lua
@@ -1,0 +1,54 @@
+-- Comparison information
+expected_t_l2norm = 2.02263
+epsilon = 0.00001
+
+-- Simulation time parameters
+dt      = 1.0
+
+main_mesh = {
+    -- mesh file
+    mesh = "../../../meshes/star_with_2_bdr_attributes.mesh",
+    -- serial and parallel refinement levels
+    ser_ref_levels = 1,
+    par_ref_levels = 1,
+}
+
+-- Solver parameters
+thermal_conduction = {
+    stiffness_solver = {
+        linear = {
+            type = "iterative",
+            iterative_options = {
+                rel_tol     = 1.0e-6,
+                abs_tol     = 1.0e-12,
+                max_iter    = 200,
+                print_level = 0,
+                solver_type = "cg",
+                prec_type   = "AMGX",
+            },
+        },
+
+        nonlinear = {
+            rel_tol     = 1.0e-4,
+            abs_tol     = 1.0e-8,
+            max_iter    = 500,
+            print_level = 1,
+        },
+    },
+
+    -- polynomial interpolation order
+    order = 2,
+
+    -- material parameters
+    kappa = 0.5,
+
+    -- boundary condition parameters
+    boundary_conds = {
+        ['temperature'] = {
+            attrs = {1},
+            coef = function (x, y, z)
+                return 1.0
+            end
+        },
+    },
+}

--- a/data/input_files/tests/thermal_conduction/static_amgx_solve.lua
+++ b/data/input_files/tests/thermal_conduction/static_amgx_solve.lua
@@ -24,7 +24,7 @@ thermal_conduction = {
                 max_iter    = 200,
                 print_level = 0,
                 solver_type = "cg",
-                prec_type   = "AMGX",
+                prec_type   = "L1JacobiAMGX",
             },
         },
 

--- a/data/input_files/tests/thermal_conduction/static_solve.lua
+++ b/data/input_files/tests/thermal_conduction/static_solve.lua
@@ -1,0 +1,54 @@
+-- Comparison information
+expected_t_l2norm = 2.02263
+epsilon = 0.00001
+
+-- Simulation time parameters
+dt      = 1.0
+
+main_mesh = {
+    -- mesh file
+    mesh = "../../../meshes/star_with_2_bdr_attributes.mesh",
+    -- serial and parallel refinement levels
+    ser_ref_levels = 1,
+    par_ref_levels = 1,
+}
+
+-- Solver parameters
+thermal_conduction = {
+    stiffness_solver = {
+        linear = {
+            type = "iterative",
+            iterative_options = {
+                rel_tol     = 1.0e-6,
+                abs_tol     = 1.0e-12,
+                max_iter    = 200,
+                print_level = 0,
+                solver_type = "cg",
+                prec_type   = "JacobiSmoother",
+            },
+        },
+
+        nonlinear = {
+            rel_tol     = 1.0e-4,
+            abs_tol     = 1.0e-8,
+            max_iter    = 500,
+            print_level = 1,
+        },
+    },
+
+    -- polynomial interpolation order
+    order = 2,
+
+    -- material parameters
+    kappa = 0.5,
+
+    -- boundary condition parameters
+    boundary_conds = {
+        ['temperature'] = {
+            attrs = {1},
+            coef = function (x, y, z)
+                return 1.0
+            end
+        },
+    },
+}

--- a/data/input_files/tests/thermal_conduction/static_solve_multiple_bcs.lua
+++ b/data/input_files/tests/thermal_conduction/static_solve_multiple_bcs.lua
@@ -16,6 +16,10 @@ main_mesh = {
     par_ref_levels = 1,
 }
 
+temp_func = function (x, y, z)
+    return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+end
+
 -- Solver parameters
 thermal_conduction = {
     stiffness_solver = {
@@ -49,15 +53,11 @@ thermal_conduction = {
     boundary_conds = {
         ['temperature_1'] = {
             attrs = {1},
-            coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-            end
+            coef = temp_func
         },
         ['temperature_2'] = {
             attrs = {2},
-            coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-            end
+            coef = temp_func
         },
     },
 }

--- a/data/input_files/tests/thermal_conduction/static_solve_multiple_bcs.lua
+++ b/data/input_files/tests/thermal_conduction/static_solve_multiple_bcs.lua
@@ -5,6 +5,9 @@ epsilon = 0.00001
 -- Simulation time parameters
 dt      = 1.0
 
+-- Simulation output format
+output_type = "GLVis"
+
 main_mesh = {
     -- mesh file
     mesh = "../../../meshes/star_with_2_bdr_attributes.mesh",

--- a/data/input_files/tests/thermal_conduction/static_solve_multiple_bcs.lua
+++ b/data/input_files/tests/thermal_conduction/static_solve_multiple_bcs.lua
@@ -1,0 +1,60 @@
+-- Comparison information
+expected_x_l2norm = 2.56980679
+epsilon = 0.00001
+
+-- Simulation time parameters
+dt      = 1.0
+
+main_mesh = {
+    -- mesh file
+    mesh = "../../../meshes/star_with_2_bdr_attributes.mesh",
+    -- serial and parallel refinement levels
+    ser_ref_levels = 1,
+    par_ref_levels = 1,
+}
+
+-- Solver parameters
+thermal_conduction = {
+    stiffness_solver = {
+        linear = {
+            type = "iterative",
+            iterative_options = {
+                rel_tol     = 1.0e-6,
+                abs_tol     = 1.0e-12,
+                max_iter    = 200,
+                print_level = 0,
+                solver_type = "cg",
+                prec_type   = "JacobiSmoother",
+            },
+        },
+
+        nonlinear = {
+            rel_tol     = 1.0e-4,
+            abs_tol     = 1.0e-8,
+            max_iter    = 500,
+            print_level = 1,
+        },
+    },
+
+    -- polynomial interpolation order
+    order = 2,
+
+    -- material parameters
+    kappa = 0.5,
+
+    -- boundary condition parameters
+    boundary_conds = {
+        ['temperature_1'] = {
+            attrs = {1},
+            coef = function (x, y, z)
+                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+            end
+        },
+        ['temperature_2'] = {
+            attrs = {2},
+            coef = function (x, y, z)
+                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+            end
+        },
+    },
+}

--- a/data/input_files/tests/thermal_conduction/static_solve_repeated_bcs.lua
+++ b/data/input_files/tests/thermal_conduction/static_solve_repeated_bcs.lua
@@ -7,7 +7,7 @@ dt      = 1.0
 
 main_mesh = {
     -- mesh file
-    mesh = "../../../meshes/star_with_2_bdr_attributes.mesh",
+    mesh = "../../../meshes/star.mesh",
     -- serial and parallel refinement levels
     ser_ref_levels = 1,
     par_ref_levels = 1,
@@ -51,9 +51,9 @@ thermal_conduction = {
             end
         },
         ['temperature_2'] = {
-            attrs = {2},
+            attrs = {1},
             coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+                return 2 * math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
             end
         },
     },

--- a/data/input_files/tests/thermal_conduction/static_solve_repeated_bcs.lua
+++ b/data/input_files/tests/thermal_conduction/static_solve_repeated_bcs.lua
@@ -13,6 +13,10 @@ main_mesh = {
     par_ref_levels = 1,
 }
 
+temp_func = function (x, y, z)
+    return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+end
+
 -- Solver parameters
 thermal_conduction = {
     stiffness_solver = {
@@ -46,14 +50,12 @@ thermal_conduction = {
     boundary_conds = {
         ['temperature_1'] = {
             attrs = {1},
-            coef = function (x, y, z)
-                return math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
-            end
+            coef = temp_func
         },
         ['temperature_2'] = {
             attrs = {1},
             coef = function (x, y, z)
-                return 2 * math.sqrt(x ^ 2 + y ^ 2 + z ^ 2)
+                return 2 * temp_func(x, y, z)
             end
         },
     },

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -21,6 +21,7 @@ axom::inlet::Inlet initialize(axom::sidre::DataStore& datastore, const std::stri
   // Initialize Inlet
   auto luareader = std::make_unique<axom::inlet::LuaReader>();
   luareader->parseFile(input_file_path);
+  luareader->solState().open_libraries(sol::lib::math);
 
   // Store inlet data under its own group
   axom::sidre::Group* inlet_root = datastore.getRoot()->createGroup("input_file");
@@ -158,7 +159,8 @@ serac::input::CoefficientInputOptions FromInlet<serac::input::CoefficientInputOp
     auto scalar_func = [func(std::move(func))](const mfem::Vector& input) {
       return func({input.GetData(), input.Size()});
     };
-    return {std::move(scalar_func), base["component"]};
+    const int component = base.contains("component") ? base["component"] : -1;
+    return {std::move(scalar_func), component};
   }
   return {};
 }

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -19,8 +19,8 @@ axom::inlet::Inlet initialize(axom::sidre::DataStore& datastore, const std::stri
 {
   // Initialize Inlet
   auto luareader = std::make_unique<axom::inlet::LuaReader>();
-  luareader->parseFile(input_file_path);
   luareader->solState().open_libraries(sol::lib::math);
+  luareader->parseFile(input_file_path);
 
   // Store inlet data under its own group
   axom::sidre::Group* inlet_root = datastore.getRoot()->createGroup("input_file");

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -81,10 +81,7 @@ NonlinearSolid::NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const Nonlin
     auto velo = options.initial_velocity->constructVector(dim);
     setVelocity(velo);
   }
-
-  if (options.viscosity) {
-    setViscosity(std::make_unique<mfem::ConstantCoefficient>(*(options.viscosity)));
-  }
+  setViscosity(std::make_unique<mfem::ConstantCoefficient>(options.viscosity));
 
   for (const auto& [name, bc] : options.boundary_conditions) {
     // FIXME: Better naming for boundary conditions?
@@ -295,7 +292,7 @@ void NonlinearSolid::InputOptions::defineInputFileSchema(axom::inlet::Table& tab
   table.addDouble("mu", "Shear modulus in the Neo-Hookean hyperelastic model.").defaultValue(0.25);
   table.addDouble("K", "Bulk modulus in the Neo-Hookean hyperelastic model.").defaultValue(5.0);
 
-  table.addDouble("viscosity", "Viscosity constant");
+  table.addDouble("viscosity", "Viscosity constant").defaultValue(0.0);
 
   auto& stiffness_solver_table =
       table.addTable("stiffness_solver", "Linear and Nonlinear stiffness Solver Parameters.");
@@ -358,9 +355,7 @@ NonlinearSolid::InputOptions FromInlet<NonlinearSolid::InputOptions>::operator()
   result.mu = base["mu"];
   result.K  = base["K"];
 
-  if (base.contains("viscosity")) {
-    result.viscosity = base["viscosity"];
-  }
+  result.viscosity = base["viscosity"];
 
   result.boundary_conditions =
       base["boundary_conds"].get<std::unordered_map<std::string, serac::input::BoundaryConditionInputOptions>>();

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -68,6 +68,8 @@ public:
     double mu;
     double K;
 
+    std::optional<double> viscosity;
+
     // Boundary condition information
     std::unordered_map<std::string, input::BoundaryConditionInputOptions> boundary_conditions;
 

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -68,7 +68,7 @@ public:
     double mu;
     double K;
 
-    std::optional<double> viscosity;
+    double viscosity;
 
     // Boundary condition information
     std::unordered_map<std::string, input::BoundaryConditionInputOptions> boundary_conditions;

--- a/src/serac/physics/thermal_conduction.cpp
+++ b/src/serac/physics/thermal_conduction.cpp
@@ -239,7 +239,7 @@ void ThermalConduction::InputOptions::defineInputFileSchema(axom::inlet::Table& 
 
   auto& stiffness_solver_table =
       table.addTable("stiffness_solver", "Linear and Nonlinear stiffness Solver Parameters.");
-  serac::EquationSolver::defineInputFileSchema(stiffness_solver_table);
+  serac::mfem_ext::EquationSolver::DefineInputFileSchema(stiffness_solver_table);
 
   auto& dynamics_table = table.addTable("dynamics", "Parameters for mass matrix inversion");
   dynamics_table.addString("timestepper", "Timestepper (ODE) method to use");

--- a/src/serac/physics/thermal_conduction.hpp
+++ b/src/serac/physics/thermal_conduction.hpp
@@ -67,6 +67,8 @@ public:
     SolverOptions solver_options;
     // Conductivity
     double kappa;
+    double cp;
+    double rho;
 
     // Boundary condition information
     std::unordered_map<std::string, input::BoundaryConditionInputOptions> boundary_conditions;

--- a/src/serac/physics/thermal_conduction.hpp
+++ b/src/serac/physics/thermal_conduction.hpp
@@ -50,6 +50,31 @@ public:
     std::optional<TimesteppingOptions> dyn_options = std::nullopt;
   };
 
+  /**
+   * @brief Stores all information held in the input file that
+   * is used to configure the solver
+   */
+  struct InputOptions {
+    /**
+     * @brief Input file parameters specific to this class
+     *
+     * @param[in] table Inlet's Table that input files will be added to
+     **/
+    static void defineInputFileSchema(axom::inlet::Table& table);
+
+    // The order of the field
+    int           order;
+    SolverOptions solver_options;
+    // Conductivity
+    double kappa;
+
+    // Boundary condition information
+    std::unordered_map<std::string, input::BoundaryConditionInputOptions> boundary_conditions;
+
+    // Initial conditions for temperature
+    std::optional<input::CoefficientInputOptions> initial_temperature;
+  };
+
   static IterativeSolverOptions defaultLinearOptions()
   {
     return {.rel_tol     = 1.0e-6,
@@ -84,6 +109,14 @@ public:
    * @param[in] options The system solver parameters
    */
   ThermalConduction(int order, std::shared_ptr<mfem::ParMesh> mesh, const SolverOptions& options);
+
+  /**
+   * @brief Construct a new Thermal Solver object
+   *
+   * @param[in] mesh The MFEM parallel mesh to solve the PDE on
+   * @param[in] options The solver information parsed from the input file
+   */
+  ThermalConduction(std::shared_ptr<mfem::ParMesh> mesh, const InputOptions& options);
 
   /**
    * @brief Set essential temperature boundary conditions (strongly enforced)
@@ -274,5 +307,10 @@ protected:
 };
 
 }  // namespace serac
+
+template <>
+struct FromInlet<serac::ThermalConduction::InputOptions> {
+  serac::ThermalConduction::InputOptions operator()(const axom::inlet::Table& base);
+};
 
 #endif

--- a/src/serac/physics/utilities/equation_solver.cpp
+++ b/src/serac/physics/utilities/equation_solver.cpp
@@ -360,7 +360,7 @@ void EquationSolver::defineInputFileSchema(axom::inlet::Table& table)
   iterative_table.addDouble("abs_tol", "Absolute tolerance for the linear solve.").defaultValue(1.0e-8);
   iterative_table.addInt("max_iter", "Maximum iterations for the linear solve.").defaultValue(5000);
   iterative_table.addInt("print_level", "Linear print level.").defaultValue(0);
-  iterative_table.addString("solver_type", "Solver type (gmres|minres).").defaultValue("gmres");
+  iterative_table.addString("solver_type", "Solver type (gmres|minres|cg).").defaultValue("gmres");
   iterative_table.addString("prec_type", "Preconditioner type (JacobiSmoother|L1JacobiSmoother|AMG|BlockILU).")
       .defaultValue("JacobiSmoother");
 
@@ -399,6 +399,8 @@ LinearSolverOptions FromInlet<LinearSolverOptions>::operator()(const axom::inlet
       iter_options.lin_solver = serac::LinearSolver::GMRES;
     } else if (solver_type == "minres") {
       iter_options.lin_solver = serac::LinearSolver::MINRES;
+    } else if (solver_type == "cg") {
+      iter_options.lin_solver = serac::LinearSolver::CG;
     } else {
       std::string msg = fmt::format("Unknown Linear solver type given: {0}", solver_type);
       SLIC_ERROR(msg);

--- a/src/serac/physics/utilities/equation_solver.cpp
+++ b/src/serac/physics/utilities/equation_solver.cpp
@@ -414,6 +414,8 @@ LinearSolverOptions FromInlet<LinearSolverOptions>::operator()(const axom::inlet
       iter_options.prec = serac::HypreBoomerAMGPrec{};
     } else if (prec_type == "AMGX") {
       iter_options.prec = serac::AMGXPrec{};
+    } else if (prec_type == "L1JacobiAMGX") {
+      iter_options.prec = serac::AMGXPrec{.smoother = serac::AMGXSolver::JACOBI_L1};
     } else if (prec_type == "BlockILU") {
       iter_options.prec = serac::BlockILUPrec{};
     } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 if (ENABLE_GTEST)
 
-    set(test_dependencies serac_physics serac_coefficients gtest test_utils)
+    set(test_dependencies serac_physics serac_coefficients test_utils)
 
     blt_add_library(
         NAME        test_utils

--- a/tests/benchmark_expr_templates.cpp
+++ b/tests/benchmark_expr_templates.cpp
@@ -8,7 +8,7 @@
 
 #include <utility>
 
-#include "numerics/expr_template_ops.hpp"
+#include "serac/numerics/expr_template_ops.hpp"
 
 static std::pair<mfem::Vector, mfem::Vector> sample_vectors(const int entries)
 {

--- a/tests/serac_component_bc.cpp
+++ b/tests/serac_component_bc.cpp
@@ -24,7 +24,7 @@ TEST(nonlinear_solid_solver, qs_attribute_solve)
   MPI_Barrier(MPI_COMM_WORLD);
   std::string input_file_path =
       std::string(SERAC_REPO_DIR) + "/data/input_files/tests/nonlinear_solid/qs_attribute_solve.lua";
-  test_utils::runNonlinSolidTest(input_file_path);
+  test_utils::runModuleTest<NonlinearSolid>(input_file_path);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
@@ -40,7 +40,7 @@ TEST(nonlinear_solid_solver, qs_component_solve)
   // Initialize Inlet and read input file
   auto inlet = serac::input::initialize(datastore, input_file_path);
 
-  test_utils::defineNonlinSolidInputFileSchema(inlet);
+  test_utils::defineTestSchema<NonlinearSolid>(inlet);
 
   // Build the mesh
   auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();

--- a/tests/serac_input.cpp
+++ b/tests/serac_input.cpp
@@ -90,14 +90,6 @@ TEST_F(InputTest, coef_build_scalar)
   EXPECT_NO_THROW(coef_opts.constructScalar());
 }
 
-TEST_F(InputTest, coef_build_scalar_missing_component)
-{
-  reader_->parseString("coef_opts = { coef = function(x, y, z) return y * 2 + z end }");
-  auto& coef_table = inlet_->addTable("coef_opts");
-  input::CoefficientInputOptions::defineInputFileSchema(coef_table);
-  EXPECT_THROW(coef_table.get<input::CoefficientInputOptions>(), SlicErrorException);
-}
-
 TEST_F(InputTest, coef_build_vec_from_scalar)
 {
   reader_->parseString("coef_opts = { coef = function(x, y, z) return y * 2 + z end, component = 1}");

--- a/tests/serac_nonlinear_solid.cpp
+++ b/tests/serac_nonlinear_solid.cpp
@@ -19,8 +19,7 @@
 
 namespace serac {
 
-class InputFileTest : public ::testing::TestWithParam<std::string> {
-};
+using test_utils::InputFileTest;
 
 TEST_P(InputFileTest, nonlin_solid)
 {

--- a/tests/serac_nonlinear_solid.cpp
+++ b/tests/serac_nonlinear_solid.cpp
@@ -26,7 +26,7 @@ TEST_P(InputFileTest, nonlin_solid)
   MPI_Barrier(MPI_COMM_WORLD);
   std::string input_file_path =
       std::string(SERAC_REPO_DIR) + "/data/input_files/tests/nonlinear_solid/" + GetParam() + ".lua";
-  test_utils::runNonlinSolidTest(input_file_path);
+  test_utils::runModuleTest<NonlinearSolid>(input_file_path);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
@@ -55,7 +55,7 @@ TEST(nonlinear_solid_solver, qs_custom_solve)
   // Initialize Inlet and read input file
   auto inlet = serac::input::initialize(datastore, input_file_path);
 
-  test_utils::defineNonlinSolidInputFileSchema(inlet);
+  test_utils::defineTestSchema<NonlinearSolid>(inlet);
 
   // Build the mesh
   auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -38,7 +38,7 @@ TEST(thermal_solver, static_solve)
   std::string input_file_path =
       std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/static_solve.lua";
   auto pmesh = buildBallMesh(10000);
-  test_utils::runThermalConductionTest(input_file_path, pmesh);
+  test_utils::runModuleTest<ThermalConduction>(input_file_path, pmesh);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
@@ -47,7 +47,7 @@ TEST_P(InputFileTest, thermal_conduction)
   MPI_Barrier(MPI_COMM_WORLD);
   std::string input_file_path =
       std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/" + GetParam() + ".lua";
-  test_utils::runThermalConductionTest(input_file_path);
+  test_utils::runModuleTest<ThermalConduction>(input_file_path);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
@@ -123,7 +123,7 @@ TEST(thermal_solver, static_amgx_solve)
   std::string input_file_path =
       std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/static_amgx_solve.lua";
   auto pmesh = buildBallMesh(10000);
-  test_utils::runThermalConductionTest(input_file_path, pmesh);
+  test_utils::runModuleTest<ThermalConduction>(input_file_path, pmesh);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 #endif

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -35,37 +35,10 @@ double InitialTemperature(const mfem::Vector& x)
 TEST(thermal_solver, static_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);
-
+  std::string input_file_path =
+      std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/static_solve.lua";
   auto pmesh = buildBallMesh(10000);
-
-  // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticOptions());
-
-  // Initialize the temperature boundary condition
-  auto u_0 = std::make_shared<mfem::FunctionCoefficient>(One);
-
-  std::set<int> temp_bdr = {1};
-
-  // Set the temperature BC in the thermal solver
-  therm_solver.setTemperatureBCs(temp_bdr, u_0);
-
-  // Set the conductivity of the thermal operator
-  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(std::move(kappa));
-
-  // Complete the setup without allocating the mass matrices and dynamic
-  // operator
-  therm_solver.completeSetup();
-
-  // Perform the static solve
-  double dt = 1.0;
-  therm_solver.advanceTimestep(dt);
-
-  // Measure the L2 norm of the solution and check the value
-  mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
-  EXPECT_NEAR(2.02263, u_norm, 0.00001);
-
+  test_utils::runThermalConductionTest(input_file_path, pmesh);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
@@ -147,39 +120,10 @@ TEST(thermal_solver_rework, dyn_imp_solve_time_varying)
 TEST(thermal_solver, static_amgx_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);
-
+  std::string input_file_path =
+      std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/static_amgx_solve.lua";
   auto pmesh = buildBallMesh(10000);
-
-  auto options                                                 = ThermalConduction::defaultQuasistaticOptions();
-  std::get<IterativeSolverOptions>(options.T_lin_options).prec = AMGXPrec{.smoother = AMGXSolver::JACOBI_L1};
-  // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, options);
-
-  // Initialize the temperature boundary condition
-  auto u_0 = std::make_shared<mfem::FunctionCoefficient>(One);
-
-  std::set<int> temp_bdr = {1};
-
-  // Set the temperature BC in the thermal solver
-  therm_solver.setTemperatureBCs(temp_bdr, u_0);
-
-  // Set the conductivity of the thermal operator
-  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(std::move(kappa));
-
-  // Complete the setup without allocating the mass matrices and dynamic
-  // operator
-  therm_solver.completeSetup();
-
-  // Perform the static solve
-  double dt = 1.0;
-  therm_solver.advanceTimestep(dt);
-
-  // Measure the L2 norm of the solution and check the value
-  mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
-  EXPECT_NEAR(2.02263, u_norm, 0.00001);
-
+  test_utils::runThermalConductionTest(input_file_path, pmesh);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 #endif

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -17,6 +17,8 @@
 
 namespace serac {
 
+using test_utils::InputFileTest;
+
 double One(const mfem::Vector& /*x*/) { return 1.0; }
 double BoundaryTemperature(const mfem::Vector& x) { return x.Norml2(); }
 double OtherBoundaryTemperature(const mfem::Vector& x) { return 2 * x.Norml2(); }
@@ -67,183 +69,19 @@ TEST(thermal_solver, static_solve)
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-TEST(thermal_solver, static_solve_multiple_bcs)
+TEST_P(InputFileTest, thermal_conduction)
 {
   MPI_Barrier(MPI_COMM_WORLD);
   std::string input_file_path =
-      std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/static_solve_multiple_bcs.lua";
+      std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/" + GetParam() + ".lua";
   test_utils::runThermalConductionTest(input_file_path);
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-TEST(thermal_solver, static_solve_repeated_bcs)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
+const std::string input_files[] = {"static_solve_multiple_bcs", "static_solve_repeated_bcs", "dyn_exp_solve",
+                                   "dyn_imp_solve"};
 
-  // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/meshes/star.mesh";
-
-  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
-
-  // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultQuasistaticOptions());
-
-  // Initialize the temperature boundary condition
-  auto u_0 = std::make_shared<mfem::FunctionCoefficient>(BoundaryTemperature);
-  auto u_1 = std::make_shared<mfem::FunctionCoefficient>(OtherBoundaryTemperature);
-
-  std::set<int> temp_bdr = {1};
-
-  // Set the temperature BC in the thermal solver
-  therm_solver.setTemperatureBCs(temp_bdr, u_0);
-  therm_solver.setTemperatureBCs(temp_bdr, u_1);
-
-  // Set the conductivity of the thermal operator
-  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(std::move(kappa));
-
-  // Complete the setup without allocating the mass matrices and dynamic
-  // operator
-  therm_solver.completeSetup();
-
-  // Perform the static solve
-  double dt = 1.0;
-  therm_solver.advanceTimestep(dt);
-
-  // Measure the L2 norm of the solution and check the value
-  mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
-  EXPECT_NEAR(2.56980679, u_norm, 0.00001);
-
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST(thermal_solver, dyn_exp_solve)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
-
-  // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/meshes/star.mesh";
-
-  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
-
-  auto options                     = ThermalConduction::defaultDynamicOptions();
-  options.dyn_options->timestepper = TimestepMethod::ForwardEuler;
-
-  // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, options);
-
-  // Initialize the state grid function
-  auto u_0 = std::make_shared<mfem::FunctionCoefficient>(InitialTemperature);
-  therm_solver.setTemperature(*u_0);
-
-  std::set<int> temp_bdr = {1};
-  therm_solver.setTemperatureBCs(temp_bdr, u_0);
-
-  // Set the conductivity of the thermal operator
-  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(std::move(kappa));
-
-  // Setup glvis output
-  therm_solver.initializeOutput(serac::OutputType::ParaView, "thermal_explicit");
-
-  // Complete the setup including the dynamic operators
-  therm_solver.completeSetup();
-
-  // Set timestep options
-  double t         = 0.0;
-  double t_final   = 0.001;
-  double dt        = 0.0001;
-  bool   last_step = false;
-
-  // Output the initial state
-  therm_solver.outputState();
-
-  for (int ti = 1; !last_step; ti++) {
-    double dt_real = std::min(dt, t_final - t);
-    t += dt_real;
-    last_step = (t >= t_final - 1e-8 * dt);
-
-    // Advance the timestep
-    therm_solver.advanceTimestep(dt_real);
-  }
-
-  // Output the final state
-  therm_solver.outputState();
-
-  // Measure the L2 norm of the solution and check the value
-  mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
-  EXPECT_NEAR(2.6493029, u_norm, 0.00001);
-
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST(thermal_solver, dyn_imp_solve)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
-
-  // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/meshes/star.mesh";
-
-  auto pmesh = buildMeshFromFile(mesh_file, 1, 1);
-
-  // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultDynamicOptions());
-
-  // Initialize the state grid function
-  auto u_0 = std::make_shared<mfem::FunctionCoefficient>(InitialTemperature);
-  therm_solver.setTemperature(*u_0);
-
-  std::set<int> temp_bdr = {1};
-  therm_solver.setTemperatureBCs(temp_bdr, u_0);
-
-  // Set the density function
-  auto rho = std::make_unique<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setDensity(std::move(rho));
-
-  // Set the specific heat capacity function
-  auto cp = std::make_unique<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setSpecificHeatCapacity(std::move(cp));
-
-  // Set the conductivity of the thermal operator
-  auto kappa = std::make_unique<mfem::ConstantCoefficient>(0.5);
-  therm_solver.setConductivity(std::move(kappa));
-
-  // Setup glvis output
-  therm_solver.initializeOutput(serac::OutputType::VisIt, "thermal_implicit");
-
-  // Complete the setup including the dynamic operators
-  therm_solver.completeSetup();
-
-  // Set timestep options
-  double t         = 0.0;
-  double t_final   = 5.0;
-  double dt        = 1.0;
-  bool   last_step = false;
-
-  // Output the initial state
-  therm_solver.outputState();
-
-  for (int ti = 1; !last_step; ti++) {
-    double dt_real = std::min(dt, t_final - t);
-    t += dt_real;
-    last_step = (t >= t_final - 1e-8 * dt);
-
-    // Advance the timestep
-    therm_solver.advanceTimestep(dt_real);
-  }
-
-  // Output the final state
-  therm_solver.outputState();
-
-  // Measure the L2 norm of the solution and check the value
-  mfem::ConstantCoefficient zero(0.0);
-  double                    u_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
-  EXPECT_NEAR(2.1806652643, u_norm, 0.00001);
-
-  MPI_Barrier(MPI_COMM_WORLD);
-}
+INSTANTIATE_TEST_SUITE_P(ThermalConductionInputFileTests, InputFileTest, ::testing::ValuesIn(input_files));
 
 TEST(thermal_solver_rework, dyn_imp_solve_time_varying)
 {

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -136,7 +136,7 @@ void defineThermalConductionInputFileSchema(axom::inlet::Inlet& inlet)
   }
 }
 
-void runThermalConductionTest(const std::string& input_file)
+void runThermalConductionTest(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh)
 {
   // Create DataStore
   axom::sidre::DataStore datastore;
@@ -147,9 +147,14 @@ void runThermalConductionTest(const std::string& input_file)
   defineThermalConductionInputFileSchema(inlet);
 
   // Build the mesh
-  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file);
-  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
+  std::shared_ptr<mfem::ParMesh> mesh;
+  if (custom_mesh) {
+    mesh = custom_mesh;
+  } else {
+    auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
+    auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file);
+    mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
+  }
 
   // Define the thermal solver object
   auto              thermal_solver_options = inlet["thermal_conduction"].get<serac::ThermalConduction::InputOptions>();

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -67,11 +67,16 @@ void defineTestSchema<ThermalConduction>(axom::inlet::Inlet& inlet)
 }
 
 namespace detail {
+
+// Utility type for use in always-false static assertions
 template <typename>
 struct AlwaysFalse {
   static constexpr bool value = false;
 };
 
+/**
+ * @brief Returns the name of the module used by the input file
+ */
 template <typename PhysicsModule>
 std::string moduleName()
 {
@@ -91,6 +96,12 @@ std::string moduleName<ThermalConduction>()
   return "thermal_conduction";
 }
 
+/**
+ * @brief Verifies the solution fields against the input file
+ * @param[in] module The module whose fields should be verified
+ * @param[in] inlet The Inlet object from which expected solution values will be obtained
+ * @param[in] dim The mesh dimension
+ */
 template <typename PhysicsModule>
 void verifyFields(const PhysicsModule&, const axom::inlet::Inlet&, const int)
 {

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -17,7 +17,8 @@ namespace serac {
 
 namespace test_utils {
 
-void defineNonlinSolidInputFileSchema(axom::inlet::Inlet& inlet)
+template <>
+void defineTestSchema<NonlinearSolid>(axom::inlet::Inlet& inlet)
 {
   // Simulation time parameters
   inlet.addDouble("dt", "Time step.");
@@ -41,79 +42,8 @@ void defineNonlinSolidInputFileSchema(axom::inlet::Inlet& inlet)
   }
 }
 
-void runNonlinSolidTest(const std::string& input_file)
-{
-  // Create DataStore
-  axom::sidre::DataStore datastore;
-
-  // Initialize Inlet and read input file
-  auto inlet = serac::input::initialize(datastore, input_file);
-
-  defineNonlinSolidInputFileSchema(inlet);
-
-  // Build the mesh
-  auto mesh_options   = inlet["main_mesh"].get<serac::mesh::InputOptions>();
-  auto full_mesh_path = serac::input::findMeshFilePath(mesh_options.relative_mesh_file_name, input_file);
-  auto mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
-
-  // Define the solid solver object
-  auto           solid_solver_options = inlet["nonlinear_solid"].get<serac::NonlinearSolid::InputOptions>();
-  NonlinearSolid solid_solver(mesh, solid_solver_options);
-
-  const bool is_dynamic = inlet["nonlinear_solid"].contains("dynamics");
-
-  if (is_dynamic) {
-    auto visc = std::make_unique<mfem::ConstantCoefficient>(0.0);
-    solid_solver.setViscosity(std::move(visc));
-  }
-
-  // Initialize the output
-  solid_solver.initializeOutput(serac::OutputType::VisIt, "nonlin_solid");
-
-  // Complete the solver setup
-  solid_solver.completeSetup();
-  // Output the initial state
-  solid_solver.outputState();
-
-  double dt = inlet["dt"];
-
-  // Check if dynamic
-  if (is_dynamic) {
-    double t       = 0.0;
-    double t_final = inlet["t_final"];
-
-    // Perform time-integration
-    // (looping over the time iterations, ti, with a time-step dt).
-    bool last_step = false;
-    for (int ti = 1; !last_step; ti++) {
-      double dt_real = std::min(dt, t_final - t);
-      t += dt_real;
-      last_step = (t >= t_final - 1e-8 * dt);
-
-      solid_solver.advanceTimestep(dt_real);
-    }
-  } else {
-    solid_solver.advanceTimestep(dt);
-  }
-
-  // Output the final state
-  solid_solver.outputState();
-
-  mfem::Vector zero(mesh->Dimension());
-  zero = 0.0;
-  mfem::VectorConstantCoefficient zerovec(zero);
-
-  if (inlet.contains("expected_x_l2norm")) {
-    double x_norm = solid_solver.displacement().gridFunc().ComputeLpError(2.0, zerovec);
-    EXPECT_NEAR(inlet["expected_x_l2norm"], x_norm, inlet["epsilon"]);
-  }
-  if (inlet.contains("expected_v_l2norm")) {
-    double v_norm = solid_solver.velocity().gridFunc().ComputeLpError(2.0, zerovec);
-    EXPECT_NEAR(inlet["expected_v_l2norm"], v_norm, inlet["epsilon"]);
-  }
-}
-
-void defineThermalConductionInputFileSchema(axom::inlet::Inlet& inlet)
+template <>
+void defineTestSchema<ThermalConduction>(axom::inlet::Inlet& inlet)
 {
   // Simulation time parameters
   inlet.addDouble("dt", "Time step.");
@@ -136,7 +66,70 @@ void defineThermalConductionInputFileSchema(axom::inlet::Inlet& inlet)
   }
 }
 
-void runThermalConductionTest(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh)
+template void defineTestSchema<NonlinearSolid>(axom::inlet::Inlet& inlet);
+template void defineTestSchema<ThermalConduction>(axom::inlet::Inlet& inlet);
+
+namespace detail {
+template <typename>
+struct AlwaysFalse {
+  static constexpr bool value = false;
+};
+
+template <typename PhysicsModule>
+std::string moduleName()
+{
+  static_assert(AlwaysFalse<PhysicsModule>::value, "Test driver is not supported for selected type");
+  return {};
+}
+
+template <>
+std::string moduleName<NonlinearSolid>()
+{
+  return "nonlinear_solid";
+}
+
+template <>
+std::string moduleName<ThermalConduction>()
+{
+  return "thermal_conduction";
+}
+
+template <typename PhysicsModule>
+void verifyFields(const PhysicsModule& module, const axom::inlet::Inlet& inlet, const int dim)
+{
+  static_assert(AlwaysFalse<PhysicsModule>::value, "Test driver is not supported for selected type");
+}
+
+template <>
+void verifyFields(const NonlinearSolid& module, const axom::inlet::Inlet& inlet, const int dim)
+{
+  mfem::Vector zero(dim);
+  zero = 0.0;
+  mfem::VectorConstantCoefficient zerovec(zero);
+
+  if (inlet.contains("expected_x_l2norm")) {
+    double x_norm = module.displacement().gridFunc().ComputeLpError(2.0, zerovec);
+    EXPECT_NEAR(inlet["expected_x_l2norm"], x_norm, inlet["epsilon"]);
+  }
+  if (inlet.contains("expected_v_l2norm")) {
+    double v_norm = module.velocity().gridFunc().ComputeLpError(2.0, zerovec);
+    EXPECT_NEAR(inlet["expected_v_l2norm"], v_norm, inlet["epsilon"]);
+  }
+}
+
+template <>
+void verifyFields(const ThermalConduction& module, const axom::inlet::Inlet& inlet, const int)
+{
+  mfem::ConstantCoefficient zero(0.0);
+  if (inlet.contains("expected_t_l2norm")) {
+    double t_norm = module.temperature().gridFunc().ComputeLpError(2.0, zero);
+    EXPECT_NEAR(inlet["expected_t_l2norm"], t_norm, inlet["epsilon"]);
+  }
+}
+}  // namespace detail
+
+template <typename PhysicsModule>
+void runModuleTest(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh)
 {
   // Create DataStore
   axom::sidre::DataStore datastore;
@@ -144,7 +137,7 @@ void runThermalConductionTest(const std::string& input_file, std::shared_ptr<mfe
   // Initialize Inlet and read input file
   auto inlet = serac::input::initialize(datastore, input_file);
 
-  defineThermalConductionInputFileSchema(inlet);
+  defineTestSchema<PhysicsModule>(inlet);
 
   // Build the mesh
   std::shared_ptr<mfem::ParMesh> mesh;
@@ -156,19 +149,21 @@ void runThermalConductionTest(const std::string& input_file, std::shared_ptr<mfe
     mesh = serac::buildMeshFromFile(full_mesh_path, mesh_options.ser_ref_levels, mesh_options.par_ref_levels);
   }
 
-  // Define the thermal solver object
-  auto              thermal_solver_options = inlet["thermal_conduction"].get<serac::ThermalConduction::InputOptions>();
-  ThermalConduction therm_solver(mesh, thermal_solver_options);
+  const std::string module_name = detail::moduleName<PhysicsModule>();
 
-  const bool is_dynamic = inlet["thermal_conduction"].contains("dynamics");
-  therm_solver.initializeOutput(serac::OutputType::GLVis, "thermal_solver");
+  // Define the solid solver object
+  auto          module_options = inlet[module_name].get<typename PhysicsModule::InputOptions>();
+  PhysicsModule module(mesh, module_options);
 
-  // Complete the setup without allocating the mass matrices and dynamic
-  // operator
-  therm_solver.completeSetup();
+  const bool is_dynamic = inlet[module_name].contains("dynamics");
 
+  // Initialize the output
+  module.initializeOutput(serac::OutputType::VisIt, module_name);
+
+  // Complete the solver setup
+  module.completeSetup();
   // Output the initial state
-  therm_solver.outputState();
+  module.outputState();
 
   double dt = inlet["dt"];
 
@@ -185,25 +180,21 @@ void runThermalConductionTest(const std::string& input_file, std::shared_ptr<mfe
       t += dt_real;
       last_step = (t >= t_final - 1e-8 * dt);
 
-      // Advance the timestep
-      therm_solver.advanceTimestep(dt_real);
+      module.advanceTimestep(dt_real);
     }
   } else {
-    // Perform the static solve
-    therm_solver.advanceTimestep(dt);
+    module.advanceTimestep(dt);
   }
 
   // Output the final state
-  therm_solver.outputState();
+  module.outputState();
 
-  mfem::ConstantCoefficient zero(0.0);
-
-  // Measure the L2 norm of the solution and check the value
-  if (inlet.contains("expected_t_l2norm")) {
-    double t_norm = therm_solver.temperature().gridFunc().ComputeLpError(2.0, zero);
-    EXPECT_NEAR(inlet["expected_t_l2norm"], t_norm, inlet["epsilon"]);
-  }
+  detail::verifyFields(module, inlet, mesh->Dimension());
 }
+
+template void runModuleTest<NonlinearSolid>(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh);
+template void runModuleTest<ThermalConduction>(const std::string&             input_file,
+                                               std::shared_ptr<mfem::ParMesh> custom_mesh);
 
 }  // end namespace test_utils
 

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -66,9 +66,6 @@ void defineTestSchema<ThermalConduction>(axom::inlet::Inlet& inlet)
   }
 }
 
-template void defineTestSchema<NonlinearSolid>(axom::inlet::Inlet& inlet);
-template void defineTestSchema<ThermalConduction>(axom::inlet::Inlet& inlet);
-
 namespace detail {
 template <typename>
 struct AlwaysFalse {
@@ -95,7 +92,7 @@ std::string moduleName<ThermalConduction>()
 }
 
 template <typename PhysicsModule>
-void verifyFields(const PhysicsModule& module, const axom::inlet::Inlet& inlet, const int dim)
+void verifyFields(const PhysicsModule&, const axom::inlet::Inlet&, const int)
 {
   static_assert(AlwaysFalse<PhysicsModule>::value, "Test driver is not supported for selected type");
 }

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -55,6 +55,7 @@ void defineTestSchema<NonlinearSolid>(axom::inlet::Inlet& inlet)
 
   // Physics
   auto& solid_solver_table = inlet.addTable("nonlinear_solid", "Finite deformation solid mechanics module");
+  // This is the "standard" schema for the actual physics module
   serac::NonlinearSolid::InputOptions::defineInputFileSchema(solid_solver_table);
 
   defineCommonTestSchema(inlet);
@@ -68,6 +69,7 @@ void defineTestSchema<ThermalConduction>(axom::inlet::Inlet& inlet)
 
   // Physics
   auto& conduction_table = inlet.addTable("thermal_conduction", "Thermal conduction module");
+  // This is the "standard" schema for the actual physics module
   serac::ThermalConduction::InputOptions::defineInputFileSchema(conduction_table);
 
   defineCommonTestSchema(inlet);

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -11,13 +11,11 @@ namespace serac {
 
 namespace test_utils {
 
-void defineNonlinSolidInputFileSchema(axom::inlet::Inlet& inlet);
+template <typename PhysicsModule>
+void defineTestSchema(axom::inlet::Inlet& inlet);
 
-void runNonlinSolidTest(const std::string& input_file);
-
-void defineThermalConductionInputFileSchema(axom::inlet::Inlet& inlet);
-
-void runThermalConductionTest(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh = {});
+template <typename PhysicsModule>
+void runModuleTest(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh = {});
 
 class InputFileTest : public ::testing::TestWithParam<std::string> {
 };

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -11,9 +11,19 @@ namespace serac {
 
 namespace test_utils {
 
+/**
+ * @brief Defines the full schema for an integration test on the provided
+ * Inlet object
+ */
 template <typename PhysicsModule>
 void defineTestSchema(axom::inlet::Inlet& inlet);
 
+/**
+ * @brief Runs a simulation and checks the output fields if "correct" answers
+ * were defined in the input file
+ * @param[in] input_file The Lua input file
+ * @param[in] custom_mesh Overrides the mesh described in the input file
+ */
 template <typename PhysicsModule>
 void runModuleTest(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh = {});
 

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -17,7 +17,7 @@ void runNonlinSolidTest(const std::string& input_file);
 
 void defineThermalConductionInputFileSchema(axom::inlet::Inlet& inlet);
 
-void runThermalConductionTest(const std::string& input_file);
+void runThermalConductionTest(const std::string& input_file, std::shared_ptr<mfem::ParMesh> custom_mesh = {});
 
 class InputFileTest : public ::testing::TestWithParam<std::string> {
 };

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -14,6 +14,10 @@ void defineNonlinSolidInputFileSchema(axom::inlet::Inlet& inlet);
 
 void runNonlinSolidTest(const std::string& input_file);
 
+void defineThermalConductionInputFileSchema(axom::inlet::Inlet& inlet);
+
+void runThermalConductionTest(const std::string& input_file);
+
 }  // end namespace test_utils
 
 }  // end namespace serac

--- a/tests/test_utilities.hpp
+++ b/tests/test_utilities.hpp
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include <gtest/gtest.h>
 #include "serac/infrastructure/input.hpp"
 
 namespace serac {
@@ -17,6 +18,9 @@ void runNonlinSolidTest(const std::string& input_file);
 void defineThermalConductionInputFileSchema(axom::inlet::Inlet& inlet);
 
 void runThermalConductionTest(const std::string& input_file);
+
+class InputFileTest : public ::testing::TestWithParam<std::string> {
+};
 
 }  // end namespace test_utils
 


### PR DESCRIPTION
This PR moves the thermal solver tests to input files.

Most of this PR is analogous to the similar PR(s) for the `NonlinearSolid` module, so I have templated the test utility functions on the physics module to reduce duplication.