### PR TITLE
docfix: update clang 9 to clang 10 in quickstart

### DIFF
--- a/src/docs/sphinx/quickstart.rst
+++ b/src/docs/sphinx/quickstart.rst
@@ -122,7 +122,7 @@ Serac.
 
 Unless otherwise specified Spack will default to a compiler.  This is generally not a good idea when
 developing large codes. To specify which compiler to use add the compiler specification to the ``--spec`` Uberenv
-command line option. On TOSS3, we recommend and have tested ``--spec=%clang@9.0.0``.  More compiler specs
+command line option. On TOSS3, we recommend and have tested ``--spec=%clang@10.0.0``.  More compiler specs
 can be found in the Spack compiler files in our repository:
 ``scripts/spack/configs/<platform>/compilers.yaml``.
 
@@ -145,11 +145,11 @@ Some helpful uberenv options include :
 * ``--spec=+glvis`` (build the optional glvis visualization library)
 * ``--spec=+caliper`` (build the `Caliper performance profiling library <https://github.com/LLNL/Caliper>`_)
 * ``--spec=+devtools`` (also build the devtools with one command)
-* ``--spec=%clang@9.0.0`` (build with a specific compiler as defined in the ``compiler.yaml`` file)
+* ``--spec=%clang@10.0.0`` (build with a specific compiler as defined in the ``compiler.yaml`` file)
 * ``--spack-config-dir=<Path to spack configuration directory>`` (use specific Spack configuration files)
 * ``--prefix=<Path>`` (required, build and install the dependencies in a particular location) - this *must be outside* of your local Serac repository
 
-The modifiers to the Spack specification ``spec`` can be chained together, e.g. ``--spec=%clang@9.0.0+debug+glvis+devtools``.
+The modifiers to the Spack specification ``spec`` can be chained together, e.g. ``--spec=%clang@10.0.0+debug+glvis+devtools``.
 
 If you already have a Spack instance from another project that you would like to reuse,
 you can do so by changing the uberenv command as follows:


### PR DESCRIPTION
This commit updates clang version in the quickstart documentation from
`%clang@9.0.0` to `%clang@10.0.0` because the former is not listed in
`serac/scripts/spack/configs/toss_3_x86_64_ib/{packages,compilers}.yaml`,
but the latter is.

A quick Linux shell one-liner in the repo to confirm that
`%clang@9.0.0` is missing from those files is

```bash
find $(git rev-parse --show-toplevel) -name "*.yaml" -print0 | xargs -0 grep -Hin "clang@9.0.0"
```

Replacing `9.0.0` with `10.0.0` in the above command confirms that
`clang@10.0.0` is present, hence the update.