### PR TITLE
fix missing include directory for axom_smoketest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,14 @@ install(TARGETS              serac
 if (SERAC_ENABLE_CODEVELOP)
     # Add Axom's targets to our export set
     # TODO: we should ask Axom for this list in the future
+
+
+    # This really shouldn't be needed but it keeps getting dropped from axom.
+    # It certainly shouldn't go here either.
+    target_include_directories(axom SYSTEM PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/axom/src>
+    )
+
     set(axom_exported_targets axom cli11 fmt hdf5 lua sol sparsehash)
     install(TARGETS              ${axom_exported_targets}
             EXPORT               serac-targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,16 +162,14 @@ install(TARGETS              serac
         )
 
 if (SERAC_ENABLE_CODEVELOP)
-    # Add Axom's targets to our export set
-    # TODO: we should ask Axom for this list in the future
-
-
     # This really shouldn't be needed but it keeps getting dropped from axom.
     # It certainly shouldn't go here either.
     target_include_directories(axom SYSTEM PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/axom/src>
     )
 
+    # Add Axom's targets to our export set
+    # TODO: we should ask Axom for this list in the future
     set(axom_exported_targets axom cli11 fmt hdf5 lua sol sparsehash)
     install(TARGETS              ${axom_exported_targets}
             EXPORT               serac-targets

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -41,14 +41,6 @@ blt_add_library(
     DEPENDS_ON  ${infrastructure_depends}
     )
 
-if (SERAC_ENABLE_CODEVELOP)
-    # This really shouldn't be needed but it keeps getting dropped from axom.
-    # It certainly shouldn't go here either.
-    target_include_directories(serac_infrastructure SYSTEM PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../axom/src>
-        )
-endif()
-
 target_include_directories(serac_infrastructure PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>


### PR DESCRIPTION
This is a small workaround to an error related to a missing include directory when building `axom_smoketest.cpp` when using axom as a submodule. Thanks to @white238 for proposing the fix!

I don't believe we fully understand why this workaround is necessary, so it's still worth investigating why one of the `axom` target's include directories is not being propagated to targets linked to it.