### PR TITLE
Add link to MFEM to the readme and sphinx landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Status](https://dev.azure.com/llnl-serac/serac/_apis/build/status/LLNL.serac?bra
 
 Serac is a 3D implicit nonlinear thermal-structural simulation code. Its primary purpose is to investigate multiphysics 
 abstraction strategies and implicit finite element-based algorithm development for emerging computing architectures. 
-It also serves as a proxy-app for LLNL's Smith code.
+It also serves as a proxy-app for LLNL's Smith code and heavily leverages the [MFEM finite element library](https://mfem.org/).
 
 Documentation
 ------

--- a/src/docs/index.rst
+++ b/src/docs/index.rst
@@ -8,7 +8,8 @@ Serac
 =======
 
 Serac is a 3D implicit nonlinear thermal-structural simulation code. It's primary purpose is to investigate multiphysics abstraction
-strategies and implicit finite element-based algorithm development for emerging computing architectures. It also serves as a proxy-app for LLNL's Smith code.
+strategies and implicit finite element-based algorithm development for emerging computing architectures. It also serves as a proxy-app for LLNL's 
+Smith code and heavily leverages the `MFEM finite element library <https://mfem.org/>`_.
 
 
   *  :ref:`Quickstart/Build Instructions <quickstart-label>`


### PR DESCRIPTION
This adds a link to the MFEM webpage to our README and sphinx documentation.