### PR TITLE
Make spack package `cuda_arch` required if +cuda variant is used

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -151,6 +151,7 @@ class Serac(CMakePackage, CudaPackage):
     conflicts('%intel', msg="Intel has a bug with c++17 support as of May 2020")
 
     # Libraries that have a GPU variant
+    conflicts('cuda_arch=none', when='+cuda', msg='CUDA architecture is required')
     depends_on("amgx@2.1.x", when="+cuda")
     cuda_deps = ["mfem", "axom"]
     for dep in cuda_deps:


### PR DESCRIPTION
Adds an extra check to make sure `cuda_arch` is specified if `+cuda` variant is used. Without this there may be issues with compilation of amgx.