### PR TITLE
fix: FindHDF5 try_compile requires enabling C lang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 
 cmake_minimum_required(VERSION 3.8)
 
-project(serac LANGUAGES CXX)
+project(serac LANGUAGES CXX C)
 
 # MPI is required in Serac.
 set(ENABLE_MPI ON CACHE BOOL "")


### PR DESCRIPTION
This commit adds `C` to the Serac project languages in the project's
root `CMakeLists.txt` file to resolve an unknown file extension error
emitted by CMake when invoked by `spack install serac` within
`uberenv`. During this invocation, if `C` is not a member of the
`LANGUAGES` argument in the `project(serac ...)` macro invocation, the
built-in `FindHDF5` CMake module will throw an error. Adding `C to the
`LANGUAGES` argument of this macro invocation resolves this error.