### PR TITLE
Use correct type in `avg` function MPI call

### DIFF
--- a/src/serac/physics/utilities/finite_element_state.cpp
+++ b/src/serac/physics/utilities/finite_element_state.cpp
@@ -70,7 +70,7 @@ double avg(const FiniteElementState& state)
   double global_sum;
   double local_sum = state.trueVec().Sum();
   int    global_size;
-  double local_size = state.trueVec().Size();
+  int    local_size = state.trueVec().Size();
   MPI_Allreduce(&local_sum, &global_sum, 1, MPI_DOUBLE, MPI_SUM, state.comm());
   MPI_Allreduce(&local_size, &global_size, 1, MPI_INT, MPI_SUM, state.comm());
   return global_sum / global_size;


### PR DESCRIPTION
Thought i looked at the output after the last commit but apparently I didn't. Please merge as soon as this passes tests and has two reviews.

This fixes `nan` and `inf` as all the values in the average fields in the summary file.