### PR TITLE
Add the nested test directories to the code checks

### DIFF
--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -75,17 +75,18 @@ macro(serac_add_code_checks)
                               CHECKS            "clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*"
                               SRC_FILES         ${_src_sources})
 
-    # NOTE: GLOB operator ** did not appear to be supported by cmake did not recursively find test subdirectories
+    # Create list of recursive test directory glob expressions
+    # NOTE: GLOB operator ** did not appear to be supported by cmake and did not recursively find test subdirectories
+    # NOTE: Do not include all directories at root (for example: blt)
 
+    set(_test_glob_dirs "${PROJECT_SOURCE_DIR}/tests/*.*pp"
+                        "${PROJECT_SOURCE_DIR}/src/tests/*.*pp")
+    foreach(i RANGE 10)
+        set(_temp "${_temp}/*")
+        list(APPEND _test_glob_dirs "${PROJECT_SOURCE_DIR}/src${_temp}/tests/*.*pp")
+    endforeach()
     set(_test_sources)
-    file(GLOB_RECURSE _test_sources "${PROJECT_SOURCE_DIR}/tests/*.*pp" 
-                                    "${PROJECT_SOURCE_DIR}/*/tests/*.*pp" 
-                                    "${PROJECT_SOURCE_DIR}/*/*/tests/*.*pp" 
-                                    "${PROJECT_SOURCE_DIR}/*/*/*/tests/*.*pp"
-                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/tests/*.*pp"
-                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/*/tests/*.*pp"
-                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/*/*/tests/*.*pp"
-                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/*/*/*/tests/*.*pp")
+    file(GLOB_RECURSE _test_sources ${_test_glob_dirs})
 
     blt_add_clang_tidy_target(NAME              ${arg_PREFIX}_guidelines_check_tests
                               CHECKS            "clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers"

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -80,8 +80,7 @@ macro(serac_add_code_checks)
     # NOTE: GLOB operator ** did not appear to be supported by cmake and did not recursively find test subdirectories
     # NOTE: Do not include all directories at root (for example: blt)
 
-    file(GLOB_RECURSE _src_and_test_files "${PROJECT_SOURCE_DIR}/src/*.cpp" "{PROJECT_SOURCE_DIR}/tests/*.cpp")
-    set(_test_sources ${_src_and_test_files})
+    file(GLOB_RECURSE _test_sources "${PROJECT_SOURCE_DIR}/src/*.cpp" "{PROJECT_SOURCE_DIR}/tests/*.cpp")
     list(FILTER _test_sources INCLUDE REGEX ".*/tests/.*pp")
 
     blt_add_clang_tidy_target(NAME              ${arg_PREFIX}_guidelines_check_tests

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -75,12 +75,22 @@ macro(serac_add_code_checks)
                               CHECKS            "clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*"
                               SRC_FILES         ${_src_sources})
 
+    # NOTE: GLOB operator ** did not appear to be supported by cmake did not recursively find test subdirectories
+
     set(_test_sources)
-    file(GLOB_RECURSE _test_sources "tests/*.cpp" "tests/*.hpp")
+    file(GLOB_RECURSE _test_sources "${PROJECT_SOURCE_DIR}/tests/*.*pp" 
+                                    "${PROJECT_SOURCE_DIR}/*/tests/*.*pp" 
+                                    "${PROJECT_SOURCE_DIR}/*/*/tests/*.*pp" 
+                                    "${PROJECT_SOURCE_DIR}/*/*/*/tests/*.*pp"
+                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/tests/*.*pp"
+                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/*/tests/*.*pp"
+                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/*/*/tests/*.*pp"
+                                    "${PROJECT_SOURCE_DIR}/*/*/*/*/*/*/*/tests/*.*pp")
 
     blt_add_clang_tidy_target(NAME              ${arg_PREFIX}_guidelines_check_tests
                               CHECKS            "clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers"
                               SRC_FILES         ${_test_sources})
+                                  
     if (ENABLE_COVERAGE)
         blt_add_code_coverage_target(NAME   ${arg_PREFIX}_coverage
                                      RUNNER ${CMAKE_MAKE_PROGRAM} test

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -69,7 +69,7 @@ macro(serac_add_code_checks)
 
 
     set(_src_sources)
-    file(GLOB_RECURSE _src_sources "src/*.cpp" "src/*.hpp")
+    file(GLOB_RECURSE _src_sources "src/*.cpp" "src/*.hpp" "src/*.inl")
 
     blt_add_clang_tidy_target(NAME              ${arg_PREFIX}_guidelines_check
                               CHECKS            "clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*"
@@ -79,14 +79,9 @@ macro(serac_add_code_checks)
     # NOTE: GLOB operator ** did not appear to be supported by cmake and did not recursively find test subdirectories
     # NOTE: Do not include all directories at root (for example: blt)
 
-    set(_test_glob_dirs "${PROJECT_SOURCE_DIR}/tests/*.*pp"
-                        "${PROJECT_SOURCE_DIR}/src/tests/*.*pp")
-    foreach(i RANGE 10)
-        set(_temp "${_temp}/*")
-        list(APPEND _test_glob_dirs "${PROJECT_SOURCE_DIR}/src${_temp}/tests/*.*pp")
-    endforeach()
-    set(_test_sources)
-    file(GLOB_RECURSE _test_sources ${_test_glob_dirs})
+    file(GLOB_RECURSE _src_and_test_files "${PROJECT_SOURCE_DIR}/src/*.cpp" "{PROJECT_SOURCE_DIR}/tests/*.cpp")
+    set(_test_sources ${_src_and_test_files})
+    list(FILTER _test_sources INCLUDE REGEX ".*/tests/.*pp")
 
     blt_add_clang_tidy_target(NAME              ${arg_PREFIX}_guidelines_check_tests
                               CHECKS            "clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*,-cppcoreguidelines-avoid-magic-numbers"

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -70,6 +70,7 @@ macro(serac_add_code_checks)
 
     set(_src_sources)
     file(GLOB_RECURSE _src_sources "src/*.cpp" "src/*.hpp" "src/*.inl")
+    list(FILTER _src_sources EXCLUDE REGEX ".*/tests/.*pp")
 
     blt_add_clang_tidy_target(NAME              ${arg_PREFIX}_guidelines_check
                               CHECKS            "clang-analyzer-*,clang-analyzer-cplusplus*,cppcoreguidelines-*"


### PR DESCRIPTION
Now that we have tests nested throughout source, we should recursively check for test subdirectories. Note: this is gross because cmake apparently doesn't understand GLOB **.