### PR TITLE
Fix full build rule

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,11 +20,11 @@ stages:
 
 .src_workflow:
   rules:
-    - if: '"$FULL_BUILD" != "ON"'
+    - if: '$FULL_BUILD != "ON"'
 
 .full_workflow:
   rules:
-    - if: '"$FULL_BUILD" == "ON"'
+    - if: '$FULL_BUILD == "ON"'
 
 ####
 # Template

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,7 +7,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   PROJECT_ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
-  TPL_BUILD_ROOT: ${CI_BUILDS_DIR}/serac_tpls/${CI_RUNNER_ID}/${CI_JOB_NAME}
+  FULL_BUILD_ROOT: ${CI_BUILDS_DIR}/serac/${CI_JOB_NAME}
 
 stages:
   - allocate
@@ -50,14 +50,14 @@ stages:
     - *run_update_uberenv
     - echo -e "section_start:$(date +%s):full_build_and_test\r\e[0K
       Full Build and Test ${CI_PROJECT_NAME}"
-    - ${ALLOC_COMMAND} python3 scripts/llnl/build_tpls.py -v --spec="${SPEC} ${EXTRA_SPEC}" --directory=${TPL_BUILD_ROOT}
+    - ${ALLOC_COMMAND} python3 scripts/llnl/build_tpls.py -v --spec="${SPEC} ${EXTRA_SPEC}" --directory=${FULL_BUILD_ROOT}
     - echo -e "section_end:$(date +%s):full_build_and_test\r\e[0K"
   artifacts:
     paths:
-      - ${TPL_BUILD_ROOT}/${SYS_TYPE}/*/_serac_build_and_test_*/output.log*.txt
-      - ${TPL_BUILD_ROOT}/${SYS_TYPE}/*/_serac_build_and_test_*/build-*/output.log*.txt
+      - ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/_serac_build_and_test_*/output.log*.txt
+      - ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/_serac_build_and_test_*/build-*/output.log*.txt
     reports:
-      junit: ${TPL_BUILD_ROOT}/${SYS_TYPE}/*/_serac_build_and_test_*/build-*/junit.xml
+      junit: ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/_serac_build_and_test_*/build-*/junit.xml
 
 # This is where jobs are included
 include:

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -43,7 +43,7 @@ lassen-clang_10_0_1-src:
 lassen-clang_10_0_1-full:
   variables:
     COMPILER: "clang@10.0.1"
-    SPEC: "@develop+cuda%${COMPILER}"
+    SPEC: "%${COMPILER}+cuda"
     EXTRA_SPEC: "cuda_arch=70"
     # The "-cuda" at the end of the host-config needs to be hardcoded for now
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}-cuda.cmake"

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -67,11 +67,11 @@ quartz-gcc_8_3_1-src:
 quartz-clang_10_0_0-full:
   variables:
     COMPILER: "clang@10.0.0"
-    SPEC: "@develop%${COMPILER}"
+    SPEC: "%${COMPILER}"
   extends: .full_build_on_quartz
 
 quartz-gcc_8_3_1-full:
   variables:
     COMPILER: "gcc@8.3.1"
-    SPEC: "@develop%${COMPILER}"
+    SPEC: "%${COMPILER}"
   extends: .full_build_on_quartz


### PR DESCRIPTION
This mirrors fixes in Axom.

* The quotes messed up the FULL_BUILD trigger.
* Full build path length caused problems in Axom, so we were probably close to the limit.  This will give us some more of a buffer. 
* We might need to tweak this but when we have a main, we won't want the develop there.  Plus it runs off the checked out repository anyways.