### PR TITLE
hotfix: push back AMGX to specific commit

### DIFF
--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda.cmake
@@ -53,7 +53,7 @@ set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rele
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_02_01_09_06_11/clang-10.0.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_02_10_08_19_49/clang-10.0.1" CACHE PATH "")
 
 set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1-cuda.cmake
@@ -53,7 +53,7 @@ set(MPIEXEC_EXECUTABLE "/usr/tce/packages/spectrum-mpi/spectrum-mpi-rolling-rele
 #---------------------------------------
 # Library Dependencies
 #---------------------------------------
-set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_02_01_09_09_41/clang-10.0.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_02_10_09_12_32/clang-10.0.1" CACHE PATH "")
 
 set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 

--- a/scripts/spack/packages/amgx/package.py
+++ b/scripts/spack/packages/amgx/package.py
@@ -22,7 +22,7 @@ class Amgx(CMakePackage, CudaPackage):
 
     maintainers = ['js947']
     # SERAC EDIT BEGIN
-    version('2.1.x', branch='v2.1.x')
+    version('2.1.x', commit='c5405f3f18fbe278292ed0226d970992857e266f')
     # SERAC EDIT END
     version('2.1.0', sha256='6245112b768a1dc3486b2b3c049342e232eb6281a6021fffa8b20c11631f63cc')
     version('2.0.1', sha256='6f9991f1836fbf4ba2114ce9f49febd0edc069a24f533bd94fd9aa9be72435a7')


### PR DESCRIPTION
This appears to the the cause of recent CI build failures.  

https://github.com/NVIDIA/AMGX/commit/12f80caffedece37a230d620eabe039cfbaedf6f is the last known good commit, I have not attempted to bisect it but it is broken by https://github.com/NVIDIA/AMGX/commit/256956fb956343e599a18073143101ddbdd38777.

Looking at the diff here: https://github.com/NVIDIA/AMGX/compare/v2.1.x, I'm not sure which one could have broken this.

Here's the error message:
```
12: Caught amgx exception: Cannot allocate device memory
12:  at: base/src/global_thread_handle.cu:407
12: Stack trace:
12:  tests/serac_thermal_solver : amgx::memory::DeviceMemoryPool::DeviceMemoryPool(unsigned long, unsigned long, unsigned long)+0x2c8
12:  tests/serac_thermal_solver : amgx::allocate_resources(unsigned long, unsigned long, unsigned long, unsigned long, unsigned long)+0xa4
12:  tests/serac_thermal_solver : amgx::Resources::Resources(amgx::AMG_Configuration*, void*, int, int const*)+0x6cc
12:  tests/serac_thermal_solver : amgx::CWrapHandle<AMGX_resources_handle_struct*, amgx::Resources>* amgx::(anonymous namespace)::create_managed_object<amgx::Resources, AMGX_resources_handle_struct*, amgx::AMG_Configuration*, void*, int, int const*>(AMGX_resources_handle_struct**, amgx::AMG_Configuration*, void*, int, int const*)+0x8c
12:  tests/serac_thermal_solver : AMGX_resources_create()+0xb4
12:  tests/serac_thermal_solver : mfem::AmgXSolver::InitAmgX()+0x31c
12:  tests/serac_thermal_solver : mfem::AmgXSolver::InitExclusiveGPU(ompi_communicator_t* const&)+0xb0
12:  tests/serac_thermal_solver : serac::mfem_ext::detail::configureAMGX(ompi_communicator_t*, serac::AMGXPrec const&)+0x56c
12:  tests/serac_thermal_solver : serac::mfem_ext::EquationSolver::BuildIterativeLinearSolver(ompi_communicator_t*, serac::IterativeSolverOptions const&)+0x664
12:  tests/serac_thermal_solver : serac::mfem_ext::EquationSolver::EquationSolver(ompi_communicator_t*, std::variant<serac::IterativeSolverOptions, serac::CustomSolverOptions, serac::DirectSolverOptions> const&, std::optional<serac::NonlinearSolverOptions> const&)+0x10c
12:  tests/serac_thermal_solver : serac::ThermalConduction::ThermalConduction(int, std::shared_ptr<mfem::ParMesh>, serac::ThermalConduction::SolverOptions const&)+0x45c
12:  tests/serac_thermal_solver : serac::ThermalConduction::ThermalConduction(std::shared_ptr<mfem::ParMesh>, serac::ThermalConduction::InputOptions const&)+0x64
12:  tests/serac_thermal_solver : void serac::test_utils::runModuleTest<serac::ThermalConduction>(std::string const&, std::shared_ptr<mfem::ParMesh>)+0x3d0
12:  tests/serac_thermal_solver : serac::thermal_solver_static_amgx_solve_Test::TestBody()+0xbc
12:  tests/serac_thermal_solver : void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0xb4
12:  tests/serac_thermal_solver : void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x7c
12:  tests/serac_thermal_solver : testing::Test::Run()+0x120
12:  tests/serac_thermal_solver : testing::TestInfo::Run()+0x148
12:  tests/serac_thermal_solver : testing::TestSuite::Run()+0x18c
12:  tests/serac_thermal_solver : testing::internal::UnitTestImpl::RunAllTests()+0x52c
12:  tests/serac_thermal_solver : bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)+0xb4
12:  tests/serac_thermal_solver : bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*)+0x7c
12:  tests/serac_thermal_solver : testing::UnitTest::Run()+0x114
12:  tests/serac_thermal_solver : RUN_ALL_TESTS()+0x28
12:  tests/serac_thermal_solver : main()+0x64
12:  /lib64/libc.so.6 : ()+0x25300
12:  /lib64/libc.so.6 : __libc_start_main()+0xc4
```