### PR TITLE
docs/index.rst: fix use of possessive "its"

### DIFF
--- a/src/docs/index.rst
+++ b/src/docs/index.rst
@@ -7,8 +7,8 @@
 Serac
 =======
 
-Serac is a 3D implicit nonlinear thermal-structural simulation code. It's primary purpose is to investigate multiphysics abstraction
-strategies and implicit finite element-based algorithm development for emerging computing architectures. It also serves as a proxy-app for LLNL's 
+Serac is a 3D implicit nonlinear thermal-structural simulation code. Its primary purpose is to investigate multiphysics abstraction
+strategies and implicit finite element-based algorithm development for emerging computing architectures. It also serves as a proxy-app for LLNL's
 Smith code and heavily leverages the `MFEM finite element library <https://mfem.org/>`_.
 
 


### PR DESCRIPTION
This commit replaces "It's" in the documentation index page with "Its"
because its use in that sentence is possessive -- referring to Serac
-- rather than the contraction "it is".