### PR TITLE
Add setExternalForces method to NonlinearSolid

### DIFF
--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -165,9 +165,9 @@ void NonlinearSolid::completeSetup()
 
   // Add external forces
   for (auto& force : ext_force_coefs_) {
-    H_->AddDomainIntegrator(
-        new LinearToNonlinearFormIntegrator(std::make_shared<mfem::VectorDomainLFIntegrator>(*force),
-                                            std::make_shared<mfem::ParFiniteElementSpace>(*H_->ParFESpace())));
+    H_->AddDomainIntegrator(new serac::mfem_ext::LinearToNonlinearFormIntegrator(
+        std::make_shared<mfem::VectorDomainLFIntegrator>(*force),
+        std::make_shared<mfem::ParFiniteElementSpace>(*H_->ParFESpace())));
   }
 
   // Build the dof array lookup tables

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -119,9 +119,9 @@ void NonlinearSolid::setTractionBCs(const std::set<int>&                     tra
   bcs_.addNatural(trac_bdr, trac_bdr_coef, component);
 }
 
-void NonlinearSolid::setExternalForces(std::vector<std::shared_ptr<mfem::VectorCoefficient>> ext_force_coefs)
+void NonlinearSolid::addBodyForce(std::shared_ptr<mfem::VectorCoefficient> ext_force_coef)
 {
-  ext_force_coefs_ = ext_force_coefs;
+  ext_force_coefs_.push_back(ext_force_coef);
 }
 
 void NonlinearSolid::setHyperelasticMaterialParameters(const double mu, const double K)

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -122,6 +122,13 @@ public:
                       int component = -1);
 
   /**
+   * @brief Set the external force vectors on the domain
+   *
+   * @param[in] ext_force_coefs The sd::vector of vector-valued external force coefficients applied to the domain
+   */
+  void setExternalForces(std::vector<std::shared_ptr<mfem::VectorCoefficient>> ext_force_coefs);
+
+  /**
    * @brief Set the viscosity coefficient
    *
    * @param[in] visc_coef The abstract viscosity coefficient
@@ -267,6 +274,11 @@ protected:
    * @brief Stiffness bilinear form object
    */
   std::unique_ptr<mfem::ParNonlinearForm> H_;
+
+  /**
+   * @brief external force coefficents
+   */
+  std::vector<std::shared_ptr<mfem::VectorCoefficient>> ext_force_coefs_;
 
   /**
    * @brief zero vector of the appropriate dimensions

--- a/src/serac/physics/nonlinear_solid.hpp
+++ b/src/serac/physics/nonlinear_solid.hpp
@@ -122,11 +122,11 @@ public:
                       int component = -1);
 
   /**
-   * @brief Set the external force vectors on the domain
+   * @brief Add body force vectors on the domain
    *
-   * @param[in] ext_force_coefs The sd::vector of vector-valued external force coefficients applied to the domain
+   * @param[in] ext_force_coef Add a vector-valued external force coefficient applied to the domain
    */
-  void setExternalForces(std::vector<std::shared_ptr<mfem::VectorCoefficient>> ext_force_coefs);
+  void addBodyForce(std::shared_ptr<mfem::VectorCoefficient> ext_force_coef);
 
   /**
    * @brief Set the viscosity coefficient


### PR DESCRIPTION
This PR allows users to specify a `vector` of external forces (`VectorCoefficients`) to apply to a `NonlinearSolid`.

The forces are added to `NonlinearSolid.H_` because the `H_` operator is used both in the quasistatic and dynamic modes and will be consistent.

Instead of writing yet another nonlinearformintegrator, a `mfem::LinearformIntegrator` was wrapped as an `mfem::NonlinearformIntegrator`.