### PR TITLE
Enable all output to go to a directory

### DIFF
--- a/src/docs/conf.py
+++ b/src/docs/conf.py
@@ -167,9 +167,10 @@ def setup(app):
 # using the given strftime format.
 #html_last_updated_fmt = '%b %d, %Y'
 
-# If true, SmartyPants will be used to convert quotes and dashes to
-# typographically correct entities.
-#html_use_smartypants = True
+# If true, the Docutils Smart Quotes transform, originally based on SmartyPants
+# (limited to English) and currently applying to many languages, will be used to convert
+# quotes and dashes to typographically correct entities. Default: True.
+smartquotes = False
 
 # Custom sidebar templates, maps document names to template names.
 #html_sidebars = {}

--- a/src/docs/sphinx/user_guide/command_line_options.rst
+++ b/src/docs/sphinx/user_guide/command_line_options.rst
@@ -1,0 +1,44 @@
+.. ## Copyright (c) 2019-2021, Lawrence Livermore National Security, LLC and
+.. ## other Serac Project Developers. See the top-level COPYRIGHT file for details.
+.. ##
+.. ## SPDX-License-Identifier: (BSD-3-Clause)
+
+====================
+Command Line Options
+====================
+
+Below is the documentation for Serac's command line options:
+
+.. list-table:: Options
+   :widths: 25 25 25 25
+   :header-rows: 1
+   :stub-columns: 1
+
+   * - Long form
+     - Short form
+     - Variable Type
+     - Description
+   * - --help
+     - -h
+     - N/A
+     - Print this help message and exit
+   * - --input-file
+     - -i
+     - Path
+     - Input file to use
+   * - --restart-cycle
+     - -c
+     - Integer
+     - Cycle to restart from
+   * - --create-input-file-docs
+     - -d
+     - N/A
+     - Writes Sphinx documentation for input file, then exits
+   * - --output-directory
+     - -o
+     - Path
+     - Directory to put outputted files
+   * - --output-fields
+     - 
+     - N/A
+     - Writes field data to file system

--- a/src/docs/sphinx/user_guide/command_line_options.rst
+++ b/src/docs/sphinx/user_guide/command_line_options.rst
@@ -12,7 +12,6 @@ Below is the documentation for Serac's command line options:
 .. list-table:: Options
    :widths: 25 25 25 25
    :header-rows: 1
-   :stub-columns: 1
 
    * - Long form
      - Short form

--- a/src/docs/sphinx/user_guide/index.rst
+++ b/src/docs/sphinx/user_guide/index.rst
@@ -12,6 +12,7 @@ User Guide
   :maxdepth: 2
 
   simple_conduction_tutorial
+  command_line_options
   input_schema
 
 Serac can be used either by providing input files to the main executable or through a C++ API. Example lua input files are located in the `data 

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -11,21 +11,22 @@ blt_add_executable( NAME        serac_driver
                     )
 
 if (ENABLE_TESTS)
+    set(input_files_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files)
     # Make sure running serac driver doesn't completely fail
     blt_add_test(NAME          serac_driver_default
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default -i ${input_files_dir}/default.lua
                  NUM_MPI_TASKS 1 )
 
     blt_add_test(NAME          serac_driver_default_parallel
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_parallel -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_parallel -i ${input_files_dir}/default.lua
                  NUM_MPI_TASKS 2 )
 
     blt_add_test(NAME          serac_driver_no_thermal
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_no_thermal -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/tests/solid/qs_linear.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_no_thermal -i ${input_files_dir}/tests/solid/qs_linear.lua
                  NUM_MPI_TASKS 1 )
 
     blt_add_test(NAME          serac_driver_no_solid
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_no_solid -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/tests/thermal_conduction/static_solve.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_no_solid -i ${input_files_dir}/tests/thermal_conduction/static_solve.lua
                  NUM_MPI_TASKS 1 )
 
     blt_add_test(NAME          serac_driver_help
@@ -33,7 +34,7 @@ if (ENABLE_TESTS)
                  NUM_MPI_TASKS 1 )
 
     blt_add_test(NAME          serac_driver_docs
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -d -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_docs -d -i ${input_files_dir}/default.lua
                  NUM_MPI_TASKS 1 )
 endif()
 

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -13,21 +13,19 @@ blt_add_executable( NAME        serac_driver
 if (ENABLE_TESTS)
     # Make sure running serac driver doesn't completely fail
     blt_add_test(NAME          serac_driver_default
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
                  NUM_MPI_TASKS 1 )
 
-    # FIXME: Temporarily turn this off until overlapping files written to working directory do not cause 
-    #  problems on simulations ran at the same time
-    #blt_add_test(NAME          serac_driver_default_parallel
-    #             COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
-    #             NUM_MPI_TASKS 2 )
+    blt_add_test(NAME          serac_driver_default_parallel
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_parallel -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/default.lua
+                 NUM_MPI_TASKS 2 )
 
     blt_add_test(NAME          serac_driver_no_thermal
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/tests/solid/qs_linear.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_no_thermal -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/tests/solid/qs_linear.lua
                  NUM_MPI_TASKS 1 )
 
     blt_add_test(NAME          serac_driver_no_solid
-                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/tests/thermal_conduction/static_solve.lua
+                 COMMAND       ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/serac -o default_no_solid -i ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files/tests/thermal_conduction/static_solve.lua
                  NUM_MPI_TASKS 1 )
 
     blt_add_test(NAME          serac_driver_help

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
 
   // Output directory
   std::string output_directory = "";
-  search          = cli_opts.find("output_directory");
+  search                       = cli_opts.find("output_directory");
   if (search != cli_opts.end()) {
     output_directory = search->second;
   }

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -117,7 +117,7 @@ int main(int argc, char* argv[])
 
   // Intialize MFEMSidreDataCollection
   // If restart_cycle is non-empty, then this is a restart run and the data will be loaded here
-  serac::StateManager::initialize(datastore, "serac", restart_cycle);
+  serac::StateManager::initialize(datastore, "serac", output_directory, restart_cycle);
 
   // Initialize Inlet and read input file
   auto inlet = serac::input::initialize(datastore, input_file_path);
@@ -125,7 +125,8 @@ int main(int argc, char* argv[])
 
   // Optionally, create input file documentation and quit
   if (create_input_file_docs) {
-    inlet.write(axom::inlet::SphinxWriter("serac_input.rst"));
+    std::string input_docs_path = axom::utilities::filesystem::joinPath(output_directory, "serac_input.rst");
+    inlet.write(axom::inlet::SphinxWriter(input_docs_path));
     serac::exitGracefully();
   }
 
@@ -206,7 +207,7 @@ int main(int argc, char* argv[])
     main_physics->advanceTimestep(dt_real);
 
     // Output a visualization file
-    main_physics->outputState();
+    main_physics->outputState(output_directory);
 
     // Save curve data to Sidre datastore to be output later
     main_physics->saveSummary(datastore, t);

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -130,7 +130,8 @@ int main(int argc, char* argv[])
   }
 
   // Save input values to file
-  datastore.getRoot()->getGroup("input_file")->save("serac_input.json", "json");
+  std::string input_values_file = fmt::format("{0}/serac_input_values.json", output_directory);
+  datastore.getRoot()->getGroup("input_file")->save(input_values_file, "json");
 
   // Not restarting, so we need to create the mesh and register it with the StateManager
   if (!restart_cycle) {

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -92,11 +92,21 @@ int main(int argc, char* argv[])
     input_file_path = search->second;
   }
 
-  // Output directory
+  // Output directory used for all files written to the file system.
+  // Example of outputted files:
+  //
+  // * Inlet docs + input file value file
+  // * StateManager state files
+  // * Summary file
+  // * Field data files
   std::string output_directory = "";
   search                       = cli_opts.find("output_directory");
   if (search != cli_opts.end()) {
+    // if given by user use that
     output_directory = search->second;
+  } else {
+    // otherwise use input file's basename minus extension
+    output_directory = serac::input::getInputFileName(input_file_path);
   }
   axom::utilities::filesystem::makeDirsForPath(output_directory);
   SLIC_INFO(fmt::format("Output Directory: {}", output_directory));

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -130,8 +130,8 @@ int main(int argc, char* argv[])
   }
 
   // Save input values to file
-  std::string input_values_file = fmt::format("{0}/serac_input_values.json", output_directory);
-  datastore.getRoot()->getGroup("input_file")->save(input_values_file, "json");
+  std::string input_values_path = axom::utilities::filesystem::joinPath(output_directory, "serac_input_values.json");
+  datastore.getRoot()->getGroup("input_file")->save(input_values_path, "json");
 
   // Not restarting, so we need to create the mesh and register it with the StateManager
   if (!restart_cycle) {

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -92,6 +92,15 @@ int main(int argc, char* argv[])
     input_file_path = search->second;
   }
 
+  // Output directory
+  std::string output_directory = "";
+  search          = cli_opts.find("output_directory");
+  if (search != cli_opts.end()) {
+    output_directory = search->second;
+  }
+  axom::utilities::filesystem::makeDirsForPath(output_directory);
+  SLIC_INFO(fmt::format("Output Directory: {}", output_directory));
+
   // Check if a restart was requested
   std::optional<int> restart_cycle;
   if (auto cycle = cli_opts.find("restart_cycle"); cycle != cli_opts.end()) {
@@ -207,7 +216,7 @@ int main(int argc, char* argv[])
 
   serac::output::outputSummary(datastore, serac::StateManager::collectionName());
   if (output_fields) {
-    serac::output::outputFields(datastore, serac::StateManager::collectionName(), t);
+    serac::output::outputFields(datastore, serac::StateManager::collectionName(), output_directory, t);
   }
 
   serac::exitGracefully();

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -215,7 +215,7 @@ int main(int argc, char* argv[])
     last_step = (t >= t_final - 1e-8 * dt);
   }
 
-  serac::output::outputSummary(datastore, serac::StateManager::collectionName());
+  serac::output::outputSummary(datastore, serac::StateManager::collectionName(), output_directory);
   if (output_fields) {
     serac::output::outputFields(datastore, serac::StateManager::collectionName(), output_directory, t);
   }

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -190,7 +190,7 @@ int main(int argc, char* argv[])
 
   // FIXME: This and the FromInlet specialization are hacked together,
   // should be inlet["output_type"].get<OutputType>()
-  main_physics->initializeOutput(inlet.getGlobalContainer().get<serac::OutputType>(), "serac");
+  main_physics->initializeOutput(inlet.getGlobalContainer().get<serac::OutputType>(), "serac", output_directory);
 
   main_physics->initializeSummary(datastore, t_final, dt);
 
@@ -212,7 +212,7 @@ int main(int argc, char* argv[])
     main_physics->advanceTimestep(dt_real);
 
     // Output a visualization file
-    main_physics->outputState(output_directory);
+    main_physics->outputState();
 
     // Save curve data to Sidre datastore to be output later
     main_physics->saveSummary(datastore, t);

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -87,7 +87,7 @@ int main(int argc, char* argv[])
 
   // Read input file
   std::string input_file_path = "";
-  auto        search          = cli_opts.find("input_file");
+  auto        search          = cli_opts.find("input-file");
   if (search != cli_opts.end()) {
     input_file_path = search->second;
   }
@@ -100,27 +100,22 @@ int main(int argc, char* argv[])
   // * Summary file
   // * Field data files
   std::string output_directory = "";
-  search                       = cli_opts.find("output_directory");
+  search                       = cli_opts.find("output-directory");
   if (search != cli_opts.end()) {
-    // if given by user use that
     output_directory = search->second;
-  } else {
-    // otherwise use input file's basename minus extension
-    output_directory = serac::input::getInputFileName(input_file_path);
   }
   axom::utilities::filesystem::makeDirsForPath(output_directory);
-  SLIC_INFO(fmt::format("Output Directory: {}", output_directory));
 
   // Check if a restart was requested
   std::optional<int> restart_cycle;
-  if (auto cycle = cli_opts.find("restart_cycle"); cycle != cli_opts.end()) {
+  if (auto cycle = cli_opts.find("restart-cycle"); cycle != cli_opts.end()) {
     restart_cycle = std::stoi(cycle->second);
   }
 
   // Check for the doc creation command line argument
-  bool create_input_file_docs = cli_opts.find("create_input_file_docs") != cli_opts.end();
+  bool create_input_file_docs = cli_opts.find("create-input-file-docs") != cli_opts.end();
   // Check for the output fields command line argument
-  bool output_fields = cli_opts.find("output_fields") != cli_opts.end();
+  bool output_fields = cli_opts.find("output-fields") != cli_opts.end();
 
   // Create DataStore
   axom::sidre::DataStore datastore;

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -8,6 +8,7 @@
 
 #include "CLI11/CLI11.hpp"
 
+#include "serac/infrastructure/input.hpp"
 #include "serac/infrastructure/logger.hpp"
 #include "serac/infrastructure/terminator.hpp"
 
@@ -20,17 +21,17 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
   // specify all input arguments
   CLI::App    app{app_description};
   std::string input_file_path;
-  app.add_option("-i, --input_file", input_file_path, "Input file to use.")->required()->check(CLI::ExistingFile);
+  app.add_option("-i, --input-file", input_file_path, "Input file to use.")->required()->check(CLI::ExistingFile);
   int  restart_cycle;
   auto restart_opt =
-      app.add_option("-c, --restart_cycle", restart_cycle, "Cycle to restart from.")->check(CLI::PositiveNumber);
+      app.add_option("-c, --restart-cycle", restart_cycle, "Cycle to restart from.")->check(CLI::PositiveNumber);
   bool create_input_file_docs{false};
   app.add_flag("-d, --create-input-file-docs", create_input_file_docs,
                "Writes Sphinx documentation for input file, then exits");
   bool output_fields{false};
   app.add_flag("--output-fields", output_fields, "Writes field data to file system.");
   std::string output_directory;
-  app.add_option("-o, --output_directory", output_directory, "Directory to put outputted files.");
+  app.add_option("-o, --output-directory", output_directory, "Directory to put outputted files.");
 
   // Parse the arguments and check if they are good
   try {
@@ -47,33 +48,56 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
     }
   }
 
-  // Store found values
+  // Store found values and set defaults if not set above
   std::unordered_map<std::string, std::string> cli_opts;
-  cli_opts.insert({std::string("input_file"), input_file_path});
+  cli_opts.insert({std::string("input-file"), input_file_path});
   // If a restart cycle was specified
   if (restart_opt->count() > 0) {
-    cli_opts["restart_cycle"] = std::to_string(restart_cycle);
+    cli_opts["restart-cycle"] = std::to_string(restart_cycle);
   }
   if (create_input_file_docs) {
-    cli_opts.insert({"create_input_file_docs", {}});
+    cli_opts.insert({"create-input-file-docs", {}});
   }
   if (output_fields) {
-    cli_opts.insert({"output_fields", {}});
+    cli_opts.insert({"output-fields", {}});
   }
-  if (output_directory != "") {
-    cli_opts.insert({"output_directory", output_directory});
+  if (output_directory == "") {
+    // if given by user use that otherwise use input file's basename minus extension
+    output_directory = serac::input::getInputFileName(input_file_path);
   }
+  cli_opts.insert({"output-directory", output_directory});
+
   return cli_opts;
 }
+
+std::string cliValueToString(std::string value) { return value; }
+
+std::string cliValueToString(bool value) { return value ? "true" : "false"; }
+
+std::string cliValueToString(int value) { return std::to_string(value); }
 
 void printGiven(std::unordered_map<std::string, std::string>& cli_opts)
 {
   // Add header
   std::string optsMsg = fmt::format("\n{:*^80}\n", "Command Line Options");
 
-  // Add options
-  auto search = cli_opts.find("input_file");
-  if (search != cli_opts.end()) optsMsg += fmt::format("Input File: {0}\n", search->second);
+  // Create options map
+  // clang-format off
+  std::vector<std::pair<std::string, std::string>> opts_output_map{
+    {"create-input-file-docs", "Create Input File Docs"},
+    {"input-file", "Input File"},
+    {"output-directory", "Output Directory"},
+    {"output-fields", "Output Fields"},
+    {"restart-cycle", "Restart Cycle"}};
+  // clang-format on
+
+  // Add options to string
+  for (auto output_pair : opts_output_map) {
+    auto search = cli_opts.find(output_pair.first);
+    if (search != cli_opts.end()) {
+      optsMsg += fmt::format("{0}: {1}\n", output_pair.second, cliValueToString(search->second));
+    }
+  }
 
   // Add footer
   optsMsg += fmt::format("{:*^80}\n", "*");

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -70,11 +70,15 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
   return cli_opts;
 }
 
+namespace detail {
+
 std::string cliValueToString(std::string value) { return value; }
 
 std::string cliValueToString(bool value) { return value ? "true" : "false"; }
 
 std::string cliValueToString(int value) { return std::to_string(value); }
+
+} // namespace detail
 
 void printGiven(std::unordered_map<std::string, std::string>& cli_opts)
 {
@@ -95,7 +99,7 @@ void printGiven(std::unordered_map<std::string, std::string>& cli_opts)
   for (auto output_pair : opts_output_map) {
     auto search = cli_opts.find(output_pair.first);
     if (search != cli_opts.end()) {
-      optsMsg += fmt::format("{0}: {1}\n", output_pair.second, cliValueToString(search->second));
+      optsMsg += fmt::format("{0}: {1}\n", output_pair.second, detail::cliValueToString(search->second));
     }
   }
 

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -27,8 +27,8 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
   bool create_input_file_docs{false};
   app.add_flag("-d, --create-input-file-docs", create_input_file_docs,
                "Writes Sphinx documentation for input file, then exits");
-  bool output_fields{true};
-  app.add_flag("--output-fields,!--no-output-fields", output_fields, "Writes field data to file system.");
+  bool output_fields{false};
+  app.add_flag("--output-fields", output_fields, "Writes field data to file system.");
   std::string output_directory;
   app.add_option("-o, --output_directory", output_directory, "Directory to put outputted files.");
 

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -21,17 +21,17 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
   // specify all input arguments
   CLI::App    app{app_description};
   std::string input_file_path;
-  app.add_option("-i, --input-file", input_file_path, "Input file to use.")->required()->check(CLI::ExistingFile);
+  app.add_option("-i, --input-file", input_file_path, "Input file to use")->required()->check(CLI::ExistingFile);
   int  restart_cycle;
   auto restart_opt =
-      app.add_option("-c, --restart-cycle", restart_cycle, "Cycle to restart from.")->check(CLI::PositiveNumber);
+      app.add_option("-c, --restart-cycle", restart_cycle, "Cycle to restart from")->check(CLI::PositiveNumber);
   bool create_input_file_docs{false};
   app.add_flag("-d, --create-input-file-docs", create_input_file_docs,
                "Writes Sphinx documentation for input file, then exits");
   bool output_fields{false};
-  app.add_flag("--output-fields", output_fields, "Writes field data to file system.");
+  app.add_flag("--output-fields", output_fields, "Writes field data to file system");
   std::string output_directory;
-  app.add_option("-o, --output-directory", output_directory, "Directory to put outputted files.");
+  app.add_option("-o, --output-directory", output_directory, "Directory to put outputted files");
 
   // Parse the arguments and check if they are good
   try {

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -61,7 +61,7 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
     cli_opts.insert({"output_fields", {}});
   }
   if (output_directory != "") {
-    cli_opts.insert({std::string("output_directory"), output_directory});
+    cli_opts.insert({"output_directory", output_directory});
   }
   return cli_opts;
 }

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -78,7 +78,7 @@ std::string cliValueToString(bool value) { return value ? "true" : "false"; }
 
 std::string cliValueToString(int value) { return std::to_string(value); }
 
-} // namespace detail
+}  // namespace detail
 
 void printGiven(std::unordered_map<std::string, std::string>& cli_opts)
 {

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -32,7 +32,6 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
   std::string output_directory;
   app.add_option("-o, --output_directory", output_directory, "Directory to put outputted files.");
 
-
   // Parse the arguments and check if they are good
   try {
     app.parse(argc, argv);

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -29,6 +29,9 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
                "Writes Sphinx documentation for input file, then exits");
   bool output_fields{true};
   app.add_flag("--output-fields,!--no-output-fields", output_fields, "Writes field data to file system.");
+  std::string output_directory;
+  app.add_option("-o, --output_directory", output_directory, "Directory to put outputted files.");
+
 
   // Parse the arguments and check if they are good
   try {
@@ -57,6 +60,9 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
   }
   if (output_fields) {
     cli_opts.insert({"output_fields", {}});
+  }
+  if (output_directory != "") {
+    cli_opts.insert({std::string("output_directory"), output_directory});
   }
   return cli_opts;
 }

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -80,6 +80,22 @@ std::string fullDirectoryFromPath(const std::string& path)
   return dir;
 }
 
+std::string getInputFileName(const std::string& file_path)
+{
+  axom::Path  path(file_path);
+  std::string basename = path.baseName();
+  std::string name;
+
+  size_t index = basename.find_last_of(".");
+  if (index != std::string::npos) {
+    name = basename.substr(0, index);
+  } else {
+    name = basename;
+  }
+
+  return name;
+}
+
 void defineVectorInputFileSchema(axom::inlet::Container& container)
 {
   // TODO: I had to remove the required tag on x as we now have an optional vector input in the coefficients. IT would

--- a/src/serac/infrastructure/input.hpp
+++ b/src/serac/infrastructure/input.hpp
@@ -66,6 +66,16 @@ std::string findMeshFilePath(const std::string& mesh_path, const std::string& in
 std::string fullDirectoryFromPath(const std::string& file_path);
 
 /**
+ * @brief Returns the name of the input file (base name with file extension removed).
+ *
+ * // TODO: remove when axom::Path supports this
+ *
+ * @param[in] file_path path to a file
+ * @return name of input file
+ */
+std::string getInputFileName(const std::string& file_path);
+
+/**
  * @brief Defines the schema for a vector in R^{1,2,3} space
  * @param[inout] container The base container on which to define the schema
  */

--- a/src/serac/infrastructure/logger.cpp
+++ b/src/serac/infrastructure/logger.cpp
@@ -92,10 +92,7 @@ bool initialize(MPI_Comm comm)
   return true;
 }
 
-void finalize()
-{
-  axom::slic::finalize();
-}
+void finalize() { axom::slic::finalize(); }
 
 void flush() { axom::slic::flushStreams(); }
 

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -35,7 +35,7 @@ std::string file_format_string(const FileFormat file_format)
 }  // namespace detail
 
 void outputSummary(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
-                   const FileFormat file_format)
+                   const std::string& output_directory, const FileFormat file_format)
 {
   auto [_, rank] = getMPIInfo();
   if (rank != 0) {
@@ -47,7 +47,8 @@ void outputSummary(const axom::sidre::DataStore& datastore, const std::string& d
   std::string file_format_string = detail::file_format_string(file_format);
 
   const std::string file_name = fmt::format("{0}_summary.{1}", data_collection_name, file_format_string);
-  datastore.getRoot()->getGroup("serac_summary")->save(file_name, file_format_string);
+  const std::string path = axom::utilities::filesystem::joinPath(output_directory, file_name);
+  datastore.getRoot()->getGroup("serac_summary")->save(path, file_format_string);
 }
 
 void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
@@ -69,8 +70,8 @@ void outputFields(const axom::sidre::DataStore& datastore, const std::string& da
   conduit::Node extracts;
   // "relay" is the Ascents Extract type for saving data
   extracts["e1/type"]            = "relay";
-  std::string file_name = fmt::format("{}_fields.{}", data_collection_name, file_format_string);
-  std::string path = axom::utilities::filesystem::joinPath(output_directory, file_name);
+  const std::string file_name = fmt::format("{}_fields.{}", data_collection_name, file_format_string);
+  const std::string path = axom::utilities::filesystem::joinPath(output_directory, file_name);
   extracts["e1/params/path"]     = path;
   extracts["e1/params/protocol"] = file_format_string;
 

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -12,6 +12,7 @@
 
 #include "conduit/conduit.hpp"
 #include "ascent/ascent.hpp"
+#include "axom/core.hpp"
 #include "axom/sidre.hpp"
 
 #include "mpi.h"
@@ -68,7 +69,9 @@ void outputFields(const axom::sidre::DataStore& datastore, const std::string& da
   conduit::Node extracts;
   // "relay" is the Ascents Extract type for saving data
   extracts["e1/type"]            = "relay";
-  extracts["e1/params/path"]     = fmt::format("{}/{}_fields.{}", output_directory, data_collection_name, file_format_string);
+  std::string file_name = fmt::format("{}_fields.{}", data_collection_name, file_format_string);
+  std::string path = axom::utilities::filesystem::joinPath(output_directory, file_name);
+  extracts["e1/params/path"]     = path;
   extracts["e1/params/protocol"] = file_format_string;
 
   // Get domain Sidre group

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -49,8 +49,8 @@ void outputSummary(const axom::sidre::DataStore& datastore, const std::string& d
   datastore.getRoot()->getGroup("serac_summary")->save(file_name, file_format_string);
 }
 
-void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name, double time,
-                  const FileFormat file_format)
+void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
+                  const std::string& output_directory, double time, const FileFormat file_format)
 {
   SLIC_INFO_ROOT(fmt::format("Outputting field data at time: {}", time));
 
@@ -68,7 +68,7 @@ void outputFields(const axom::sidre::DataStore& datastore, const std::string& da
   conduit::Node extracts;
   // "relay" is the Ascents Extract type for saving data
   extracts["e1/type"]            = "relay";
-  extracts["e1/params/path"]     = fmt::format("{}_fields.{}", data_collection_name, file_format_string);
+  extracts["e1/params/path"]     = fmt::format("{}/{}_fields.{}", output_directory, data_collection_name, file_format_string);
   extracts["e1/params/protocol"] = file_format_string;
 
   // Get domain Sidre group

--- a/src/serac/infrastructure/output.cpp
+++ b/src/serac/infrastructure/output.cpp
@@ -47,7 +47,7 @@ void outputSummary(const axom::sidre::DataStore& datastore, const std::string& d
   std::string file_format_string = detail::file_format_string(file_format);
 
   const std::string file_name = fmt::format("{0}_summary.{1}", data_collection_name, file_format_string);
-  const std::string path = axom::utilities::filesystem::joinPath(output_directory, file_name);
+  const std::string path      = axom::utilities::filesystem::joinPath(output_directory, file_name);
   datastore.getRoot()->getGroup("serac_summary")->save(path, file_format_string);
 }
 
@@ -70,8 +70,8 @@ void outputFields(const axom::sidre::DataStore& datastore, const std::string& da
   conduit::Node extracts;
   // "relay" is the Ascents Extract type for saving data
   extracts["e1/type"]            = "relay";
-  const std::string file_name = fmt::format("{}_fields.{}", data_collection_name, file_format_string);
-  const std::string path = axom::utilities::filesystem::joinPath(output_directory, file_name);
+  const std::string file_name    = fmt::format("{}_fields.{}", data_collection_name, file_format_string);
+  const std::string path         = axom::utilities::filesystem::joinPath(output_directory, file_name);
   extracts["e1/params/path"]     = path;
   extracts["e1/params/protocol"] = file_format_string;
 

--- a/src/serac/infrastructure/output.hpp
+++ b/src/serac/infrastructure/output.hpp
@@ -39,10 +39,11 @@ enum class FileFormat
  *
  * @param[in] datastore Root of the Sidre datastore
  * @param[in] data_collection_name Name of the Data Collection stored in Sidre
+ * @param[in] output_directory Directory to write output file into
  * @param[in] file_format The output file format
  */
 void outputSummary(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
-                   const FileFormat file_format = FileFormat::JSON);
+                   const std::string& output_directory, const FileFormat file_format = FileFormat::JSON);
 
 /**
  * @brief Outputs simulation field data from the datastore to the given file

--- a/src/serac/infrastructure/output.hpp
+++ b/src/serac/infrastructure/output.hpp
@@ -39,20 +39,21 @@ enum class FileFormat
  *
  * @param[in] datastore Root of the Sidre datastore
  * @param[in] data_collection_name Name of the Data Collection stored in Sidre
- * @param[in] language The output language format
+ * @param[in] file_format The output file format
  */
 void outputSummary(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
-                   const FileFormat language = FileFormat::JSON);
+                   const FileFormat file_format = FileFormat::JSON);
 
 /**
  * @brief Outputs simulation field data from the datastore to the given file
  *
  * @param[in] datastore Root of the Sidre datastore
  * @param[in] data_collection_name Name of the Data Collection stored in Sidre
+ * @param[in] output_directory Directory to write output files into
  * @param[in] time Current simulation time
- * @param[in] language The output language format
+ * @param[in] file_format The output file format
  */
-void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name, double time,
-                  const FileFormat language = FileFormat::JSON);
+void outputFields(const axom::sidre::DataStore& datastore, const std::string& data_collection_name,
+                  const std::string& output_directory, double time, const FileFormat file_format = FileFormat::JSON);
 
 }  // namespace serac::output

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -56,10 +56,11 @@ double BasePhysics::time() const { return time_; }
 
 int BasePhysics::cycle() const { return cycle_; }
 
-void BasePhysics::initializeOutput(const serac::OutputType output_type, const std::string& root_name)
+void BasePhysics::initializeOutput(const serac::OutputType output_type, const std::string& root_name, const std::string output_directory)
 {
   root_name_   = root_name;
   output_type_ = output_type;
+  output_directory_ = output_directory;
 
   switch (output_type_) {
     case serac::OutputType::VisIt: {
@@ -100,7 +101,7 @@ void BasePhysics::initializeOutput(const serac::OutputType output_type, const st
   }
 }
 
-void BasePhysics::outputState(const std::string output_directory) const
+void BasePhysics::outputState() const
 {
   switch (output_type_) {
     case serac::OutputType::VisIt:
@@ -108,8 +109,8 @@ void BasePhysics::outputState(const std::string output_directory) const
     case serac::OutputType::ParaView:
       dc_->SetCycle(cycle_);
       dc_->SetTime(time_);
-      if (!output_directory.empty()) {
-        dc_->SetPrefixPath(output_directory);
+      if (!output_directory_.empty()) {
+        dc_->SetPrefixPath(output_directory_);
       }
       dc_->Save();
       break;
@@ -122,14 +123,14 @@ void BasePhysics::outputState(const std::string output_directory) const
 
     case serac::OutputType::GLVis: {
       const std::string mesh_name = fmt::format("{0}-mesh.{1:0>6}.{2:0>6}", root_name_, cycle_, mpi_rank_);
-      const std::string mesh_path = axom::utilities::filesystem::joinPath(output_directory, mesh_name);
+      const std::string mesh_path = axom::utilities::filesystem::joinPath(output_directory_, mesh_name);
       std::ofstream     omesh(mesh_path);
       omesh.precision(FLOAT_PRECISION_);
       state_.front().get().mesh().Print(omesh);
 
       for (FiniteElementState& state : state_) {
         std::string sol_name = fmt::format("{0}-{1}.{2:0>6}.{3:0>6}", root_name_, state.name(), cycle_, mpi_rank_);
-        const std::string sol_path = axom::utilities::filesystem::joinPath(output_directory, sol_name);
+        const std::string sol_path = axom::utilities::filesystem::joinPath(output_directory_, sol_name);
         std::ofstream     osol(sol_path);
         osol.precision(FLOAT_PRECISION_);
         state.gridFunc().Save(osol);

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -123,14 +123,14 @@ void BasePhysics::outputState(const std::string output_directory) const
     case serac::OutputType::GLVis: {
       const std::string mesh_name = fmt::format("{0}-mesh.{1:0>6}.{2:0>6}", root_name_, cycle_, mpi_rank_);
       const std::string mesh_path = axom::utilities::filesystem::joinPath(output_directory, mesh_name);
-      std::ofstream omesh(mesh_path);
+      std::ofstream     omesh(mesh_path);
       omesh.precision(FLOAT_PRECISION_);
       state_.front().get().mesh().Print(omesh);
 
       for (FiniteElementState& state : state_) {
-        std::string   sol_name = fmt::format("{0}-{1}.{2:0>6}.{3:0>6}", root_name_, state.name(), cycle_, mpi_rank_);
+        std::string sol_name = fmt::format("{0}-{1}.{2:0>6}.{3:0>6}", root_name_, state.name(), cycle_, mpi_rank_);
         const std::string sol_path = axom::utilities::filesystem::joinPath(output_directory, sol_name);
-        std::ofstream osol(sol_path);
+        std::ofstream     osol(sol_path);
         osol.precision(FLOAT_PRECISION_);
         state.gridFunc().Save(osol);
       }

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -56,10 +56,11 @@ double BasePhysics::time() const { return time_; }
 
 int BasePhysics::cycle() const { return cycle_; }
 
-void BasePhysics::initializeOutput(const serac::OutputType output_type, const std::string& root_name, const std::string output_directory)
+void BasePhysics::initializeOutput(const serac::OutputType output_type, const std::string& root_name,
+                                   const std::string output_directory)
 {
-  root_name_   = root_name;
-  output_type_ = output_type;
+  root_name_        = root_name;
+  output_type_      = output_type;
   output_directory_ = output_directory;
 
   switch (output_type_) {

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -109,7 +109,8 @@ public:
    * @param[in] root_name The root name of the output files
    * @param[in] output_directory The directory to output files to
    */
-  virtual void initializeOutput(const serac::OutputType output_type, const std::string& root_name, const std::string output_directory = "");
+  virtual void initializeOutput(const serac::OutputType output_type, const std::string& root_name,
+                                const std::string output_directory = "");
 
   /**
    * @brief Output the current state of the PDE fields

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -107,15 +107,14 @@ public:
    *
    * @param[in] output_type The type of output files to produce
    * @param[in] root_name The root name of the output files
+   * @param[in] output_directory The directory to output files to
    */
-  virtual void initializeOutput(const serac::OutputType output_type, const std::string& root_name);
+  virtual void initializeOutput(const serac::OutputType output_type, const std::string& root_name, const std::string output_directory = "");
 
   /**
    * @brief Output the current state of the PDE fields
-   *
-   * @param[in] output_directory The directory to output files to
    */
-  virtual void outputState(const std::string output_directory = "") const;
+  virtual void outputState() const;
 
   /**
    * @brief Initializes the Sidre structure for simulation summary data
@@ -179,6 +178,11 @@ protected:
    * @brief Root output name
    */
   std::string root_name_;
+
+  /**
+   * @brief Directory to output files
+   */
+  std::string output_directory_;
 
   /**
    * @brief Number of significant figures to output for floating-point

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -113,8 +113,9 @@ public:
   /**
    * @brief Output the current state of the PDE fields
    *
+   * @param[in] output_directory The directory to output files to
    */
-  virtual void outputState() const;
+  virtual void outputState(const std::string output_directory = "") const;
 
   /**
    * @brief Initializes the Sidre structure for simulation summary data

--- a/src/serac/physics/tests/test_utilities.cpp
+++ b/src/serac/physics/tests/test_utilities.cpp
@@ -158,7 +158,7 @@ void runModuleTest(const std::string& input_file, const std::string& test_name, 
   // WARNING: This must happen before serac::input::initialize, as the loading
   // process will wipe out the datastore
   if (restart_cycle) {
-    serac::StateManager::initialize(datastore, "serac", *restart_cycle);
+    serac::StateManager::initialize(datastore, "serac", "", *restart_cycle);
   } else {
     serac::StateManager::initialize(datastore);
   }

--- a/src/serac/physics/utilities/functional/tests/functional_material_state_test.cpp
+++ b/src/serac/physics/utilities/functional/tests/functional_material_state_test.cpp
@@ -235,7 +235,7 @@ TYPED_TEST(QuadratureDataStateManagerTest, basic_integrals_state_manager)
   // Then reload the state to make sure it was synced correctly, and update it again before saving
   {
     axom::sidre::DataStore datastore;
-    serac::StateManager::initialize(datastore, "serac", cycle);
+    serac::StateManager::initialize(datastore, "serac", "", cycle);
     // Since the original mesh is dead, use the mesh recovered from the save file to build a new Functional
     this->resetWithNewMesh(serac::StateManager::mesh());
     serac::QuadratureData<typename TestFixture::value_type>& qdata =
@@ -269,7 +269,7 @@ TYPED_TEST(QuadratureDataStateManagerTest, basic_integrals_state_manager)
   // is read in from a restart
   {
     axom::sidre::DataStore datastore;
-    serac::StateManager::initialize(datastore, "serac", cycle + 1);
+    serac::StateManager::initialize(datastore, "serac", "", cycle + 1);
     // Since the original mesh is dead, use the mesh recovered from the save file to build a new Functional
     this->resetWithNewMesh(serac::StateManager::mesh());
     serac::QuadratureData<typename TestFixture::value_type>& qdata =
@@ -299,7 +299,7 @@ TYPED_TEST(QuadratureDataStateManagerTest, basic_integrals_state_manager)
   // included the distance of the quadrature point from the origin (which is unique)
   {
     axom::sidre::DataStore datastore;
-    serac::StateManager::initialize(datastore, "serac", cycle + 2);
+    serac::StateManager::initialize(datastore, "serac", "", cycle + 2);
     serac::QuadratureData<typename TestFixture::value_type>& qdata =
         serac::StateManager::newQuadratureData<typename TestFixture::value_type>("test_data", this->p);
     // Make sure the changes from the distance-specified increment were propagated through and in the correct order

--- a/src/serac/physics/utilities/state_manager.cpp
+++ b/src/serac/physics/utilities/state_manager.cpp
@@ -6,6 +6,8 @@
 
 #include "serac/physics/utilities/state_manager.hpp"
 
+#include "axom/core.hpp"
+
 namespace serac {
 
 /**
@@ -20,7 +22,7 @@ std::string                                         StateManager::collection_nam
 std::vector<std::unique_ptr<SyncableData>>          StateManager::syncable_data_;
 
 void StateManager::initialize(axom::sidre::DataStore& ds, const std::string& collection_name_prefix,
-                              const std::optional<int> cycle_to_load)
+                              const std::string output_directory, const std::optional<int> cycle_to_load)
 {
   // If the global object has already been initialized, clear it out
   if (datacoll_) {
@@ -37,6 +39,11 @@ void StateManager::initialize(axom::sidre::DataStore& ds, const std::string& col
   const bool owns_mesh_data = true;
   datacoll_.emplace(collection_name_, bp_index_grp, domain_grp, owns_mesh_data);
   datacoll_->SetComm(MPI_COMM_WORLD);
+
+  if (!output_directory.empty()) {
+    datacoll_->SetPrefixPath(output_directory);
+  }
+
   if (cycle_to_load) {
     is_restart_ = true;
     // NOTE: Load invalidates previous Sidre pointers

--- a/src/serac/physics/utilities/state_manager.hpp
+++ b/src/serac/physics/utilities/state_manager.hpp
@@ -33,10 +33,11 @@ public:
    * @brief Initializes the StateManager with a sidre DataStore (into which state will be written/read)
    * @param[in] ds The DataStore to use
    * @param[in] collection_name_prefix The prefix for the name of the Sidre DataCollection to be created
+   * @param[in] output_directory The directory to output files to
    * @param[in] cycle_to_load The cycle to load - required for restarts
    */
   static void initialize(axom::sidre::DataStore& ds, const std::string& collection_name_prefix = "serac",
-                         const std::optional<int> cycle_to_load = {});
+                         const std::string output_directory = "", const std::optional<int> cycle_to_load = {});
 
   /**
    * @brief Factory method for creating a new FEState object, signature is identical to FEState constructor


### PR DESCRIPTION
This allows all output to be written/read to a user specified output directory via a new command line option `-o <dir>` or `--output_directory <dir>`.

This includes loading restarts as well.  So users will have to use the same output directory command line option if they want to restart.

Things that were moved:

- Inlet docs + input file value file
- StateManager state files
- Summary file
- Field data files

Note: I removed the SLIC logging stream that wrote to a file for two reasons:

- it's not a full capture of all output to the screen because not all things are going through SLIC
- it was created pre command line options and therefore slightly complicated to fix though doable.