### PR TITLE
Add short path option to build scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ stages:
     - *run_update_uberenv
     - echo -e "section_start:$(date +%s):full_build_and_test\r\e[0K
       Full Build and Test ${CI_PROJECT_NAME}"
-    - ${ALLOC_COMMAND} python3 scripts/llnl/build_tpls.py -v ${SPEC} --directory=${FULL_BUILD_ROOT} --short-log
+    - ${ALLOC_COMMAND} python3 scripts/llnl/build_tpls.py -v ${SPEC} --directory=${FULL_BUILD_ROOT} --short-path
     - echo -e "section_end:$(date +%s):full_build_and_test\r\e[0K"
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -51,7 +51,7 @@ stages:
     - *run_update_uberenv
     - echo -e "section_start:$(date +%s):full_build_and_test\r\e[0K
       Full Build and Test ${CI_PROJECT_NAME}"
-    - ${ALLOC_COMMAND} python3 scripts/llnl/build_tpls.py -v ${SPEC} --directory=${FULL_BUILD_ROOT}
+    - ${ALLOC_COMMAND} python3 scripts/llnl/build_tpls.py -v ${SPEC} --directory=${FULL_BUILD_ROOT} --short-log
     - echo -e "section_end:$(date +%s):full_build_and_test\r\e[0K"
   artifacts:
     paths:

--- a/scripts/llnl/build_tpls.py
+++ b/scripts/llnl/build_tpls.py
@@ -29,7 +29,12 @@ def parse_args():
     parser.add_option("-d", "--directory",
                       dest="directory",
                       default="",
-                      help="Location to build all TPL's, timestamp directory will be created (Defaults to shared location)")
+                      help="Location to build all TPL's, sys_type/timestamp directory will be created (Defaults to shared location)")
+    parser.add_option("--short-path",
+                      action="store_true",
+                      dest="short_path",
+                      default=False,
+                      help="Does not add sys_type or timestamp to tpl directory (useful for CI).")
     # Spack spec to use for the build
     parser.add_option("-s", "--spec",
                       dest="spec",
@@ -74,7 +79,7 @@ def main():
         os.chdir(repo_dir)
 
         timestamp = get_timestamp()
-        res = full_build_and_test_of_tpls(builds_dir, timestamp, opts["spec"], opts["verbose"], opts["mirror"])
+        res = full_build_and_test_of_tpls(builds_dir, timestamp, opts["spec"], opts["verbose"], opts["short_path"], opts["mirror"])
     finally:
         os.chdir(original_wd)
 

--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -454,8 +454,9 @@ def full_build_and_test_of_tpls(builds_dir, timestamp, spec, report_to_stdout = 
         print("[using mirror location: %s]" % mirror_dir)
 
     # unique install location
+    prefix = builds_dir
     if not short_path:
-        prefix = pjoin(builds_dir, get_system_type())
+        prefix = pjoin(prefix, get_system_type())
     if not os.path.exists(prefix):
         os.mkdir(prefix)
     if not short_path:

--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -434,7 +434,7 @@ def set_group_and_perms(directory):
     return 0
 
 
-def full_build_and_test_of_tpls(builds_dir, timestamp, spec, report_to_stdout = False, mirror_location = ''):
+def full_build_and_test_of_tpls(builds_dir, timestamp, spec, report_to_stdout = False, short_path = False, mirror_location = ''):
     if spec:
         specs = [spec]
     else:
@@ -454,10 +454,12 @@ def full_build_and_test_of_tpls(builds_dir, timestamp, spec, report_to_stdout = 
         print("[using mirror location: %s]" % mirror_dir)
 
     # unique install location
-    prefix = pjoin(builds_dir, get_system_type())
+    if not short_path:
+        prefix = pjoin(builds_dir, get_system_type())
     if not os.path.exists(prefix):
         os.mkdir(prefix)
-    prefix = pjoin(prefix, timestamp)
+    if not short_path:
+        prefix = pjoin(prefix, timestamp)
 
     # create a mirror
     uberenv_create_mirror(prefix, spec, "", mirror_dir)


### PR DESCRIPTION
Spack builds have a hard limit on path length depending on the OS (linux = 127, mac = 511).  This removes any extra directories added to the already long path for CI builds specifically but could be used by users. 

Testing in https://lc.llnl.gov/gitlab/smith/serac/-/pipelines/108148

Please feel free to merge if this passes and has appropriate approvals.