### PR TITLE
add precompiled header support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,14 @@ include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 # Setup Macros and dependencies
 #------------------------------------------------------------------------------
 
+blt_add_library(
+    NAME        serac_precompiled_headers
+    SOURCES     ${PROJECT_SOURCE_DIR}/src/serac/infrastructure/pch.cpp
+    DEPENDS_ON  mfem axom gtest
+)
+set_property(TARGET serac_precompiled_headers PROPERTY POSITION_INDEPENDENT_CODE 0)
+target_precompile_headers(serac_precompiled_headers PUBLIC ${PROJECT_SOURCE_DIR}/src/serac/infrastructure/pch.hpp)
+
 include(${PROJECT_SOURCE_DIR}/cmake/SeracMacros.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/SeracBasics.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/SeracCompilerFlags.cmake)

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -163,6 +163,11 @@ macro(serac_add_tests)
                            DEPENDS_ON  ${arg_DEPENDS_ON}
                            FOLDER      serac/tests )
 
+        if (TARGET serac_precompiled_headers) 
+            set_property(TARGET ${test_name} PROPERTY POSITION_INDEPENDENT_CODE 0)
+            target_precompile_headers(${test_name} REUSE_FROM serac_precompiled_headers) 
+        endif()
+
         blt_add_test(NAME          ${test_name}
                      COMMAND       ${test_name}
                      NUM_MPI_TASKS ${arg_NUM_MPI_TASKS} )

--- a/src/serac/infrastructure/pch.cpp
+++ b/src/serac/infrastructure/pch.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+// Dummy file so CMake thinks serac_precompiled_headers is a real library

--- a/src/serac/infrastructure/pch.hpp
+++ b/src/serac/infrastructure/pch.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+ #include <fstream>
+ #include <iostream>
+ #include <sys/stat.h>
+
+ #include "mfem.hpp"
+
+ #include "axom/slic.hpp"
+ #include "axom/inlet.hpp"
+ #include "axom/sidre.hpp"
+ // #include "serac/infrastructure/input.hpp"
+ // #include "serac/serac_config.hpp"
+ // #include "serac/numerics/expr_template_ops.hpp"
+ // #include "serac/numerics/mesh_utils_base.hpp"
+ // #include "serac/physics/operators/stdfunction_operator.hpp"
+ // #include "serac/physics/utilities/functional/functional.hpp"
+ // #include "serac/physics/utilities/functional/tensor.hpp"
+ // #include "serac/numerics/assembled_sparse_matrix.hpp"
+ // #include "serac/infrastructure/profiling.hpp"
+ #include <gtest/gtest.h>


### PR DESCRIPTION
see: https://github.com/LLNL/serac/issues/567

This PR revisits adding support for precompiled headers in serac. They tend to reduce compilation time a bit (tested on `serac::Functional` tests):

|    |  without precompiled headers |  with precompiled headers |
|:---: |:---: |:---: |
|`make`| 65s | 52s |
|`make -j`| 12.0s | 9.5s |
|`ninja`|11.5s| 9.1s|

Some things worth looking into:
- many of our tests have the flag `-fPIE`, but I'm not sure where it's getting added. The precompiled headers must have the same flags as the targets that use them, so for now position-independent code is turned off.
- right now, precompiled headers are not tested with CUDA, as the CUDA TPL builds seem to be broken. I'm not sure how well the NVCC toolchain supports this feature (if at all)