### PR TITLE
fix: serac spack pkg: ' install' -> 'install'

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -164,7 +164,7 @@ class Serac(CMakePackage, CudaPackage):
                 when='cuda_arch={0}'.format(sm_))
         
 
-    phases = ['hostconfig', 'cmake', 'build',' install']
+    phases = ['hostconfig', 'cmake', 'build', 'install']
 
     def _get_sys_type(self, spec):
         sys_type = spec.architecture


### PR DESCRIPTION
This commit fixes a bug in the `phases` list in the Serac Spack
package. In this list, the last element was ' install' and has been
changed in this commit to 'install'. The leading space causes an error
when Serac clients attempt to install Serac using this Spack package,
and deleting this leading space resolves this error.