### PR TITLE
Put bank name in a variable so that we override it

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ variables:
   PROJECT_ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}
   FULL_BUILD_ROOT: ${CI_BUILDS_DIR}/serac/${CI_JOB_NAME}
+  ALLOC_BANK: eng
 
 stages:
   - allocate

--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -26,15 +26,15 @@
 # Template
 .src_build_on_lassen:
   stage: build
-  variables: 
-    ALLOC_COMMAND: lalloc 1 -W 10 -q pdebug -G eng
+  variables:
+    ALLOC_COMMAND: lalloc 1 -W 10 -q pdebug -G ${ALLOC_BANK}
   extends: [.src_build_script, .on_lassen, .src_workflow]
   needs: []
 
 .full_build_on_lassen:
   stage: build
   variables:
-    ALLOC_COMMAND: lalloc 1 -W 45 -q pdebug -G eng
+    ALLOC_COMMAND: lalloc 1 -W 45 -q pdebug -G ${ALLOC_BANK}
   extends: [.full_build_script, .on_lassen, .full_workflow]
   needs: []
 

--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -19,7 +19,7 @@ quartz_allocate:
   extends: [.on_quartz, .src_workflow]
   stage: allocate
   script:
-    - salloc -p pdebug -A eng -N 1 -c 36 -t 30 --no-shell --job-name=${PROJECT_ALLOC_NAME}
+    - salloc -p pdebug -A ${ALLOC_BANK} -N 1 -c 36 -t 30 --no-shell --job-name=${PROJECT_ALLOC_NAME}
   needs: []
 
 ####
@@ -39,14 +39,14 @@ quartz_release:
 .src_build_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -A eng -t 10 -N 1 ${ASSIGN_ID}"
+    ALLOC_COMMAND: "srun -p pdebug -A ${ALLOC_BANK} -t 10 -N 1 ${ASSIGN_ID}"
   extends: [.src_build_script, .on_quartz, .src_workflow]
   needs: [quartz_allocate]
 
 .full_build_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -A eng -t 45 -N 1"
+    ALLOC_COMMAND: "srun -p pdebug -A ${ALLOC_BANK} -t 45 -N 1"
   extends: [.full_build_script, .on_quartz, .full_workflow]
   needs: []
   before_script:


### PR DESCRIPTION
Let's say that struggling to get access to `eng` bank on `lassen` forced me to think of a more generic solution.
Actually I had this idea in the back of my head, and should have gone for it a long time ago:

This simple PR makes the bank configurable, so that anyone can run the pipeline with a bank he/she has access to.
Of course, one still needs to belong to the `smithdev` group in LC to access the shared files (dependencies installations), which makes this not a complete game-changer.

Note: I need this to finally fix Uberenv CI (https://github.com/LLNL/uberenv/pull/65). Uberenv CI will use the radiuss bank. Which is also for the best, I guess.