### PR TITLE
Fix WSL/Ubuntu 20 TPL build

### DIFF
--- a/scripts/spack/configs/linux_ubuntu_20/compilers.yaml
+++ b/scripts/spack/configs/linux_ubuntu_20/compilers.yaml
@@ -7,6 +7,8 @@ compilers:
       f77: /usr/bin/gfortran
       fc: /usr/bin/gfortran
     flags: 
+      cflags: -pthread
+      cxxflags: -pthread
       ldlibs: -lpthread
     operating_system: ubuntu20.04
     target: x86_64

--- a/scripts/spack/configs/linux_ubuntu_20/compilers.yaml
+++ b/scripts/spack/configs/linux_ubuntu_20/compilers.yaml
@@ -9,7 +9,6 @@ compilers:
     flags: 
       cflags: -pthread
       cxxflags: -pthread
-      ldlibs: -lpthread
     operating_system: ubuntu20.04
     target: x86_64
     modules: []


### PR DESCRIPTION
I needed to do this to resolve missing pthread libraries at link time in the HDF5 build.