### PR TITLE
Change default output and reorient tet mesh

### DIFF
--- a/src/serac/numerics/mesh_utils.cpp
+++ b/src/serac/numerics/mesh_utils.cpp
@@ -132,13 +132,15 @@ mfem::Mesh buildBallMesh(int approx_number_of_elements)
     mesh.AddBdrTriangle(triangle);
   }
   mesh.FinalizeTetMesh();
-  mesh.ReorientTetMesh();
 
   while (mesh.GetNE() < (0.25 * approx_number_of_elements)) {
     mesh.UniformRefinement();
   }
 
   squish(mesh);
+
+  // Reorient the tet mesh for use with high order Hcurl elements
+  mesh.ReorientTetMesh();
 
   // The copy ctor is marked explicit, but this should qualify for RVO...
   return mfem::Mesh(mesh);

--- a/src/serac/numerics/mesh_utils.cpp
+++ b/src/serac/numerics/mesh_utils.cpp
@@ -131,6 +131,7 @@ mfem::Mesh buildBallMesh(int approx_number_of_elements)
   for (auto triangle : triangles) {
     mesh.AddBdrTriangle(triangle);
   }
+
   mesh.FinalizeTetMesh();
 
   while (mesh.GetNE() < (0.25 * approx_number_of_elements)) {

--- a/src/serac/numerics/mesh_utils.cpp
+++ b/src/serac/numerics/mesh_utils.cpp
@@ -132,6 +132,7 @@ mfem::Mesh buildBallMesh(int approx_number_of_elements)
     mesh.AddBdrTriangle(triangle);
   }
   mesh.FinalizeTetMesh();
+  mesh.ReorientTetMesh();
 
   while (mesh.GetNE() < (0.25 * approx_number_of_elements)) {
     mesh.UniformRefinement();

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -26,6 +26,7 @@ BasePhysics::BasePhysics()
 {
   std::tie(mpi_size_, mpi_rank_) = getMPIInfo(comm_);
   order_                         = 1;
+  root_name_                     = "serac";
 }
 
 BasePhysics::BasePhysics(int n, int p) : BasePhysics()
@@ -93,6 +94,8 @@ void BasePhysics::initializeOutput(const serac::OutputType output_type, const st
       dc_->RegisterField(state.name(), &state.gridFunc());
     }
   }
+
+  output_is_initialized_ = true;
 }
 
 void BasePhysics::outputState() const
@@ -101,6 +104,8 @@ void BasePhysics::outputState() const
     case serac::OutputType::VisIt:
       [[fallthrough]];
     case serac::OutputType::ParaView:
+      SLIC_ERROR_ROOT_IF(!output_is_initialized_,
+                         "VisIt and Paraview require call to initializeOutput before outputState.");
       dc_->SetCycle(cycle_);
       dc_->SetTime(time_);
       dc_->Save();

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -94,8 +94,6 @@ void BasePhysics::initializeOutput(const serac::OutputType output_type, const st
       dc_->RegisterField(state.name(), &state.gridFunc());
     }
   }
-
-  output_is_initialized_ = true;
 }
 
 void BasePhysics::outputState() const
@@ -104,8 +102,6 @@ void BasePhysics::outputState() const
     case serac::OutputType::VisIt:
       [[fallthrough]];
     case serac::OutputType::ParaView:
-      SLIC_ERROR_ROOT_IF(!output_is_initialized_,
-                         "VisIt and Paraview require call to initializeOutput before outputState.");
       dc_->SetCycle(cycle_);
       dc_->SetTime(time_);
       dc_->Save();

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -149,7 +149,7 @@ protected:
   /**
    * @brief Type of state variable output
    */
-  serac::OutputType output_type_;
+  serac::OutputType output_type_ = OutputType::GLVis;
 
   /**
    *@brief Whether the simulation is time-independent
@@ -205,12 +205,6 @@ protected:
    * @brief Boundary condition manager instance
    */
   BoundaryConditionManager bcs_;
-
-  /**
-   * @brief Flag denoting output initialization
-   *
-   */
-  bool output_is_initialized_ = false;
 };
 
 namespace detail {

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -205,6 +205,12 @@ protected:
    * @brief Boundary condition manager instance
    */
   BoundaryConditionManager bcs_;
+
+  /**
+   * @brief Flag denoting output initialization
+   *
+   */
+  bool output_is_initialized_ = false;
 };
 
 namespace detail {


### PR DESCRIPTION
This changes the default output type to GLVis which does not require initialization. It also reorients the tet-based ball mesh for use with high order H curl elements.