### PR TITLE
Small documentation fixes

### DIFF
--- a/src/docs/sphinx/user_guide/index.rst
+++ b/src/docs/sphinx/user_guide/index.rst
@@ -22,8 +22,7 @@ Physics Module C++ Interface
 
 A fundamental data structure in Serac is `BasePhysics <../../doxygen/html/classserac_1_1BasePhysics.html>`_. Classes derived from ``BasePhysics`` are expected to encapsulate a specific partial differential equation and all of the state data and parameters associated with it. Currently, Serac contains the following physics modules:
 
-* `Elasticity <../../doxygen/html/classserac_1_1Elasticity.html>`_
-* `Nonlinear solid mechanics <../../doxygen/html/classserac_1_1NonlinearSolid.html>`_
+* `Solid mechanics <../../doxygen/html/classserac_1_1Solid.html>`_
 * `Thermal conduction <../../doxygen/html/classserac_1_1ThermalConduction.html>`_
 * `Thermal solid mechanics <../../doxygen/html/classserac_1_1ThermalSolid.html>`_
 

--- a/src/serac/physics/integrators/nonlinear_reaction_integrator.cpp
+++ b/src/serac/physics/integrators/nonlinear_reaction_integrator.cpp
@@ -6,7 +6,7 @@
 
 #include "serac/physics/integrators/nonlinear_reaction_integrator.hpp"
 
-namespace serac::thermal::mfem_ext {
+namespace serac::mfem_ext {
 
 void NonlinearReactionIntegrator::AssembleElementVector(const mfem::FiniteElement&   element,
                                                         mfem::ElementTransformation& parent_to_reference_transformation,
@@ -92,4 +92,4 @@ void NonlinearReactionIntegrator::AssembleElementGrad(const mfem::FiniteElement&
   }
 }
 
-}  // namespace serac::thermal::mfem_ext
+}  // namespace serac::mfem_ext

--- a/src/serac/physics/integrators/nonlinear_reaction_integrator.hpp
+++ b/src/serac/physics/integrators/nonlinear_reaction_integrator.hpp
@@ -16,7 +16,7 @@
 
 #include <functional>
 
-namespace serac::thermal::mfem_ext {
+namespace serac::mfem_ext {
 
 /**
  * @brief Integrator describing a nonlinear scalar reaction in the thermal conduction equation
@@ -88,4 +88,4 @@ private:
   mutable mfem::Vector shape_;
 };
 
-}  // namespace serac::thermal::mfem_ext
+}  // namespace serac::mfem_ext

--- a/src/serac/physics/thermal_conduction.cpp
+++ b/src/serac/physics/thermal_conduction.cpp
@@ -168,7 +168,7 @@ void ThermalConduction::completeSetup()
   // Add a nonlinear reaction term if specified
   if (reaction_) {
     K_form_->AddDomainIntegrator(
-        new serac::thermal::mfem_ext::NonlinearReactionIntegrator(reaction_, d_reaction_, *reaction_scale_));
+        new serac::mfem_ext::NonlinearReactionIntegrator(reaction_, d_reaction_, *reaction_scale_));
   }
 
   // Build the dof array lookup tables


### PR DESCRIPTION
This fixes some of the doxygen links in our sphinx docs and removes the unnecessary thermal namespace from the new nonlinar reaction integrator.