### PR TITLE
Add system zlib to the ubuntu configs

### DIFF
--- a/scripts/spack/configs/linux_ubuntu_18/packages.yaml
+++ b/scripts/spack/configs/linux_ubuntu_18/packages.yaml
@@ -75,11 +75,6 @@ packages:
     externals:
     - spec: openblas
       prefix: /usr/lib/x86_64-linux-gnu/
-  zlib:
-    buildable: false
-    externals:
-    - spec: zlib
-      prefix: /usr
 
   # Lock in versions of Devtools
   cmake:

--- a/scripts/spack/configs/linux_ubuntu_18/packages.yaml
+++ b/scripts/spack/configs/linux_ubuntu_18/packages.yaml
@@ -75,6 +75,11 @@ packages:
     externals:
     - spec: openblas
       prefix: /usr/lib/x86_64-linux-gnu/
+  zlib:
+    buildable: false
+    externals:
+    - spec: zlib
+      prefix: /usr
 
   # Lock in versions of Devtools
   cmake:

--- a/scripts/spack/configs/linux_ubuntu_20/packages.yaml
+++ b/scripts/spack/configs/linux_ubuntu_20/packages.yaml
@@ -66,6 +66,11 @@ packages:
     externals:
     - spec: openblas
       prefix: /usr/lib/x86_64-linux-gnu/
+  zlib:
+    buildable: false
+    externals:
+    - spec: zlib
+      prefix: /usr
 
   # Lock in versions of Devtools
   cmake:


### PR DESCRIPTION
This uses the system-level zlib for the Ubuntu builds. This came up as one of our dependencies was using the system zlib while others were using the spack-built one.