### PR TITLE
Fix parallel driver

### DIFF
--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -16,6 +16,10 @@ if (ENABLE_TESTS)
                  COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
                  NUM_MPI_TASKS 1 )
 
+    blt_add_test(NAME          serac_driver_default_parallel
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
+                 NUM_MPI_TASKS 2 )
+
     blt_add_test(NAME          serac_driver_no_thermal
                  COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/tests/solid/qs_linear.lua
                  NUM_MPI_TASKS 1 )

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -44,8 +44,7 @@ void outputFields(const axom::sidre::DataStore& datastore, const std::string& da
   conduit::Node extracts;
   // "relay" is the Ascents Extract type for saving data
   extracts["e1/type"]            = "relay";
-  auto [_, rank]                 = serac::getMPIInfo();
-  extracts["e1/params/path"]     = fmt::format("{}_fields.{}.{}", data_collection_name, rank, output_language);
+  extracts["e1/params/path"]     = fmt::format("{}_fields.{}", data_collection_name, output_language);
   extracts["e1/params/protocol"] = output_language;
 
   // Get domain Sidre group


### PR DESCRIPTION
Ascent already handles MPI-specific aspects of naming output directories/files, so we shouldn't be including the rank.

The extracts path is global so including the rank causes ascent to try to throw an error which results in an MPI deadlock.