### PR TITLE
Build Caliper's cuda variant when cuda is enabled

### DIFF
--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -12,6 +12,10 @@
   before_script:
     # python3.8 is needed on lassen to avoid trampling on the x86 clingo wheel
     - module load python/3.8
+    # CMake >= 3.17 is needed for FindCUDAToolkit with caliper
+    # We could also extract the CMake executable location from the hostconfig in common_build_functions
+    # like we do in config-build
+    - module load cmake/3.18
     # Workaround for multiple before_scripts - see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/2301
     # See also https://github.com/LLNL/serac/pull/417#discussion_r631194968
     - if [[ $CUDA_BUILD == "ON" ]]; then module load cuda/11.2.0; fi

--- a/cmake/serac-config.cmake.in
+++ b/cmake/serac-config.cmake.in
@@ -37,6 +37,9 @@ if(NOT SERAC_FOUND)
   set(SERAC_USE_CALIPER        "@SERAC_USE_CALIPER@")
   set(SERAC_USE_PETSC          "@SERAC_USE_PETSC@")
 
+  # SERAC "builtin" TPLs
+  set(SERAC_ENABLE_CUDA "@ENABLE_CUDA@")
+
   #----------------------------------------------------------------------------
   # Bring in required  dependencies for this serac configuration
   #----------------------------------------------------------------------------
@@ -102,6 +105,10 @@ if(NOT SERAC_FOUND)
     set(SERAC_CALIPER_DIR     "@CALIPER_DIR@")
     if(NOT CALIPER_DIR) 
       set(CALIPER_DIR ${SERAC_CALIPER_DIR}) 
+    endif()
+    # See comment in SetupSeracThirdParty.cmake
+    if(SERAC_ENABLE_CUDA AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+      find_package(CUDAToolkit REQUIRED)
     endif()
     find_dependency(caliper REQUIRED NO_DEFAULT_PATH PATHS "${CALIPER_DIR}")
   endif()

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -154,6 +154,13 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
     if(CALIPER_DIR)
         serac_assert_is_directory(VARIABLE_NAME CALIPER_DIR)
 
+        # Should this logic be in the Caliper CMake package?
+        # If CMake version doesn't support CUDAToolkit the libraries
+        # are just "baked in"
+        if(ENABLE_CUDA AND CMAKE_VERSION VERSION_GREATER_EQUAL 3.17)
+            find_package(CUDAToolkit REQUIRED)
+        endif()
+
         find_package(caliper REQUIRED NO_DEFAULT_PATH 
                      PATHS ${CALIPER_DIR})
         message(STATUS "Caliper support is ON")

--- a/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.cmake
+++ b/host-configs/lassen-blueos_3_ppc64le_ib_p9-clang@10.0.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_28_03/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_20_30/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_28_03/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_20_30/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_28_03/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_20_30/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -79,7 +79,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_28_03/clang-10.0.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_20_30/clang-10.0.1" CACHE PATH "")
 
 set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 

--- a/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.cmake
+++ b/host-configs/rzansel-blueos_3_ppc64le_ib_p9-clang@10.0.1.cmake
@@ -11,11 +11,11 @@
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
-  set(CMAKE_C_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_29_53/spack/lib/spack/env/clang/clang" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_21_39/spack/lib/spack/env/clang/clang" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_29_53/spack/lib/spack/env/clang/clang++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_21_39/spack/lib/spack/env/clang/clang++" CACHE PATH "")
 
-  set(CMAKE_Fortran_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_29_53/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
+  set(CMAKE_Fortran_COMPILER "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_21_39/spack/lib/spack/env/clang/gfortran" CACHE PATH "")
 
 else()
 
@@ -79,7 +79,7 @@ set(BLT_CMAKE_IMPLICIT_LINK_DIRECTORIES_EXCLUDE "/usr/tce/packages/gcc/gcc-4.9.3
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_05_26_11_29_53/clang-10.0.1" CACHE PATH "")
+set(TPL_ROOT "/usr/WS2/smithdev/libs/serac/blueos_3_ppc64le_ib_p9/2021_06_03_05_21_39/clang-10.0.1" CACHE PATH "")
 
 set(AXOM_DIR "${TPL_ROOT}/axom-0.4.0serac" CACHE PATH "")
 

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -140,12 +140,17 @@ class Serac(CachedCMakePackage, CudaPackage):
     cuda_deps = ["mfem", "axom"]
     for dep in cuda_deps:
         depends_on("{0}+cuda".format(dep), when="+cuda")
+    depends_on("caliper+cuda", when="+caliper+cuda")
 
     for sm_ in CudaPackage.cuda_arch_values:
         depends_on('mfem+amgx cuda_arch=sm_{0}'.format(sm_),
                 when='cuda_arch={0}'.format(sm_))
         depends_on('axom cuda_arch={0}'.format(sm_),
                 when='cuda_arch={0}'.format(sm_))
+        # Caliper may not currently use its cuda_arch
+        # but probably good practice to set it
+        depends_on('caliper cuda_arch={0}'.format(sm_),
+                when='+caliper cuda_arch={0}'.format(sm_))
         
 
     def _get_sys_type(self, spec):


### PR DESCRIPTION
Do we also want to enable any of caliper/RAJA/umpire by default on TOSS (as is currently the case on blueos)?