### PR TITLE
Remove BLT_EXPORT_THIRDPARTY workaround

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ set(ENABLE_BENCHMARKS  OFF CACHE BOOL "")
 set(ENABLE_ALL_WARNINGS ON CACHE BOOL "")
 set(ENABLE_WARNINGS_AS_ERRORS ON CACHE BOOL "")
 
+# Allows MPI/CUDA/etc targets to be exported in the serac namespace
+set(BLT_EXPORT_THIRDPARTY ON CACHE BOOL "")
+
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 
 #------------------------------------------------------------------------------

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -245,4 +245,19 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
             endif()
         endif()
     endforeach()
+
+    # List of TPL targets built in to BLT - will need to be adjusted when we start using HIP
+    set(TPL_DEPS)
+    blt_list_append(TO TPL_DEPS ELEMENTS cuda cuda_runtime IF ENABLE_CUDA)
+    blt_list_append(TO TPL_DEPS ELEMENTS mpi IF ENABLE_MPI)
+
+    foreach(dep ${TPL_DEPS})
+        # If the target is EXPORTABLE, add it to the export set
+        get_target_property(_is_imported ${dep} IMPORTED)
+        if(NOT ${_is_imported})
+            install(TARGETS              ${dep}
+                    EXPORT               serac-targets
+                    DESTINATION          lib)
+        endif()
+    endforeach()
 endif()

--- a/examples/using-with-cmake/CMakeLists.txt
+++ b/examples/using-with-cmake/CMakeLists.txt
@@ -4,11 +4,6 @@ project(serac_example LANGUAGES C CXX)
 include(CMakeFindDependencyMacro)
 find_dependency(serac REQUIRED NO_DEFAULT_PATH PATHS "${SERAC_DIR}/lib/cmake")
 
-## BEGIN FIXME: REMOVE ASAP ONCE BLT_IMPORT_LIBRARY HAS EXPORTABLE OPTION
-# Create fake empty target, this stops CMake from adding -lmpi to the link line
-add_library(mpi INTERFACE)
-## END FIXME
-
 add_executable(serac_example serac_example.cpp)
 target_link_libraries(serac_example serac::serac axom ${MFEM_LIBRARIES})
 


### PR DESCRIPTION
This resolves the following FIXME by incorporating the functionality added to BLT in https://github.com/LLNL/blt/pull/436:

https://github.com/LLNL/serac/blob/4dbb20800e4914ccfb5b42903f65f589cb03b610/examples/using-with-cmake/CMakeLists.txt#L7-L10

Fixes #470 

Possibly this would have been noticed earlier if we had opened a GitHub issue instead of just leaving it as a TODO?