### PR TITLE
serac spack pkg: add `+cpp14+lua` to axom depends

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -117,7 +117,7 @@ class Serac(CachedCMakePackage, CudaPackage):
 
     # Libraries that support "build_type=RelWithDebInfo|Debug|Release|MinSizeRel"
     # "build_type=RelWithDebInfo|Debug|Release|MinSizeRel"
-    axom_spec = "axom@0.5.0serac~openmp~fortran~examples+mfem~shared"
+    axom_spec = "axom@0.5.0serac~openmp~fortran~examples+mfem~shared+cpp14+lua"
     cmake_debug_deps = [axom_spec,
                         "metis@5.1.0~shared",
                         "parmetis@4.0.3~shared"]


### PR DESCRIPTION
This commit adds the `+cpp14+lua` variants to the Axom dependency in
Serac's spack package. While these variants default to True for Axom,
it is possible for Spack to concretize a spec for Serac that uses Axom
without at least one of those variants set to True. In that situation,
the Serac build fails during the configure step because the Axom
installation lacks `sol.hpp`.

I ran into this issue when I mistakenly added `unzip@6.00` instead of
`unzip@6.0` to LiDO's
`scripts/spack/configs/toss_3_x86_64_ib/packages.yaml`. Adding these
variants to the Axom requirement forces Spack to attempt to concretize
a spec that contains `axom+cpp14+lua`, and if it is impossible to do
so, Spack returns an error much earlier in the development environment
provisioning process. Returning this error earlier made it easier for
me to diagnose my misconfiguration error re: the `unzip` package
version.