### PR TITLE
update devtool packages

### DIFF
--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/packages.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/packages.yaml
@@ -148,6 +148,7 @@ packages:
 
   # Lock in versions of Devtools
   cmake:
+    version: [3.18.0]
     externals:
     - spec: cmake@3.18.0
       prefix: /usr/tce/packages/cmake/cmake-3.18.0
@@ -156,13 +157,13 @@ packages:
     version: [2.1]
     externals:
       - spec: cppcheck@2.1
-        prefix: /usr/WS2/smithdev/devtools/blueos_3_ppc64le_ib_p9/latest/cppcheck-2.1
+        prefix: /usr/workspace/smithdev/devtools/blueos_3_ppc64le_ib_p9/latest/cppcheck-2.1
     buildable: false
   doxygen:
-    version: [1.8.17]
+    version: [1.9.3]
     externals:
-      - spec: doxygen@1.8.17
-        prefix: /usr/WS2/smithdev/devtools/blueos_3_ppc64le_ib_p9/latest/doxygen-1.8.17
+      - spec: doxygen@1.9.3
+        prefix: /usr/workspace/smithdev/devtools/blueos_3_ppc64le_ib_p9/latest/doxygen-1.9.3
     buildable: false
   llvm:
     version: [10.0.0]
@@ -170,15 +171,21 @@ packages:
     externals:
     - spec: llvm+clang@10.0.0
       prefix: /usr/tce/packages/clang/clang-10.0.0
+  py-ats:
+    version: [7.0.10]
+    externals:
+      - spec: py-ats@7.0.10
+        prefix: /usr/workspace/smithdev/devtools/blueos_3_ppc64le_ib_p9/latest/py-ats-7.0.10
+    buildable: false
+  py-sphinx:
+    version: [4.3.1]
+    externals:
+      - spec: py-sphinx@4.3.1
+        prefix: /usr/workspace/smithdev/devtools/blueos_3_ppc64le_ib_p9/latest/py-sphinx-4.3.1
+    buildable: false
   python:
     version: [3.8.2]
     externals:
       - spec: python@3.8.2
-        prefix: /usr/tce/packages/python/python-3.8.2/
-    buildable: false
-  py-sphinx:
-    version: [2.2.0]
-    externals:
-      - spec: py-sphinx@2.2.0
         prefix: /usr/tce/packages/python/python-3.8.2/
     buildable: false

--- a/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
@@ -149,31 +149,37 @@ packages:
     - spec: cmake@3.14.5
       prefix: /usr/tce/packages/cmake/cmake-3.14.5
   cppcheck:
-    version: [1.87]
+    version: [2.1]
     buildable: false
     externals:
-    - spec: cppcheck@1.87
-      prefix: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/cppcheck-1.87
+    - spec: cppcheck@2.1
+      prefix: /usr/workspace/smithdev/devtools/toss_3_x86_64_ib/latest/cppcheck-2.1
   doxygen:
-    version: [1.8.17]
+    version: [1.9.3]
     buildable: false
     externals:
-    - spec: doxygen@1.8.17
-      prefix: /usr/WS2/smithdev/devtools/toss_3_x86_64_ib/latest/doxygen-1.8.17
+    - spec: doxygen@1.9.3
+      prefix: /usr/workspace/smithdev/devtools/toss_3_x86_64_ib/latest/doxygen-1.9.3
   llvm:
     version: [10.0.0]
     buildable: false
     externals:
     - spec: llvm+clang@10.0.0
       prefix: /usr/tce/packages/clang/clang-10.0.0
+  py-ats:
+    version: [7.0.10]
+    buildable: false
+    externals:
+    - spec: py-ats@7.0.10
+      prefix: /usr/workspace/smithdev/devtools/toss_3_x86_64_ib/latest/py-ats-7.0.10
+  py-sphinx:
+    version: [4.3.1]
+    buildable: false
+    externals:
+    - spec: py-sphinx@4.3.1
+      prefix: /usr/workspace/smithdev/devtools/toss_3_x86_64_ib/latest/py-sphinx-4.3.1
   python:
     buildable: false
     externals:
     - spec: python@3.8.2
       prefix: /usr/tce/packages/python/python-3.8.2
-  py-sphinx:
-    version: [2.2.0]
-    buildable: false
-    externals:
-    - spec: py-sphinx@2.2.0
-      prefix: /usr/tce/packages/python/python-3.8.2/


### PR DESCRIPTION
I hacked the devtools into the previous host-configs in the ATS PR and missed these.  This is a noop change but will cause problems if we don't fix them for the next TPL build.