### PR TITLE
Fix the default BC in the adjoint solid solve

### DIFF
--- a/src/serac/physics/tests/serac_solid_adjoint.cpp
+++ b/src/serac/physics/tests/serac_solid_adjoint.cpp
@@ -111,7 +111,7 @@ TEST(solid_solver, adjoint)
 
   SLIC_INFO_ROOT(axom::fmt::format("Shear sensitivity vector norm: {}", shear_norm));
 
-  EXPECT_NEAR(shear_norm, 0.000211078850122, 1.0e-8);
+  EXPECT_NEAR(shear_norm, 0.0002113560243154, 1.0e-8);
 
   auto& bulk_sensitivity = solid_solver.bulkModulusSensitivity(&l2_fe_space);
 


### PR DESCRIPTION
This correctly sets the RHS to zero for the default homogenous essential boundary condition in the solid module adjoint solve. Previously, the RHS was not set while the matrix entries were eliminated.

This is needed for the LiDO project.