### PR TITLE
dual: make abs more consistent with IEEE-754

### DIFF
--- a/src/serac/physics/utilities/functional/dual.hpp
+++ b/src/serac/physics/utilities/functional/dual.hpp
@@ -201,7 +201,7 @@ constexpr auto& operator-=(dual<gradient_type>& a, double b)
 template <typename gradient_type>
 auto abs(dual<gradient_type> x)
 {
-  return (x.value > 0) ? x : -x;
+  return (x.value >= 0) ? x : -x;
 }
 
 /** @brief implementation of square root for dual numbers */


### PR DESCRIPTION
This commit modifies the definition of `serac::abs` so that its result
is more consistent with IEEE-754 arithmetic. Specifically, this commit
changes the behavior of `abs` so that it negates its argument if the
`value` field of its argument is greater than or equal to zero.

This change has two consequences:

* The statement
  ```c++
  std::signbit(serac::abs(x).value) == std::signbit(std::fabs(x.value))
  ```
  is now true instead of false, so the return value of `serac::abs`
  should consistent with IEEE-754-conformant implementations of
  `std::fabs`.

* Limiting behavior (e.g., `1 / x` where `x` underflows) should have
  the proper sign (positive or negative infinity), in cases where code
  relies on that behavior.

A minimal, Serac-less reproducer of the `std::signbit` behavior can be
seen in the compilable code snippet below:

```c++

int main(int argc, char **argv)
{
    constexpr double plus_zero = 0;
    // signed zero is defined in the IEEE-754-2008 standard,
    // Section 3.3
    constexpr double minus_plus_zero = -plus_zero;
    constexpr double minus_zero = -0;

    // std::signbit returns 1 if its sign bit corresponds
    // to a "negative" number; otherwise, it returns 0.
    std::cout << "signbit(plus_zero) = "
              << std::signbit(plus_zero) << "\n";
    std::cout << "signbit(minus_plus_zero) = "
              << std::signbit(minus_plus_zero) << "\n";
    std::cout << "signbit(minus_zero) = "
              << std::signbit(minus_zero) << "\n";

    const double abs_plus_zero = std::fabs(plus_zero);
    const double abs_minus_plus_zero = std::fabs(minus_plus_zero);
    const double abs_minus_zero = std::fabs(minus_zero);
    std::cout << "\n";

    // std::fabs always sets the sign bit to zero
    // (i.e., its return value is "positive")
    std::cout << "signbit(abs_plus_zero) = "
              << std::signbit(abs_plus_zero) << "\n";
    std::cout << "signbit(abs_minus_plus_zero) = "
              << std::signbit(abs_minus_plus_zero) << "\n";
    std::cout << "signbit(abs_minus_zero) = "
              << std::signbit(abs_minus_zero) << "\n";

    return 0;
}
```

Godbolt execution output with x86-64 Clang 10.0.0 is:

```text
SM generation compiler returned: 0
Execution build compiler returned: 0
Program returned: 0
  signbit(plus_zero) = 0
  signbit(minus_plus_zero) = 1
  signbit(minus_zero) = 0

  signbit(abs_plus_zero) = 0
  signbit(abs_minus_plus_zero) = 0
  signbit(abs_minus_zero) = 0
```