### PR TITLE
Move the SLIC calls back to ROOT

### DIFF
--- a/src/serac/infrastructure/accelerator.cpp
+++ b/src/serac/infrastructure/accelerator.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<mfem::Device> device;
 
 void initializeDevice()
 {
-  SLIC_ERROR_IF(device, "serac::accelerator::initializeDevice cannot be called more than once");
+  SLIC_ERROR_ROOT_IF(device, "serac::accelerator::initializeDevice cannot be called more than once");
   device = std::make_unique<mfem::Device>();
 #ifdef MFEM_USE_CUDA
   device->Configure("cuda");

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -59,7 +59,7 @@ std::string fullDirectoryFromPath(const std::string& path)
   char  actualpath[PATH_MAX + 1];
   char* ptr = realpath(path.c_str(), actualpath);
   if (ptr == nullptr) {
-    SLIC_ERROR("Failed to find absolute path from input file.");
+    SLIC_ERROR_ROOT("Failed to find absolute path from input file.");
   }
   std::string dir;
   axom::utilities::filesystem::getDirName(dir, std::string(actualpath));
@@ -95,7 +95,7 @@ bool CoefficientInputOptions::isVector() const
 
 std::unique_ptr<mfem::VectorCoefficient> CoefficientInputOptions::constructVector(const int dim) const
 {
-  SLIC_ERROR_IF(!isVector(), "Cannot construct a vector coefficient from scalar input");
+  SLIC_ERROR_ROOT_IF(!isVector(), "Cannot construct a vector coefficient from scalar input");
 
   if (vector_function) {
     return std::make_unique<mfem::VectorFunctionCoefficient>(dim, vector_function);
@@ -135,7 +135,7 @@ std::unique_ptr<mfem::VectorCoefficient> CoefficientInputOptions::constructVecto
 
 std::unique_ptr<mfem::Coefficient> CoefficientInputOptions::constructScalar() const
 {
-  SLIC_ERROR_IF(isVector(), "Cannot construct a scalar coefficient from vector input");
+  SLIC_ERROR_ROOT_IF(isVector(), "Cannot construct a scalar coefficient from vector input");
 
   if (scalar_function) {
     return std::make_unique<mfem::FunctionCoefficient>(scalar_function);
@@ -159,7 +159,7 @@ std::unique_ptr<mfem::Coefficient> CoefficientInputOptions::constructScalar() co
     return std::make_unique<mfem::PWConstCoefficient>(pw_constants);
 
   } else {
-    SLIC_ERROR(
+    SLIC_ERROR_ROOT(
         "Trying to build a scalar coefficient without specifying a scalar_function, constant, or piecewise_constant.");
     return nullptr;
   }
@@ -294,10 +294,10 @@ serac::input::CoefficientInputOptions FromInlet<serac::input::CoefficientInputOp
     }
   }
 
-  SLIC_ERROR_IF(coefficient_definitions > 1,
-                "Coefficient has multiple definitions. Please use only one of (constant, vector_constant, "
-                "piecewise_constant, vector_piecewise_constant, scalar_function, vector_function");
-  SLIC_ERROR_IF(coefficient_definitions == 0, "Coefficient definition does not contain known type.");
+  SLIC_ERROR_ROOT_IF(coefficient_definitions > 1,
+                     "Coefficient has multiple definitions. Please use only one of (constant, vector_constant, "
+                     "piecewise_constant, vector_piecewise_constant, scalar_function, vector_function");
+  SLIC_ERROR_ROOT_IF(coefficient_definitions == 0, "Coefficient definition does not contain known type.");
 
   return result;
 }

--- a/src/serac/infrastructure/profiling.cpp
+++ b/src/serac/infrastructure/profiling.cpp
@@ -28,7 +28,7 @@ void initializeCaliper(const std::string& options)
   if (check_result.empty()) {
     mgr->add(options.c_str());
   } else {
-    SLIC_WARNING("Caliper options invalid, ignoring: " << check_result);
+    SLIC_WARNING_ROOT("Caliper options invalid, ignoring: " << check_result);
   }
   // Defaults, should probably always be enabled
   mgr->add("event-trace, runtime-report");

--- a/src/serac/numerics/mesh_utils.cpp
+++ b/src/serac/numerics/mesh_utils.cpp
@@ -288,8 +288,8 @@ std::shared_ptr<mfem::Mesh> buildRing(int radial_refinement, double inner_radius
   auto num_vertices          = num_vertices_ring * 2;
   auto num_boundary_elements = num_elems * 2;
 
-  SLIC_ERROR_IF(outer_radius <= inner_radius,
-                "Outer radius is smaller than inner radius while building a cylinder mesh.");
+  SLIC_ERROR_ROOT_IF(outer_radius <= inner_radius,
+                     "Outer radius is smaller than inner radius while building a cylinder mesh.");
 
   std::vector<std::vector<double>> vertices(static_cast<size_type>(num_vertices), std::vector<double>(dim, 0.));
   for (size_type i = 0; i < num_vertices_ring; i++) {
@@ -459,6 +459,6 @@ serac::mesh::InputOptions FromInlet<serac::mesh::InputOptions>::operator()(const
   // If it reaches here, we haven't found a supported type
   serac::logger::flush();
   std::string err_msg = fmt::format("Specified type not supported: {0}", mesh_type);
-  SLIC_ERROR(err_msg);
+  SLIC_ERROR_ROOT(err_msg);
   return {};
 }

--- a/src/serac/physics/nonlinear_solid.cpp
+++ b/src/serac/physics/nonlinear_solid.cpp
@@ -102,7 +102,7 @@ NonlinearSolid::NonlinearSolid(std::shared_ptr<mfem::ParMesh> mesh, const Nonlin
       std::shared_ptr<mfem::VectorCoefficient> trac_coef(bc.coef_opts.constructVector(dim));
       setTractionBCs(bc.attrs, trac_coef);
     } else {
-      SLIC_WARNING("Ignoring boundary condition with unknown name: " << name);
+      SLIC_WARNING_ROOT("Ignoring boundary condition with unknown name: " << name);
     }
   }
 }
@@ -388,15 +388,16 @@ NonlinearSolid::InputOptions FromInlet<NonlinearSolid::InputOptions>::operator()
         {"NewmarkBeta", TimestepMethod::Newmark},
         {"BackwardEuler", TimestepMethod::BackwardEuler}};
     std::string timestep_method = dynamics["timestepper"];
-    SLIC_ERROR_IF(timestep_methods.count(timestep_method) == 0, "Unrecognized timestep method: " << timestep_method);
+    SLIC_ERROR_ROOT_IF(timestep_methods.count(timestep_method) == 0,
+                       "Unrecognized timestep method: " << timestep_method);
     dyn_options.timestepper = timestep_methods.at(timestep_method);
 
     // FIXME: Implement all supported methods as part of an ODE schema
     const static std::map<std::string, DirichletEnforcementMethod> enforcement_methods = {
         {"RateControl", DirichletEnforcementMethod::RateControl}};
     std::string enforcement_method = dynamics["enforcement_method"];
-    SLIC_ERROR_IF(enforcement_methods.count(enforcement_method) == 0,
-                  "Unrecognized enforcement method: " << enforcement_method);
+    SLIC_ERROR_ROOT_IF(enforcement_methods.count(enforcement_method) == 0,
+                       "Unrecognized enforcement method: " << enforcement_method);
     dyn_options.enforcement_method = enforcement_methods.at(enforcement_method);
 
     result.solver_options.dyn_options = std::move(dyn_options);

--- a/src/serac/physics/operators/odes.cpp
+++ b/src/serac/physics/operators/odes.cpp
@@ -42,7 +42,7 @@ void SecondOrderODE::SetTimestepper(const serac::TimestepMethod timestepper)
       // TODO: do a more thorough stability analysis for mfem::GeneralizedAlpha2Solver
       // to characterize which parameter combinations work with time-varying
       // dirichlet constraints
-      SLIC_WARNING(
+      SLIC_WARNING_ROOT(
           "Cannot guarantee stability for AverageAccerlation with time-dependent Dirichlet Boundary Conditions");
       second_order_ode_solver_ = std::make_unique<mfem::AverageAccelerationSolver>();
       break;
@@ -59,7 +59,7 @@ void SecondOrderODE::SetTimestepper(const serac::TimestepMethod timestepper)
       first_order_system_ode_solver_ = std::make_unique<mfem::BackwardEulerSolver>();
       break;
     default:
-      SLIC_ERROR("Timestep method was not a supported second-order ODE method");
+      SLIC_ERROR_ROOT("Timestep method was not a supported second-order ODE method");
   }
 
   if (second_order_ode_solver_) {
@@ -113,7 +113,7 @@ void SecondOrderODE::Step(mfem::Vector& x, mfem::Vector& dxdt, double& time, dou
     x    = bx.GetBlock(0);
     dxdt = bx.GetBlock(1);
   } else {
-    SLIC_ERROR("Neither second_order_ode_solver_ nor first_order_system_ode_solver_ specified");
+    SLIC_ERROR_ROOT("Neither second_order_ode_solver_ nor first_order_system_ode_solver_ specified");
   }
 }
 
@@ -208,7 +208,7 @@ void SecondOrderODE::Solve(const double time, const double c0, const double c1, 
   d2u_dt2 += d2U_dt2_;
 
   solver_.Mult(zero_, d2u_dt2);
-  SLIC_WARNING_IF(!solver_.NonlinearSolver().GetConverged(), "Newton Solver did not converge.");
+  SLIC_WARNING_ROOT_IF(!solver_.NonlinearSolver().GetConverged(), "Newton Solver did not converge.");
 
   state_.d2u_dt2 = d2u_dt2;
 }
@@ -258,7 +258,7 @@ void FirstOrderODE::SetTimestepper(const serac::TimestepMethod timestepper)
       ode_solver_ = std::make_unique<mfem::SDIRK34Solver>();
       break;
     default:
-      SLIC_ERROR("Timestep method was not a supported first-order ODE method");
+      SLIC_ERROR_ROOT("Timestep method was not a supported first-order ODE method");
   }
   ode_solver_->Init(*this);
 }
@@ -314,7 +314,7 @@ void FirstOrderODE::Solve(const double dt, const mfem::Vector& u, mfem::Vector& 
   du_dt += dU_dt_;
 
   solver_.Mult(zero_, du_dt);
-  SLIC_WARNING_IF(!solver_.NonlinearSolver().GetConverged(), "Newton Solver did not converge.");
+  SLIC_WARNING_ROOT_IF(!solver_.NonlinearSolver().GetConverged(), "Newton Solver did not converge.");
 
   state_.du_dt       = du_dt;
   state_.previous_dt = dt;

--- a/src/serac/physics/thermal_conduction.cpp
+++ b/src/serac/physics/thermal_conduction.cpp
@@ -76,7 +76,7 @@ ThermalConduction::ThermalConduction(std::shared_ptr<mfem::ParMesh> mesh, const 
       std::shared_ptr<mfem::Coefficient> flux_coef(bc.coef_opts.constructScalar());
       setFluxBCs(bc.attrs, flux_coef);
     } else {
-      SLIC_WARNING("Ignoring boundary condition with unknown name: " << name);
+      SLIC_WARNING_ROOT("Ignoring boundary condition with unknown name: " << name);
     }
   }
 }
@@ -279,15 +279,16 @@ ThermalConduction::InputOptions FromInlet<ThermalConduction::InputOptions>::oper
         {"BackwardEuler", TimestepMethod::BackwardEuler},
         {"ForwardEuler", TimestepMethod::ForwardEuler}};
     std::string timestep_method = dynamics["timestepper"];
-    SLIC_ERROR_IF(timestep_methods.count(timestep_method) == 0, "Unrecognized timestep method: " << timestep_method);
+    SLIC_ERROR_ROOT_IF(timestep_methods.count(timestep_method) == 0,
+                       "Unrecognized timestep method: " << timestep_method);
     dyn_options.timestepper = timestep_methods.at(timestep_method);
 
     // FIXME: Implement all supported methods as part of an ODE schema
     const static std::map<std::string, DirichletEnforcementMethod> enforcement_methods = {
         {"RateControl", DirichletEnforcementMethod::RateControl}};
     std::string enforcement_method = dynamics["enforcement_method"];
-    SLIC_ERROR_IF(enforcement_methods.count(enforcement_method) == 0,
-                  "Unrecognized enforcement method: " << enforcement_method);
+    SLIC_ERROR_ROOT_IF(enforcement_methods.count(enforcement_method) == 0,
+                       "Unrecognized enforcement method: " << enforcement_method);
     dyn_options.enforcement_method = enforcement_methods.at(enforcement_method);
 
     result.solver_options.dyn_options = std::move(dyn_options);

--- a/src/serac/physics/utilities/boundary_condition.cpp
+++ b/src/serac/physics/utilities/boundary_condition.cpp
@@ -15,7 +15,7 @@ BoundaryCondition::BoundaryCondition(GeneralCoefficient coef, const std::optiona
     : coef_(coef), component_(component), markers_(num_attrs)
 {
   if (std::get_if<std::shared_ptr<mfem::VectorCoefficient>>(&coef_)) {
-    SLIC_ERROR_IF(component_, "A vector coefficient must be applied to all components");
+    SLIC_ERROR_ROOT_IF(component_, "A vector coefficient must be applied to all components");
   }
   markers_ = 0;
   for (const int attr : attrs) {
@@ -48,7 +48,7 @@ void BoundaryCondition::setTrueDofs(FiniteElementState& state)
 
 void BoundaryCondition::project(FiniteElementState& state) const
 {
-  SLIC_ERROR_IF(!true_dofs_, "Only essential boundary conditions can be projected over all DOFs.");
+  SLIC_ERROR_ROOT_IF(!true_dofs_, "Only essential boundary conditions can be projected over all DOFs.");
   // Value semantics for convenience
   auto tdofs = *true_dofs_;
   auto size  = tdofs.Size();
@@ -78,7 +78,7 @@ void BoundaryCondition::project(FiniteElementState& state) const
 
 void BoundaryCondition::project() const
 {
-  SLIC_ERROR_IF(!state_, "Boundary condition must be associated with a FiniteElementState.");
+  SLIC_ERROR_ROOT_IF(!state_, "Boundary condition must be associated with a FiniteElementState.");
   project(*state_);
 }
 
@@ -108,13 +108,13 @@ void BoundaryCondition::projectBdr(FiniteElementState& state, const double time,
 
 void BoundaryCondition::projectBdr(const double time, const bool should_be_scalar) const
 {
-  SLIC_ERROR_IF(!state_, "Boundary condition must be associated with a FiniteElementState.");
+  SLIC_ERROR_ROOT_IF(!state_, "Boundary condition must be associated with a FiniteElementState.");
   projectBdr(*state_, time, should_be_scalar);
 }
 
 void BoundaryCondition::projectBdrToDofs(mfem::Vector& dof_values, const double time, const bool should_be_scalar) const
 {
-  SLIC_ERROR_IF(!state_, "Boundary condition must be associated with a FiniteElementState.");
+  SLIC_ERROR_ROOT_IF(!state_, "Boundary condition must be associated with a FiniteElementState.");
   auto gf = state_->gridFunc();
   gf.SetFromTrueDofs(dof_values);
   projectBdr(gf, time, should_be_scalar);
@@ -123,16 +123,16 @@ void BoundaryCondition::projectBdrToDofs(mfem::Vector& dof_values, const double 
 
 void BoundaryCondition::eliminateFromMatrix(mfem::HypreParMatrix& k_mat) const
 {
-  SLIC_ERROR_IF(!true_dofs_, "Can only eliminate essential boundary conditions.");
+  SLIC_ERROR_ROOT_IF(!true_dofs_, "Can only eliminate essential boundary conditions.");
   eliminated_matrix_entries_.reset(k_mat.EliminateRowsCols(*true_dofs_));
 }
 
 void BoundaryCondition::eliminateToRHS(mfem::HypreParMatrix& k_mat_post_elim, const mfem::Vector& soln,
                                        mfem::Vector& rhs) const
 {
-  SLIC_ERROR_IF(!true_dofs_, "Can only eliminate essential boundary conditions.");
-  SLIC_ERROR_IF(!eliminated_matrix_entries_,
-                "Must set eliminated matrix entries with eliminateFrom before applying to RHS.");
+  SLIC_ERROR_ROOT_IF(!true_dofs_, "Can only eliminate essential boundary conditions.");
+  SLIC_ERROR_ROOT_IF(!eliminated_matrix_entries_,
+                     "Must set eliminated matrix entries with eliminateFrom before applying to RHS.");
   mfem::EliminateBC(k_mat_post_elim, *eliminated_matrix_entries_, *true_dofs_, soln, rhs);
 }
 
@@ -147,32 +147,32 @@ void BoundaryCondition::apply(mfem::HypreParMatrix& k_mat_post_elim, mfem::Vecto
 const mfem::Coefficient& BoundaryCondition::scalarCoefficient() const
 {
   auto scalar_coef = std::get_if<std::shared_ptr<mfem::Coefficient>>(&coef_);
-  SLIC_ERROR_IF(!scalar_coef,
-                "Asking for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
+  SLIC_ERROR_ROOT_IF(!scalar_coef,
+                     "Asking for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
   return **scalar_coef;
 }
 
 mfem::Coefficient& BoundaryCondition::scalarCoefficient()
 {
   auto scalar_coef = std::get_if<std::shared_ptr<mfem::Coefficient>>(&coef_);
-  SLIC_ERROR_IF(!scalar_coef,
-                "Asking for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
+  SLIC_ERROR_ROOT_IF(!scalar_coef,
+                     "Asking for a scalar coefficient on a BoundaryCondition that contains a vector coefficient.");
   return **scalar_coef;
 }
 
 const mfem::VectorCoefficient& BoundaryCondition::vectorCoefficient() const
 {
   auto vec_coef = std::get_if<std::shared_ptr<mfem::VectorCoefficient>>(&coef_);
-  SLIC_ERROR_IF(!vec_coef,
-                "Asking for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
+  SLIC_ERROR_ROOT_IF(!vec_coef,
+                     "Asking for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
   return **vec_coef;
 }
 
 mfem::VectorCoefficient& BoundaryCondition::vectorCoefficient()
 {
   auto vec_coef = std::get_if<std::shared_ptr<mfem::VectorCoefficient>>(&coef_);
-  SLIC_ERROR_IF(!vec_coef,
-                "Asking for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
+  SLIC_ERROR_ROOT_IF(!vec_coef,
+                     "Asking for a vector coefficient on a BoundaryCondition that contains a scalar coefficient.");
   return **vec_coef;
 }
 

--- a/src/serac/physics/utilities/boundary_condition.hpp
+++ b/src/serac/physics/utilities/boundary_condition.hpp
@@ -59,9 +59,9 @@ public:
   bool tagEquals(const Tag tag) const
   {
     static_assert(std::is_enum_v<Tag>, "Only enumerations can be used to tag a boundary condition.");
-    SLIC_ERROR_IF(!tag_, "No tag has been configured for this boundary condition");
+    SLIC_ERROR_ROOT_IF(!tag_, "No tag has been configured for this boundary condition");
     bool tags_same_type = typeid(tag).hash_code() == tag_->second;
-    SLIC_WARNING_IF(!tags_same_type, "Attempting to compare tags of two different enum types (always false)");
+    SLIC_WARNING_ROOT_IF(!tags_same_type, "Attempting to compare tags of two different enum types (always false)");
     return (static_cast<int>(tag) == tag_->first) && tags_same_type;
   }
 
@@ -149,7 +149,7 @@ public:
    */
   const mfem::Array<int>& getTrueDofs() const
   {
-    SLIC_ERROR_IF(!true_dofs_, "True DOFs only available with essential BC.");
+    SLIC_ERROR_ROOT_IF(!true_dofs_, "True DOFs only available with essential BC.");
     return *true_dofs_;
   }
 

--- a/src/serac/physics/utilities/boundary_condition_manager.cpp
+++ b/src/serac/physics/utilities/boundary_condition_manager.cpp
@@ -22,7 +22,7 @@ void BoundaryConditionManager::addEssential(const std::set<int>& ess_bdr, serac:
 
   // Check if anything was removed
   if (filtered_attrs.size() < ess_bdr.size()) {
-    SLIC_WARNING("Multiple definition of essential boundary! Using first definition given.");
+    SLIC_WARNING_ROOT("Multiple definition of essential boundary! Using first definition given.");
   }
 
   BoundaryCondition bc(ess_bdr_coef, component, filtered_attrs, num_attrs_);


### PR DESCRIPTION
Most of our SLIC calls are in problem definition and set up and therefore should only appear on the root processor. This changes them to ROOT since we no longer need the MPI rank at the logging call site.