### PR TITLE
fix: serac spack pkg: fetch git repo via https

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -76,7 +76,7 @@ class Serac(CMakePackage, CudaPackage):
     """FIXME: Put a proper description of your package here."""
 
     homepage = "https://www.github.com/LLNL/serac"
-    git      = "ssh://git@github.com:LLNL/serac.git"
+    git      = "https://github.com/LLNL/serac.git"
 
     version('develop', branch='develop', submodules=True, preferred=True)
 


### PR DESCRIPTION
This commit changes the Serac Spack package git fetch URI from an SSH
address to an HTTPS address. When attempting to install Serac via
Uberenv, Spack returns a fetch error if the SSH URI is used; this
error is resolved if the HTTPS URI is used instead. A cursory search
of the Spack GitHub repo appears to indicate that all git repo URIs
used in Spack packages in that repo are HTTPS URIs; there were no SSH
URIs for git repos, as far as I could tell.

An alternate, equivalent change would be to delete the `git = ...`
statement; here, an explicit URI was chosen for clarity, and for ease
of modification in the event that Spack can fetch git repos from SSH
URIs in the future.