### PR TITLE
Add runtime device memory query

### DIFF
--- a/src/serac/infrastructure/accelerator.hpp
+++ b/src/serac/infrastructure/accelerator.hpp
@@ -87,16 +87,22 @@ void initializeDevice();
 void terminateDevice();
 
 #if defined(__CUDACC__)
+
 /**
  * @brief Utility method to display last cuda error message
  *
  * @param[in] success_string A string to print if there are no CUDA error messages
+ * @param[in] exit_on_error Exit on CUDA error
  */
-inline void displayLastCUDAErrorMessage(const char* success_string = "")
+inline void displayLastCUDAErrorMessage(const char* success_string = "", bool exit_on_error = false)
 {
   auto error = cudaGetLastError();
   if (error != cudaError::cudaSuccess) {
-    SLIC_ERROR_ROOT(serac::profiling::concat("Last CUDA Error Message :", cudaGetErrorString(error)));
+    if (exit_on_error) {
+      SLIC_ERROR_ROOT(serac::profiling::concat("Last CUDA Error Message :", cudaGetErrorString(error)));
+    } else {
+      SLIC_WARNING_ROOT(serac::profiling::concat("Last CUDA Error Message :", cudaGetErrorString(error)));
+    }
   } else if (strlen(success_string) > 0) {
     SLIC_INFO_ROOT(success_string);
   }
@@ -117,6 +123,17 @@ inline std::tuple<std::size_t, std::size_t> getCUDAMemInfo()
   displayLastCUDAErrorMessage();
   return std::make_tuple(free_memory, total_memory);
 }
+
+/**
+ * @brief returns a string with GPU memory information
+ */
+
+std::string getCUDAMemInfoString()
+{
+  auto [free_memory, total_memory] = getCUDAMemInfo();
+  return fmt::format("Free memory: {} Total_memory: {}", free_memory, total_memory);
+}
+
 #endif
 
 /**

--- a/src/serac/infrastructure/accelerator.hpp
+++ b/src/serac/infrastructure/accelerator.hpp
@@ -41,8 +41,10 @@
 #define SERAC_SUPPRESS_NVCC_HOSTDEVICE_WARNING
 #endif
 
-#include <iostream>
 #include <memory>
+
+#include "serac/infrastructure/logger.hpp"
+#include "serac/infrastructure/profiling.hpp"
 
 /**
  * @brief Accelerator functionality
@@ -88,17 +90,30 @@ void terminateDevice();
 /**
  * @brief Utility method to display last cuda error message
  *
- * @param[in] o The output stream to post success or CUDA error messages
  * @param[in] success_string A string to print if there are no CUDA error messages
  */
-inline void displayLastCUDAErrorMessage(std::ostream& o, const char* success_string = "")
+inline void displayLastCUDAErrorMessage(const char* success_string = "")
 {
   auto error = cudaGetLastError();
   if (error != cudaError::cudaSuccess) {
-    o << "Last CUDA Error Message :" << cudaGetErrorString(error) << std::endl;
+    SLIC_ERROR_ROOT(serac::profiling::concat("Last CUDA Error Message :", cudaGetErrorString(error)));
   } else if (strlen(success_string) > 0) {
-    o << success_string << std::endl;
+    SLIC_INFO_ROOT(success_string);
   }
+}
+
+/**
+ * @brief Utility method to query the amount of memory (bytes) that is free on the device at runtime
+ *
+ * @return tuple of free and total memory at the moment on the device context
+ */
+
+inline std::tuple<std::size_t, std::size_t> getCUDAMemInfo()
+{
+  std::size_t free_memory, total_memory;
+  auto        error = cudaMemGetInfo(&free_memory, &total_memory);
+  displayLastCUDAErrorMessage();
+  return std::make_tuple(free_memory, total_memory);
 }
 #endif
 

--- a/src/serac/infrastructure/accelerator.hpp
+++ b/src/serac/infrastructure/accelerator.hpp
@@ -94,7 +94,7 @@ void terminateDevice();
  * @param[in] success_string A string to print if there are no CUDA error messages
  * @param[in] exit_on_error Exit on CUDA error
  */
-inline void displayLastCUDAErrorMessage(const char* success_string = "", bool exit_on_error = false)
+inline void displayLastCUDAMessage(const char* success_string = "", bool exit_on_error = false)
 {
   auto error = cudaGetLastError();
   if (error != cudaError::cudaSuccess) {
@@ -120,7 +120,7 @@ inline std::tuple<std::size_t, std::size_t> getCUDAMemInfo()
 {
   std::size_t free_memory, total_memory;
   auto        error = cudaMemGetInfo(&free_memory, &total_memory);
-  displayLastCUDAErrorMessage();
+  displayLastCUDAMessage();
   return std::make_tuple(free_memory, total_memory);
 }
 

--- a/src/serac/infrastructure/accelerator.hpp
+++ b/src/serac/infrastructure/accelerator.hpp
@@ -105,6 +105,8 @@ inline void displayLastCUDAErrorMessage(const char* success_string = "")
 /**
  * @brief Utility method to query the amount of memory (bytes) that is free on the device at runtime
  *
+ * Granularity appears to be about 2MB of device memory on volta.
+ *
  * @return tuple of free and total memory at the moment on the device context
  */
 

--- a/src/serac/physics/utilities/functional/domain_integral_cuda.cuh
+++ b/src/serac/physics/utilities/functional/domain_integral_cuda.cuh
@@ -222,7 +222,7 @@ void evaluation_kernel_cuda(serac::detail::GPULaunchConfiguration config, const 
   auto r = detail::Reshape<test>(R.ReadWrite(), test_ndof, num_elements);
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage(std::cout);
+  serac::accelerator::displayLastCUDAErrorMessage();
 
   if constexpr (policy == serac::detail::ThreadParallelizationStrategy::THREAD_PER_QUADRATURE_POINT) {
     int blocks_quadrature_element = (num_elements * rule.size() + config.blocksize - 1) / config.blocksize;
@@ -236,7 +236,7 @@ void evaluation_kernel_cuda(serac::detail::GPULaunchConfiguration config, const 
   }
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage(std::cout);
+  serac::accelerator::displayLastCUDAErrorMessage();
 }
 
 /**
@@ -412,7 +412,7 @@ void gradient_kernel_cuda(serac::detail::GPULaunchConfiguration config, const mf
   auto dr = detail::Reshape<test>(dR.ReadWrite(), test_ndof, num_elements);
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage(std::cout);
+  serac::accelerator::displayLastCUDAErrorMessage();
 
   // call gradient_cuda
   if constexpr (policy == serac::detail::ThreadParallelizationStrategy::THREAD_PER_QUADRATURE_POINT) {
@@ -427,7 +427,7 @@ void gradient_kernel_cuda(serac::detail::GPULaunchConfiguration config, const mf
   }
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage(std::cout);
+  serac::accelerator::displayLastCUDAErrorMessage();
   dR.HostRead();
 }
 

--- a/src/serac/physics/utilities/functional/domain_integral_cuda.cuh
+++ b/src/serac/physics/utilities/functional/domain_integral_cuda.cuh
@@ -222,7 +222,7 @@ void evaluation_kernel_cuda(serac::detail::GPULaunchConfiguration config, const 
   auto r = detail::Reshape<test>(R.ReadWrite(), test_ndof, num_elements);
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage();
+  serac::accelerator::displayLastCUDAMessage();
 
   if constexpr (policy == serac::detail::ThreadParallelizationStrategy::THREAD_PER_QUADRATURE_POINT) {
     int blocks_quadrature_element = (num_elements * rule.size() + config.blocksize - 1) / config.blocksize;
@@ -236,7 +236,7 @@ void evaluation_kernel_cuda(serac::detail::GPULaunchConfiguration config, const 
   }
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage();
+  serac::accelerator::displayLastCUDAMessage();
 }
 
 /**
@@ -412,7 +412,7 @@ void gradient_kernel_cuda(serac::detail::GPULaunchConfiguration config, const mf
   auto dr = detail::Reshape<test>(dR.ReadWrite(), test_ndof, num_elements);
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage();
+  serac::accelerator::displayLastCUDAMessage();
 
   // call gradient_cuda
   if constexpr (policy == serac::detail::ThreadParallelizationStrategy::THREAD_PER_QUADRATURE_POINT) {
@@ -427,7 +427,7 @@ void gradient_kernel_cuda(serac::detail::GPULaunchConfiguration config, const mf
   }
 
   cudaDeviceSynchronize();
-  serac::accelerator::displayLastCUDAErrorMessage();
+  serac::accelerator::displayLastCUDAMessage();
   dR.HostRead();
 }
 

--- a/src/serac/physics/utilities/functional/tests/functional_comparisons_cuda.cu
+++ b/src/serac/physics/utilities/functional/tests/functional_comparisons_cuda.cu
@@ -180,7 +180,7 @@ void functional_test(H1<p> test, H1<p> trial, Dimension<dim>)
 
   EXPECT_NEAR(0., error.Norml2() / r1.Norml2(), 1.e-14);
 
-  serac::accelerator::displayLastCUDAErrorMessage();
+  serac::accelerator::displayLastCUDAMessage();
 
   // Compute the gradient using functional
   mfem::Operator& grad2 = SERAC_PROFILE_EXPR(concat("functional_GetGradient", postfix), residual.GetGradient(U));
@@ -198,7 +198,6 @@ void functional_test(H1<p> test, H1<p> trial, Dimension<dim>)
   // Ensure the two methods generate the same result
   EXPECT_NEAR(0., mfem::Vector(g1 - g2).Norml2() / g1.Norml2(), 1.e-14);
 
-  //  auto [functional_free_memory, functional_total_memory] = serac::accelerator::getCUDAMemInfo();
   std::cout << "Functional:" << serac::accelerator::getCUDAMemInfoString() << std::endl;
 
   serac::profiling::terminateCaliper();

--- a/src/serac/physics/utilities/functional/tests/functional_comparisons_cuda.cu
+++ b/src/serac/physics/utilities/functional/tests/functional_comparisons_cuda.cu
@@ -94,8 +94,7 @@ void functional_test(H1<p> test, H1<p> trial, Dimension<dim>)
 
   std::string postfix = concat("_H1<", p, ">");
 
-  auto [free_memory, total_memory] = serac::accelerator::getCUDAMemInfo();
-  std::cout << "Free memory:" << free_memory << " Total_memory:" << total_memory << std::endl;
+  std::cout << serac::accelerator::getCUDAMemInfoString() << std::endl;
 
   serac::profiling::initializeCaliper();
 
@@ -143,8 +142,7 @@ void functional_test(H1<p> test, H1<p> trial, Dimension<dim>)
   u_global.GetTrueDofs(U);
 
   cudaDeviceSynchronize();
-  auto [mfem_free_memory, mfem_total_memory] = serac::accelerator::getCUDAMemInfo();
-  std::cout << "MFEM Free memory:" << mfem_free_memory << " Total_memory:" << mfem_total_memory << std::endl;
+  std::cout << "MFEM " << serac::accelerator::getCUDAMemInfoString() << std::endl;
 
   // Set up the same problem using functional
 
@@ -200,10 +198,8 @@ void functional_test(H1<p> test, H1<p> trial, Dimension<dim>)
   // Ensure the two methods generate the same result
   EXPECT_NEAR(0., mfem::Vector(g1 - g2).Norml2() / g1.Norml2(), 1.e-14);
 
-  cudaDeviceSynchronize();
-  auto [functional_free_memory, functional_total_memory] = serac::accelerator::getCUDAMemInfo();
-  std::cout << "Functional: Free memory:" << functional_free_memory << " Total_memory:" << functional_total_memory
-            << std::endl;
+  //  auto [functional_free_memory, functional_total_memory] = serac::accelerator::getCUDAMemInfo();
+  std::cout << "Functional:" << serac::accelerator::getCUDAMemInfoString() << std::endl;
 
   serac::profiling::terminateCaliper();
 }
@@ -427,9 +423,7 @@ int main(int argc, char* argv[])
   ::testing::InitGoogleTest(&argc, argv);
 
   cudaDeviceSynchronize();
-  auto [functional_free_memory, functional_total_memory] = serac::accelerator::getCUDAMemInfo();
-  std::cout << "Initial: Free memory:" << functional_free_memory << " Total_memory:" << functional_total_memory
-            << std::endl;
+  std::cout << "Initial:" << serac::accelerator::getCUDAMemInfoString() << std::endl;
 
   auto [num_procs, myid] = serac::initialize(argc, argv);
 


### PR DESCRIPTION
- Change serac::accelerator::displayLastCUDAErrorMessage to instead use SLIC for reporting.
- Add runtime device memory query to figure out how much memory has been used by MFEM or serac

Added into `tests/functional_comparisons_cuda` as an example.