### PR TITLE
FIX: CI quartz skip and resource release

### DIFF
--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -1,5 +1,5 @@
 ####
-# This is the share configuration of jobs for quartz
+# This is the shared configuration of jobs for quartz
 .on_quartz:
   tags:
     - shell
@@ -39,6 +39,7 @@ release_resources_build_quartz:
 .pr_build_on_quartz:
   stage: q_build
   extends: [.srun_build_script, .on_quartz, .pr_workflow]
+  needs: [allocate_resources_build_quartz]
 
 .main_build_with_deps_on_quartz:
   stage: q_build_with_deps

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -7,7 +7,7 @@
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
       when: never
-    - if: '$CI_JOB_NAME =~ /release_resources/'
+    - if: '$CI_JOB_NAME =~ /release_resources_build_quartz/'
       when: always
     - when: on_success
 


### PR DESCRIPTION
Two small fixes for the CI:

- When `needs` is not present (default behavior), a job expects all the pervious stages to pass. In order to allow quartz jobs to run independently of lassen status (and in parallel) I added a `needs` relationship with the allocation job.
- I also fixed the `release_resources` job conditional execution so that it will always free resources even on failure.