### PR TITLE
WIP: Add attribute lists to functional boundary integrals

### DIFF
--- a/src/serac/physics/utilities/functional/boundary_integral.hpp
+++ b/src/serac/physics/utilities/functional/boundary_integral.hpp
@@ -283,7 +283,8 @@ public:
    */
   template <int dim, typename lambda_type, typename qpt_data_type = void>
   BoundaryIntegral(int num_elements, const mfem::Vector& J, const mfem::Vector& X, const mfem::Vector& normals,
-                   Dimension<dim>, lambda_type&& qf, mfem::Array<int>& dofs, QuadratureData<qpt_data_type>& data = dummy_qdata)
+                   Dimension<dim>, lambda_type&& qf, mfem::Array<int>& dofs,
+                   QuadratureData<qpt_data_type>& data = dummy_qdata)
       : J_(J), X_(X), normals_(normals), dofs_(dofs)
 
   {
@@ -338,9 +339,9 @@ public:
    */
   void GradientMult(const mfem::Vector& input_E, mfem::Vector& output_E) const { gradient_(input_E, output_E); }
 
-  const mfem::Array<int>& dofs() const {return dofs_;} 
+  const mfem::Array<int>& dofs() const { return dofs_; }
 
-private :
+private:
   /**
    * @brief Jacobians of the element transformations at all quadrature points
    */

--- a/src/serac/physics/utilities/functional/boundary_integral.hpp
+++ b/src/serac/physics/utilities/functional/boundary_integral.hpp
@@ -283,9 +283,9 @@ public:
    */
   template <int dim, typename lambda_type, typename qpt_data_type = void>
   BoundaryIntegral(int num_elements, const mfem::Vector& J, const mfem::Vector& X, const mfem::Vector& normals,
-                   Dimension<dim>, lambda_type&& qf, mfem::Array<int>& dofs,
+                   Dimension<dim>, lambda_type&& qf, const mfem::Array<int>& attr,
                    QuadratureData<qpt_data_type>& data = dummy_qdata)
-      : J_(J), X_(X), normals_(normals), dofs_(dofs)
+      : J_(J), X_(X), normals_(normals), attribute_markers_(attr)
 
   {
     constexpr auto geometry                      = supported_geometries[dim];
@@ -339,7 +339,7 @@ public:
    */
   void GradientMult(const mfem::Vector& input_E, mfem::Vector& output_E) const { gradient_(input_E, output_E); }
 
-  const mfem::Array<int>& dofs() const { return dofs_; }
+  const mfem::Array<int>& GetAttributeMarkers() const { return attribute_markers_; }
 
 private:
   /**
@@ -357,7 +357,7 @@ private:
    */
   const mfem::Vector normals_;
 
-  mfem::Array<int> dofs_;
+  const mfem::Array<int> attribute_markers_;
 
   /**
    * @brief Type-erased handle to evaluation kernel

--- a/src/serac/physics/utilities/functional/boundary_integral.hpp
+++ b/src/serac/physics/utilities/functional/boundary_integral.hpp
@@ -283,8 +283,8 @@ public:
    */
   template <int dim, typename lambda_type, typename qpt_data_type = void>
   BoundaryIntegral(int num_elements, const mfem::Vector& J, const mfem::Vector& X, const mfem::Vector& normals,
-                   Dimension<dim>, lambda_type&& qf, QuadratureData<qpt_data_type>& data = dummy_qdata)
-      : J_(J), X_(X), normals_(normals)
+                   Dimension<dim>, lambda_type&& qf, mfem::Array<int>& dofs, QuadratureData<qpt_data_type>& data = dummy_qdata)
+      : J_(J), X_(X), normals_(normals), dofs_(dofs)
 
   {
     constexpr auto geometry                      = supported_geometries[dim];
@@ -338,7 +338,9 @@ public:
    */
   void GradientMult(const mfem::Vector& input_E, mfem::Vector& output_E) const { gradient_(input_E, output_E); }
 
-private:
+  const mfem::Array<int>& dofs() const {return dofs_;} 
+
+private :
   /**
    * @brief Jacobians of the element transformations at all quadrature points
    */
@@ -353,6 +355,8 @@ private:
    * @brief physical coordinates of surface unit normals at all quadrature points
    */
   const mfem::Vector normals_;
+
+  mfem::Array<int> dofs_;
 
   /**
    * @brief Type-erased handle to evaluation kernel

--- a/src/serac/physics/utilities/functional/tests/functional_boundary_test.cpp
+++ b/src/serac/physics/utilities/functional/tests/functional_boundary_test.cpp
@@ -69,13 +69,16 @@ void boundary_test(mfem::ParMesh& mesh, H1<p> test, H1<p> trial, Dimension<dim>)
 
   Functional<test_space(trial_space)> residual(&fespace, &fespace);
 
+  mfem::Array<int> boundary_attrs(mesh.bdr_attributes.Max());
+  boundary_attrs = 1;
+
   residual.AddBoundaryIntegral(
       Dimension<dim - 1>{},
       [&](auto x, auto n, auto u) {
         tensor<double, dim> b{sin(x[0]), x[0] * x[1]};
         return x[0] * x[1] + dot(b, n) + rho * u;
       },
-      mesh);
+      mesh, boundary_attrs);
 
   mfem::Vector r1 = (*J) * U + (*F);
   mfem::Vector r2 = residual(U);
@@ -130,6 +133,9 @@ void boundary_test(mfem::ParMesh& mesh, L2<p> test, L2<p> trial, Dimension<dim>)
 
   Functional<test_space(trial_space)> residual(&fespace, &fespace);
 
+  mfem::Array<int> boundary_attrs(mesh.bdr_attributes.Max());
+  boundary_attrs = 1;
+
   residual.AddBoundaryIntegral(
       Dimension<dim - 1>{},
       [&]([[maybe_unused]] auto x, [[maybe_unused]] auto n, [[maybe_unused]] auto u) {
@@ -137,7 +143,7 @@ void boundary_test(mfem::ParMesh& mesh, L2<p> test, L2<p> trial, Dimension<dim>)
         // tensor<double,dim> b{sin(x[0]), x[0] * x[1]};
         return x[0] * x[1] + /*dot(b, n) +*/ rho * u;
       },
-      mesh);
+      mesh, boundary_attrs);
 
   mfem::Vector r1 = (*J) * U + (*F);
   mfem::Vector r2 = residual(U);


### PR DESCRIPTION
This allows boundary integrals to be defined on a specific set of mesh attributes. Ideally this would be handled by the `GetFaceRestriction` operators, but that would require a fairly major MFEM change. 

This work around calculates the boundary integrals on all external faces, but only accumulates the ones with the correct attribute marking.