### PR TITLE
functional: add missing headers to CMakeLists.txt

### DIFF
--- a/src/serac/physics/utilities/functional/CMakeLists.txt
+++ b/src/serac/physics/utilities/functional/CMakeLists.txt
@@ -10,13 +10,16 @@ blt_list_append( TO functional_depends ELEMENTS caliper IF SERAC_USE_CALIPER )
 
 # Add the library first
 set(functional_headers
-    functional.hpp
-    tensor.hpp
+    boundary_integral.hpp
+    domain_integral.hpp
     dual.hpp
-    tuple_arithmetic.hpp
+    finite_element.hpp
+    functional.hpp
+    integral_utilities.hpp
     polynomials.hpp
     quadrature.hpp
-    finite_element.hpp
+    tensor.hpp
+    tuple_arithmetic.hpp
     )
 
 set(functional_detail_headers


### PR DESCRIPTION
This commit adds some missing headers from the functional directory to
CMakeLists.txt so these headers are installed when Serac is installed
into a prefix. For my own sanity and to avoid missing headers, I
alphabetized the header list I modified.