### PR TITLE
Remove the extra adjoint solve warning.

### DIFF
--- a/src/serac/physics/solid.cpp
+++ b/src/serac/physics/solid.cpp
@@ -471,9 +471,6 @@ const FiniteElementState& Solid::solveAdjoint(mfem::ParLinearForm& adjoint_load_
 {
   SLIC_ERROR_ROOT_IF(!is_quasistatic_, "Adjoint analysis only vaild for quasistatic problems.");
   SLIC_ERROR_ROOT_IF(previous_solve_ == PreviousSolve::None, "Adjoint analysis only valid following a forward solve.");
-  SLIC_WARNING_ROOT_IF(previous_solve_ == PreviousSolve::Adjoint,
-                       "Adjoint analysis only valid following a forward solve. The previous solve was an adjoint. "
-                       "Ensure that the correct displacement state is set for adjoint analysis.");
 
   // Set the mesh nodes to the reference configuration
   mesh_.NewNodes(*reference_nodes_);


### PR DESCRIPTION
This removes the warning about performing an adjoint solve immediately following another adjoint solve. This will happen regularly in the case of multiple QoIs. Resolves https://github.com/LLNL/serac/issues/539 .