### PR TITLE
Add an option to allocate the gridfunction outside of sidre

### DIFF
--- a/tests/serac_error_handling.cpp
+++ b/tests/serac_error_handling.cpp
@@ -62,8 +62,6 @@ TEST(serac_error_handling, bc_project_requires_state)
   EXPECT_THROW(bc.project(), SlicErrorException);
 
   FiniteElementState state(*mesh);
-  // Explicitly allocate the gridfunction as it is not being managed by Sidre
-  state.gridFunc().GetMemory().New(state.gridFunc().Size());
   bc.setTrueDofs(state);
   EXPECT_NO_THROW(bc.project());
 }


### PR DESCRIPTION
Resolves #420

Ended up having to switch the gridfunction back to a `MaybeOwningPointer`