### PR TITLE
Enable a few extra compiler flags, -Wpedantic on Clang

### DIFF
--- a/cmake/SeracCompilerFlags.cmake
+++ b/cmake/SeracCompilerFlags.cmake
@@ -14,9 +14,9 @@ endif()
 # Need to add symbols to dynamic symtab in order to be visible from stacktraces
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -rdynamic")
 
-# Enable extra warnings and warnings for overshadowed variable definitions
-blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS DEFAULT "-Wshadow -Wall -Wextra")
+# Enable warnings for overshadowed variable definitions
+blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS DEFAULT "-Wshadow")
 
 # Only clang has fine-grained control over the designated initializer warnings
-# This can be removed when C++20 is available
+# This can be added to the GCC flags when C++20 is available
 blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS CLANG "-Wpedantic -Wno-c++20-designator")

--- a/cmake/SeracCompilerFlags.cmake
+++ b/cmake/SeracCompilerFlags.cmake
@@ -14,5 +14,9 @@ endif()
 # Need to add symbols to dynamic symtab in order to be visible from stacktraces
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -rdynamic")
 
-# Enable warnings for overshadowed variable definitions
-blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS DEFAULT "-Wshadow")
+# Enable extra warnings and warnings for overshadowed variable definitions
+blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS DEFAULT "-Wshadow -Wall -Wextra")
+
+# Only clang has fine-grained control over the designated initializer warnings
+# This can be removed when C++20 is available
+blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS CLANG "-Wpedantic -Wno-c++20-designator")

--- a/cmake/SeracCompilerFlags.cmake
+++ b/cmake/SeracCompilerFlags.cmake
@@ -14,8 +14,9 @@ endif()
 # Need to add symbols to dynamic symtab in order to be visible from stacktraces
 string(APPEND CMAKE_EXE_LINKER_FLAGS " -rdynamic")
 
-# Enable warnings for overshadowed variable definitions
-blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS DEFAULT "-Wshadow")
+# Enable warnings for things not covered by -Wall -Wextra
+set(_extra_flags "-Wshadow -Wdouble-promotion -Wconversion -Wundef -Wnull-dereference -Wold-style-cast")
+blt_append_custom_compiler_flag(FLAGS_VAR CMAKE_CXX_FLAGS DEFAULT ${_extra_flags})
 
 # Only clang has fine-grained control over the designated initializer warnings
 # This can be added to the GCC flags when C++20 is available

--- a/src/serac/coefficients/coefficient_extensions.cpp
+++ b/src/serac/coefficients/coefficient_extensions.cpp
@@ -80,8 +80,8 @@ mfem::Array<int> MakeBdrAttributeList(mfem::Mesh& m, mfem::Coefficient& c, std::
 double AttributeModifierCoefficient::Eval(mfem::ElementTransformation& Tr, const mfem::IntegrationPoint& ip)
 {
   // Store old attribute and change to new attribute
-  double attr  = Tr.Attribute;
-  Tr.Attribute = attr_list_[Tr.ElementNo];
+  const int attr = Tr.Attribute;
+  Tr.Attribute   = attr_list_[Tr.ElementNo];
 
   // Evaluate with new attribute
   double result = coef_.Eval(Tr, ip);

--- a/src/serac/numerics/expr_template_impl.hpp
+++ b/src/serac/numerics/expr_template_impl.hpp
@@ -70,7 +70,7 @@ using enable_if_mfem_vec = std::enable_if_t<std::is_base_of_v<mfem::Vector, std:
  * types on which pointer arithmetic can be performed.
  */
 template <typename vec>
-auto index(vec&& v, const std::size_t idx)
+auto index(vec&& v, const int idx)
 {
   if constexpr (std::is_same_v<std::decay_t<vec>, mfem::HypreParVector>) {
     return static_cast<const double*>(v)[idx];
@@ -103,11 +103,11 @@ public:
    * expression at index @p i
    * @param i The index to evaluate at
    */
-  double operator[](size_t i) const { return op_(index(v_, i)); }
+  double operator[](int i) const { return op_(index(v_, i)); }
   /**
    * @brief Returns the size of the vector expression
    */
-  size_t Size() const { return v_.Size(); }
+  int Size() const { return v_.Size(); }
 
 private:
   const vec_t<vec> v_;
@@ -190,20 +190,19 @@ public:
   BinaryVectorExpr(vec_arg_t<lhs> u, vec_arg_t<rhs> v)
       : u_(std::forward<vec_t<lhs>>(u)), v_(std::forward<vec_t<rhs>>(v))
   {
-    // MFEM uses int to represent a size type, so cast to size_t for consistency
-    SLIC_ERROR_IF(static_cast<std::size_t>(u_.Size()) != static_cast<std::size_t>(v_.Size()),
-                  "Vector sizes in binary operation must be equal");
+    // MFEM uses int to represent a size type, so cast to int for consistency
+    SLIC_ERROR_IF(u_.Size() != v_.Size(), "Vector sizes in binary operation must be equal");
   }
   /**
    * @brief Returns the fully evaluated value for the vector
    * expression at index @p i
    * @param i The index to evaluate at
    */
-  double operator[](size_t i) const { return op_(index(u_, i), index(v_, i)); }
+  double operator[](int i) const { return op_(index(u_, i), index(v_, i)); }
   /**
    * @brief Returns the size of the vector expression
    */
-  size_t Size() const { return v_.Size(); }
+  int Size() const { return v_.Size(); }
 
 private:
   const vec_t<lhs> u_;
@@ -249,11 +248,11 @@ public:
    * expression at index @p i
    * @param i The index to evaluate at
    */
-  double operator[](size_t i) const { return result_[i]; }
+  double operator[](int i) const { return result_[i]; }
   /**
    * @brief Returns the size of the vector expression
    */
-  size_t Size() const { return result_.Size(); }
+  int Size() const { return result_.Size(); }
 
 private:
   mfem::Vector result_;

--- a/src/serac/numerics/vector_expression.hpp
+++ b/src/serac/numerics/vector_expression.hpp
@@ -29,12 +29,12 @@ public:
    * expression at index @p i
    * @param i The index to evaluate at
    */
-  double operator[](size_t i) const { return asDerived()[i]; }
+  double operator[](int i) const { return asDerived()[i]; }
 
   /**
    * @brief Returns the size of the vector expression
    */
-  size_t Size() const { return asDerived().Size(); }
+  int Size() const { return asDerived().Size(); }
 
   /**
    * @brief Implicit conversion operator for fully evaluating
@@ -44,7 +44,7 @@ public:
   operator mfem::Vector() const
   {
     mfem::Vector result(Size());
-    for (size_t i = 0; i < Size(); i++) {
+    for (int i = 0; i < Size(); i++) {
       result[i] = (*this)[i];
     }
     return result;
@@ -85,52 +85,11 @@ mfem::Vector evaluate(const VectorExpr<T>& expr)
 template <typename T>
 void evaluate(const VectorExpr<T>& expr, mfem::Vector& result)
 {
-  SLIC_ERROR_IF(expr.Size() != static_cast<std::size_t>(result.Size()),
-                "Vector sizes in expression assignment must be equal");
+  SLIC_ERROR_IF(expr.Size() != result.Size(), "Vector sizes in expression assignment must be equal");
   // Get the underlying array for indexing compatibility with mfem::HypreParVector
   double* result_arr = result;
-  for (size_t i = 0; i < expr.Size(); i++) {
+  for (int i = 0; i < expr.Size(); i++) {
     result_arr[i] = expr[i];
-  }
-}
-
-/**
- * @brief Fully evaluates a vector expression into an actual mfem::Vector
- * @param expr The expression to evaluate
- * @param vec The vector to populate with the expression result
- * @param comm The MPI_Comm to use for parallel evaluation
- * @note The performance in a release build is comparable to the serial
- * implementation, though because this populates the vector on all ranks
- * the cost of the data copies may exceed any parallelization benefit
- * for the actual calculation
- */
-template <typename T>
-void evaluate(const VectorExpr<T>& expr, mfem::Vector& result, MPI_Comm comm)
-{
-  const auto SIZE = expr.Size();
-  SLIC_ERROR_IF(SIZE != static_cast<std::size_t>(result.Size()), "Vector sizes in expression assignment must be equal");
-  int num_procs = 0;
-  int rank      = 0;
-  MPI_Comm_size(comm, &num_procs);
-  MPI_Comm_rank(comm, &rank);
-
-  double* result_arr = result;
-
-  // If the array size is not divisible by # elements, add one
-  const long long per_proc = (SIZE / num_procs) + ((SIZE % num_procs != 0) ? 1 : 0);
-
-  // Truncate the number of elements for the last process
-  const long long n_entries = (rank == num_procs - 1) ? SIZE - ((num_procs - 1) * per_proc) : per_proc;
-
-  // Fill in this rank's segment of the vector
-  for (long long i = 0; i < n_entries; i++) {
-    result_arr[i + (per_proc * rank)] = expr[i + (per_proc * rank)];
-  }
-
-  // Transmit each segment of the vector to all the other processes
-  for (int i = 0; i < num_procs; i++) {
-    const long long n_ele = (i == num_procs - 1) ? SIZE - ((num_procs - 1) * per_proc) : per_proc;
-    MPI_Bcast(&result_arr[per_proc * i], n_ele, MPI_DOUBLE, i, comm);
   }
 }
 

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -26,7 +26,7 @@ BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh)
 BasePhysics::BasePhysics(std::shared_ptr<mfem::ParMesh> mesh, int n, int p) : BasePhysics(mesh)
 {
   order_ = p;
-  gf_initialized_.assign(n, false);
+  gf_initialized_.assign(static_cast<std::size_t>(n), false);
 }
 
 void BasePhysics::setTrueDofs(const mfem::Array<int>& true_dofs, serac::GeneralCoefficient ess_bdr_coef, int component)

--- a/src/serac/physics/utilities/equation_solver.cpp
+++ b/src/serac/physics/utilities/equation_solver.cpp
@@ -110,7 +110,7 @@ private:
 std::ostream& operator<<(std::ostream& out, const JSONTable& table)
 {
   out << "{";
-  std::string indent(table.depth_ * 2, ' ');  // Double-space indenting
+  std::string indent(static_cast<std::size_t>(table.depth_) * 2, ' ');  // Double-space indenting
   char        sep = ' ';                      // Start with empty separator to avoid trailing comma
   for (const auto& [key, val] : table.literals_) {
     out << sep << "\n" << indent << "\"" << key << "\": ";

--- a/tests/benchmark_expr_templates.cpp
+++ b/tests/benchmark_expr_templates.cpp
@@ -180,25 +180,6 @@ static void BM_large_expr_single_alloc_EXPR(benchmark::State& state)
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-static void BM_large_expr_single_alloc_par_EXPR(benchmark::State& state)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
-
-  // Number of rows is the argument that varies
-  const int rows  = state.range(0);
-  auto [lhs, rhs] = sample_vectors(rows);
-
-  mfem::Vector expr_result(rows);
-
-  for (auto _ : state) {
-    // This code gets timed
-    evaluate(lhs + rhs + lhs + rhs + lhs + rhs + lhs + rhs + lhs + rhs + lhs + rhs + lhs + rhs, expr_result,
-             MPI_COMM_WORLD);
-  }
-
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
 static void BM_large_expr_single_alloc_hypre_par_EXPR(benchmark::State& state)
 {
   MPI_Barrier(MPI_COMM_WORLD);
@@ -229,7 +210,6 @@ BENCHMARK(BM_large_expr_MFEM)->RangeMultiplier(2)->Range(10, 10 << 10);
 BENCHMARK(BM_large_expr_single_alloc_EXPR)->RangeMultiplier(2)->Range(10, 10 << 10);
 
 // Too slow
-BENCHMARK(BM_large_expr_single_alloc_par_EXPR)->RangeMultiplier(2)->Range(10, 10 << 5);
 BENCHMARK(BM_large_expr_single_alloc_hypre_par_EXPR)->RangeMultiplier(2)->Range(10, 10 << 10);
 
 //------------------------------------------------------------------------------

--- a/tests/expr_templates.cpp
+++ b/tests/expr_templates.cpp
@@ -67,7 +67,7 @@ TEST(expr_templates, basic_add)
   mfem::Vector expr_result = lhs + rhs;
 
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -93,7 +93,7 @@ TEST(expr_templates, basic_add_hyprepar)
   double* expr_local = expr_result;
 
   for (int i = 0; i < expr_result.Size(); i++) {
-    EXPECT_FLOAT_EQ(mfem_local[i], expr_local[i]);
+    EXPECT_DOUBLE_EQ(mfem_local[i], expr_local[i]);
   }
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -117,7 +117,7 @@ TEST(expr_templates, basic_div)
   mfem::Vector expr_result = a / scalar;
 
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
 
   // Dividing a scalar by a vector
@@ -129,7 +129,7 @@ TEST(expr_templates, basic_div)
   expr_result = scalar / a;
 
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -149,7 +149,7 @@ TEST(expr_templates, basic_add_lambda)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -173,7 +173,7 @@ TEST(expr_templates, subtraction_not_commutative)
   mfem::Vector result1 = a + c - b;  // Parsed as (a + c) - b
   mfem::Vector result2 = c - b + a;  // Parsed as (c - b) + a
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(result1[i], result2[i]);
+    EXPECT_DOUBLE_EQ(result1[i], result2[i]);
   }
 
   mfem::Vector result3 = a - c;
@@ -205,7 +205,7 @@ TEST(expr_templates, subtraction_not_commutative_rvalue)
   mfem::Vector resulta1 = c - a - b;
   mfem::Vector resulta2 = fext(0.0) - a - b;
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(resulta1[i], resulta2[i]);
+    EXPECT_DOUBLE_EQ(resulta1[i], resulta2[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -219,7 +219,7 @@ TEST(expr_templates, addition_commutative)
   mfem::Vector result1 = a + b;
   mfem::Vector result2 = b + a;
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(result1[i], result2[i]);
+    EXPECT_DOUBLE_EQ(result1[i], result2[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -238,7 +238,7 @@ TEST(expr_templates, scalar_mult_commutative)
   mfem::Vector result1 = scalar * a;
   mfem::Vector result2 = a * scalar;
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(result1[i], result2[i]);
+    EXPECT_DOUBLE_EQ(result1[i], result2[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -261,7 +261,7 @@ TEST(expr_templates, move_from_temp_lambda)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -284,7 +284,7 @@ TEST(expr_templates, move_from_temp_vec_lambda)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < size; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -303,7 +303,7 @@ TEST(expr_templates, small_matvec)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < rows; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -333,7 +333,7 @@ TEST(expr_templates, small_mixed_expr)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < rows; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -363,7 +363,7 @@ TEST(expr_templates, small_mixed_expr_single_alloc)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < rows; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -392,7 +392,7 @@ TEST(expr_templates, large_mixed_expr)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < rows; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }
@@ -423,7 +423,7 @@ TEST(expr_templates, complex_expr_lambda)
 
   EXPECT_EQ(mfem_result.Size(), expr_result.Size());
   for (int i = 0; i < rows; i++) {
-    EXPECT_FLOAT_EQ(mfem_result[i], expr_result[i]);
+    EXPECT_DOUBLE_EQ(mfem_result[i], expr_result[i]);
   }
   MPI_Barrier(MPI_COMM_WORLD);
 }

--- a/tests/mfem_ex9p_blockilu.cpp
+++ b/tests/mfem_ex9p_blockilu.cpp
@@ -501,7 +501,7 @@ int main(int argc, char* argv[])
       *u = *U;
 
       if (myid == 0) {
-        EXPECT_FLOAT_EQ(u->Norml2(), UNMODIFIED_SOLN.at(static_cast<std::size_t>(ti / vis_steps) - 1));
+        EXPECT_DOUBLE_EQ(u->Norml2(), UNMODIFIED_SOLN.at(static_cast<std::size_t>(ti / vis_steps) - 1));
       }
 
       if (visualization) {

--- a/tests/mfem_ex9p_blockilu.cpp
+++ b/tests/mfem_ex9p_blockilu.cpp
@@ -501,7 +501,7 @@ int main(int argc, char* argv[])
       *u = *U;
 
       if (myid == 0) {
-        EXPECT_FLOAT_EQ(u->Norml2(), UNMODIFIED_SOLN.at((ti / vis_steps) - 1));
+        EXPECT_FLOAT_EQ(u->Norml2(), UNMODIFIED_SOLN.at(static_cast<std::size_t>(ti / vis_steps) - 1));
       }
 
       if (visualization) {

--- a/tests/serac_cuda_smoketest.cpp
+++ b/tests/serac_cuda_smoketest.cpp
@@ -47,5 +47,5 @@ TEST(cuda_smoketest, vec_add)
 
   vector_add(out, a, b, N);
 
-  std::for_each(out, out + N, [](const float f) { EXPECT_FLOAT_EQ(f, 6.0); });
+  std::for_each(out, out + N, [](const float f) { EXPECT_DOUBLE_EQ(f, 6.0); });
 }

--- a/tests/serac_input.cpp
+++ b/tests/serac_input.cpp
@@ -46,7 +46,7 @@ TEST_F(InputTest, vec_1d)
   input::defineVectorInputFileSchema(vec_table);
   auto vec = vec_table.get<mfem::Vector>();
   EXPECT_EQ(vec.Size(), 1);
-  EXPECT_FLOAT_EQ(vec(0), 4.75);
+  EXPECT_DOUBLE_EQ(vec(0), 4.75);
 }
 
 TEST_F(InputTest, vec_2d)
@@ -56,8 +56,8 @@ TEST_F(InputTest, vec_2d)
   input::defineVectorInputFileSchema(vec_table);
   auto vec = vec_table.get<mfem::Vector>();
   EXPECT_EQ(vec.Size(), 2);
-  EXPECT_FLOAT_EQ(vec(0), 4.75);
-  EXPECT_FLOAT_EQ(vec(1), 6.81);
+  EXPECT_DOUBLE_EQ(vec(0), 4.75);
+  EXPECT_DOUBLE_EQ(vec(1), 6.81);
 }
 
 TEST_F(InputTest, vec_3d)
@@ -67,9 +67,9 @@ TEST_F(InputTest, vec_3d)
   input::defineVectorInputFileSchema(vec_table);
   auto vec = vec_table.get<mfem::Vector>();
   EXPECT_EQ(vec.Size(), 3);
-  EXPECT_FLOAT_EQ(vec(0), 4.75);
-  EXPECT_FLOAT_EQ(vec(1), 6.81);
-  EXPECT_FLOAT_EQ(vec(2), -8.33);
+  EXPECT_DOUBLE_EQ(vec(0), 4.75);
+  EXPECT_DOUBLE_EQ(vec(1), 6.81);
+  EXPECT_DOUBLE_EQ(vec(2), -8.33);
 }
 
 TEST_F(InputTest, coef_build_scalar)
@@ -86,7 +86,7 @@ TEST_F(InputTest, coef_build_scalar)
   test_vec(2)                 = 3;
   const auto& func            = std::get<input::CoefficientInputOptions::ScalarFunc>(coef_opts.func);
   auto        expected_result = test_vec(1) * 2 + test_vec(2);
-  EXPECT_FLOAT_EQ(func(test_vec), expected_result);
+  EXPECT_DOUBLE_EQ(func(test_vec), expected_result);
   EXPECT_NO_THROW(coef_opts.constructScalar());
 }
 
@@ -118,7 +118,7 @@ TEST_F(InputTest, coef_build_vector)
   mfem::Vector result(3);
   func(test_vec, result);
   for (int i = 0; i < result.Size(); i++) {
-    EXPECT_FLOAT_EQ(result[i], expected_result[i]);
+    EXPECT_DOUBLE_EQ(result[i], expected_result[i]);
   }
   EXPECT_NO_THROW(coef_opts.constructVector());
 }


### PR DESCRIPTION
Resolves #352

Turning on `-Wconversion` required a few changes to the expression templates as `mfem::Vector` uses `int` for indices and sizes.

I also removed the MPI-parallel expression template evaluation outside of a `HypreParVector` that I had experimented with a few months back, as it's really too slow to be practical.