### PR TITLE
Fix the doxygen mainpage to include the new solid module

### DIFF
--- a/src/docs/doxygen/mainpage.md
+++ b/src/docs/doxygen/mainpage.md
@@ -4,8 +4,7 @@
 
 * [Base physics](@ref serac::BasePhysics)
 * [Thermal conduction](@ref serac::ThermalConduction)
-* [Nonlinear solid mechanics](@ref serac::NonlinearSolid)
-* [Elasticity](@ref serac::Elasticity)
+* [Solid mechanics](@ref serac::Solid)
 * [Thermal-structural mechanics](@ref serac::ThermalSolid)
 
 #### Simulation Utilities ####

--- a/src/serac/infrastructure/cli.hpp
+++ b/src/serac/infrastructure/cli.hpp
@@ -16,7 +16,7 @@
 #include <string>
 #include <unordered_map>
 
-// Command line functionality
+/// Command line functionality
 namespace serac::cli {
 
 /**

--- a/src/serac/infrastructure/cli.hpp
+++ b/src/serac/infrastructure/cli.hpp
@@ -16,7 +16,9 @@
 #include <string>
 #include <unordered_map>
 
-/// Command line functionality
+/**
+ * @brief Command line functionality
+ */
 namespace serac::cli {
 
 /**


### PR DESCRIPTION
This changes the links in the doxygen mainpage to point to the new solid module and deletes the dead links.