### PR TITLE
Switch GCC Docker from 8.4 -> 9.3

### DIFF
--- a/.github/workflows/docker_build_tpls.yml
+++ b/.github/workflows/docker_build_tpls.yml
@@ -11,7 +11,7 @@ jobs:
     name: Builds a docker image and extracts generated hostconfigs
     strategy:
       matrix:
-        compiler: [clang-10, gcc-8]
+        compiler: [clang-10, gcc-9]
     env:
       REPO: seracllnl/tpls
       HOSTCONFIG_LOC: /home/serac/export_hostconfig

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,12 +10,12 @@ jobs:
     matrix:
       linux_gcc8:
           VM_ImageName: 'ubuntu-20.04'
-          Compiler_ImageName: 'seracllnl/tpls:gcc-8_06-29-21_12h-37m'
-          TEST_TARGET: 'linux_gcc8'
-          HOST_CONFIG: 'docker-linux-ubuntu20.04-ivybridge-gcc@8.4.0.cmake'
+          Compiler_ImageName: 'seracllnl/tpls:gcc-9_07-06-21_13h-00m'
+          TEST_TARGET: 'linux_gcc9'
+          HOST_CONFIG: 'docker-linux-ubuntu20.04-ivybridge-gcc@9.3.0.cmake'
       linux_clang10:
           VM_ImageName: 'ubuntu-20.04'
-          Compiler_ImageName: 'seracllnl/tpls:clang-10_06-30-21_11h-37m'
+          Compiler_ImageName: 'seracllnl/tpls:clang-10_07-06-21_13h-00m'
           TEST_TARGET: 'linux_clang10'
           HOST_CONFIG: 'docker-linux-ubuntu20.04-ivybridge-clang@10.0.0.cmake'
 
@@ -41,7 +41,7 @@ jobs:
 - job: Check_Code
   variables:
     VM_ImageName: 'ubuntu-20.04'
-    Compiler_ImageName: 'seracllnl/tpls:clang-10_06-30-21_11h-37m'
+    Compiler_ImageName: 'seracllnl/tpls:clang-10_07-06-21_13h-00m'
     TEST_TARGET: 'linux_clang10'
     HOST_CONFIG: 'docker-linux-ubuntu20.04-ivybridge-clang@10.0.0'
 

--- a/host-configs/docker/docker-linux-ubuntu20.04-ivybridge-clang@10.0.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu20.04-ivybridge-clang@10.0.0.cmake
@@ -27,9 +27,9 @@ else()
 
 endif()
 
-set(CMAKE_C_FLAGS "-fPIC -pthread -fPIC -pthread" CACHE STRING "")
+set(CMAKE_C_FLAGS "-fPIC -pthread" CACHE STRING "")
 
-set(CMAKE_CXX_FLAGS "-fPIC -pthread " CACHE STRING "")
+set(CMAKE_CXX_FLAGS "-fPIC -pthread" CACHE STRING "")
 
 #------------------------------------------------------------------------------
 # MPI

--- a/host-configs/docker/docker-linux-ubuntu20.04-ivybridge-gcc@9.3.0.cmake
+++ b/host-configs/docker/docker-linux-ubuntu20.04-ivybridge-gcc@9.3.0.cmake
@@ -7,7 +7,7 @@
 #------------------------------------------------------------------------------
 # Compilers
 #------------------------------------------------------------------------------
-# Compiler Spec: gcc@8.4.0
+# Compiler Spec: gcc@9.3.0
 #------------------------------------------------------------------------------
 if(DEFINED ENV{SPACK_CC})
 
@@ -19,9 +19,9 @@ if(DEFINED ENV{SPACK_CC})
 
 else()
 
-  set(CMAKE_C_COMPILER "/usr/bin/gcc" CACHE PATH "")
+  set(CMAKE_C_COMPILER "/usr/bin/gcc-9" CACHE PATH "")
 
-  set(CMAKE_CXX_COMPILER "/usr/bin/g++" CACHE PATH "")
+  set(CMAKE_CXX_COMPILER "/usr/bin/g++-9" CACHE PATH "")
 
   set(CMAKE_Fortran_COMPILER "/usr/bin/gfortran" CACHE PATH "")
 
@@ -59,7 +59,7 @@ set(ENABLE_MPI ON CACHE BOOL "")
 # TPLs
 #------------------------------------------------------------------------------
 
-set(TPL_ROOT "/home/serac/serac_tpls/gcc-8.4.0" CACHE PATH "")
+set(TPL_ROOT "/home/serac/serac_tpls/gcc-9.3.0" CACHE PATH "")
 
 set(ASCENT_DIR "${TPL_ROOT}/ascent-0.7.1serac" CACHE PATH "")
 

--- a/scripts/docker/dockerfile_gcc-9
+++ b/scripts/docker/dockerfile_gcc-9
@@ -1,0 +1,28 @@
+FROM axom/compilers:ubuntu-20-gcc-9_07-06-21_11h-51m
+LABEL maintainer="bramwell1@llnl.gov"
+ARG branch=develop
+
+SHELL ["/bin/bash", "-c"]
+RUN sudo apt-get update -y
+RUN sudo apt-get install ssh libopenblas-dev mpich gfortran -fy
+
+RUN sudo useradd -m -s /bin/bash -G sudo serac
+
+WORKDIR "/home/serac"
+USER serac
+
+RUN git clone --recursive --branch $branch --single-branch --depth 1 https://github.com/LLNL/serac.git
+
+# New containers will use Python3
+RUN cd serac && python3 ./scripts/uberenv/uberenv.py --spack-config-dir=./scripts/spack/configs/docker/ubuntu20/ \
+                                                       --project-json=.uberenv_config.json \
+                                                       --spec=%gcc@9.3.0 --prefix=/home/serac/serac_tpls -k
+# white238: commented out due to logs disapearing and this being saved due to layering
+#RUN rm -rf /home/serac/serac_tpls/builds
+
+RUN mkdir -p /home/serac/export_hostconfig
+RUN cp ./serac/*.cmake /home/serac/export_hostconfig
+
+# Make sure the new hostconfig worked
+RUN cd serac && python3 config-build.py -hc *.cmake -bp build && cd build && make -j && make -j test
+RUN rm -rf serac

--- a/scripts/docker/dockerfile_gcc-9
+++ b/scripts/docker/dockerfile_gcc-9
@@ -24,5 +24,5 @@ RUN mkdir -p /home/serac/export_hostconfig
 RUN cp ./serac/*.cmake /home/serac/export_hostconfig
 
 # Make sure the new hostconfig worked
-RUN cd serac && python3 config-build.py -hc *.cmake -bp build && cd build && make -j && make -j test
+RUN cd serac && python3 config-build.py -hc *.cmake -bp build && cd build && make -j4 && make -j4 test
 RUN rm -rf serac

--- a/scripts/spack/configs/docker/ubuntu20/compilers.yaml
+++ b/scripts/spack/configs/docker/ubuntu20/compilers.yaml
@@ -24,9 +24,24 @@ compilers:
       modules: []
       operating_system: ubuntu20.04
       paths:
-        cc: /usr/bin/gcc
-        cxx: /usr/bin/g++
+        cc: /usr/bin/gcc-8
+        cxx: /usr/bin/g++-8
         f77: /usr/bin/gfortran
         fc: /usr/bin/gfortran
       spec: gcc@8.4.0
+      target: x86_64
+  - compiler:
+      environment: {}
+      extra_rpaths: []
+      flags:
+        cflags: -pthread
+        cxxflags: -pthread
+      modules: []
+      operating_system: ubuntu20.04
+      paths:
+        cc: /usr/bin/gcc-9
+        cxx: /usr/bin/g++-9
+        f77: /usr/bin/gfortran
+        fc: /usr/bin/gfortran
+      spec: gcc@9.3.0
       target: x86_64


### PR DESCRIPTION
We already test GCC 8 on every commit via GitLab CI, so I thought it would be useful to test the GCC 9 that (most of?) the WSL folks are using.  Also I'm convinced GCC 8 on Docker might be cursed.