### PR TITLE
Change the example output directory

### DIFF
--- a/examples/simple_conduction/with_input_file.cpp
+++ b/examples/simple_conduction/with_input_file.cpp
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
   serac::ThermalConduction conduction(conduction_opts);
   // _create_module_end
   // _output_type_start
-  conduction.initializeOutput(inlet.getGlobalContainer().get<serac::OutputType>(), "simple_conduction_with_input_file");
+  conduction.initializeOutput(inlet.getGlobalContainer().get<serac::OutputType>(), "simple_conduction_with_input_file_output");
   // _output_type_end
   // Complete the solver setup
   conduction.completeSetup();

--- a/examples/simple_conduction/without_input_file.cpp
+++ b/examples/simple_conduction/without_input_file.cpp
@@ -61,7 +61,7 @@ int main(int argc, char* argv[])
   // _bc_end
 
   // _output_type_start
-  conduction.initializeOutput(serac::OutputType::ParaView, "simple_conduction_without_input_file");
+  conduction.initializeOutput(serac::OutputType::ParaView, "simple_conduction_without_input_file_output");
   // _output_type_end
 
   // _run_sim_start


### PR DESCRIPTION
When the examples were run in the same directory as the executable, the output would fail as we are using the same name.