### PR TITLE
fix input.cpp: bypass possible null deref error 

### DIFF
--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -160,9 +160,7 @@ std::unique_ptr<mfem::Coefficient> CoefficientInputOptions::constructScalar() co
     auto max_attr_elem = std::max_element(scalar_pw_const.begin(), scalar_pw_const.end(),
                                           [](auto a, auto b) { return a.first < b.first; });
 
-    // NOTE(oxberry1@llnl.gov): gcc 8.3.1 Release builds emit
-    // "potential null pointer dereference [-Werror=null-dereference]"
-    // for max_attr_elem->first if not guarded by an if statement
+    // Check for a valid iterator to avoid compiler warnings
     if (max_attr_elem != scalar_pw_const.end()) {
       // Create an mfem vector for the attributes
       // Note that this vector expects zero indexing
@@ -175,11 +173,11 @@ std::unique_ptr<mfem::Coefficient> CoefficientInputOptions::constructScalar() co
 
       // Create the MFEM coefficient
       return std::make_unique<mfem::PWConstCoefficient>(pw_constants);
-    } // Control falls through to error if max_attr_elem is scalar_pw_const.end()
-  } // Control falls through to error if none of the if-else conditions is true
-  
+    }
+  }
+
   SLIC_ERROR_ROOT(
-        "Trying to build a scalar coefficient without specifying a scalar_function, constant, or piecewise_constant.");
+      "Trying to build a scalar coefficient without specifying a scalar_function, constant, or piecewise_constant.");
   return nullptr;
 }
 


### PR DESCRIPTION
A non-forked version of https://github.com/LLNL/serac/pull/446.

Resolves https://github.com/LLNL/serac/issues/443.

> This commit works around a "possible null dereference" error emitted
by Serac builds with "%gcc@8.3.1 build_type=Release" by guarding the
dereference in question with a conditional that only passes control to
the statement dereferencing the potentially null iterator if that
iterator is, in fact, non-null.

> This warning seems kind of silly because another enclosing conditional ensures the dereferenced iterator is non-null, but the fix is straightforward.