### PR TITLE
Rectangular StdFunctionOperators

### DIFF
--- a/src/serac/physics/operators/stdfunction_operator.hpp
+++ b/src/serac/physics/operators/stdfunction_operator.hpp
@@ -31,14 +31,22 @@ namespace serac::mfem_ext {
 class StdFunctionOperator : public mfem::Operator {
 public:
   /**
-   * @brief Default constructor for creating an uninitialized StdFunctionOperator
+   * @brief Default constructor for creating a square uninitialized StdFunctionOperator
    *
-   * @param[in] n The size of the operator
+   * @param[in] n The size of the square operator
    */
   StdFunctionOperator(int n) : mfem::Operator(n) {}
 
   /**
-   * @brief Constructor for a StdFunctionOperator that only defines mfem::Operator::Mult
+   * @brief Default constructor for creating a rectangular uninitialized StdFunctionOperator
+   *
+   * @param[in] h The height of the operator
+   * @param[in] w The width of the operator
+   */
+  StdFunctionOperator(int h, int w) : mfem::Operator(h, w) {}
+
+  /**
+   * @brief Constructor for a square StdFunctionOperator that only defines mfem::Operator::Mult
    *
    * @param[in] n The size fo the operator
    * @param[in] function The function that defines the mult (typically residual evaluation) method
@@ -49,7 +57,20 @@ public:
   }
 
   /**
-   * @brief Constructor for a StdFunctionOperator that defines mfem::Operator::Mult and mfem::Operator::GetGradient
+   * @brief Constructor for a rectangular StdFunctionOperator that only defines mfem::Operator::Mult
+   *
+   * @param[in] h The height of the operator
+   * @param[in] w The width of the operator
+   * @param[in] function The function that defines the mult (typically residual evaluation) method
+   */
+  StdFunctionOperator(int h, int w, std::function<void(const mfem::Vector&, mfem::Vector&)> function)
+      : mfem::Operator(h, w), function_(function)
+  {
+  }
+
+  /**
+   * @brief Constructor for a square StdFunctionOperator that defines mfem::Operator::Mult and
+   * mfem::Operator::GetGradient
    *
    * @param[in] n The size of the operator
    * @param[in] function The function that defines the mult (typically residual evaluation) method
@@ -58,6 +79,21 @@ public:
   StdFunctionOperator(int n, std::function<void(const mfem::Vector&, mfem::Vector&)> function,
                       std::function<mfem::Operator&(const mfem::Vector&)> jacobian)
       : mfem::Operator(n), function_(function), jacobian_(jacobian)
+  {
+  }
+
+  /**
+   * @brief Constructor for a rectangular StdFunctionOperator that defines mfem::Operator::Mult and
+   * mfem::Operator::GetGradient
+   *
+   * @param[in] h The height of the operator
+   * @param[in] w The width of the operator
+   * @param[in] function The function that defines the mult (typically residual evaluation) method
+   * @param[in] jacobian The function that defines the GetGradient (typically residual jacobian evaluation) method
+   */
+  StdFunctionOperator(int h, int w, std::function<void(const mfem::Vector&, mfem::Vector&)> function,
+                      std::function<mfem::Operator&(const mfem::Vector&)> jacobian)
+      : mfem::Operator(h, w), function_(function), jacobian_(jacobian)
   {
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,11 +45,12 @@ if (ENABLE_GTEST)
     endforeach()
 
 
-    set(coefficent_tests
+    set(utility_tests
+        serac_operator.cpp
         serac_component_bc.cpp
         serac_wrapper_tests.cpp)
 
-    foreach(filename ${coefficent_tests})
+    foreach(filename ${utility_tests})
         get_filename_component(test_name ${filename} NAME_WE)
 
         blt_add_executable(NAME        ${test_name}

--- a/tests/serac_operator.cpp
+++ b/tests/serac_operator.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "serac/physics/operators/stdfunction_operator.hpp"
+#include "serac/numerics/expr_template_ops.hpp"
 
 #include "mfem.hpp"
 
@@ -49,8 +50,8 @@ TEST(serac_operators, rectangular_operator)
       [&mat](const mfem::Vector&) -> mfem::Operator& { return mat; });
 
   // Compute the action of the equivalent rectangular operators
-  mat.Mult(in, out_1);
-  c.Mult(in, out_2);
+  out_1 = mat * in;
+  out_2 = c * in;
 
   // Compare the results
   for (int i = 0; i < out_1.Size(); ++i) {

--- a/tests/serac_operator.cpp
+++ b/tests/serac_operator.cpp
@@ -1,0 +1,83 @@
+// Copyright (c) 2019-2021, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include <gtest/gtest.h>
+
+#include "serac/physics/operators/stdfunction_operator.hpp"
+
+#include "mfem.hpp"
+
+namespace serac {
+
+TEST(serac_operators, rectangular_operator)
+{
+  // profile mesh refinement
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Construct a sample rectangular matrix
+  mfem::DenseMatrix mat(2, 3);
+  mat(0, 0) = 0.0;
+  mat(0, 1) = 1.0;
+  mat(0, 2) = 2.0;
+  mat(1, 0) = 3.0;
+  mat(1, 1) = 4.0;
+  mat(1, 2) = 5.0;
+
+  // Construct an input vector to test the rectangular stdfunction operator
+  mfem::Vector in(3);
+  in(0) = 6.0;
+  in(1) = 7.0;
+  in(2) = 8.0;
+
+  // Construct container vectors for the output
+  mfem::Vector out_1(2);
+  out_1 = 0.0;
+
+  mfem::Vector out_2(2);
+  out_2 = 0.0;
+
+  // Test the constructors for the rectangular stdfunction operators
+  mfem_ext::StdFunctionOperator a(2, 3);
+
+  mfem_ext::StdFunctionOperator b(2, 3, [&mat](const mfem::Vector& input, mfem::Vector& out) { mat.Mult(input, out); });
+
+  mfem_ext::StdFunctionOperator c(
+      2, 3, [&mat](const mfem::Vector& input, mfem::Vector& out) { mat.Mult(input, out); },
+      [&mat](const mfem::Vector&) -> mfem::Operator& { return mat; });
+
+  // Compute the action of the equivalent rectangular operators
+  mat.Mult(in, out_1);
+  c.Mult(in, out_2);
+
+  // Compare the results
+  for (int i = 0; i < out_1.Size(); ++i) {
+    EXPECT_NEAR(out_1(i), out_2(i), 1.0e-10);
+  }
+
+  MPI_Barrier(MPI_COMM_WORLD);
+}
+
+}  // namespace serac
+
+//------------------------------------------------------------------------------
+#include "axom/slic/core/SimpleLogger.hpp"
+
+int main(int argc, char* argv[])
+{
+  int result = 0;
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  MPI_Init(&argc, &argv);
+
+  axom::slic::SimpleLogger logger;  // create & initialize test logger, finalized when
+                                    // exiting main scope
+  result = RUN_ALL_TESTS();
+
+  MPI_Finalize();
+
+  return result;
+}

--- a/tests/serac_operator.cpp
+++ b/tests/serac_operator.cpp
@@ -54,7 +54,7 @@ TEST(serac_operators, rectangular_operator)
 
   // Compare the results
   for (int i = 0; i < out_1.Size(); ++i) {
-    EXPECT_NEAR(out_1(i), out_2(i), 1.0e-10);
+    EXPECT_DOUBLE_EQ(out_1(i), out_2(i));
   }
 
   MPI_Barrier(MPI_COMM_WORLD);


### PR DESCRIPTION
This adds the ability to define rectangular MFEM operators using the `StdFunctionOperator` class.