### PR TITLE
Move time-varying thermal test to Inlet

### DIFF
--- a/data/input_files/tests/thermal_conduction/dyn_imp_solve_time_varying.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_imp_solve_time_varying.lua
@@ -1,0 +1,77 @@
+-- by construction, f(x, y, t) satisfies df_dt == d2f_dx2 + d2f_dy2
+temp_func = function (v, t)
+    return 1.0 + 6.0 * v.x * t - 2.0 * v.y * t + (v.x - v.y) * v.x * v.x
+end
+
+-- Comparison information
+epsilon = 0.00005
+
+exact_solution = {
+    scalar_function = temp_func
+}
+
+-- Simulation time parameters
+dt      = 0.5
+t_final = 5.0
+
+-- Simulation output format
+output_type = "VisIt"
+
+main_mesh = {
+    type = "file",
+    -- mesh file
+    mesh = "../../../meshes/star.mesh",
+    -- serial and parallel refinement levels
+    ser_ref_levels = 2,
+    par_ref_levels = 1,
+}
+
+-- Solver parameters
+thermal_conduction = {
+    stiffness_solver = {
+        linear = {
+            type = "iterative",
+            iterative_options = {
+                rel_tol     = 1.0e-6,
+                abs_tol     = 1.0e-12,
+                max_iter    = 200,
+                print_level = 0,
+                solver_type = "cg",
+                prec_type   = "JacobiSmoother",
+            },
+        },
+
+        nonlinear = {
+            rel_tol     = 1.0e-4,
+            abs_tol     = 1.0e-8,
+            max_iter    = 500,
+            print_level = 1,
+        },
+    },
+
+    dynamics = {
+        timestepper = "BackwardEuler",
+        enforcement_method = "RateControl",
+    },
+
+    -- polynomial interpolation order
+    order = 2,
+
+    -- material parameters
+    kappa = 1.0,
+    -- rho = 0.5,
+    -- cp = 0.5,
+
+    -- initial conditions
+    initial_temperature = {
+        scalar_function = temp_func
+    },
+
+    -- boundary condition parameters
+    boundary_conds = {
+        ['temperature'] = {
+            attrs = {1},
+            scalar_function = temp_func
+        },
+    },
+}

--- a/data/input_files/tests/thermal_conduction/dyn_imp_solve_time_varying.lua
+++ b/data/input_files/tests/thermal_conduction/dyn_imp_solve_time_varying.lua
@@ -59,8 +59,6 @@ thermal_conduction = {
 
     -- material parameters
     kappa = 1.0,
-    -- rho = 0.5,
-    -- cp = 0.5,
 
     -- initial conditions
     initial_temperature = {

--- a/src/serac/physics/utilities/equation_solver.cpp
+++ b/src/serac/physics/utilities/equation_solver.cpp
@@ -454,7 +454,7 @@ NonlinearSolverOptions FromInlet<NonlinearSolverOptions>::operator()(const axom:
 EquationSolver FromInlet<EquationSolver>::operator()(const axom::inlet::Table& base)
 {
   auto lin = base["linear"].get<LinearSolverOptions>();
-  if (base.hasTable("nonlinear")) {
+  if (base.contains("nonlinear")) {
     auto nonlin = base["nonlinear"].get<NonlinearSolverOptions>();
     return EquationSolver(MPI_COMM_WORLD, lin, nonlin);
   }

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -21,19 +21,6 @@ namespace serac {
 
 using test_utils::InputFileTest;
 
-double One(const mfem::Vector& /*x*/) { return 1.0; }
-double BoundaryTemperature(const mfem::Vector& x) { return x.Norml2(); }
-double OtherBoundaryTemperature(const mfem::Vector& x) { return 2 * x.Norml2(); }
-
-double InitialTemperature(const mfem::Vector& x)
-{
-  if (x.Norml2() < 0.5) {
-    return 2.0;
-  } else {
-    return 1.0;
-  }
-}
-
 TEST(thermal_solver, static_solve)
 {
   MPI_Barrier(MPI_COMM_WORLD);

--- a/tests/serac_thermal_solver.cpp
+++ b/tests/serac_thermal_solver.cpp
@@ -54,69 +54,9 @@ TEST_P(InputFileTest, thermal_conduction)
 }
 
 const std::string input_files[] = {"static_solve_multiple_bcs", "static_solve_repeated_bcs", "dyn_exp_solve",
-                                   "dyn_imp_solve"};
+                                   "dyn_imp_solve", "dyn_imp_solve_time_varying"};
 
 INSTANTIATE_TEST_SUITE_P(ThermalConductionInputFileTests, InputFileTest, ::testing::ValuesIn(input_files));
-
-TEST(thermal_solver_rework, dyn_imp_solve_time_varying)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
-
-  // Open the mesh
-  std::string mesh_file = std::string(SERAC_REPO_DIR) + "/data/meshes/star.mesh";
-
-  auto pmesh = buildMeshFromFile(mesh_file, 2, 1);
-
-  // Initialize the second order thermal solver on the parallel mesh
-  ThermalConduction therm_solver(2, pmesh, ThermalConduction::defaultDynamicOptions());
-
-  // by construction, f(x, y, t) satisfies df_dt == d2f_dx2 + d2f_dy2
-  auto f = std::make_shared<mfem::FunctionCoefficient>([](const mfem::Vector& x, double t) {
-    return 1.0 + 6.0 * x[0] * t - 2.0 * x[1] * t + (x[0] - x[1]) * x[0] * x[0];
-  });
-
-  therm_solver.setTemperature(*f);
-
-  std::set<int> temp_bdr = {1};
-  therm_solver.setTemperatureBCs(temp_bdr, f);
-
-  // Set the conductivity of the thermal operator
-  auto kappa = std::make_unique<mfem::ConstantCoefficient>(1.0);
-  therm_solver.setConductivity(std::move(kappa));
-
-  // Setup glvis output
-  therm_solver.initializeOutput(serac::OutputType::VisIt, "thermal_implicit");
-
-  // Complete the setup including the dynamic operators
-  therm_solver.completeSetup();
-
-  // Set timestep options
-  double t         = 0.0;
-  double t_final   = 5.0;
-  double dt        = 0.5;
-  bool   last_step = false;
-
-  // Output the initial state
-  therm_solver.outputState();
-
-  for (int ti = 1; !last_step; ti++) {
-    double dt_real = std::min(dt, t_final - t);
-    t += dt_real;
-    last_step = (t >= t_final - 1e-8 * dt);
-
-    // Advance the timestep
-    therm_solver.advanceTimestep(dt_real);
-  }
-
-  // Output the final state
-  therm_solver.outputState();
-
-  f->SetTime(t);
-  double error = therm_solver.temperature().gridFunc().ComputeLpError(2.0, *f);
-  EXPECT_NEAR(0.0, error, 0.00005);
-
-  MPI_Barrier(MPI_COMM_WORLD);
-}
 
 #ifdef MFEM_USE_AMGX
 TEST(thermal_solver, static_amgx_solve)

--- a/tests/test_utilities.cpp
+++ b/tests/test_utilities.cpp
@@ -65,6 +65,9 @@ void defineTestSchema<ThermalConduction>(axom::inlet::Inlet& inlet)
   // Integration test parameters
   inlet.addDouble("expected_t_l2norm", "Correct L2 norm of the temperature field");
 
+  auto& exact = inlet.addTable("exact_solution", "Exact solution for the temperature field");
+  serac::input::CoefficientInputOptions::defineInputFileSchema(exact);
+
   // Physics
   auto& conduction_table = inlet.addTable("thermal_conduction", "Thermal conduction module");
   // This is the "standard" schema for the actual physics module
@@ -139,6 +142,13 @@ void verifyFields(const ThermalConduction& phys_module, const axom::inlet::Inlet
   if (inlet.contains("expected_t_l2norm")) {
     double t_norm = phys_module.temperature().gridFunc().ComputeLpError(2.0, zero);
     EXPECT_NEAR(inlet["expected_t_l2norm"], t_norm, inlet["epsilon"]);
+  }
+
+  if (inlet.contains("exact_solution")) {
+    auto   coef_options = inlet["exact_solution"].get<serac::input::CoefficientInputOptions>();
+    auto   exact        = coef_options.constructScalar();
+    double error        = module.temperature().gridFunc().ComputeLpError(2.0, exact);
+    EXPECT_NEAR(error, 0.0, inlet["epsilon"]);
   }
 }
 }  // namespace detail


### PR DESCRIPTION
This is sort of a follow-up to #363 in that it integrates the new custom function signatures from Inlet.

I also "borrowed" the very useful exact solution checking logic from #373 