### PR TITLE
Output curve field data

### DIFF
--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -39,7 +39,7 @@ quartz_release:
 .src_build_on_quartz:
   stage: build
   variables:
-    ALLOC_COMMAND: "srun -p pdebug -A ${ALLOC_BANK} -t 10 -N 1 ${ASSIGN_ID}"
+    ALLOC_COMMAND: "srun -p pdebug -A ${ALLOC_BANK} -t 15 -N 1 ${ASSIGN_ID}"
   extends: [.src_build_script, .on_quartz, .src_workflow]
   needs: [quartz_allocate]
 

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -180,6 +180,9 @@ int main(int argc, char* argv[])
 
   // Enter the time step loop.
   for (int ti = 1; !last_step; ti++) {
+    // Flush all messages held by the logger
+    serac::logger::flush();
+
     // Compute the real timestep. This may be less than dt for the last timestep.
     double dt_real = std::min(dt, t_final - t);
 

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
   // should be inlet["output_type"].get<OutputType>()
   main_physics->initializeOutput(inlet.getGlobalContainer().get<serac::OutputType>(), "serac");
 
-  main_physics->initializeCurves(datastore, static_cast<axom::IndexType>(ceil(t_final / dt)));  // size assumption okay?
+  main_physics->initializeCurves(datastore, t_final, dt);
 
   // Enter the time step loop.
   for (int ti = 1; !last_step; ti++) {

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -205,9 +205,9 @@ int main(int argc, char* argv[])
     last_step = (t >= t_final - 1e-8 * dt);
   }
 
-  serac::output::outputCurves(datastore, serac::StateManager::collectionName(), serac::output::Language::JSON);
+  serac::output::outputCurves(datastore, serac::StateManager::collectionName());
   if (output_fields) {
-    serac::output::outputFields(datastore, serac::StateManager::collectionName(), t, serac::output::Language::JSON);
+    serac::output::outputFields(datastore, serac::StateManager::collectionName(), t);
   }
 
   serac::exitGracefully();

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -176,6 +176,8 @@ int main(int argc, char* argv[])
   // should be inlet["output_type"].get<OutputType>()
   main_physics->initializeOutput(inlet.getGlobalContainer().get<serac::OutputType>(), "serac");
 
+  main_physics->initializeCurves(datastore, static_cast<axom::IndexType>(ceil(t_final / dt)));  // size assumption okay?
+
   // Enter the time step loop.
   for (int ti = 1; !last_step; ti++) {
     // Compute the real timestep. This may be less than dt for the last timestep.
@@ -193,10 +195,14 @@ int main(int argc, char* argv[])
     // Output a visualization file
     main_physics->outputState();
 
+    // Save curve data to Sidre datastore to be output later
+    main_physics->saveCurves(datastore, t);
+
     // Determine if this is the last timestep
     last_step = (t >= t_final - 1e-8 * dt);
   }
 
+  serac::output::outputCurves(datastore, serac::StateManager::collectionName(), serac::output::Language::JSON);
   if (output_fields) {
     serac::output::outputFields(datastore, serac::StateManager::collectionName(), t, serac::output::Language::JSON);
   }

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -176,7 +176,7 @@ int main(int argc, char* argv[])
   // should be inlet["output_type"].get<OutputType>()
   main_physics->initializeOutput(inlet.getGlobalContainer().get<serac::OutputType>(), "serac");
 
-  main_physics->initializeCurves(datastore, t_final, dt);
+  main_physics->initializeSummary(datastore, t_final, dt);
 
   // Enter the time step loop.
   for (int ti = 1; !last_step; ti++) {
@@ -199,13 +199,13 @@ int main(int argc, char* argv[])
     main_physics->outputState();
 
     // Save curve data to Sidre datastore to be output later
-    main_physics->saveCurves(datastore, t);
+    main_physics->saveSummary(datastore, t);
 
     // Determine if this is the last timestep
     last_step = (t >= t_final - 1e-8 * dt);
   }
 
-  serac::output::outputCurves(datastore, serac::StateManager::collectionName());
+  serac::output::outputSummary(datastore, serac::StateManager::collectionName());
   if (output_fields) {
     serac::output::outputFields(datastore, serac::StateManager::collectionName(), t);
   }

--- a/src/serac/infrastructure/initialize.cpp
+++ b/src/serac/infrastructure/initialize.cpp
@@ -6,6 +6,14 @@
 
 #include "serac/infrastructure/initialize.hpp"
 
+#ifdef WIN32
+#include <windows.h>
+#include <tchar.h>
+#else
+#include <unistd.h>
+#include <limits.h>
+#endif
+
 #include "serac/infrastructure/accelerator.hpp"
 #include "serac/infrastructure/logger.hpp"
 #include "serac/infrastructure/profiling.hpp"
@@ -25,6 +33,46 @@ std::pair<int, int> getMPIInfo(MPI_Comm comm)
     SLIC_ERROR("Failed to determine MPI rank");
   }
   return {num_procs, rank};
+}
+
+#define INFO_BUFFER_SIZE 32767
+
+std::string getHostName()
+{
+  std::string hostName = "";
+#ifdef WIN32
+  TCHAR infoBuf[INFO_BUFFER_SIZE];
+  DWORD bufCharCount = INFO_BUFFER_SIZE;
+  bufCharCount       = INFO_BUFFER_SIZE;
+  if (!GetComputerName(infoBuf, &bufCharCount)) {
+    hostName = std::string(infoBuf);
+  }
+#else
+  char infoBuf[HOST_NAME_MAX];
+  if (gethostname(infoBuf, HOST_NAME_MAX) == 0) {
+    hostName = std::string(infoBuf);
+  }
+#endif
+  return hostName;
+}
+
+std::string getUserName()
+{
+  std::string userName = "";
+#ifdef WIN32
+  TCHAR infoBuf[INFO_BUFFER_SIZE];
+  DWORD bufCharCount = INFO_BUFFER_SIZE;
+  bufCharCount       = INFO_BUFFER_SIZE;
+  if (GetUserName(infoBuf, &bufCharCount)) {
+    userName = std::string(infoBuf);
+  }
+#else
+  char infoBuf[LOGIN_NAME_MAX];
+  if (getlogin_r(infoBuf, LOGIN_NAME_MAX) == 0) {
+    userName = std::string(infoBuf);
+  }
+#endif
+  return userName;
 }
 
 std::pair<int, int> initialize(int argc, char* argv[], MPI_Comm comm)

--- a/src/serac/infrastructure/initialize.hpp
+++ b/src/serac/infrastructure/initialize.hpp
@@ -11,6 +11,7 @@
  */
 #pragma once
 
+#include <string>
 #include <utility>
 
 #include "mpi.h"
@@ -19,6 +20,7 @@ namespace serac {
 
 /**
  * @brief Returns the number of processes and rank for an MPI communicator
+ *
  * @param comm The MPI communicator to initialize with
  * @return A pair containing {size, rank} relative to the provided MPI communicator
  * @pre The logger must be initialized (to display error messages)
@@ -26,7 +28,26 @@ namespace serac {
 std::pair<int, int> getMPIInfo(MPI_Comm comm = MPI_COMM_WORLD);
 
 /**
+ * @brief Returns the name of the machine
+ *
+ * @todo Remove when moved to Axom
+ *
+ * @return The name of the current machine, empty string on failure
+ */
+std::string getHostName();
+
+/**
+ * @brief Returns the name of the current user
+ *
+ * @todo Remove when moved to Axom
+ *
+ * @return The name of the current user, empty string on failure
+ */
+std::string getUserName();
+
+/**
  * @brief Initializes MPI, signal handling, and logging
+ *
  * @param argc The number of command-line arguments
  * @param argv The command-line arguments, as C-strings
  * @param comm The MPI communicator to initialize with

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -33,22 +33,20 @@ std::string file_format_string(const FileFormat file_format)
 }
 }  // namespace detail
 
-void outputCurves(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
-                  const FileFormat file_format)
+void outputSummary(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
+                   const FileFormat file_format)
 {
   auto [_, rank] = getMPIInfo();
   if (rank != 0) {
     return;
   }
 
-  if (file_format == FileFormat::HDF5) {
-    // FIXME: remove this error when implemented, do we even want hdf5 curves?
-    SLIC_ERROR_ROOT("hdf5 has not been implemented in outputCurves");
-  }
+  // FIXME: remove this error when implemented, do we even want hdf5 curves?
+  SLIC_ERROR_ROOT_IF(file_format == FileFormat::HDF5, "hdf5 has not been implemented in outputCurves");
   std::string file_format_string = detail::file_format_string(file_format);
 
-  const std::string file_name = fmt::format("{0}_curves.{1}", data_collection_name, file_format_string);
-  datastore.getRoot()->getGroup("serac_curves")->save(file_name, file_format_string);
+  const std::string file_name = fmt::format("{0}_summary.{1}", data_collection_name, file_format_string);
+  datastore.getRoot()->getGroup("serac_summary")->save(file_name, file_format_string);
 }
 
 void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name, double time,

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -18,6 +18,29 @@
 
 namespace serac::output {
 
+void outputCurves(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
+                  const Language language)
+{
+  auto [_, rank] = getMPIInfo();
+  if (rank != 0) {
+     return;
+  }
+
+  std::string output_language = "";
+  if (language == Language::JSON) {
+    output_language = "json";
+  } else if (language == Language::HDF5) {
+    // FIXME: remove this error when implemented, do we even want hdf5 curves?
+    SLIC_ERROR_ROOT("hdf5 has not been implemented in outputCurves");
+    output_language = "hdf5";
+  } else if (language == Language::YAML) {
+    output_language = "yaml";
+  }
+
+  const std::string file_name = fmt::format("{0}_curves.{1}", data_collection_name, output_language);
+  datastore.getRoot()->getGroup("serac_curves")->save(file_name, output_language);
+}
+
 void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name, double time,
                   const Language language)
 {

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -23,7 +23,7 @@ void outputCurves(const axom::sidre::DataStore& datastore, const std::string& da
 {
   auto [_, rank] = getMPIInfo();
   if (rank != 0) {
-     return;
+    return;
   }
 
   std::string output_language = "";

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -41,8 +41,8 @@ void outputSummary(const axom::sidre::DataStore& datastore, const std::string& d
     return;
   }
 
-  // FIXME: remove this error when implemented, do we even want hdf5 curves?
-  SLIC_ERROR_ROOT_IF(file_format == FileFormat::HDF5, "hdf5 has not been implemented in outputCurves");
+  SLIC_ERROR_ROOT_IF(file_format == FileFormat::HDF5,
+                     "Output file format ('hdf5') is not supported for Serac summary files.");
   std::string file_format_string = detail::file_format_string(file_format);
 
   const std::string file_name = fmt::format("{0}_summary.{1}", data_collection_name, file_format_string);

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -31,7 +31,7 @@ std::string file_format_string(const FileFormat file_format)
   }
   return value;
 }
-}
+}  // namespace detail
 
 void outputCurves(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
                   const FileFormat file_format)

--- a/src/serac/infrastructure/output.hpp
+++ b/src/serac/infrastructure/output.hpp
@@ -34,15 +34,15 @@ enum class FileFormat
 };
 
 /**
- * @brief Outputs simulation curve data from the datastore to the given file
+ * @brief Outputs simulation summary data from the datastore to the given file
  * only on rank 0
  *
  * @param[in] datastore Root of the Sidre datastore
  * @param[in] data_collection_name Name of the Data Collection stored in Sidre
  * @param[in] language The output language format
  */
-void outputCurves(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
-                  const FileFormat language = FileFormat::JSON);
+void outputSummary(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
+                   const FileFormat language = FileFormat::JSON);
 
 /**
  * @brief Outputs simulation field data from the datastore to the given file

--- a/src/serac/infrastructure/output.hpp
+++ b/src/serac/infrastructure/output.hpp
@@ -24,9 +24,9 @@
 namespace serac::output {
 
 /**
- * @brief The output file languages supported
+ * @brief The output file formats supported
  */
-enum class Language
+enum class FileFormat
 {
   HDF5,
   JSON,
@@ -42,7 +42,7 @@ enum class Language
  * @param[in] language The output language format
  */
 void outputCurves(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
-                  const Language language = Language::JSON);
+                  const FileFormat language = FileFormat::JSON);
 
 /**
  * @brief Outputs simulation field data from the datastore to the given file
@@ -53,6 +53,6 @@ void outputCurves(const axom::sidre::DataStore& datastore, const std::string& da
  * @param[in] language The output language format
  */
 void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name, double time,
-                  const Language language = Language::JSON);
+                  const FileFormat language = FileFormat::JSON);
 
 }  // namespace serac::output

--- a/src/serac/infrastructure/output.hpp
+++ b/src/serac/infrastructure/output.hpp
@@ -34,7 +34,18 @@ enum class Language
 };
 
 /**
- * @brief Outputs simulation data from the datastore to the given file
+ * @brief Outputs simulation curve data from the datastore to the given file
+ * only on rank 0
+ *
+ * @param[in] datastore Root of the Sidre datastore
+ * @param[in] data_collection_name Name of the Data Collection stored in Sidre
+ * @param[in] language The output language format
+ */
+void outputCurves(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
+                  const Language language = Language::JSON);
+
+/**
+ * @brief Outputs simulation field data from the datastore to the given file
  *
  * @param[in] datastore Root of the Sidre datastore
  * @param[in] data_collection_name Name of the Data Collection stored in Sidre

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -202,12 +202,12 @@ void BasePhysics::saveCurves(axom::sidre::DataStore& datastore, const double t) 
   }
 
   for (FiniteElementState& state : state_) {
-    l1norm_value = norm(state, 1);
-    l2norm_value = norm(state, 2);
+    l1norm_value   = norm(state, 1);
+    l2norm_value   = norm(state, 2);
     linfnorm_value = norm(state, mfem::infinity());
-    avg_value = avg(state);
-    max_value = max(state);
-    min_value = min(state);
+    avg_value      = avg(state);
+    max_value      = max(state);
+    min_value      = min(state);
 
     // Don't save curves on anything other than root node
     if (rank == 0) {

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -136,7 +136,7 @@ void BasePhysics::outputState() const
   }
 }
 
-void BasePhysics::initializeCurves(axom::sidre::DataStore& datastore, axom::IndexType array_size) const
+void BasePhysics::initializeCurves(axom::sidre::DataStore& datastore, double t_final, double dt) const
 {
   // Curves Sidre Structure
   // Sidre root
@@ -161,6 +161,9 @@ void BasePhysics::initializeCurves(axom::sidre::DataStore& datastore, axom::Inde
   SLIC_ERROR_ROOT_IF(sidre_root->hasGroup(curves_group_name),
                      fmt::format("Sidre Group '{0}' cannot exist when initializeCurves is called", curves_group_name));
   axom::sidre::Group* curves_group = sidre_root->createGroup(curves_group_name);
+
+  // Calculate how many time steps which is the array size
+  axom::IndexType array_size = static_cast<axom::IndexType>(ceil(t_final / dt));
 
   // t: array of each time step value
   axom::sidre::View*         t_array_view = curves_group->createView("t");

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -9,7 +9,6 @@
 #include <fstream>
 
 #include "fmt/fmt.hpp"
-#include "mpi.h"
 
 #include "serac/infrastructure/initialize.hpp"
 #include "serac/infrastructure/logger.hpp"

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -119,12 +119,17 @@ public:
   /**
    * @brief Initializes the Sidre structure for curves data
    *
+   * @param[in] datastore Sidre DataStore where curves are saved
+   * @param[in] t_final Final time of the simulation
+   * @param[in] dt The time step
    */
-  virtual void initializeCurves(axom::sidre::DataStore& datastore, axom::IndexType array_size) const;
+  virtual void initializeCurves(axom::sidre::DataStore& datastore, const double t_final, const double dt) const;
 
   /**
    * @brief Saves the curves data to the Sidre Datastore
    *
+   * @param[in] datastore Sidre DataStore where curves are saved
+   * @param[in] t The current time of the simulation
    */
   virtual void saveCurves(axom::sidre::DataStore& datastore, const double t) const;
 

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -16,6 +16,7 @@
 #include <memory>
 
 #include "mfem.hpp"
+#include "axom/sidre.hpp"
 
 #include "serac/physics/utilities/boundary_condition_manager.hpp"
 #include "serac/physics/utilities/equation_solver.hpp"
@@ -114,6 +115,18 @@ public:
    *
    */
   virtual void outputState() const;
+
+  /**
+   * @brief Initializes the Sidre structure for curves data
+   *
+   */
+  virtual void initializeCurves(axom::sidre::DataStore& datastore, axom::IndexType array_size) const;
+
+  /**
+   * @brief Saves the curves data to the Sidre Datastore
+   *
+   */
+  virtual void saveCurves(axom::sidre::DataStore& datastore, const double t) const;
 
   /**
    * @brief Destroy the Base Solver object

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -117,21 +117,21 @@ public:
   virtual void outputState() const;
 
   /**
-   * @brief Initializes the Sidre structure for curves data
+   * @brief Initializes the Sidre structure for simulation summary data
    *
-   * @param[in] datastore Sidre DataStore where curves are saved
+   * @param[in] datastore Sidre DataStore where data are saved
    * @param[in] t_final Final time of the simulation
    * @param[in] dt The time step
    */
-  virtual void initializeCurves(axom::sidre::DataStore& datastore, const double t_final, const double dt) const;
+  virtual void initializeSummary(axom::sidre::DataStore& datastore, const double t_final, const double dt) const;
 
   /**
-   * @brief Saves the curves data to the Sidre Datastore
+   * @brief Saves the summary data to the Sidre Datastore
    *
    * @param[in] datastore Sidre DataStore where curves are saved
    * @param[in] t The current time of the simulation
    */
-  virtual void saveCurves(axom::sidre::DataStore& datastore, const double t) const;
+  virtual void saveSummary(axom::sidre::DataStore& datastore, const double t) const;
 
   /**
    * @brief Destroy the Base Solver object

--- a/src/serac/physics/utilities/finite_element_state.cpp
+++ b/src/serac/physics/utilities/finite_element_state.cpp
@@ -76,16 +76,16 @@ double avg(const FiniteElementState& state)
 
 double max(const FiniteElementState& state)
 {
-  double max, local_max = state.trueVec().Max();
-  MPI_Allreduce(&local_max, &max, 1, MPI_DOUBLE, MPI_MAX, state.comm());
-  return max;
+  double global_max, local_max = state.trueVec().Max();
+  MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX, state.comm());
+  return global_max;
 }
 
 double min(const FiniteElementState& state)
 {
-  double min, local_min = state.trueVec().Min();
-  MPI_Allreduce(&local_min, &min, 1, MPI_DOUBLE, MPI_MIN, state.comm());
-  return min;
+  double global_min, local_min = state.trueVec().Min();
+  MPI_Allreduce(&local_min, &global_min, 1, MPI_DOUBLE, MPI_MIN, state.comm());
+  return global_min;
 }
 
 double norm(const FiniteElementState& state, const double p)

--- a/src/serac/physics/utilities/finite_element_state.cpp
+++ b/src/serac/physics/utilities/finite_element_state.cpp
@@ -67,8 +67,8 @@ FiniteElementState& FiniteElementState::operator=(const double value)
 
 double avg(const FiniteElementState& state)
 {
-  double global_sum, local_sum = state.trueVec().Sum();
-  int global_size, local_size = state.trueVec().Size();
+  double global_sum, local_sum   = state.trueVec().Sum();
+  int    global_size, local_size = state.trueVec().Size();
   MPI_Allreduce(&local_sum, &global_sum, 1, MPI_DOUBLE, MPI_SUM, state.comm());
   MPI_Allreduce(&local_size, &global_size, 1, MPI_INT, MPI_SUM, state.comm());
   return global_sum / global_size;

--- a/src/serac/physics/utilities/finite_element_state.cpp
+++ b/src/serac/physics/utilities/finite_element_state.cpp
@@ -8,6 +8,8 @@
 
 #include "mpi.h"
 
+#include "serac/infrastructure/initialize.hpp"
+
 namespace serac {
 
 namespace detail {
@@ -65,8 +67,7 @@ FiniteElementState& FiniteElementState::operator=(const double value)
 
 double avg(const FiniteElementState& state)
 {
-  int count;
-  MPI_Comm_size(state.comm(), &count);
+  auto [count, _] = getMPIInfo(state.comm());
   double sum, local_avg = state.trueVec().Sum() / state.trueVec().Size();
   MPI_Allreduce(&local_avg, &sum, 1, MPI_DOUBLE, MPI_SUM, state.comm());
   return sum / count;

--- a/src/serac/physics/utilities/finite_element_state.cpp
+++ b/src/serac/physics/utilities/finite_element_state.cpp
@@ -67,10 +67,11 @@ FiniteElementState& FiniteElementState::operator=(const double value)
 
 double avg(const FiniteElementState& state)
 {
-  auto [count, _] = getMPIInfo(state.comm());
-  double sum, local_avg = state.trueVec().Sum() / state.trueVec().Size();
-  MPI_Allreduce(&local_avg, &sum, 1, MPI_DOUBLE, MPI_SUM, state.comm());
-  return sum / count;
+  double global_sum, local_sum = state.trueVec().Sum();
+  int global_size, local_size = state.trueVec().Size();
+  MPI_Allreduce(&local_sum, &global_sum, 1, MPI_DOUBLE, MPI_SUM, state.comm());
+  MPI_Allreduce(&local_size, &global_size, 1, MPI_INT, MPI_SUM, state.comm());
+  return global_sum / global_size;
 }
 
 double max(const FiniteElementState& state)

--- a/src/serac/physics/utilities/finite_element_state.cpp
+++ b/src/serac/physics/utilities/finite_element_state.cpp
@@ -67,8 +67,10 @@ FiniteElementState& FiniteElementState::operator=(const double value)
 
 double avg(const FiniteElementState& state)
 {
-  double global_sum, local_sum   = state.trueVec().Sum();
-  int    global_size, local_size = state.trueVec().Size();
+  double global_sum;
+  double local_sum = state.trueVec().Sum();
+  int    global_size;
+  double local_size = state.trueVec().Size();
   MPI_Allreduce(&local_sum, &global_sum, 1, MPI_DOUBLE, MPI_SUM, state.comm());
   MPI_Allreduce(&local_size, &global_size, 1, MPI_INT, MPI_SUM, state.comm());
   return global_sum / global_size;
@@ -76,14 +78,16 @@ double avg(const FiniteElementState& state)
 
 double max(const FiniteElementState& state)
 {
-  double global_max, local_max = state.trueVec().Max();
+  double global_max;
+  double local_max = state.trueVec().Max();
   MPI_Allreduce(&local_max, &global_max, 1, MPI_DOUBLE, MPI_MAX, state.comm());
   return global_max;
 }
 
 double min(const FiniteElementState& state)
 {
-  double global_min, local_min = state.trueVec().Min();
+  double global_min;
+  double local_min = state.trueVec().Min();
   MPI_Allreduce(&local_min, &global_min, 1, MPI_DOUBLE, MPI_MIN, state.comm());
   return global_min;
 }

--- a/src/serac/physics/utilities/finite_element_state.hpp
+++ b/src/serac/physics/utilities/finite_element_state.hpp
@@ -158,6 +158,8 @@ public:
    * Returns a non-owning reference to the vector of true DOFs
    */
   mfem::HypreParVector& trueVec() { return true_vec_; }
+  /// \overload
+  const mfem::HypreParVector& trueVec() const { return true_vec_; }
 
   /**
    * Returns the name of the FEState (field)
@@ -254,6 +256,32 @@ private:
   mfem::HypreParVector                              true_vec_;
   std::string                                       name_ = "";
 };
+
+// FIXME: Should these go somewhere else?
+
+/**
+ * @brief Find the average value of a finite element state across all nodes
+ *
+ * @param state The state variable to compute a max of
+ * @return The average value
+ */
+double avg(const FiniteElementState& state);
+
+/**
+ * @brief Find the max value of a finite element state across all nodes
+ *
+ * @param state The state variable to compute a max of
+ * @return The max value
+ */
+double max(const FiniteElementState& state);
+
+/**
+ * @brief Find the min value of a finite element state across all nodes
+ *
+ * @param state The state variable to compute a min of
+ * @return The min value
+ */
+double min(const FiniteElementState& state);
 
 /**
  * @brief Calculate the Lp norm of a finite element state

--- a/src/serac/physics/utilities/finite_element_state.hpp
+++ b/src/serac/physics/utilities/finite_element_state.hpp
@@ -257,8 +257,6 @@ private:
   std::string                                       name_ = "";
 };
 
-// FIXME: Should these go somewhere else?
-
 /**
  * @brief Find the average value of a finite element state across all nodes
  *


### PR DESCRIPTION
This outputs a new file, `serac_datacoll_curves.json`, that contains various curve data at each time step.  This is outputting the following values:

* L1 norm
* L2 norm
* L infinity norm
* average
* minimum
* maximum

once per time step, to the root mpi tasks Sidre tree under "serac_curves".  As well as the time step value, t.

At the end of the of the simulation run it outputs this to a json file.

Example output:

```
{
  "t": [0.25, 0.5, 0.75, 1.0],
  "temperature": 
  {
    "l1norms": [10.8455612450063, 10.8769266938811, 10.9262526637677, 10.9890569744431],
    "l2norms": [4.00325571439491, 3.98778843947879, 3.988193145272, 3.99834571962069],
    "linfnorms": [1.99858754555508, 1.99602762948269, 1.99349091868975, 1.9915520450815],
    "avgs": [1.36394528852752, 1.36810524509546, 1.374153349967, 1.38184017005875],
    "mins": [1.00067514812945, 1.00311180843846, 1.00816133998986, 1.01610881694094],
    "maxs": [2.0, 2.0, 2.0, 2.0]
  },
  "velocity": 
  {
    "l1norms": [0.0, 0.0, 0.0, 0.0],
    "l2norms": [0.0, 0.0, 0.0, 0.0],
    "linfnorms": [0.0, 0.0, 0.0, 0.0],
    "avgs": [0.0, 0.0, 0.0, 0.0],
    "mins": [0.0, 0.0, 0.0, 0.0],
    "maxs": [0.0, 0.0, 0.0, 0.0]
  },
  "displacement": 
  {
    "l1norms": [0.0, 0.924962166264643, 1.84283834206585, 2.74688270159081],
    "l2norms": [0.0, 0.4275976012174, 0.851821419489431, 1.26946055313981],
    "linfnorms": [0.0, 0.310353229084647, 0.618487529803454, 0.921952178076032],
    "avgs": [0.0, 0.0391142766414546, 0.0763267241134098, 0.111371682619804],
    "mins": [0.0, -0.0382275916996528, -0.0908270569236879, -0.156722895441363],
    "maxs": [0.0, 0.317086042420179, 0.632902614360887, 0.944383108329756]
  },
  "sidre_group_name": "serac_curves"
}
```


Future improvements:

* toggle which values output in input file
* change language the file is output (is this even something we should encourage?)