### PR TITLE
Hopefully fix intermittent HDF5 issue

### DIFF
--- a/src/serac/physics/tests/serac_thermal_solver.cpp
+++ b/src/serac/physics/tests/serac_thermal_solver.cpp
@@ -50,7 +50,7 @@ TEST(thermal_solver, dyn_imp_solve_restart)
     MPI_Barrier(MPI_COMM_WORLD);
     const std::string input_file_path =
         std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/dyn_imp_solve.lua";
-    test_utils::runModuleTest<ThermalConduction>(input_file_path, "dyn_imp_solve_restart_first_phase");
+    test_utils::runModuleTest<ThermalConduction>(input_file_path, "dyn_imp_solve_restart");
     MPI_Barrier(MPI_COMM_WORLD);
   }
 
@@ -62,7 +62,7 @@ TEST(thermal_solver, dyn_imp_solve_restart)
     const std::string input_file_path =
         std::string(SERAC_REPO_DIR) + "/data/input_files/tests/thermal_conduction/dyn_imp_solve_restart.lua";
     const int restart_cycle = 5;
-    test_utils::runModuleTest<ThermalConduction>(input_file_path, "dyn_imp_solve_restart_second_phase", restart_cycle);
+    test_utils::runModuleTest<ThermalConduction>(input_file_path, "dyn_imp_solve_restart", restart_cycle);
     MPI_Barrier(MPI_COMM_WORLD);
   }
 

--- a/src/serac/physics/tests/test_utilities.cpp
+++ b/src/serac/physics/tests/test_utilities.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+#include "axom/core.hpp"
+
 #include "serac/infrastructure/input.hpp"
 #include "serac/numerics/mesh_utils.hpp"
 #include "serac/physics/solid.hpp"
@@ -198,10 +200,12 @@ void runModuleTest(const std::string& input_file, const std::string& test_name, 
   // Initialize the DataCollection
   // WARNING: This must happen before serac::input::initialize, as the loading
   // process will wipe out the datastore
+  std::string output_directory = test_name;
+  axom::utilities::filesystem::makeDirsForPath(output_directory);
   if (restart_cycle) {
-    serac::StateManager::initialize(datastore, "serac", "", *restart_cycle);
+    serac::StateManager::initialize(datastore, "serac", output_directory, *restart_cycle);
   } else {
-    serac::StateManager::initialize(datastore);
+    serac::StateManager::initialize(datastore, "serac", output_directory);
   }
 
   // Initialize Inlet and read input file


### PR DESCRIPTION
We are not being careful about writing to the same directory/files with sidre/spio.

This test seems to fail often and intermittently.  This will ensure that this specific test goes to a unique output directory and stop this from happening:

https://dev.azure.com/llnl-serac/serac/_build/results?buildId=5471&view=logs&j=2742912e-f547-59b4-f336-65c28301f30c&t=cd7bfce2-9b19-5c4f-5f3a-913e42776d4e&l=3475

More work needs to happen to go through the other places that `serac::StateManager::initialize` is called to make sure we aren't writing to the same location.