### PR TITLE
Banish Puke Green

### DIFF
--- a/src/docs/conf.py
+++ b/src/docs/conf.py
@@ -107,7 +107,7 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []

--- a/src/docs/conf.py
+++ b/src/docs/conf.py
@@ -107,7 +107,7 @@ exclude_patterns = ['_build']
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'default'
+pygments_style = 'emacs'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
The background color of the code-blocks makes me sad.  This puts it back to the default color scheme.

Before:
https://serac.readthedocs.io/en/latest/sphinx/user_guide/simple_conduction_tutorial.html

After:
https://serac.readthedocs.io/en/feature-white238-banishpukegreen/sphinx/user_guide/simple_conduction_tutorial.html