### PR TITLE
Basic providence/build information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ message(STATUS "Serac Code Checks: ${SERAC_ENABLE_CODE_CHECKS}")
 # CUDA
 list(APPEND BLT_C_FILE_EXTS ".cuh")
 # Configured C++ files
-list(APPEND BLT_C_FILE_EXTS ".cpp.in")
+list(APPEND BLT_C_FILE_EXTS ".cpp.in" ".hpp.in")
 
 if (SERAC_ENABLE_CODE_CHECKS)
     serac_add_code_checks(PREFIX   serac

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,8 +140,11 @@ configure_file(
 
 message(STATUS "Serac Code Checks: ${SERAC_ENABLE_CODE_CHECKS}")
 
-# Add CUDA related files to code style checking list
+# Add extra file extensions for code styling
+# CUDA
 list(APPEND BLT_C_FILE_EXTS ".cuh")
+# Configured C++ files
+list(APPEND BLT_C_FILE_EXTS ".cpp.in")
 
 if (SERAC_ENABLE_CODE_CHECKS)
     serac_add_code_checks(PREFIX   serac

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,8 @@ configure_file(
 message(STATUS "Serac Code Checks: ${SERAC_ENABLE_CODE_CHECKS}")
 
 # Add extra file extensions for code styling
+# Note: Add them also to serac_add_code_checks in cmake/SeracMacros.cmake
+
 # CUDA
 list(APPEND BLT_C_FILE_EXTS ".cuh")
 # Configured C++ files

--- a/cmake/SeracConfigHeader.cmake
+++ b/cmake/SeracConfigHeader.cmake
@@ -36,7 +36,7 @@ message(STATUS "Configuring Serac version ${SERAC_VERSION_FULL}")
 #------------------------------------------------------------------------------
 # Create variable for every TPL
 #------------------------------------------------------------------------------
-set(TPL_DEPS AXOM CONDUIT CUDA FMT HDF5 MFEM MPI TRIBOL CALIPER PETSC RAJA UMPIRE)
+set(TPL_DEPS AXOM CONDUIT CUDA FMT HDF5 LUA MFEM MPI TRIBOL CALIPER PETSC RAJA UMPIRE)
 foreach(dep ${TPL_DEPS})
     if( ${dep}_FOUND OR ENABLE_${dep} )
         set(SERAC_USE_${dep} TRUE)
@@ -72,7 +72,7 @@ serac_convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   SERAC_BIN_DIR)
 #------------------------------------------------------------------------------
 # Create Config Header
 #------------------------------------------------------------------------------
-configure_file(
+serac_configure_file(
     ${PROJECT_SOURCE_DIR}/src/serac/serac_config.hpp.in
     ${CMAKE_BINARY_DIR}/include/serac/serac_config.hpp
 )

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -32,7 +32,8 @@ macro(serac_add_code_checks)
          "${options}" "${singleValueArgs}" "${multiValueArgs}" ${ARGN})
 
     set(_all_sources)
-    file(GLOB_RECURSE _all_sources "*.cpp" "*.hpp" "*.inl" "*.cuh" "*.cu")
+    # Note: any extensions added here should also be added to BLT's lists in CMakeLists.txt
+    file(GLOB_RECURSE _all_sources "*.cpp" "*.hpp" "*.inl" "*.cuh" "*.cu" "*.cpp.in" "*.hpp.in")
 
     # Check for includes/excludes
     if (NOT DEFINED arg_INCLUDES)

--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -95,6 +95,7 @@ macro(serac_add_code_checks)
 
 endmacro(serac_add_code_checks)
 
+
 #------------------------------------------------------------------------------
 # Asserts that the given VARIABLE_NAME's value is a directory and exists.
 # Fails with a helpful message when it doesn't.
@@ -131,6 +132,7 @@ macro(serac_convert_to_native_escaped_file_path path output)
     file(TO_NATIVE_PATH ${path} ${output})
     string(REPLACE "\\" "\\\\"  ${output} "${${output}}")
 endmacro(serac_convert_to_native_escaped_file_path)
+
 
 ##------------------------------------------------------------------------------
 ## serac_add_tests( SOURCES       [source1 [source2 ...]]
@@ -169,3 +171,19 @@ macro(serac_add_tests)
     endforeach()
 
 endmacro(serac_add_tests)
+
+
+##------------------------------------------------------------------------------
+## serac_configure_file
+##
+## This macro is a thin wrapper over the builtin configure_file command.
+## It has the same arguments/options as configure_file but introduces an
+## intermediate file that is only copied to the target file if the target differs
+## from the intermediate.
+##------------------------------------------------------------------------------
+macro(serac_configure_file _source _target)
+    set(_tmp_target ${_target}.tmp)
+    configure_file(${_source} ${_tmp_target} ${ARGN})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_tmp_target} ${_target})
+    execute_process(COMMAND ${CMAKE_COMMAND} -E remove ${_tmp_target})
+endmacro(serac_configure_file)

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -231,6 +231,7 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
             message(FATAL_ERROR "Given AXOM_DIR did not contain a required header: axom/inlet/LuaReader.hpp"
                                 "\nTry building Axom with '-DLUA_DIR=path/to/lua/install'\n ")
         endif()
+        set(LUA_FOUND TRUE CACHE BOOL "")
 
         # MFEMSidreDataCollection.hpp
         find_path(

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -20,6 +20,7 @@
 #include "axom/core.hpp"
 #include "mfem.hpp"
 
+#include "serac/infrastructure/about.hpp"
 #include "serac/infrastructure/cli.hpp"
 #include "serac/infrastructure/initialize.hpp"
 #include "serac/infrastructure/input.hpp"
@@ -87,6 +88,15 @@ int main(int argc, char* argv[])
   // Handle Command line
   std::unordered_map<std::string, std::string> cli_opts =
       serac::cli::defineAndParse(argc, argv, "Serac: a high order nonlinear thermomechanical simulation code");
+
+  // Optionally, print about info and quit
+  // TODO: add option for just version and a longer for about?
+  bool print_version = cli_opts.find("version") != cli_opts.end();
+  if (print_version) {
+    SLIC_INFO(serac::about());
+    serac::exitGracefully();
+  }
+
   serac::cli::printGiven(cli_opts);
 
   // Read input file
@@ -115,9 +125,6 @@ int main(int argc, char* argv[])
     restart_cycle = std::stoi(cycle->second);
   }
 
-  // Check for the doc creation command line argument
-  bool create_input_file_docs = cli_opts.find("create-input-file-docs") != cli_opts.end();
-
   // Create DataStore
   axom::sidre::DataStore datastore;
 
@@ -129,6 +136,7 @@ int main(int argc, char* argv[])
   serac::defineInputFileSchema(inlet);
 
   // Optionally, create input file documentation and quit
+  bool create_input_file_docs = cli_opts.find("create-input-file-docs") != cli_opts.end();
   if (create_input_file_docs) {
     std::string input_docs_path = axom::utilities::filesystem::joinPath(output_directory, "serac_input.rst");
     inlet.write(axom::inlet::SphinxWriter(input_docs_path));

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -8,7 +8,16 @@ if(ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
 
+# This file contains metadata that often changes (ie. git sha).
+# Hide these changes in the source file so we do not force
+# a full rebuild.
+serac_configure_file(
+  about.cpp.in
+  ${PROJECT_BINARY_DIR}/src/serac/infrastructure/about.cpp
+ )
+
 set(infrastructure_headers
+    about.hpp
     accelerator.hpp
     cli.hpp
     initialize.hpp
@@ -21,6 +30,7 @@ set(infrastructure_headers
     )
 
 set(infrastructure_sources
+    ${PROJECT_BINARY_DIR}/src/serac/infrastructure/about.cpp
     accelerator.cpp
     cli.cpp
     initialize.cpp

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -12,14 +12,15 @@ endif()
 # Hide these changes in the source file so we do not force
 # a full rebuild.
 serac_configure_file(
-  about.cpp.in
-  ${PROJECT_BINARY_DIR}/src/serac/infrastructure/about.cpp
+  git_sha.hpp.in
+  ${PROJECT_BINARY_DIR}/include/serac/infrastructure/git_sha.hpp
  )
 
 set(infrastructure_headers
     about.hpp
     accelerator.hpp
     cli.hpp
+    ${PROJECT_BINARY_DIR}/include/serac/infrastructure/git_sha.hpp
     initialize.hpp
     input.hpp
     logger.hpp
@@ -30,7 +31,7 @@ set(infrastructure_headers
     )
 
 set(infrastructure_sources
-    ${PROJECT_BINARY_DIR}/src/serac/infrastructure/about.cpp
+    about.cpp
     accelerator.cpp
     cli.cpp
     initialize.cpp

--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -8,8 +8,6 @@
 
 #include "serac/serac_config.hpp"
 
-#include "serac/infrastructure/git_sha.hpp"
-
 #include "axom/config.hpp"
 #include "axom/core.hpp"
 #include "axom/fmt.hpp"
@@ -45,6 +43,7 @@
 //#include "tribol/config.hpp"
 #endif
 
+#include "serac/infrastructure/git_sha.hpp"
 #include "serac/infrastructure/logger.hpp"
 
 namespace serac {
@@ -191,14 +190,7 @@ std::string about()
   return about;
 }
 
-std::string gitSHA()
-{
-  // Note: This is generated at configure time so that
-  // when the sha changes it doesn't force a full rebuild
-  // of Serac. Do not add it to the config header.
-  // Note: This will not update unless you re-run CMake between commits.
-  return SERAC_GIT_SHA;
-}
+std::string gitSHA() { return SERAC_GIT_SHA; }
 
 std::string version(bool add_SHA)
 {

--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -8,6 +8,8 @@
 
 #include "serac/serac_config.hpp"
 
+#include "serac/infrastructure/git_sha.hpp"
+
 #include "axom/config.hpp"
 #include "axom/core.hpp"
 #include "axom/fmt.hpp"
@@ -195,7 +197,7 @@ std::string gitSHA()
   // when the sha changes it doesn't force a full rebuild
   // of Serac. Do not add it to the config header.
   // Note: This will not update unless you re-run CMake between commits.
-  return "@SERAC_GIT_SHA@";
+  return "SERAC_GIT_SHA";
 }
 
 std::string version(bool add_SHA)

--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -197,7 +197,7 @@ std::string gitSHA()
   // when the sha changes it doesn't force a full rebuild
   // of Serac. Do not add it to the config header.
   // Note: This will not update unless you re-run CMake between commits.
-  return "SERAC_GIT_SHA";
+  return SERAC_GIT_SHA;
 }
 
 std::string version(bool add_SHA)

--- a/src/serac/infrastructure/about.cpp.in
+++ b/src/serac/infrastructure/about.cpp.in
@@ -1,0 +1,214 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "serac/infrastructure/about.hpp"
+
+#include "serac/serac_config.hpp"
+
+#include "axom/config.hpp"
+#include "axom/core.hpp"
+#include "axom/fmt.hpp"
+
+#ifdef SERAC_USE_CALIPER
+#include "caliper/caliper-config.h"
+#endif
+
+#ifdef SERAC_USE_CONDUIT
+#include "conduit_config.h"
+#endif
+
+#ifdef SERAC_USE_HDF5
+#include "hdf5.h"
+#endif
+
+#ifdef SERAC_USE_LUA
+#include "lua.h"
+#endif
+
+#include "mfem.hpp"
+
+#ifdef SERAC_USE_RAJA
+#include "RAJA/config.hpp"
+#endif
+
+#ifdef SERAC_USE_UMPIRE
+#include "umpire/Umpire.hpp"
+#endif
+
+#ifdef SERAC_USE_TRIBOL
+// TODO: This can be uncommented when Tribol MR!59 gets merged and we update to it
+//#include "tribol/config.hpp"
+#endif
+
+#include "serac/infrastructure/logger.hpp"
+
+namespace serac {
+
+std::string about()
+{
+  using namespace axom::fmt;
+  constexpr std::string_view on = "ON";
+  constexpr std::string_view off = "OFF";
+  std::string on_or_off;
+
+  std::string about = "\n";
+
+  // Version info
+  about += format("Serac Version:   {0}\n", version(false));
+  about += format("Git Commit SHA:  {0}\n", gitSHA());
+  about += "\n";
+
+  // General configuration
+#ifdef SERAC_DEBUG
+  about += format("Debug Build:     {0}\n", on);
+#else
+  about += format("Debug Build:     {0}\n", off);
+#endif
+
+#ifdef SERAC_USE_CUDA
+  about += format("CUDA:            {0}\n", on);
+#else
+  about += format("CUDA:            {0}\n", off);
+#endif
+
+#ifdef SERAC_USE_LUMBERJACK
+  about += format("Lumberjack:      {0}\n", on);
+#else
+  about += format("Lumberjack:      {0}\n", off);
+#endif
+
+  about += "\n";
+
+  //------------------------
+  // Libraries
+  //------------------------
+
+  // Print out version of enabled libraries and list disabled ones by name
+
+  std::vector<std::string> disabled_libs;
+
+  about += "Enabled Libraries:\n";
+
+  // Axom
+  about += format("Axom Version:    {0}\n", axom::getVersion());
+
+  // Caliper
+#ifdef SERAC_USE_CALIPER
+  about += format("Caliper Version: {0}\n", CALIPER_VERSION);
+#else
+  disabled_libs.push_back("Caliper");
+#endif
+
+  // Conduit
+#ifdef SERAC_USE_CONDUIT
+  about += format("Conduit Version: {0}\n", CONDUIT_VERSION);
+#else
+  disabled_libs.push_back("Conduit");
+#endif
+
+  // HDF5
+#ifdef SERAC_USE_HDF5
+  unsigned int h5_maj, h5_min, h5_rel;
+  std::string h5_version;
+  if(H5get_libversion(&h5_maj, &h5_min, &h5_rel) < 0){
+    SLIC_ERROR("Failed to retrieve HDF5 version.");
+  } else {
+    h5_version = format("{0}.{1}.{2}", h5_maj, h5_min, h5_rel);
+  }
+  about += format("HDF5 Version:    {0}\n", h5_version);
+#else
+  disabled_libs.push_back("HDF5");
+#endif
+
+  // Lua
+#ifdef SERAC_USE_LUA
+  std::string lua_version{LUA_RELEASE};
+  if (axom::utilities::string::startsWith(lua_version, "Lua ")){
+    lua_version.erase(0, 4);
+  }
+  about += format("Lua Version:     {0}\n", lua_version);
+#else
+  disabled_libs.push_back("Lua");
+#endif
+
+  // MFEM
+  const char* mfem_version = mfem::GetVersionStr();
+  if(mfem_version == nullptr){
+    SLIC_ERROR("Failed to retrieve MFEM version.");
+  }
+  const char* mfem_sha = mfem::GetGitStr();
+  if(mfem_sha == nullptr){
+    SLIC_ERROR("Failed to retrieve MFEM Git SHA.");
+  }
+  std::string mfem_full_version = std::string(mfem_version);
+  if (axom::utilities::string::startsWith(mfem_full_version, "MFEM ")){
+    mfem_full_version.erase(0, 5);
+  }
+  if(mfem_sha[0] != '\0'){
+    mfem_full_version += format(" (Git SHA: {0})", mfem_sha);
+  }
+  about += format("MFEM Version:    {0}\n", mfem_full_version);
+
+  // RAJA
+#ifdef SERAC_USE_RAJA
+  about += format("RAJA Version:    {0}.{1}.{2}\n", RAJA_VERSION_MAJOR, RAJA_VERSION_MINOR, RAJA_VERSION_PATCHLEVEL);
+#else
+  disabled_libs.push_back("RAJA");
+#endif
+
+  // Tribol
+#ifdef SERAC_USE_TRIBOL
+// TODO: This can be un-hardcoded when Tribol MR!59 gets merged and we update to it
+//  about += format("Tribol Version:    {0}\n", TRIBOL_VERSION_FULL);
+  about += "Tribol Version:    0.1.0\n";
+#else
+  disabled_libs.push_back("Tribol");
+#endif
+
+  // Umpire
+#ifdef SERAC_USE_UMPIRE
+  about += format("Umpire Version:  {0}.{1}.{2}\n", umpire::get_major_version(), umpire::get_minor_version(), umpire::get_patch_version());
+#else
+  disabled_libs.push_back("Umpire");
+#endif
+
+  about += "\n";
+
+  about += "Disabled Libraries:\n";
+  if(disabled_libs.size() == 0){
+    about += "None\n";
+  }
+  else {
+    for(auto& lib : disabled_libs) {
+      about += lib + "\n";
+    }
+  }
+
+  return about;
+}
+
+std::string gitSHA()
+{
+  // Note: This is generated at configure time so that
+  // when the sha changes it doesn't force a full rebuild
+  // of Serac. Do not add it to the config header.
+  // Note: This will not update unless you re-run CMake between commits.
+  return "@SERAC_GIT_SHA@";
+}
+
+std::string version(bool add_SHA)
+{
+  std::string version = axom::fmt::format("v{0}.{1}.{2}", SERAC_VERSION_MAJOR, SERAC_VERSION_MINOR, SERAC_VERSION_PATCH);
+
+  std::string sha = gitSHA();
+  if (add_SHA && !sha.empty()){
+    version += "-" + sha;      
+  }
+
+  return version;
+}
+
+}  // namespace serac

--- a/src/serac/infrastructure/about.cpp.in
+++ b/src/serac/infrastructure/about.cpp.in
@@ -50,9 +50,8 @@ namespace serac {
 std::string about()
 {
   using namespace axom::fmt;
-  constexpr std::string_view on = "ON";
+  constexpr std::string_view on  = "ON";
   constexpr std::string_view off = "OFF";
-  std::string on_or_off;
 
   std::string about = "\n";
 
@@ -112,8 +111,8 @@ std::string about()
   // HDF5
 #ifdef SERAC_USE_HDF5
   unsigned int h5_maj, h5_min, h5_rel;
-  std::string h5_version;
-  if(H5get_libversion(&h5_maj, &h5_min, &h5_rel) < 0){
+  std::string  h5_version;
+  if (H5get_libversion(&h5_maj, &h5_min, &h5_rel) < 0) {
     SLIC_ERROR("Failed to retrieve HDF5 version.");
   } else {
     h5_version = format("{0}.{1}.{2}", h5_maj, h5_min, h5_rel);
@@ -126,7 +125,7 @@ std::string about()
   // Lua
 #ifdef SERAC_USE_LUA
   std::string lua_version{LUA_RELEASE};
-  if (axom::utilities::string::startsWith(lua_version, "Lua ")){
+  if (axom::utilities::string::startsWith(lua_version, "Lua ")) {
     lua_version.erase(0, 4);
   }
   about += format("Lua Version:     {0}\n", lua_version);
@@ -136,18 +135,18 @@ std::string about()
 
   // MFEM
   const char* mfem_version = mfem::GetVersionStr();
-  if(mfem_version == nullptr){
+  if (mfem_version == nullptr) {
     SLIC_ERROR("Failed to retrieve MFEM version.");
   }
   const char* mfem_sha = mfem::GetGitStr();
-  if(mfem_sha == nullptr){
+  if (mfem_sha == nullptr) {
     SLIC_ERROR("Failed to retrieve MFEM Git SHA.");
   }
   std::string mfem_full_version = std::string(mfem_version);
-  if (axom::utilities::string::startsWith(mfem_full_version, "MFEM ")){
+  if (axom::utilities::string::startsWith(mfem_full_version, "MFEM ")) {
     mfem_full_version.erase(0, 5);
   }
-  if(mfem_sha[0] != '\0'){
+  if (mfem_sha[0] != '\0') {
     mfem_full_version += format(" (Git SHA: {0})", mfem_sha);
   }
   about += format("MFEM Version:    {0}\n", mfem_full_version);
@@ -161,8 +160,8 @@ std::string about()
 
   // Tribol
 #ifdef SERAC_USE_TRIBOL
-// TODO: This can be un-hardcoded when Tribol MR!59 gets merged and we update to it
-//  about += format("Tribol Version:    {0}\n", TRIBOL_VERSION_FULL);
+  // TODO: This can be un-hardcoded when Tribol MR!59 gets merged and we update to it
+  //  about += format("Tribol Version:    {0}\n", TRIBOL_VERSION_FULL);
   about += "Tribol Version:    0.1.0\n";
 #else
   disabled_libs.push_back("Tribol");
@@ -170,7 +169,8 @@ std::string about()
 
   // Umpire
 #ifdef SERAC_USE_UMPIRE
-  about += format("Umpire Version:  {0}.{1}.{2}\n", umpire::get_major_version(), umpire::get_minor_version(), umpire::get_patch_version());
+  about += format("Umpire Version:  {0}.{1}.{2}\n", umpire::get_major_version(), umpire::get_minor_version(),
+                  umpire::get_patch_version());
 #else
   disabled_libs.push_back("Umpire");
 #endif
@@ -178,11 +178,10 @@ std::string about()
   about += "\n";
 
   about += "Disabled Libraries:\n";
-  if(disabled_libs.size() == 0){
+  if (disabled_libs.size() == 0) {
     about += "None\n";
-  }
-  else {
-    for(auto& lib : disabled_libs) {
+  } else {
+    for (auto& lib : disabled_libs) {
       about += lib + "\n";
     }
   }
@@ -201,11 +200,12 @@ std::string gitSHA()
 
 std::string version(bool add_SHA)
 {
-  std::string version = axom::fmt::format("v{0}.{1}.{2}", SERAC_VERSION_MAJOR, SERAC_VERSION_MINOR, SERAC_VERSION_PATCH);
+  std::string version =
+      axom::fmt::format("v{0}.{1}.{2}", SERAC_VERSION_MAJOR, SERAC_VERSION_MINOR, SERAC_VERSION_PATCH);
 
   std::string sha = gitSHA();
-  if (add_SHA && !sha.empty()){
-    version += "-" + sha;      
+  if (add_SHA && !sha.empty()) {
+    version += "-" + sha;
   }
 
   return version;

--- a/src/serac/infrastructure/about.hpp
+++ b/src/serac/infrastructure/about.hpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file about.hpp
+ *
+ * @brief This file contains the interface used for retrieving information
+ * about how the driver is configured.
+ */
+
+#pragma once
+
+#include <string>
+
+namespace serac {
+
+/**
+ * @brief Returns a string about the configuration of Serac
+ *
+ * @return string containing various configuration information about Serac
+ */
+std::string about();
+
+/**
+ * @brief Returns a string for the Git SHA when the driver was built
+ *
+ * Note: This will not update unless you re-run CMake between commits.
+ *
+ * @return string value of the Git SHA if built in a Git repo, empty if not
+ */
+std::string gitSHA();
+
+/**
+ * @brief Returns a string for the version of Serac
+ *
+ * @param[in] add_SHA boolean for whether to add the Git SHA to the version if available
+ *
+ * @return string value of the version of Serac
+ */
+std::string version(bool add_SHA = true);
+
+}  // namespace serac

--- a/src/serac/infrastructure/about.hpp
+++ b/src/serac/infrastructure/about.hpp
@@ -27,7 +27,7 @@ std::string about();
 /**
  * @brief Returns a string for the Git SHA when the driver was built
  *
- * Note: This will not update unless you re-run CMake between commits.
+ * Note: This will not update unless you reconfigure CMake after a commit.
  *
  * @return string value of the Git SHA if built in a Git repo, empty if not
  */

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -7,7 +7,6 @@
 #include "serac/infrastructure/cli.hpp"
 
 #include "axom/CLI11.hpp"
-#include "axom/core.hpp"
 
 #include "serac/infrastructure/input.hpp"
 #include "serac/infrastructure/logger.hpp"

--- a/src/serac/infrastructure/git_sha.hpp.in
+++ b/src/serac/infrastructure/git_sha.hpp.in
@@ -4,8 +4,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef SERAC_GIT_SHA_HPP
-#define SERAC_GIT_SHA_HPP
+#pragma once
 
 /*NOTE: Do not include this file in anywhere other than about.cpp.
  * This variable changes often and will force a full rebuild on all dependent files
@@ -16,5 +15,3 @@
 // clang-format off
 #define SERAC_GIT_SHA "@SERAC_GIT_SHA@"
 // clang-format on
-
-#endif /* SERAC_GIT_SHA_HPP */

--- a/src/serac/infrastructure/git_sha.hpp.in
+++ b/src/serac/infrastructure/git_sha.hpp.in
@@ -1,0 +1,20 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#ifndef SERAC_GIT_SHA_HPP
+#define SERAC_GIT_SHA_HPP
+
+/*NOTE: Do not include this file in anywhere other than about.cpp.
+ * This variable changes often and will force a full rebuild on all dependent files
+ * any time you git commit and re-run cmake. It is added in serac::version()
+ * and serac::about(), as well as accessible from serac::gitSha().
+ */
+
+// clang-format off
+#define SERAC_GIT_SHA "@SERAC_GIT_SHA@"
+// clang-format on
+
+#endif /* SERAC_GIT_SHA_HPP */

--- a/src/serac/serac_config.hpp.in
+++ b/src/serac/serac_config.hpp.in
@@ -12,7 +12,10 @@
 #define SERAC_VERSION_MINOR @SERAC_VERSION_MINOR@
 #define SERAC_VERSION_PATCH @SERAC_VERSION_PATCH@
 #define SERAC_VERSION_FULL  "@SERAC_VERSION_FULL@"
-#cmakedefine SERAC_GIT_SHA "@SERAC_GIT_SHA@"
+/*NOTE: Do not add SERAC_GIT_SHA here.  This will force
+ * full rebuild on all local changes. It is added in serac::version()
+ * and serac::about(), as well as accessible from serac::gitSha().
+ */
 
 
 // Serac Locations
@@ -21,15 +24,17 @@
 
 // General defines
 #cmakedefine SERAC_DEBUG
+
+#cmakedefine SERAC_USE_CUDA
 #cmakedefine SERAC_USE_LUMBERJACK
 
 
 // Compiler defines for TPLs
 #cmakedefine SERAC_USE_AXOM
 #cmakedefine SERAC_USE_CONDUIT
-#cmakedefine SERAC_USE_CUDA
 #cmakedefine SERAC_USE_FMT
 #cmakedefine SERAC_USE_HDF5
+#cmakedefine SERAC_USE_LUA
 #cmakedefine SERAC_USE_MFEM
 #cmakedefine SERAC_USE_MPI
 #cmakedefine SERAC_USE_TRIBOL

--- a/src/serac/serac_config.hpp.in
+++ b/src/serac/serac_config.hpp.in
@@ -42,4 +42,4 @@
 #cmakedefine SERAC_USE_RAJA
 #cmakedefine SERAC_USE_UMPIRE
 
-#endif /* SERAC_CONFIG_CPP */
+#endif /* SERAC_CONFIG_HPP */

--- a/src/serac/serac_config.hpp.in
+++ b/src/serac/serac_config.hpp.in
@@ -4,8 +4,7 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
-#ifndef SERAC_CONFIG_HPP
-#define SERAC_CONFIG_HPP
+#pragma once
 
 // Serac Version Information
 // clang-format off
@@ -41,5 +40,3 @@
 #cmakedefine SERAC_USE_CALIPER
 #cmakedefine SERAC_USE_RAJA
 #cmakedefine SERAC_USE_UMPIRE
-
-#endif /* SERAC_CONFIG_HPP */

--- a/src/serac/serac_config.hpp.in
+++ b/src/serac/serac_config.hpp.in
@@ -8,15 +8,16 @@
 #define SERAC_CONFIG_HPP
 
 // Serac Version Information
+// clang-format off
 #define SERAC_VERSION_MAJOR @SERAC_VERSION_MAJOR@
 #define SERAC_VERSION_MINOR @SERAC_VERSION_MINOR@
 #define SERAC_VERSION_PATCH @SERAC_VERSION_PATCH@
 #define SERAC_VERSION_FULL  "@SERAC_VERSION_FULL@"
+// clang-format on
 /*NOTE: Do not add SERAC_GIT_SHA here.  This will force
  * full rebuild on all local changes. It is added in serac::version()
  * and serac::about(), as well as accessible from serac::gitSha().
  */
-
 
 // Serac Locations
 #define SERAC_REPO_DIR "@SERAC_REPO_DIR@"
@@ -27,7 +28,6 @@
 
 #cmakedefine SERAC_USE_CUDA
 #cmakedefine SERAC_USE_LUMBERJACK
-
 
 // Compiler defines for TPLs
 #cmakedefine SERAC_USE_AXOM
@@ -42,5 +42,4 @@
 #cmakedefine SERAC_USE_RAJA
 #cmakedefine SERAC_USE_UMPIRE
 
-
-#endif  /* SERAC_CONFIG_CPP */
+#endif /* SERAC_CONFIG_CPP */


### PR DESCRIPTION
* Add basic about information (accessible via new command line option '-v')
* Move git sha out of config header to stop full rebuilding
* Add macro that only touches configured files if they change

This will be improved in a future PR but it was a good stopping point.

Future improvement:
* Add more TPLs (sundials for example)
* Have a providence class in Axom track these and help with pretty printing and other formats than just printing to screen