### PR TITLE
Add a testing cmake macro

### DIFF
--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -125,3 +125,41 @@ macro(serac_convert_to_native_escaped_file_path path output)
     file(TO_NATIVE_PATH ${path} ${output})
     string(REPLACE "\\" "\\\\"  ${output} "${${output}}")
 endmacro(serac_convert_to_native_escaped_file_path)
+
+##------------------------------------------------------------------------------
+## serac_add_tests( SOURCES       [source1 [source2 ...]]
+##                  DEPENDS_ON    [dep1 [dep2 ...]]
+##                  NUM_MPI_TASKS [num tasks])
+##
+## Adds tests from the given sources
+##------------------------------------------------------------------------------
+
+macro(serac_add_tests)
+
+    set(options )
+    set(singleValueArgs NUM_MPI_TASKS)
+    set(multiValueArgs SOURCES DEPENDS_ON)
+
+    # Parse the arguments to the macro
+    cmake_parse_arguments(arg
+        "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if ( NOT DEFINED arg_NUM_MPI_TASKS )
+        set( arg_NUM_MPI_TASKS 1 )
+    endif()
+
+    foreach(filename ${arg_SOURCES})
+        get_filename_component(test_name ${filename} NAME_WE)
+
+        blt_add_executable(NAME        ${test_name}
+                           SOURCES     ${filename}
+                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
+                           DEPENDS_ON  ${arg_DEPENDS_ON}
+                           FOLDER      serac/tests )
+
+        blt_add_test(NAME          ${test_name}
+                     COMMAND       ${test_name}
+                     NUM_MPI_TASKS ${arg_NUM_MPI_TASKS} )
+    endforeach()
+
+endmacro(serac_add_tests)

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -131,7 +131,7 @@ endmacro(serac_convert_to_native_escaped_file_path)
 ##                  DEPENDS_ON    [dep1 [dep2 ...]]
 ##                  NUM_MPI_TASKS [num tasks])
 ##
-## Adds tests from the given sources
+## Creates an executable per given source and then adds the test to CTest
 ##------------------------------------------------------------------------------
 
 macro(serac_add_tests)

--- a/src/serac/coefficients/tests/CMakeLists.txt
+++ b/src/serac/coefficients/tests/CMakeLists.txt
@@ -4,25 +4,11 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-if (ENABLE_GTEST)
+set(test_dependencies serac_physics test_utils)
+blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
-    set(test_dependencies serac_physics test_utils)
-    blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
+set(coefficient_tests
+    serac_component_bc.cpp)
 
-    set(coefficient_tests
-        serac_component_bc.cpp)
-
-    foreach(filename ${coefficient_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
-
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 1 )
-    endforeach()
-
-endif()
+serac_add_tests( SOURCES ${coefficient_tests}
+                 DEPENDS_ON ${test_dependencies})

--- a/src/serac/infrastructure/tests/CMakeLists.txt
+++ b/src/serac/infrastructure/tests/CMakeLists.txt
@@ -4,27 +4,13 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-if (ENABLE_GTEST)
+set(test_dependencies gtest serac_physics)
+blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
-    set(test_dependencies gtest)
-    blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
+set(infrastructure_tests
+    serac_error_handling.cpp
+    serac_input.cpp
+    serac_profiling.cpp)
 
-    set(intrastructure_tests
-        serac_error_handling.cpp
-        serac_input.cpp
-        serac_profiling.cpp)
-
-    foreach(filename ${infrastructure_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
-
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 1 )
-    endforeach()
-
-endif()
+serac_add_tests( SOURCES ${infrastructure_tests}
+                 DEPENDS_ON ${test_dependencies})

--- a/src/serac/numerics/tests/CMakeLists.txt
+++ b/src/serac/numerics/tests/CMakeLists.txt
@@ -4,54 +4,32 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-if (ENABLE_GTEST)
+set(test_dependencies gtest serac_numerics)
+blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
-    set(test_dependencies gtest serac_numerics)
-    blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
+set(numerics_parallel_tests
+    serac_mesh.cpp
+    )
 
-    set(numerics_parallel_tests
-        serac_mesh.cpp
-        )
+serac_add_tests( SOURCES ${numerics_parallel_tests}
+                 DEPENDS_ON ${test_dependencies}
+                 NUM_MPI_TASKS 2)
 
-    foreach(filename ${numerics_parallel_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
+set(numerics_serial_tests
+    expr_templates.cpp
+    mesh_generation.cpp
+    )
 
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 2 )
-    endforeach()
+serac_add_tests( SOURCES ${numerics_serial_tests}
+                 DEPENDS_ON ${test_dependencies}
+                 NUM_MPI_TASKS 1)
 
-    set(numerics_serial_tests
-        expr_templates.cpp
-        mesh_generation.cpp
-        )
-
-    foreach(filename ${numerics_serial_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
-
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 1 )
-    endforeach()
-
-    if(ENABLE_BENCHMARKS)
-        blt_add_executable( NAME        benchmark_expr_templates
-                            SOURCES     benchmark_expr_templates.cpp
-                            DEPENDS_ON  gbenchmark ${test_dependencies}
-                            FOLDER      serac/tests)
-        blt_add_benchmark(  NAME        benchmark_expr_templates
-                            COMMAND     benchmark_expr_templates "--benchmark_min_time=0.0 --v=3 --benchmark_format=console"
-                            NUM_MPI_TASKS 4)
-    endif()
-
+if(ENABLE_BENCHMARKS)
+    blt_add_executable( NAME        benchmark_expr_templates
+                        SOURCES     benchmark_expr_templates.cpp
+                        DEPENDS_ON  gbenchmark ${test_dependencies}
+                        FOLDER      serac/tests)
+    blt_add_benchmark(  NAME        benchmark_expr_templates
+                        COMMAND     benchmark_expr_templates "--benchmark_min_time=0.0 --v=3 --benchmark_format=console"
+                        NUM_MPI_TASKS 4)
 endif()

--- a/src/serac/physics/integrators/tests/CMakeLists.txt
+++ b/src/serac/physics/integrators/tests/CMakeLists.txt
@@ -4,25 +4,11 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-if (ENABLE_GTEST)
+set(test_dependencies gtest serac_physics_integrators)
+blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
-    set(test_dependencies gtest serac_physics_integrators)
-    blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
+set(integrator_tests
+    serac_wrapper_tests.cpp)
 
-    set(integrator_tests
-        serac_wrapper_tests.cpp)
-
-    foreach(filename ${integrator_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
-
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 1 )
-    endforeach()
-
-endif()
+serac_add_tests( SOURCES ${integrator_tests}
+                 DEPENDS_ON ${test_dependencies})    

--- a/src/serac/physics/operators/tests/CMakeLists.txt
+++ b/src/serac/physics/operators/tests/CMakeLists.txt
@@ -4,26 +4,12 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-if (ENABLE_GTEST)
+set(test_dependencies gtest serac_physics_operators)
+blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
-    set(test_dependencies gtest serac_physics_operators)
-    blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
+set(operators_tests
+    serac_operator.cpp
+    serac_odes.cpp)
 
-    set(operators_tests
-        serac_operator.cpp
-        serac_odes.cpp)
-
-    foreach(filename ${operators_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
-
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 1 )
-    endforeach()
-
-endif()
+serac_add_tests( SOURCES ${operators_tests}
+                 DEPENDS_ON ${test_dependencies})

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -4,55 +4,33 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-if (ENABLE_GTEST)
+set(test_dependencies serac_physics test_utils)
+blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
 
-    set(test_dependencies serac_physics test_utils)
-    blt_list_append( TO test_dependencies ELEMENTS caliper IF ${SERAC_USE_CALIPER} )
+blt_add_library(
+    NAME        test_utils
+    SOURCES     test_utilities.cpp
+    HEADERS     test_utilities.hpp
+    DEPENDS_ON  serac_physics gtest
+    )
 
-    blt_add_library(
-        NAME        test_utils
-        SOURCES     test_utilities.cpp
-        HEADERS     test_utilities.hpp
-        DEPENDS_ON  serac_physics gtest
-        )
+set(solver_tests
+    serac_solid.cpp
+    serac_solid_reuse_mesh.cpp
+    serac_solid_adjoint.cpp
+    serac_thermal_solver.cpp
+    serac_thermal_structural_solver.cpp
+    )
 
-    set(solver_tests
-        serac_solid.cpp
-        serac_solid_reuse_mesh.cpp
-        serac_solid_adjoint.cpp
-        serac_thermal_solver.cpp
-        serac_thermal_structural_solver.cpp
-        )
+serac_add_tests( SOURCES ${solver_tests}
+                 DEPENDS_ON ${test_dependencies}
+                 NUM_MPI_TASKS 2)
 
-    foreach(filename ${solver_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
+set(solver_utility_tests
+    serac_dtor.cpp
+    serac_boundary_cond.cpp
+    serac_newmark_test.cpp)
 
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 2 )
-    endforeach()
-
-    set(solver_utility_tests
-        serac_dtor.cpp
-        serac_boundary_cond.cpp
-        serac_newmark_test.cpp)
-
-    foreach(filename ${solver_utility_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
-
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  ${test_dependencies}
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 2 )
-    endforeach()
-
-endif()
+serac_add_tests( SOURCES ${solver_utility_tests}
+                 DEPENDS_ON ${test_dependencies}
+                 NUM_MPI_TASKS 2)

--- a/src/serac/physics/utilities/functional/tests/CMakeLists.txt
+++ b/src/serac/physics/utilities/functional/tests/CMakeLists.txt
@@ -18,19 +18,9 @@ set(functional_tests_serial
     hcurl_unit_tests.cpp
     test_tensor_ad.cpp
     tuple_arithmetic_unit_tests.cpp)
-    
-foreach(filename ${functional_tests_serial})
-    get_filename_component(test_name ${filename} NAME_WE)
-    
-    blt_add_executable(NAME        ${test_name}
-                       SOURCES     ${filename}
-                       OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON  gtest serac_functional ${functional_depends}
-                       FOLDER      serac/tests )
-    blt_add_test(NAME          ${test_name}
-                 COMMAND       ${test_name}
-                 NUM_MPI_TASKS 1 )
-endforeach()
+
+serac_add_tests( SOURCES ${functional_tests_serial}
+                 DEPENDS_ON gtest serac_functional ${functional_depends})
 
 # Then add the examples/tests
 set(functional_tests_mpi
@@ -38,20 +28,10 @@ set(functional_tests_mpi
     functional_comparison_L2.cpp
     functional_material_state_test.cpp
     )
-    
-foreach(filename ${functional_tests_mpi})
-    get_filename_component(test_name ${filename} NAME_WE)
-    
-    blt_add_executable(NAME        ${test_name}
-                       SOURCES     ${filename}
-                       OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                       DEPENDS_ON  gtest serac_functional ${functional_depends}
-                       FOLDER      serac/tests )
-    blt_add_test(NAME          ${test_name}
-                 COMMAND       ${test_name}
-                 NUM_MPI_TASKS 4)
-endforeach()
 
+serac_add_tests( SOURCES ${functional_tests_mpi}
+                 DEPENDS_ON gtest serac_functional ${functional_depends}
+                 NUM_MPI_TASKS 4 )
 
 # not sure how we want to handle performance-related tests
 set(functional_performance_tests
@@ -71,18 +51,8 @@ if(ENABLE_CUDA)
 
     set(functional_tests_cuda
         tensor_unit_tests_cuda.cu)
-        
-    foreach(filename ${functional_tests_cuda})
-        get_filename_component(test_name ${filename} NAME_WE)
-        
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  gtest serac_functional ${functional_depends} cuda
-                           FOLDER      serac/tests)
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 1)
-    endforeach()
+
+    serac_add_tests( SOURCES ${functional_tests_cuda
+                    DEPENDS_ON gtest serac_functional ${functional_depends} cuda)
 
 endif()

--- a/src/serac/physics/utilities/functional/tests/CMakeLists.txt
+++ b/src/serac/physics/utilities/functional/tests/CMakeLists.txt
@@ -52,7 +52,7 @@ if(ENABLE_CUDA)
     set(functional_tests_cuda
         tensor_unit_tests_cuda.cu)
 
-    serac_add_tests( SOURCES ${functional_tests_cuda
+    serac_add_tests( SOURCES ${functional_tests_cuda}
                     DEPENDS_ON gtest serac_functional ${functional_depends} cuda)
 
 endif()

--- a/src/serac/physics/utilities/functional/tests/CMakeLists.txt
+++ b/src/serac/physics/utilities/functional/tests/CMakeLists.txt
@@ -53,6 +53,6 @@ if(ENABLE_CUDA)
         tensor_unit_tests_cuda.cu)
 
     serac_add_tests( SOURCES ${functional_tests_cuda}
-                    DEPENDS_ON gtest serac_functional ${functional_depends} cuda)
+                     DEPENDS_ON gtest serac_functional ${functional_depends} cuda)
 
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,65 +4,35 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-if (ENABLE_GTEST)
+set(mfem_tests
+    mfem_ex9p_blockilu.cpp
+    )
 
-    set(mfem_tests
-        mfem_ex9p_blockilu.cpp
-        )
+serac_add_tests( SOURCES ${mfem_tests}
+                 DEPENDS_ON gtest serac_physics_utilities
+                 NUM_MPI_TASKS 2)
 
-    foreach(filename ${mfem_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
+set(language_tests
+    copy_elision.cpp
+    mfem_array_std_algo.cpp)
 
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  gtest serac_physics_utilities
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 2 )
-    endforeach()
+serac_add_tests( SOURCES ${language_tests}
+                 DEPENDS_ON gtest mfem mpi)
 
-    set(language_tests
-        copy_elision.cpp
-        mfem_array_std_algo.cpp)
+if(ENABLE_CUDA)
+    # CUDA smoke test
+    blt_add_library( NAME       serac_cuda_smoketest_kernel
+                     SOURCES    serac_cuda_smoketest_kernel.cpp 
+                     DEPENDS_ON cuda)
 
-    foreach(filename ${language_tests})
-        get_filename_component(test_name ${filename} NAME_WE)
+    serac_add_tests( SOURCES serac_cuda_smoketest.cpp
+                     DEPENDS_ON serac_cuda_smoketest_kernel gtest)
+endif()
 
-        blt_add_executable(NAME        ${test_name}
-                           SOURCES     ${filename}
-                           OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                           DEPENDS_ON  gtest mfem mpi 
-                           FOLDER      serac/tests )
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS 1 )
-    endforeach()
+if(SERAC_USE_PETSC)
 
-    if(ENABLE_CUDA)
-        # CUDA smoke test
-        blt_add_library( NAME       serac_cuda_smoketest_kernel
-                         SOURCES    serac_cuda_smoketest_kernel.cpp 
-                         DEPENDS_ON cuda)
-        blt_add_executable( NAME        serac_cuda_smoketest
-                            SOURCES     serac_cuda_smoketest.cpp 
-                            OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON  serac_cuda_smoketest_kernel gtest
-                            FOLDER      serac/tests)
-        blt_add_test( NAME          serac_cuda_smoketest
-                      COMMAND       serac_cuda_smoketest )
-    endif()
-
-    if(SERAC_USE_PETSC)
-        blt_add_executable( NAME        petsc_smoketest
-                            SOURCES     petsc_smoketest.cpp
-                            OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                            DEPENDS_ON  PETSc gtest
-                            FOLDER      serac/tests )
-        blt_add_test(NAME         petsc_smoketest
-                    COMMAND       petsc_smoketest
-                    NUM_MPI_TASKS 4 )
-    endif()
+    serac_add_tests( SOURCES petsc_smoketest.cpp
+                     DEPENDS_ON PETSc gtest
+                     NUM_MPI_TASKS 4)
 
 endif()


### PR DESCRIPTION
This resolves some lingering issues from https://github.com/LLNL/serac/pull/515 . Specifically, it adds a serac-specific testing macro and GTEST_ENABLED checks, removing a considerable amount of boilerplate code.