### PR TITLE
Thermal sensitivities with `Functional`

### DIFF
--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -51,7 +51,7 @@ namespace serac {
 std::string about()
 {
   using namespace axom::fmt;
-  constexpr std::string_view on  = "ON";
+  constexpr std::string_view                  on  = "ON";
   [[maybe_unused]] constexpr std::string_view off = "OFF";
 
   std::string about = "\n";

--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -52,7 +52,7 @@ std::string about()
 {
   using namespace axom::fmt;
   constexpr std::string_view on  = "ON";
-  constexpr std::string_view off = "OFF";
+  [[maybe_unused]] constexpr std::string_view off = "OFF";
 
   std::string about = "\n";
 

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -86,7 +86,7 @@ std::string getInputFileName(const std::string& file_path)
   std::string basename = path.baseName();
   std::string name;
 
-  size_t index = basename.find_last_of(".");
+  std::size_t index = basename.find_last_of(".");
   if (index != std::string::npos) {
     name = basename.substr(0, index);
   } else {

--- a/src/serac/numerics/functional/boundary_integral.hpp
+++ b/src/serac/numerics/functional/boundary_integral.hpp
@@ -123,7 +123,7 @@ public:
    * @param[in] which the index of the argument being differentiated
    * @see action_of_gradient_kernel
    */
-  void GradientMult(const mfem::Vector& input_E, mfem::Vector& output_E, size_t which) const
+  void GradientMult(const mfem::Vector& input_E, mfem::Vector& output_E, std::size_t which) const
   {
     action_of_gradient_[which](input_E, output_E);
   }
@@ -134,7 +134,7 @@ public:
    * nelems)
    * @param[in] which the index of the argument being differentiated
    */
-  void ComputeElementGradients(ExecArrayView<double, 3, ExecutionSpace::CPU> K_b, size_t which) const
+  void ComputeElementGradients(ExecArrayView<double, 3, ExecutionSpace::CPU> K_b, std::size_t which) const
   {
     element_gradient_[which](K_b);
   }

--- a/src/serac/numerics/functional/boundary_integral_kernels.hpp
+++ b/src/serac/numerics/functional/boundary_integral_kernels.hpp
@@ -144,7 +144,7 @@ struct EvaluationKernel<void, KernelConfig<Q, geom, test, trials...>, void, lamb
    * @param qf q-function
    */
   EvaluationKernel(KernelConfig<Q, geom, test, trials...>, const mfem::Vector& J, const mfem::Vector& X,
-                   const mfem::Vector& N, size_t num_elements, lambda qf)
+                   const mfem::Vector& N, std::size_t num_elements, lambda qf)
       : J_(J), X_(X), N_(N), num_elements_(num_elements), qf_(qf)
   {
   }
@@ -161,7 +161,7 @@ struct EvaluationKernel<void, KernelConfig<Q, geom, test, trials...>, void, lamb
     for (uint32_t j = 0; j < num_trial_spaces; j++) {
       ptrs[j] = U[j].Read();
     }
-    EVector_t u(ptrs, size_t(num_elements_));
+    EVector_t u(ptrs, std::size_t(num_elements_));
 
     using test_element              = finite_element<geom, test>;
     using element_residual_type     = typename test_element::residual_type;
@@ -214,7 +214,7 @@ struct EvaluationKernel<void, KernelConfig<Q, geom, test, trials...>, void, lamb
   const mfem::Vector& J_;             ///< values of sqrt(det(J^T * J)) at each quadrature point
   const mfem::Vector& X_;             ///< Spatial positions of each quadrature point
   const mfem::Vector& N_;             ///< Unit surface normals at each quadrature point
-  size_t              num_elements_;  ///< how many elements in the domain
+  std::size_t         num_elements_;  ///< how many elements in the domain
   lambda              qf_;            ///< q-function
 };
 
@@ -242,7 +242,7 @@ struct EvaluationKernel<DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>
    */
   EvaluationKernel(DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>,
                    CPUArrayView<derivatives_type, 2> qf_derivatives, const mfem::Vector& J, const mfem::Vector& X,
-                   const mfem::Vector& N, size_t num_elements, lambda qf)
+                   const mfem::Vector& N, std::size_t num_elements, lambda qf)
       : qf_derivatives_(qf_derivatives), J_(J), X_(X), N_(N), num_elements_(num_elements), qf_(qf)
   {
   }
@@ -259,7 +259,7 @@ struct EvaluationKernel<DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>
     for (uint32_t j = 0; j < num_trial_spaces; j++) {
       ptrs[j] = U[j].Read();
     }
-    EVector_t u(ptrs, size_t(num_elements_));
+    EVector_t u(ptrs, std::size_t(num_elements_));
 
     using test_element              = finite_element<geom, test>;
     using element_residual_type     = typename test_element::residual_type;
@@ -321,7 +321,7 @@ struct EvaluationKernel<DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>
   const mfem::Vector&                      J_;               ///< values of sqrt(det(J^T * J)) at each quadrature point
   const mfem::Vector&                      X_;               ///< Spatial positions of each quadrature point
   const mfem::Vector&                      N_;               ///< Unit surface normals at each quadrature point
-  size_t                                   num_elements_;    ///< how many elements in the domain
+  std::size_t                              num_elements_;    ///< how many elements in the domain
   lambda                                   qf_;              ///< q-function
 };
 
@@ -362,7 +362,7 @@ EvaluationKernel(DerivativeWRT<i>, KernelConfig<Q, geom, test, trials...>, CPUAr
 template <Geometry g, typename test, typename trial, int Q, typename derivatives_type>
 void action_of_gradient_kernel(const mfem::Vector& dU, mfem::Vector& dR,
                                CPUArrayView<derivatives_type, 2> qf_derivatives, const mfem::Vector& J_,
-                               size_t num_elements)
+                               std::size_t num_elements)
 {
   using test_element               = finite_element<g, test>;
   using trial_element              = finite_element<g, trial>;
@@ -443,7 +443,7 @@ void action_of_gradient_kernel(const mfem::Vector& dU, mfem::Vector& dR,
  */
 template <Geometry g, typename test, typename trial, int Q, typename derivatives_type>
 void element_gradient_kernel(CPUArrayView<double, 3> dk, CPUArrayView<derivatives_type, 2> qf_derivatives,
-                             const mfem::Vector& J_, size_t num_elements)
+                             const mfem::Vector& J_, std::size_t num_elements)
 {
   using test_element               = finite_element<g, test>;
   using trial_element              = finite_element<g, trial>;

--- a/src/serac/numerics/functional/domain_integral.hpp
+++ b/src/serac/numerics/functional/domain_integral.hpp
@@ -162,7 +162,7 @@ public:
    * @param[out] output_E The output of the evalution; per-element DOF residuals
    * @param[in] which_trial_space specifies which trial space input_E correpsonds to
    */
-  void GradientMult(const mfem::Vector& input_E, mfem::Vector& output_E, size_t which_trial_space) const
+  void GradientMult(const mfem::Vector& input_E, mfem::Vector& output_E, std::size_t which_trial_space) const
   {
     action_of_gradient_[which_trial_space](input_E, output_E);
   }
@@ -174,7 +174,7 @@ public:
    * elem)
    * @param[in] which_trial_space specifies which trial space K_e correpsonds to
    */
-  void ComputeElementGradients(ExecArrayView<double, 3, ExecutionSpace::CPU> K_e, size_t which_trial_space) const
+  void ComputeElementGradients(ExecArrayView<double, 3, ExecutionSpace::CPU> K_e, std::size_t which_trial_space) const
   {
     element_gradient_[which_trial_space](K_e);
   }

--- a/src/serac/numerics/functional/domain_integral_kernels.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels.hpp
@@ -112,7 +112,7 @@ struct EvaluationKernel<void, KernelConfig<Q, geom, test, trials...>, void, lamb
    * @param data user-specified quadrature data to pass to the q-function
    */
   EvaluationKernel(KernelConfig<Q, geom, test, trials...>, const mfem::Vector& J, const mfem::Vector& X,
-                   size_t num_elements, lambda qf, QuadratureData<qpt_data_type>& data)
+                   std::size_t num_elements, lambda qf, QuadratureData<qpt_data_type>& data)
       : J_(J), X_(X), num_elements_(num_elements), qf_(qf), data_(data)
   {
   }
@@ -129,7 +129,7 @@ struct EvaluationKernel<void, KernelConfig<Q, geom, test, trials...>, void, lamb
     for (uint32_t j = 0; j < num_trial_spaces; j++) {
       ptrs[j] = U[j].Read();
     }
-    EVector_t u(ptrs, size_t(num_elements_));
+    EVector_t u(ptrs, std::size_t(num_elements_));
 
     using test_element              = finite_element<geom, test>;
     using element_residual_type     = typename test_element::residual_type;
@@ -181,7 +181,7 @@ struct EvaluationKernel<void, KernelConfig<Q, geom, test, trials...>, void, lamb
 
   const mfem::Vector&            J_;             ///< Jacobian matrix entries at each quadrature point
   const mfem::Vector&            X_;             ///< Spatial positions of each quadrature point
-  size_t                         num_elements_;  ///< how many elements in the domain
+  std::size_t                    num_elements_;  ///< how many elements in the domain
   lambda                         qf_;            ///< q-function
   QuadratureData<qpt_data_type>& data_;          ///< (optional) user-provided quadrature data
 };
@@ -212,7 +212,7 @@ struct EvaluationKernel<DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>
    */
   EvaluationKernel(DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>,
                    CPUArrayView<derivatives_type, 2> qf_derivatives, const mfem::Vector& J, const mfem::Vector& X,
-                   size_t num_elements, lambda qf, QuadratureData<qpt_data_type>& data)
+                   std::size_t num_elements, lambda qf, QuadratureData<qpt_data_type>& data)
       : qf_derivatives_(qf_derivatives), J_(J), X_(X), num_elements_(num_elements), qf_(qf), data_(data)
   {
   }
@@ -229,7 +229,7 @@ struct EvaluationKernel<DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>
     for (uint32_t j = 0; j < num_trial_spaces; j++) {
       ptrs[j] = U[j].Read();
     }
-    EVector_t u(ptrs, size_t(num_elements_));
+    EVector_t u(ptrs, std::size_t(num_elements_));
 
     using test_element              = finite_element<geom, test>;
     using element_residual_type     = typename test_element::residual_type;
@@ -287,7 +287,7 @@ struct EvaluationKernel<DerivativeWRT<I>, KernelConfig<Q, geom, test, trials...>
   ExecArrayView<derivatives_type, 2, exec> qf_derivatives_;  ///< derivatives of the q-function w.r.t. trial space `I`
   const mfem::Vector&                      J_;               ///< Jacobian matrix entries at each quadrature point
   const mfem::Vector&                      X_;               ///< Spatial positions of each quadrature point
-  size_t                                   num_elements_;    ///< how many elements in the domain
+  std::size_t                              num_elements_;    ///< how many elements in the domain
   lambda                                   qf_;              ///< q-function
   QuadratureData<qpt_data_type>&           data_;            ///< (optional) user-provided quadrature data
 };
@@ -332,7 +332,7 @@ EvaluationKernel(DerivativeWRT<i>, KernelConfig<Q, geom, test, trials...>, CPUAr
 template <Geometry g, typename test, typename trial, int Q, typename derivatives_type>
 void action_of_gradient_kernel(const mfem::Vector& dU, mfem::Vector& dR,
                                CPUArrayView<derivatives_type, 2> qf_derivatives, const mfem::Vector& J_,
-                               size_t num_elements)
+                               std::size_t num_elements)
 {
   using test_element               = finite_element<g, test>;
   using trial_element              = finite_element<g, trial>;
@@ -409,7 +409,7 @@ void action_of_gradient_kernel(const mfem::Vector& dU, mfem::Vector& dR,
 template <Geometry g, typename test, typename trial, int Q, typename derivatives_type>
 void element_gradient_kernel(ExecArrayView<double, 3, ExecutionSpace::CPU> dk,
                              CPUArrayView<derivatives_type, 2> qf_derivatives, const mfem::Vector& J_,
-                             size_t num_elements)
+                             std::size_t num_elements)
 {
   using test_element               = finite_element<g, test>;
   using trial_element              = finite_element<g, trial>;

--- a/src/serac/numerics/functional/dual.hpp
+++ b/src/serac/numerics/functional/dual.hpp
@@ -277,7 +277,7 @@ auto pow(dual<gradient_type> a, double b)
 template <typename T, int... n>
 auto& operator<<(std::ostream& out, dual<T> A)
 {
-  out << '(' << A.value << ' ' << A.gradient << ')';
+  out << "dual{" << A.value << ", " << A.gradient << '}';
   return out;
 }
 

--- a/src/serac/numerics/functional/evector_view.hpp
+++ b/src/serac/numerics/functional/evector_view.hpp
@@ -21,7 +21,7 @@ namespace serac {
  * @tparam element_type the finite element types whose data is stored in this container
  */
 template <serac::ExecutionSpace exec, typename element_type>
-auto ArrayViewForElement(const double* ptr, size_t num_elements, element_type)
+auto ArrayViewForElement(const double* ptr, std::size_t num_elements, element_type)
 {
   if constexpr (element_type::components == 1) {
     return ExecArrayView<const double, 2, exec>(ptr, num_elements, element_type::ndof);
@@ -64,7 +64,7 @@ struct EVectorView {
    * @param pointers the list of raw pointers to E-vector data provided by mfem
    * @param num_elements the number of elements
    */
-  EVectorView(std::array<const double*, n> pointers, size_t num_elements)
+  EVectorView(std::array<const double*, n> pointers, std::size_t num_elements)
   {
     for_constexpr<n>([&](auto i) {
       serac::get<i>(data) = ArrayViewForElement<exec>(pointers[i], num_elements, serac::get<i>(element_types_tuple{}));
@@ -89,10 +89,10 @@ struct EVectorView {
       auto& arr = serac::get<I>(data);
 
       if constexpr (components == 1) {
-        serac::get<I>(values) = make_tensor<ndof>([&arr, e](int i) { return arr(e, size_t(i)); });
+        serac::get<I>(values) = make_tensor<ndof>([&arr, e](int i) { return arr(e, std::size_t(i)); });
       } else {
         serac::get<I>(values) =
-            make_tensor<components, ndof>([&arr, e](int j, int i) { return arr(e, size_t(j), size_t(i)); });
+            make_tensor<components, ndof>([&arr, e](int j, int i) { return arr(e, std::size_t(j), std::size_t(i)); });
       }
     });
 

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -408,14 +408,14 @@ public:
    * note: it accepts a vector of mfem::Vectors that must be of length `num_trial_spaces`. This interface
    * assumes no derivative information is needed.
    *
-   * @param trial_inputs an array of trial space dofs used to carry out the calculation.
+   * @param input_T an array of trial space dofs used to carry out the calculation.
    */
-  mfem::Vector& operator()(std::vector<std::reference_wrapper<const mfem::Vector>> trial_inputs)
+  mfem::Vector& operator()(std::vector<std::reference_wrapper<const mfem::Vector>> input_T)
   {
-    SLIC_ERROR_IF(trial_inputs.size() != num_trial_spaces,
+    SLIC_ERROR_IF(input_T.size() != num_trial_spaces,
                   "The input vector of trial spaces is not equal to the number of trial spaces defined in the "
                   "Functional constructor");
-    return (*this)(trial_inputs, Index<-1>{});
+    return (*this)(input_T, Index<-1>{});
   }
 
   /**
@@ -424,7 +424,7 @@ public:
    * note: it accepts a vector of mfem::Vectors that must be of length `num_trial_spaces`.
    *
    * @tparam wrt The index of the input trial vector to additional compute derivatives with respect to
-   * @param trial_inputs an array of trial space dofs used to carry out the calculation.
+   * @param input_T an array of trial space dofs used to carry out the calculation.
    */
   template <int wrt>
   typename operator_paren_return_index<wrt>::type operator()(

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -331,7 +331,7 @@ public:
    * arguments may be a dual_vector, to indicate that Functional::operator() should not only evaluate the
    * element calculations, but also differentiate them w.r.t. the specified dual_vector argument
    */
-  void ActionOfGradient(const mfem::Vector& input_T, mfem::Vector& output_T, size_t which) const
+  void ActionOfGradient(const mfem::Vector& input_T, mfem::Vector& output_T, std::size_t which) const
   {
     P_trial_[which]->Mult(input_T, input_L_[which]);
 
@@ -506,7 +506,7 @@ public:
    *
    * TODO: remove this interface completely
    */
-  void SetEssentialBC(const mfem::Array<int>& ess_attr, size_t which)
+  void SetEssentialBC(const mfem::Array<int>& ess_attr, std::size_t which)
   {
     // TODO check that it actually makes sense to apply bcs to this trial space
     trial_space_[which]->GetEssentialTrueDofs(ess_attr, ess_tdof_list_);

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -399,16 +399,16 @@ public:
     [[maybe_unused]] constexpr int                          wrt = index_of_differentiation<T...>();
     std::vector<std::reference_wrapper<const mfem::Vector>> input_T{args...};
 
-    return this->evaluate_index(input_T, Index<wrt>{});
+    return (*this)(input_T, Index<wrt>{});
   }
 
-  mfem::Vector& evaluate_index(std::vector<std::reference_wrapper<const mfem::Vector>> input_T)
+  mfem::Vector& operator()(std::vector<std::reference_wrapper<const mfem::Vector>> input_T)
   {
-    return this->evaluate_index(input_T, Index<-1>{});
+    return (*this)(input_T, Index<-1>{});
   }
 
   template <int wrt>
-  typename operator_paren_return_index<wrt>::type evaluate_index(
+  typename operator_paren_return_index<wrt>::type operator()(
       std::vector<std::reference_wrapper<const mfem::Vector>> input_T, Index<wrt>)
   {
     // get the values for each local processor

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -402,11 +402,30 @@ public:
     return (*this)(input_T, Index<wrt>{});
   }
 
-  mfem::Vector& operator()(std::vector<std::reference_wrapper<const mfem::Vector>> input_T)
+  /**
+   * @brief this function lets the user evaluate the serac::Functional with the given trial space values
+   *
+   * note: it accepts a vector of mfem::Vectors that must be of length `num_trial_spaces`. This interface
+   * assumes no derivative information is needed.
+   *
+   * @param trial_inputs an array of trial space dofs used to carry out the calculation.
+   */
+  mfem::Vector& operator()(std::vector<std::reference_wrapper<const mfem::Vector>> trial_inputs)
   {
-    return (*this)(input_T, Index<-1>{});
+    SLIC_ERROR_IF(trial_inputs.size() != num_trial_spaces,
+                  "The input vector of trial spaces is not equal to the number of trial spaces defined in the "
+                  "Functional constructor");
+    return (*this)(trial_inputs, Index<-1>{});
   }
 
+  /**
+   * @brief this function lets the user evaluate the serac::Functional with the given trial space values
+   *
+   * note: it accepts a vector of mfem::Vectors that must be of length `num_trial_spaces`.
+   *
+   * @tparam wrt The index of the input trial vector to additional compute derivatives with respect to
+   * @param trial_inputs an array of trial space dofs used to carry out the calculation.
+   */
   template <int wrt>
   typename operator_paren_return_index<wrt>::type operator()(
       std::vector<std::reference_wrapper<const mfem::Vector>> input_T, Index<wrt>)

--- a/src/serac/numerics/functional/functional_qoi.inl
+++ b/src/serac/numerics/functional/functional_qoi.inl
@@ -255,7 +255,7 @@ public:
    * arguments may be a dual_vector, to indicate that Functional::operator() should not only evaluate the
    * element calculations, but also differentiate them w.r.t. the specified dual_vector argument
    */
-  double ActionOfGradient(const mfem::Vector& input_T, size_t which) const
+  double ActionOfGradient(const mfem::Vector& input_T, std::size_t which) const
   {
     P_trial_[which]->Mult(input_T, input_L_[which]);
 

--- a/src/serac/numerics/functional/functional_qoi.inl
+++ b/src/serac/numerics/functional/functional_qoi.inl
@@ -499,9 +499,6 @@ private:
   /// @brief Manages DOFs for the trial space
   std::array<mfem::ParFiniteElementSpace*, num_trial_spaces> trial_space_;
 
-  /// @brief The set of true DOF indices to which an essential BC should be applied
-  mfem::Array<int> ess_tdof_list_;
-
   /**
    * @brief Operator that converts true (global) DOF values to local (current rank) DOF values
    * for the test space

--- a/src/serac/numerics/functional/quadrature.hpp
+++ b/src/serac/numerics/functional/quadrature.hpp
@@ -33,7 +33,7 @@ struct QuadratureRule {
   tensor<double, n, dim> points;
 
   /// @brief Returns the number of points in the rule
-  constexpr size_t size() const { return n; }
+  constexpr std::size_t size() const { return n; }
 };
 
 /**

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -392,9 +392,9 @@ SERAC_HOST_DEVICE zero& get(zero& x)
 
 /** @brief let `zero` be accessed like a tuple */
 template <int i>
-SERAC_HOST_DEVICE const zero& get(const zero& x)
+SERAC_HOST_DEVICE zero get(zero)
 {
-  return x;
+  return zero{};
 }
 
 /** @brief the dot product of anything with `zero` is `zero` */

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1595,9 +1595,10 @@ auto& operator<<(std::ostream& out, const tensor<T, n...>& A)
  * @param[in] out the std::ostream to write to (e.g. std::cout or std::ofstream)
  * @param[in] A The tensor to write out
  */
-auto& operator<<(std::ostream& out, serac::zero) { 
-  out << "zero"; 
-  return out; 
+auto& operator<<(std::ostream& out, serac::zero)
+{
+  out << "zero";
+  return out;
 }
 
 /**

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1579,12 +1579,25 @@ auto inv(tensor<dual<gradient_type>, n, n> A)
 template <typename T, int... n>
 auto& operator<<(std::ostream& out, const tensor<T, n...>& A)
 {
-  out << '{' << A[0];
+  out << "tensor{" << A[0];
   for (int i = 1; i < tensor<T, n...>::first_dim; i++) {
     out << ", " << A[i];
   }
   out << '}';
   return out;
+}
+
+/**
+ * @brief recursively serialize the entries in a tensor to an ostream.
+ * Output format uses braces and comma separators to mimic C syntax for multidimensional array
+ * initialization.
+ *
+ * @param[in] out the std::ostream to write to (e.g. std::cout or std::ofstream)
+ * @param[in] A The tensor to write out
+ */
+auto& operator<<(std::ostream& out, serac::zero) { 
+  out << "zero"; 
+  return out; 
 }
 
 /**

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -390,6 +390,13 @@ SERAC_HOST_DEVICE zero& get(zero& x)
   return x;
 }
 
+/** @brief let `zero` be accessed like a tuple */
+template <int i>
+SERAC_HOST_DEVICE const zero& get(const zero& x)
+{
+  return x;
+}
+
 /** @brief the dot product of anything with `zero` is `zero` */
 template <typename T>
 SERAC_HOST_DEVICE zero dot(const T&, zero)

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1593,7 +1593,6 @@ auto& operator<<(std::ostream& out, const tensor<T, n...>& A)
  * initialization.
  *
  * @param[in] out the std::ostream to write to (e.g. std::cout or std::ofstream)
- * @param[in] A The tensor to write out
  */
 auto& operator<<(std::ostream& out, serac::zero)
 {

--- a/src/serac/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
@@ -171,12 +171,12 @@ TEST(TupleArithmeticUnitTests, tensor_output_with_tuple_input)
 
 TEST(TupleArithmeticUnitTests, ostream_output)
 {
-  constexpr auto f = [=](auto inputs) { 
+  constexpr auto f = [=](auto inputs) {
     auto [x, y] = inputs;
-    return serac::tuple { exp(x), sin(dot(y, y) + x) };
+    return serac::tuple{exp(x), sin(dot(y, y) + x)};
   };
-    
-  serac::tuple inputs { 1.0, serac::tensor< double, 3 >{1.0, 3.0, 2.0} };  
+
+  serac::tuple inputs{1.0, serac::tensor<double, 3>{1.0, 3.0, 2.0}};
 
   auto outputs = f(make_dual(inputs));
 

--- a/src/serac/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
@@ -169,6 +169,22 @@ TEST(TupleArithmeticUnitTests, tensor_output_with_tuple_input)
   EXPECT_NEAR(norm(df1 - df0) / norm(df0), 0.0, 2.0e-8);
 }
 
+TEST(TupleArithmeticUnitTests, ostream_output)
+{
+  constexpr auto f = [=](auto inputs) { 
+    auto [x, y] = inputs;
+    return serac::tuple { exp(x), sin(dot(y, y) + x) };
+  };
+    
+  serac::tuple inputs { 1.0, serac::tensor< double, 3 >{1.0, 3.0, 2.0} };  
+
+  auto outputs = f(make_dual(inputs));
+
+  std::cout << get_gradient(outputs) << std::endl;
+  // prints:
+  // tuple{tuple{2.71828, zero}, tuple{-0.759688, tensor{-1.51938, -4.55813, -3.03875}}}
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/serac/numerics/functional/tuple.hpp
+++ b/src/serac/numerics/functional/tuple.hpp
@@ -578,7 +578,7 @@ SERAC_HOST_DEVICE constexpr auto operator*(const tuple<T...>& x, const double a)
  * @param A the tuple of values
  * @brief helper used to implement printing a tuple of values
  */
-template <typename... T, size_t... i>
+template <typename... T, std::size_t... i>
 auto& print_helper(std::ostream& out, const serac::tuple<T...>& A, std::integer_sequence<size_t, i...>)
 {
   out << "tuple{";

--- a/src/serac/numerics/functional/tuple.hpp
+++ b/src/serac/numerics/functional/tuple.hpp
@@ -572,6 +572,33 @@ SERAC_HOST_DEVICE constexpr auto operator*(const tuple<T...>& x, const double a)
 }
 
 /**
+ * @tparam T the types stored in the tuple
+ * @tparam i a list of indices used to acces each element of the tuple
+ * @param out the ostream to write the output to
+ * @param A the tuple of values
+ * @brief helper used to implement printing a tuple of values 
+ */
+template <typename ... T, size_t ... i >
+auto& print_helper(std::ostream& out, const serac::tuple<T ...>& A, std::integer_sequence< size_t, i ... >) {
+  out << "tuple{";
+  (..., (out << (i == 0? "" : ", ") << serac::get<i>(A)));
+  out << "}";
+  return out;
+}
+
+/**
+ * @tparam T the types stored in the tuple
+ * @param out the ostream to write the output to
+ * @param A the tuple of values
+ * @brief print a tuple of values 
+ */
+template <typename ... T>
+auto& operator<<(std::ostream& out, const serac::tuple<T ...>& A)
+{
+  return print_helper(out, A, std::make_integer_sequence<size_t, sizeof ... (T) >());
+}
+
+/**
  * @brief A helper to apply a lambda to a tuple
  *
  * @tparam lambda The functor type

--- a/src/serac/numerics/functional/tuple.hpp
+++ b/src/serac/numerics/functional/tuple.hpp
@@ -576,12 +576,13 @@ SERAC_HOST_DEVICE constexpr auto operator*(const tuple<T...>& x, const double a)
  * @tparam i a list of indices used to acces each element of the tuple
  * @param out the ostream to write the output to
  * @param A the tuple of values
- * @brief helper used to implement printing a tuple of values 
+ * @brief helper used to implement printing a tuple of values
  */
-template <typename ... T, size_t ... i >
-auto& print_helper(std::ostream& out, const serac::tuple<T ...>& A, std::integer_sequence< size_t, i ... >) {
+template <typename... T, size_t... i>
+auto& print_helper(std::ostream& out, const serac::tuple<T...>& A, std::integer_sequence<size_t, i...>)
+{
   out << "tuple{";
-  (..., (out << (i == 0? "" : ", ") << serac::get<i>(A)));
+  (..., (out << (i == 0 ? "" : ", ") << serac::get<i>(A)));
   out << "}";
   return out;
 }
@@ -590,12 +591,12 @@ auto& print_helper(std::ostream& out, const serac::tuple<T ...>& A, std::integer
  * @tparam T the types stored in the tuple
  * @param out the ostream to write the output to
  * @param A the tuple of values
- * @brief print a tuple of values 
+ * @brief print a tuple of values
  */
-template <typename ... T>
-auto& operator<<(std::ostream& out, const serac::tuple<T ...>& A)
+template <typename... T>
+auto& operator<<(std::ostream& out, const serac::tuple<T...>& A)
 {
-  return print_helper(out, A, std::make_integer_sequence<size_t, sizeof ... (T) >());
+  return print_helper(out, A, std::make_integer_sequence<size_t, sizeof...(T)>());
 }
 
 /**

--- a/src/serac/physics/materials/CMakeLists.txt
+++ b/src/serac/physics/materials/CMakeLists.txt
@@ -15,6 +15,7 @@ set(materials_headers
     thermal_expansion_material.hpp
     solid_utils.hpp
     thermal_functional_material.hpp
+    parameterized_thermal_functional_material.hpp    
     solid_functional_material.hpp
     functional_material_utils.hpp
     )

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -36,17 +36,30 @@ struct is_parameterized<T, std::void_t<decltype(std::declval<T&>().numParameters
 
 /**
  * @brief Wrapper to treat an unparameterized material as a parameterized one
- * 
+ *
  * @tparam UnparameterizedMaterialType The unparameterized material
  */
 template <typename UnparameterizedMaterialType>
 struct TriviallyParameterizedMaterial {
+  /**
+   * @brief Material response wrapper for an unparameterized material in a parameterized context
+   *
+   * @tparam T1 Spatial position type
+   * @tparam T2 Temperature type
+   * @tparam T3 Temperature gradient type
+   * @tparam S Unused parameter pack type
+   * @param x Spatial position
+   * @param u Temperature
+   * @param du_dx Temperature gradient
+   * @return Material response of the unparameterized material
+   */
   template <typename T1, typename T2, typename T3, typename... S>
   SERAC_HOST_DEVICE auto operator()(const T1& x, const T2& u, const T3& du_dx, S...) const
   {
     return mat(x, u, du_dx);
   }
 
+  /// Underlying unparameterized material
   UnparameterizedMaterialType mat;
 };
 
@@ -63,14 +76,33 @@ auto parameterize_material(T& material)
   }
 }
 
+/**
+ * @brief Wrapper to treat an unparameterized source as a parameterized one
+ *
+ * @tparam UnparameterizedSourceType The unparameterized source
+ */
 template <typename UnparameterizedSourceType>
 struct TriviallyParameterizedSource {
+  /**
+   * @brief Wrapper for an unparameterized source in a parameterized context
+   *
+   * @tparam T1 Spatial position type
+   * @tparam T2 Temperature type
+   * @tparam T3 Temperature gradient type
+   * @tparam S Unused parameter pack type
+   * @param x Spatial position
+   * @param t Time
+   * @param u Temperature
+   * @param du_dx Temperature gradient
+   * @return Volumetric source for the unparameterized source
+   */
   template <typename T1, typename T2, typename T3, typename... S>
   SERAC_HOST_DEVICE auto operator()(const T1& x, double t, const T2& u, const T3& du_dx, S...) const
   {
     return source(x, t, u, du_dx);
   }
 
+  /// Underlying unparameterized source
   UnparameterizedSourceType source;
 };
 
@@ -87,14 +119,33 @@ auto parameterize_source(T& source)
   }
 }
 
+/**
+ * @brief Wrapper for unparameterized boundary flux types to be used in a parameterized setting
+ *
+ * @tparam UnparameterizedFluxType The unparameterized boundary flux type
+ */
 template <typename UnparameterizedFluxType>
 struct TriviallyParameterizedFlux {
+  /**
+   * @brief The wrapper for an unparameterized boundary flux object to be called using the parameterized
+   * call signature
+   *
+   * @tparam T1 Spatial position type
+   * @tparam T2 Normal vector type
+   * @tparam T3 Temperature type
+   * @tparam S Unused parameter pack type
+   * @param x Spatial position
+   * @param n Normal vector
+   * @param u Temperature
+   * @return Computed boundary flux to be applied
+   */
   template <typename T1, typename T2, typename T3, typename... S>
   SERAC_HOST_DEVICE auto operator()(const T1& x, const T2& n, const T3& u, S...) const
   {
     return flux(x, n, u);
   }
 
+  /// Underlying unparameterized flux
   UnparameterizedFluxType flux;
 };
 

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -63,9 +63,21 @@ struct TriviallyParameterizedMaterial {
   UnparameterizedMaterialType mat;
 };
 
+/**
+ * @brief Template deduction guide for the trivially parameterized material
+ *
+ * @tparam T The unparameterized material type
+ */
 template <typename T>
 TriviallyParameterizedMaterial(T) -> TriviallyParameterizedMaterial<T>;
 
+/**
+ * @brief Convert an unparameterized material to one which accepts parameter values in the paren operator
+ *
+ * @tparam T The unparameterized material type
+ * @param material The unparameterized material
+ * @return The parameterized material
+ */
 template <typename T>
 auto parameterize_material(T& material)
 {
@@ -106,9 +118,21 @@ struct TriviallyParameterizedSource {
   UnparameterizedSourceType source;
 };
 
+/**
+ * @brief Template deduction guide for the trivially parameterized source
+ *
+ * @tparam T The unparameterized source type
+ */
 template <typename T>
 TriviallyParameterizedSource(T) -> TriviallyParameterizedSource<T>;
 
+/**
+ * @brief Convert an unparameterized source to one which accepts parameter values in the paren operator
+ *
+ * @tparam T The unparameterized source type
+ * @param source The unparameterized source
+ * @return The parameterized source
+ */
 template <typename T>
 auto parameterize_source(T& source)
 {
@@ -149,9 +173,21 @@ struct TriviallyParameterizedFlux {
   UnparameterizedFluxType flux;
 };
 
+/**
+ * @brief Template deduction guide for the trivially parameterized flux
+ *
+ * @tparam T The unparameterized flux type
+ */
 template <typename T>
 TriviallyParameterizedFlux(T) -> TriviallyParameterizedFlux<T>;
 
+/**
+ * @brief Convert an unparameterized flux to one which accepts parameter values in the paren operator
+ *
+ * @tparam T The unparameterized flux type
+ * @param material The unparameterized flux
+ * @return The parameterized flux
+ */
 template <typename T>
 auto parameterize_flux(T& flux)
 {

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -79,7 +79,7 @@ TriviallyParameterizedMaterial(T) -> TriviallyParameterizedMaterial<T>;
  * @return The parameterized material
  */
 template <typename T>
-auto parameterize_material(T& material)
+auto parameterizeMaterial(T& material)
 {
   if constexpr (is_parameterized<T>::value) {
     return material;
@@ -134,7 +134,7 @@ TriviallyParameterizedSource(T) -> TriviallyParameterizedSource<T>;
  * @return The parameterized source
  */
 template <typename T>
-auto parameterize_source(T& source)
+auto parameterizeSource(T& source)
 {
   if constexpr (is_parameterized<T>::value) {
     return source;
@@ -189,7 +189,7 @@ TriviallyParameterizedFlux(T) -> TriviallyParameterizedFlux<T>;
  * @return The parameterized flux
  */
 template <typename T>
-auto parameterize_flux(T& flux)
+auto parameterizeFlux(T& flux)
 {
   if constexpr (is_parameterized<T>::value) {
     return flux;

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -17,13 +17,29 @@
 namespace serac {
 
 // Use SFINAE to add static assertions checking if the given thermal material type is acceptable
-template <typename T, int dim, typename = void>
+template <typename T, int dim, int params, typename = void>
 struct has_density : std::false_type {
 };
 
 template <typename T, int dim>
-struct has_density<T, dim, std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>()))>>
+struct has_density<T, dim, 0, std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>()))>>
     : std::true_type {
+};
+template <typename T, int dim>
+struct has_density<T, dim, 1,
+                   std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>(), double{}))>>
+    : std::true_type {
+};
+template <typename T, int dim>
+struct has_density<
+    T, dim, 2,
+    std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>(), double{}, double{}))>>
+    : std::true_type {
+};
+template <typename T, int dim>
+struct has_density<T, dim, 3,
+                   std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>(), double{},
+                                                                   double{}, double{}))>> : std::true_type {
 };
 
 template <typename T, typename = void>
@@ -34,28 +50,68 @@ template <typename T>
 struct is_parameterized<T, std::void_t<decltype(std::declval<T&>().numParameters())>> : std::true_type {
 };
 
-template <typename T, int dim, typename = void>
+template <typename T, int dim, int params, typename = void>
 struct has_specific_heat_capacity : std::false_type {
 };
 
 template <typename T, int dim>
-struct has_specific_heat_capacity<T, dim,
+struct has_specific_heat_capacity<T, dim, 0,
                                   std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
                                       std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>()))>>
     : std::true_type {
 };
 
-template <typename T, int dim, typename = void>
+template <typename T, int dim>
+struct has_specific_heat_capacity<
+    T, dim, 1,
+    std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
+        std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>(), double{}))>> : std::true_type {
+};
+
+template <typename T, int dim>
+struct has_specific_heat_capacity<
+    T, dim, 2,
+    std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
+        std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>(), double{}, double{}))>>
+    : std::true_type {
+};
+
+template <typename T, int dim>
+struct has_specific_heat_capacity<
+    T, dim, 3,
+    std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
+        std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>(), double{}, double{}, double{}))>>
+    : std::true_type {
+};
+
+template <typename T, int dim, int params, typename = void>
 struct has_thermal_flux : std::false_type {
 };
 
 template <typename T, int dim>
 struct has_thermal_flux<
-    T, dim,
+    T, dim, 0,
     std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>()))>>
     : std::true_type {
 };
-
+template <typename T, int dim>
+struct has_thermal_flux<T, dim, 1,
+                        std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(),
+                                                                std::declval<tensor<double, dim>&>(), double{}))>>
+    : std::true_type {
+};
+template <typename T, int dim>
+struct has_thermal_flux<
+    T, dim, 2,
+    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
+                                            double{}, double{}))>> : std::true_type {
+};
+template <typename T, int dim>
+struct has_thermal_flux<
+    T, dim, 3,
+    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
+                                            double{}, double{}, double{}))>> : std::true_type {
+};
 template <typename T, int dim, typename = void>
 struct has_stress : std::false_type {
 };
@@ -66,16 +122,38 @@ struct has_stress<T, dim, std::void_t<decltype(std::declval<T&>()(std::declval<t
 };
 
 // Use SFINAE to add static assertions checking if the given thermal source type is acceptable
-template <typename T, int dim, typename = void>
+template <typename T, int dim, int params, typename = void>
 struct has_thermal_source : std::false_type {
 };
 
 template <typename T, int dim>
 struct has_thermal_source<
-    T, dim,
+    T, dim, 0,
     std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<double>(),
                                             std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>()))>>
     : std::true_type {
+};
+
+template <typename T, int dim>
+struct has_thermal_source<T, dim, 1,
+                          std::void_t<decltype(std::declval<T&>()(
+                              std::declval<tensor<double, dim>&>(), std::declval<double>(),
+                              std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(), double{}))>>
+    : std::true_type {
+};
+template <typename T, int dim>
+struct has_thermal_source<
+    T, dim, 2,
+    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<double>(),
+                                            std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
+                                            double{}, double{}))>> : std::true_type {
+};
+template <typename T, int dim>
+struct has_thermal_source<
+    T, dim, 3,
+    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<double>(),
+                                            std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
+                                            double{}, double{}, double{}))>> : std::true_type {
 };
 
 // Use SFINAE to add static assertions checking if the given thermal source type is acceptable
@@ -92,15 +170,35 @@ struct has_body_force<T, dim,
 };
 
 // Use SFINAE to add static assertions checking if the given thermal flux boundary type is acceptable
-template <typename T, int dim, typename = void>
+template <typename T, int dim, int params, typename = void>
 struct has_thermal_flux_boundary : std::false_type {
 };
 
 template <typename T, int dim>
 struct has_thermal_flux_boundary<
-    T, dim,
+    T, dim, 0,
     std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
                                             std::declval<tensor<double, 1>&>()))>> : std::true_type {
+};
+template <typename T, int dim>
+struct has_thermal_flux_boundary<
+    T, dim, 1,
+    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
+                                            std::declval<tensor<double, 1>&>(), double{}))>> : std::true_type {
+};
+template <typename T, int dim>
+struct has_thermal_flux_boundary<
+    T, dim, 2,
+    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
+                                            std::declval<tensor<double, 1>&>(), double{}, double{}))>>
+    : std::true_type {
+};
+template <typename T, int dim>
+struct has_thermal_flux_boundary<
+    T, dim, 3,
+    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
+                                            std::declval<tensor<double, 1>&>(), double{}, double{}, double{}))>>
+    : std::true_type {
 };
 
 // Use SFINAE to add static assertions checking if the given thermal flux boundary type is acceptable

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -26,6 +26,14 @@ struct has_density<T, dim, std::void_t<decltype(std::declval<T&>().density(std::
     : std::true_type {
 };
 
+template <typename T, typename = void>
+struct is_parameterized : std::false_type {
+};
+
+template <typename T>
+struct is_parameterized<T, std::void_t<decltype(std::declval<T&>().numParameters())>> : std::true_type {
+};
+
 template <typename T, int dim, typename = void>
 struct has_specific_heat_capacity : std::false_type {
 };

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -185,7 +185,7 @@ TriviallyParameterizedFlux(T) -> TriviallyParameterizedFlux<T>;
  * @brief Convert an unparameterized flux to one which accepts parameter values in the paren operator
  *
  * @tparam T The unparameterized flux type
- * @param material The unparameterized flux
+ * @param flux The unparameterized flux
  * @return The parameterized flux
  */
 template <typename T>

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -17,29 +17,13 @@
 namespace serac {
 
 // Use SFINAE to add static assertions checking if the given thermal material type is acceptable
-template <typename T, int dim, int params, typename = void>
+template <typename T, int dim, typename = void>
 struct has_density : std::false_type {
 };
 
 template <typename T, int dim>
-struct has_density<T, dim, 0, std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>()))>>
+struct has_density<T, dim, std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>()))>>
     : std::true_type {
-};
-template <typename T, int dim>
-struct has_density<T, dim, 1,
-                   std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>(), double{}))>>
-    : std::true_type {
-};
-template <typename T, int dim>
-struct has_density<
-    T, dim, 2,
-    std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>(), double{}, double{}))>>
-    : std::true_type {
-};
-template <typename T, int dim>
-struct has_density<T, dim, 3,
-                   std::void_t<decltype(std::declval<T&>().density(std::declval<tensor<double, dim>&>(), double{},
-                                                                   double{}, double{}))>> : std::true_type {
 };
 
 template <typename T, typename = void>
@@ -50,68 +34,6 @@ template <typename T>
 struct is_parameterized<T, std::void_t<decltype(std::declval<T&>().numParameters())>> : std::true_type {
 };
 
-template <typename T, int dim, int params, typename = void>
-struct has_specific_heat_capacity : std::false_type {
-};
-
-template <typename T, int dim>
-struct has_specific_heat_capacity<T, dim, 0,
-                                  std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
-                                      std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>()))>>
-    : std::true_type {
-};
-
-template <typename T, int dim>
-struct has_specific_heat_capacity<
-    T, dim, 1,
-    std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
-        std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>(), double{}))>> : std::true_type {
-};
-
-template <typename T, int dim>
-struct has_specific_heat_capacity<
-    T, dim, 2,
-    std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
-        std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>(), double{}, double{}))>>
-    : std::true_type {
-};
-
-template <typename T, int dim>
-struct has_specific_heat_capacity<
-    T, dim, 3,
-    std::void_t<decltype(std::declval<T&>().specificHeatCapacity(
-        std::declval<tensor<double, dim>&>(), std::declval<tensor<double, 1>&>(), double{}, double{}, double{}))>>
-    : std::true_type {
-};
-
-template <typename T, int dim, int params, typename = void>
-struct has_thermal_flux : std::false_type {
-};
-
-template <typename T, int dim>
-struct has_thermal_flux<
-    T, dim, 0,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>()))>>
-    : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_flux<T, dim, 1,
-                        std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(),
-                                                                std::declval<tensor<double, dim>&>(), double{}))>>
-    : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_flux<
-    T, dim, 2,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
-                                            double{}, double{}))>> : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_flux<
-    T, dim, 3,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
-                                            double{}, double{}, double{}))>> : std::true_type {
-};
 template <typename T, int dim, typename = void>
 struct has_stress : std::false_type {
 };
@@ -119,41 +41,6 @@ struct has_stress : std::false_type {
 template <typename T, int dim>
 struct has_stress<T, dim, std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim, dim>&>()))>>
     : std::true_type {
-};
-
-// Use SFINAE to add static assertions checking if the given thermal source type is acceptable
-template <typename T, int dim, int params, typename = void>
-struct has_thermal_source : std::false_type {
-};
-
-template <typename T, int dim>
-struct has_thermal_source<
-    T, dim, 0,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<double>(),
-                                            std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>()))>>
-    : std::true_type {
-};
-
-template <typename T, int dim>
-struct has_thermal_source<T, dim, 1,
-                          std::void_t<decltype(std::declval<T&>()(
-                              std::declval<tensor<double, dim>&>(), std::declval<double>(),
-                              std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(), double{}))>>
-    : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_source<
-    T, dim, 2,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<double>(),
-                                            std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
-                                            double{}, double{}))>> : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_source<
-    T, dim, 3,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<double>(),
-                                            std::declval<tensor<double, 1>&>(), std::declval<tensor<double, dim>&>(),
-                                            double{}, double{}, double{}))>> : std::true_type {
 };
 
 // Use SFINAE to add static assertions checking if the given thermal source type is acceptable
@@ -166,38 +53,6 @@ struct has_body_force<T, dim,
                       std::void_t<decltype(std::declval<T&>()(
                           std::declval<tensor<double, dim>&>(), std::declval<double>(),
                           std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim, dim>&>()))>>
-    : std::true_type {
-};
-
-// Use SFINAE to add static assertions checking if the given thermal flux boundary type is acceptable
-template <typename T, int dim, int params, typename = void>
-struct has_thermal_flux_boundary : std::false_type {
-};
-
-template <typename T, int dim>
-struct has_thermal_flux_boundary<
-    T, dim, 0,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
-                                            std::declval<tensor<double, 1>&>()))>> : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_flux_boundary<
-    T, dim, 1,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
-                                            std::declval<tensor<double, 1>&>(), double{}))>> : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_flux_boundary<
-    T, dim, 2,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
-                                            std::declval<tensor<double, 1>&>(), double{}, double{}))>>
-    : std::true_type {
-};
-template <typename T, int dim>
-struct has_thermal_flux_boundary<
-    T, dim, 3,
-    std::void_t<decltype(std::declval<T&>()(std::declval<tensor<double, dim>&>(), std::declval<tensor<double, dim>&>(),
-                                            std::declval<tensor<double, 1>&>(), double{}, double{}, double{}))>>
     : std::true_type {
 };
 

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -34,19 +34,24 @@ template <typename T>
 struct is_parameterized<T, std::void_t<decltype(std::declval<T&>().numParameters())>> : std::true_type {
 };
 
-template <typename unparameterized_material_type>
-struct trivially_parameterized_material {
+/**
+ * @brief Wrapper to treat an unparameterized material as a parameterized one
+ * 
+ * @tparam UnparameterizedMaterialType The unparameterized material
+ */
+template <typename UnparameterizedMaterialType>
+struct TriviallyParameterizedMaterial {
   template <typename T1, typename T2, typename T3, typename... S>
   SERAC_HOST_DEVICE auto operator()(const T1& x, const T2& u, const T3& du_dx, S...) const
   {
     return mat(x, u, du_dx);
   }
 
-  unparameterized_material_type mat;
+  UnparameterizedMaterialType mat;
 };
 
 template <typename T>
-trivially_parameterized_material(T) -> trivially_parameterized_material<T>;
+TriviallyParameterizedMaterial(T) -> TriviallyParameterizedMaterial<T>;
 
 template <typename T>
 auto parameterize_material(T& material)
@@ -54,23 +59,23 @@ auto parameterize_material(T& material)
   if constexpr (is_parameterized<T>::value) {
     return material;
   } else {
-    return trivially_parameterized_material{material};
+    return TriviallyParameterizedMaterial{material};
   }
 }
 
-template <typename unparameterized_source_type>
-struct trivially_parameterized_source {
+template <typename UnparameterizedSourceType>
+struct TriviallyParameterizedSource {
   template <typename T1, typename T2, typename T3, typename... S>
   SERAC_HOST_DEVICE auto operator()(const T1& x, double t, const T2& u, const T3& du_dx, S...) const
   {
     return source(x, t, u, du_dx);
   }
 
-  unparameterized_source_type source;
+  UnparameterizedSourceType source;
 };
 
 template <typename T>
-trivially_parameterized_source(T) -> trivially_parameterized_source<T>;
+TriviallyParameterizedSource(T) -> TriviallyParameterizedSource<T>;
 
 template <typename T>
 auto parameterize_source(T& source)
@@ -78,23 +83,23 @@ auto parameterize_source(T& source)
   if constexpr (is_parameterized<T>::value) {
     return source;
   } else {
-    return trivially_parameterized_source{source};
+    return TriviallyParameterizedSource{source};
   }
 }
 
-template <typename unparameterized_flux_type>
-struct trivially_parameterized_flux {
+template <typename UnparameterizedFluxType>
+struct TriviallyParameterizedFlux {
   template <typename T1, typename T2, typename T3, typename... S>
   SERAC_HOST_DEVICE auto operator()(const T1& x, const T2& n, const T3& u, S...) const
   {
     return flux(x, n, u);
   }
 
-  unparameterized_flux_type flux;
+  UnparameterizedFluxType flux;
 };
 
 template <typename T>
-trivially_parameterized_flux(T) -> trivially_parameterized_flux<T>;
+TriviallyParameterizedFlux(T) -> TriviallyParameterizedFlux<T>;
 
 template <typename T>
 auto parameterize_flux(T& flux)
@@ -102,7 +107,7 @@ auto parameterize_flux(T& flux)
   if constexpr (is_parameterized<T>::value) {
     return flux;
   } else {
-    return trivially_parameterized_flux{flux};
+    return TriviallyParameterizedFlux{flux};
   }
 }
 

--- a/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
@@ -29,7 +29,7 @@ public:
    * added to the parameter value to get the total conductivity.
    */
   ParameterizedLinearIsotropicConductor(double density = 1.0, double specific_heat_capacity = 1.0,
-                                        double conductivity_offset = 1.0)
+                                        double conductivity_offset = 0.0)
       : density_(density), specific_heat_capacity_(specific_heat_capacity), conductivity_offset_(conductivity_offset)
   {
     SLIC_ERROR_ROOT_IF(conductivity_offset_ < 0.0,
@@ -99,8 +99,8 @@ struct ParameterizedSource {
    * @return The thermal source value
    */
   template <typename T1, typename T2, typename T3, typename T4>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const double /* t */, const T2& /* u */, const T3& /* du_dx */,
-                                    const T4& parameter) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const double /* time */, const T2& /* temperature */,
+                                    const T3& /* temperature_gradient */, const T4& parameter) const
   {
     return source_offset_ + parameter;
   }
@@ -129,7 +129,8 @@ struct ParameterizedFlux {
    * @return The flux applied to the boundary
    */
   template <typename T1, typename T2, typename T3, typename T4>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* n */, const T3& /* u */, const T4& parameter) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* normal */, const T3& /* temperature */,
+                                    const T4& parameter) const
   {
     return flux_offset_ + parameter;
   }

--- a/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
@@ -1,0 +1,94 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file thermal_functional_material.hpp
+ *
+ * @brief The material and load types for the thermal functional physics module
+ */
+
+#pragma once
+
+#include "serac/physics/materials/thermal_functional_material.hpp"
+
+/// ThermalConductionFunctional helper structs
+namespace serac::Thermal {
+
+class ParameterizedLinearIsotropicConductor {
+public:
+  ParameterizedLinearIsotropicConductor(double density = 1.0, double specific_heat_capacity = 1.0,
+                                        double conductivity = 1.0)
+      : density_(density), specific_heat_capacity_(specific_heat_capacity), conductivity_(conductivity)
+  {
+    assert(conductivity > 0.0);
+    assert(density > 0.0);
+    assert(specific_heat_capacity > 0.0);
+  }
+
+  template <typename T1, typename T2, typename T3, typename T4>
+  SERAC_HOST_DEVICE auto operator()(const T1&, const T2&, const T3& temperature_gradient, const T4& parameter) const
+  {
+    return MaterialResponse{.density                = density_,
+                            .specific_heat_capacity = specific_heat_capacity_,
+                            .heat_flux              = -1.0 * (conductivity_ + parameter) * temperature_gradient};
+  }
+
+  static constexpr int numParameters() { return 1; }
+
+private:
+  double density_;
+  double specific_heat_capacity_;
+  double conductivity_;
+};
+
+/// Parameterized thermal source model
+struct ParameterizedSource {
+  /// The constant source
+  double source_ = 0.0;
+
+  /**
+   * @brief Evaluation function for the constant thermal source model
+   *
+   * @tparam T1 type of the position vector
+   * @tparam T2 type of the temperature
+   * @tparam T3 type of the temperature gradient
+   * @tparam dim The dimension of the problem
+   * @return The thermal source value
+   */
+  template <typename T1, typename T2, typename T3, typename T4>
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const double /* t */, const T2& /* u */, const T3& /* du_dx */,
+                                    const T4& parameter) const
+  {
+    return source_ + parameter;
+  }
+
+  static constexpr int numParameters() { return 1; }
+};
+
+/// Constant thermal flux boundary model
+struct ParameterizedFlux {
+  /// The constant flux applied to the boundary
+  double flux_ = 0.0;
+
+  /**
+   * @brief Evaluation function for the thermal flux on a boundary
+   *
+   * @tparam T1 Type of the position vector
+   * @tparam T2 Type of the normal vector
+   * @tparam T3 Type of the temperature on the boundary
+   * @tparam dim The dimension of the problem
+   * @return The flux applied to the boundary
+   */
+  template <typename T1, typename T2, typename T3, typename T4>
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* n */, const T3& /* u */, const T4& parameter) const
+  {
+    return flux_ + parameter;
+  }
+
+  static constexpr int numParameters() { return 1; }
+};
+
+}  // namespace serac::Thermal

--- a/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
@@ -20,13 +20,12 @@ namespace serac::Thermal {
 /// Linear isotropic conductor with a parameterized conductivity
 class ParameterizedLinearIsotropicConductor {
 public:
-
   /**
    * @brief Construct a new Parameterized Linear Isotropic Conductor object
-   * 
+   *
    * @param density Density of the material (mass/volume)
    * @param specific_heat_capacity Specific heat capacity of the material (energy / (mass * temp))
-   * @param conductivity_offset Thermal conductivity offset of the material (power / (length * temp)). This is 
+   * @param conductivity_offset Thermal conductivity offset of the material (power / (length * temp)). This is
    * added to the parameter value to get the total conductivity.
    */
   ParameterizedLinearIsotropicConductor(double density = 1.0, double specific_heat_capacity = 1.0,
@@ -44,17 +43,19 @@ public:
 
   /**
    * @brief Thermal material response operator
-   * 
+   *
    * @tparam T1 Spatial position type
    * @tparam T2 Temperature type
    * @tparam T3 Temperature gradient type
    * @tparam T4 Parameter type
    * @param temperature_gradient The spatial gradient of the temperature (d temperature dx)
-   * @param parameter The user-defined parameter used to compute the conductivity (total conductivity = conductivity offset + parameter)
+   * @param parameter The user-defined parameter used to compute the conductivity (total conductivity = conductivity
+   * offset + parameter)
    * @return The density, specific heat capacity, and heat flux of the material.
    */
   template <typename T1, typename T2, typename T3, typename T4>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */, const T3& temperature_gradient, const T4& parameter) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */, const T3& temperature_gradient,
+                                    const T4& parameter) const
   {
     return MaterialResponse{.density                = density_,
                             .specific_heat_capacity = specific_heat_capacity_,
@@ -63,7 +64,7 @@ public:
 
   /**
    * @brief The number of parameters in the model
-   * 
+   *
    * @return The number of parameters in the model
    */
   static constexpr int numParameters() { return 1; }
@@ -103,7 +104,7 @@ struct ParameterizedSource {
 
   /**
    * @brief The number of parameters in the model
-   * 
+   *
    * @return The number of parameters in the model
    */
   static constexpr int numParameters() { return 1; }
@@ -132,7 +133,7 @@ struct ParameterizedFlux {
 
   /**
    * @brief The number of parameters in the model
-   * 
+   *
    * @return The number of parameters in the model
    */
   static constexpr int numParameters() { return 1; }

--- a/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
@@ -17,37 +17,72 @@
 /// ThermalConductionFunctional helper structs
 namespace serac::Thermal {
 
+/// Linear isotropic conductor with a parameterized conductivity
 class ParameterizedLinearIsotropicConductor {
 public:
+
+  /**
+   * @brief Construct a new Parameterized Linear Isotropic Conductor object
+   * 
+   * @param density Density of the material (mass/volume)
+   * @param specific_heat_capacity Specific heat capacity of the material (energy / (mass * temp))
+   * @param conductivity_offset Thermal conductivity offset of the material (power / (length * temp)). This is 
+   * added to the parameter value to get the total conductivity.
+   */
   ParameterizedLinearIsotropicConductor(double density = 1.0, double specific_heat_capacity = 1.0,
-                                        double conductivity = 1.0)
-      : density_(density), specific_heat_capacity_(specific_heat_capacity), conductivity_(conductivity)
+                                        double conductivity_offset = 1.0)
+      : density_(density), specific_heat_capacity_(specific_heat_capacity), conductivity_offset_(conductivity_offset)
   {
-    assert(conductivity > 0.0);
-    assert(density > 0.0);
-    assert(specific_heat_capacity > 0.0);
+    SLIC_ERROR_ROOT_IF(conductivity_offset_ < 0.0,
+                       "Conductivity must be positive in the linear isotropic conductor material model.");
+
+    SLIC_ERROR_ROOT_IF(density_ < 0.0, "Density must be positive in the linear isotropic conductor material model.");
+
+    SLIC_ERROR_ROOT_IF(specific_heat_capacity_ < 0.0,
+                       "Specific heat capacity must be positive in the linear isotropic conductor material model.");
   }
 
+  /**
+   * @brief Thermal material response operator
+   * 
+   * @tparam T1 Spatial position type
+   * @tparam T2 Temperature type
+   * @tparam T3 Temperature gradient type
+   * @tparam T4 Parameter type
+   * @param temperature_gradient The spatial gradient of the temperature (d temperature dx)
+   * @param parameter The user-defined parameter used to compute the conductivity (total conductivity = conductivity offset + parameter)
+   * @return The density, specific heat capacity, and heat flux of the material.
+   */
   template <typename T1, typename T2, typename T3, typename T4>
-  SERAC_HOST_DEVICE auto operator()(const T1&, const T2&, const T3& temperature_gradient, const T4& parameter) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */, const T3& temperature_gradient, const T4& parameter) const
   {
     return MaterialResponse{.density                = density_,
                             .specific_heat_capacity = specific_heat_capacity_,
-                            .heat_flux              = -1.0 * (conductivity_ + parameter) * temperature_gradient};
+                            .heat_flux              = -1.0 * (conductivity_offset_ + parameter) * temperature_gradient};
   }
 
+  /**
+   * @brief The number of parameters in the model
+   * 
+   * @return The number of parameters in the model
+   */
   static constexpr int numParameters() { return 1; }
 
 private:
+  /// Density
   double density_;
+
+  /// Specific heat capacity
   double specific_heat_capacity_;
-  double conductivity_;
+
+  /// Conductivity offset
+  double conductivity_offset_;
 };
 
 /// Parameterized thermal source model
 struct ParameterizedSource {
-  /// The constant source
-  double source_ = 0.0;
+  /// The constant source offset
+  double source_offset_ = 0.0;
 
   /**
    * @brief Evaluation function for the constant thermal source model
@@ -55,23 +90,29 @@ struct ParameterizedSource {
    * @tparam T1 type of the position vector
    * @tparam T2 type of the temperature
    * @tparam T3 type of the temperature gradient
-   * @tparam dim The dimension of the problem
+   * @tparam T4 type of the parameter
+   * @param parameter user-defined parameter
    * @return The thermal source value
    */
   template <typename T1, typename T2, typename T3, typename T4>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const double /* t */, const T2& /* u */, const T3& /* du_dx */,
                                     const T4& parameter) const
   {
-    return source_ + parameter;
+    return source_offset_ + parameter;
   }
 
+  /**
+   * @brief The number of parameters in the model
+   * 
+   * @return The number of parameters in the model
+   */
   static constexpr int numParameters() { return 1; }
 };
 
 /// Constant thermal flux boundary model
 struct ParameterizedFlux {
   /// The constant flux applied to the boundary
-  double flux_ = 0.0;
+  double flux_offset_ = 0.0;
 
   /**
    * @brief Evaluation function for the thermal flux on a boundary
@@ -79,15 +120,21 @@ struct ParameterizedFlux {
    * @tparam T1 Type of the position vector
    * @tparam T2 Type of the normal vector
    * @tparam T3 Type of the temperature on the boundary
-   * @tparam dim The dimension of the problem
+   * @tparam T4 Type of the parameter
+   * @param parameter The user-defined parameter value
    * @return The flux applied to the boundary
    */
   template <typename T1, typename T2, typename T3, typename T4>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* n */, const T3& /* u */, const T4& parameter) const
   {
-    return flux_ + parameter;
+    return flux_offset_ + parameter;
   }
 
+  /**
+   * @brief The number of parameters in the model
+   * 
+   * @return The number of parameters in the model
+   */
   static constexpr int numParameters() { return 1; }
 };
 

--- a/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_thermal_functional_material.hpp
@@ -57,9 +57,12 @@ public:
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */, const T3& temperature_gradient,
                                     const T4& parameter) const
   {
-    return MaterialResponse{.density                = density_,
-                            .specific_heat_capacity = specific_heat_capacity_,
-                            .heat_flux              = -1.0 * (conductivity_offset_ + parameter) * temperature_gradient};
+    using FluxType = decltype((conductivity_offset_ + parameter) * temperature_gradient);
+
+    return MaterialResponse<double, double, FluxType>{
+        .density                = density_,
+        .specific_heat_capacity = specific_heat_capacity_,
+        .heat_flux              = -1.0 * (conductivity_offset_ + parameter) * temperature_gradient};
   }
 
   /**

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -52,9 +52,11 @@ public:
   template <typename T1, typename T2, typename T3>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
   {
-    return MaterialResponse{.density                = density_,
-                            .specific_heat_capacity = specific_heat_capacity_,
-                            .heat_flux              = -1.0 * conductivity_ * du_dx};
+    using FluxType = decltype(conductivity_ * du_dx);
+
+    return MaterialResponse<double, double, FluxType>{.density                = density_,
+                                                      .specific_heat_capacity = specific_heat_capacity_,
+                                                      .heat_flux              = -1.0 * conductivity_ * du_dx};
   }
 
 private:
@@ -99,9 +101,11 @@ public:
   template <typename T1, typename T2, typename T3>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
   {
-    return MaterialResponse{.density                = density_,
-                            .specific_heat_capacity = specific_heat_capacity_,
-                            .heat_flux              = -1.0 * conductivity_ * du_dx};
+    using FluxType = decltype(conductivity_ * du_dx);
+
+    return MaterialResponse<double, double, FluxType>{.density                = density_,
+                                                      .specific_heat_capacity = specific_heat_capacity_,
+                                                      .heat_flux              = -1.0 * conductivity_ * du_dx};
   }
 
 private:

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -17,10 +17,22 @@
 /// ThermalConductionFunctional helper structs
 namespace serac::Thermal {
 
+/**
+ * @brief Response data type for thermal conduction simulations
+ *
+ * @tparam T1 Density type
+ * @tparam T2 Specific heat capacity type
+ * @tparam T3 Thermal flux type
+ */
 template <typename T1, typename T2, typename T3>
 struct MaterialResponse {
+  /// Density of the material (mass/volume)
   T1 density;
+
+  /// Specific heat capacity of the material (energy / (mass * temp))
   T2 specific_heat_capacity;
+
+  /// Heat flux of the material (power/area)
   T3 heat_flux;
 };
 
@@ -49,6 +61,16 @@ public:
                        "Specific heat capacity must be positive in the linear isotropic conductor material model.");
   }
 
+  /**
+   * @brief Material response call for a linear isotropic material
+   *
+   * @tparam T1 Spatial position type
+   * @tparam T2 Temperature type
+   * @tparam T3 Temperature gradient type
+   * @param[in] du_dx Temperature gradient
+   * @return The calculated material response (density, specific heat capacity, thermal flux) for a linear
+   * isotropic material
+   */
   template <typename T1, typename T2, typename T3>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
   {
@@ -98,6 +120,16 @@ public:
                        "Conductivity tensor must be symmetric and positive definite.");
   }
 
+  /**
+   * @brief Material response call for a linear anisotropic material
+   *
+   * @tparam T1 Spatial position type
+   * @tparam T2 Temperature type
+   * @tparam T3 Temperature gradient type
+   * @param[in] du_dx Temperature gradient
+   * @return The calculated material response (density, specific heat capacity, thermal flux) for a linear
+   * anisotropic material
+   */
   template <typename T1, typename T2, typename T3>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
   {

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -122,7 +122,7 @@ public:
   template <typename T1, typename T2, typename T3>
   SERAC_HOST_DEVICE T2 operator()(const T1& /* temperature */, const T2& temperature_gradient, const T3&) const
   {
-    return -1.0 * conductivity_ * temperature_gradient;
+    return -1.0 * temperature_gradient;
   }
 
   constexpr int numParams() const { return 1; }
@@ -134,9 +134,9 @@ public:
    * @return The density
    */
   template <int dim, typename T1>
-  SERAC_HOST_DEVICE double density(const tensor<double, dim>& /* x */, const T1&) const
+  SERAC_HOST_DEVICE T1 density(const tensor<double, dim>& /* x */, const T1& parameter) const
   {
-    return density_;
+    return density_ + 0.0 * parameter;
   }
 
   /**

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -126,14 +126,16 @@ public:
     return -1.0 * conductivity_ * temperature_gradient + 0.0 * parameter;
   }
 
+  constexpr int numParams() const { return 1; }
+
   /**
    * @brief The density (mass per volume) of the material model
    *
    * @tparam dim The dimension of the problem
    * @return The density
    */
-  template <int dim>
-  SERAC_HOST_DEVICE double density(const tensor<double, dim>& /* x */) const
+  template <int dim, typename T>
+  SERAC_HOST_DEVICE double density(const tensor<double, dim>& /* x */, const T& parameter) const
   {
     return density_;
   }
@@ -144,13 +146,14 @@ public:
    * @tparam dim The dimension of the problem
    * @tparam T Type of the temperature variable
    */
-  template <typename T, int dim>
-  SERAC_HOST_DEVICE double specificHeatCapacity(const tensor<double, dim>& /* x */, const T& /* temperature */) const
+  template <typename T1, typename T2, int dim>
+  SERAC_HOST_DEVICE double specificHeatCapacity(const tensor<double, dim>& /* x */, const T1& /* temperature */,
+                                                const T2& parameter) const
   {
-    return specific_heat_capacity_;
+    return specific_heat_capacity_ + 0.0 * parameter;
   }
 
-  constexpr int numParameters() { return 1; }
+  static constexpr int numParameters() { return 1; }
 
 private:
   /// Density

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -120,10 +120,9 @@ public:
    * @return The thermal flux of the material model
    */
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE T2 operator()(const T1& /* temperature */, const T2& temperature_gradient,
-                                  const T3& parameter) const
+  SERAC_HOST_DEVICE T2 operator()(const T1& /* temperature */, const T2& temperature_gradient, const T3&) const
   {
-    return -1.0 * conductivity_ * temperature_gradient + 0.0 * parameter;
+    return -1.0 * conductivity_ * temperature_gradient;
   }
 
   constexpr int numParams() const { return 1; }
@@ -134,8 +133,8 @@ public:
    * @tparam dim The dimension of the problem
    * @return The density
    */
-  template <int dim, typename T>
-  SERAC_HOST_DEVICE double density(const tensor<double, dim>& /* x */, const T& parameter) const
+  template <int dim, typename T1>
+  SERAC_HOST_DEVICE double density(const tensor<double, dim>& /* x */, const T1&) const
   {
     return density_;
   }
@@ -148,9 +147,9 @@ public:
    */
   template <typename T1, typename T2, int dim>
   SERAC_HOST_DEVICE double specificHeatCapacity(const tensor<double, dim>& /* x */, const T1& /* temperature */,
-                                                const T2& parameter) const
+                                                const T2&) const
   {
-    return specific_heat_capacity_ + 0.0 * parameter;
+    return specific_heat_capacity_;
   }
 
   static constexpr int numParameters() { return 1; }

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -136,7 +136,7 @@ public:
   template <int dim, typename T1>
   SERAC_HOST_DEVICE T1 density(const tensor<double, dim>& /* x */, const T1& parameter) const
   {
-    return density_ + 0.0 * parameter;
+    return density_ + 0.01 * parameter;
   }
 
   /**

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -50,11 +50,11 @@ public:
   }
 
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1&, const T2&, const T3& temperature_gradient) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
   {
     return MaterialResponse{.density                = density_,
                             .specific_heat_capacity = specific_heat_capacity_,
-                            .heat_flux              = -conductivity_ * temperature_gradient};
+                            .heat_flux              = -1.0 * conductivity_ * du_dx};
   }
 
 private:
@@ -65,34 +65,6 @@ private:
   double specific_heat_capacity_;
 
   /// Constant isotropic thermal conductivity
-  double conductivity_;
-};
-
-class ParameterizedLinearIsotropicConductor {
-public:
-  ParameterizedLinearIsotropicConductor(double density = 1.0, double specific_heat_capacity = 1.0,
-                                        double conductivity = 1.0)
-      : density_(density), specific_heat_capacity_(specific_heat_capacity), conductivity_(conductivity)
-  {
-    assert(conductivity > 0.0);
-    assert(density > 0.0);
-    assert(specific_heat_capacity > 0.0);
-  }
-
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  SERAC_HOST_DEVICE auto operator()(const T1&, const T2&, const T3& temperature_gradient, const T4& parameter_1,
-                                    const T5& parameter_2) const
-  {
-    return MaterialResponse{.density                = density_ + 0.01 * parameter_1,
-                            .specific_heat_capacity = specific_heat_capacity_,
-                            .heat_flux              = -1.0 * (conductivity_ + parameter_2) * temperature_gradient};
-  }
-
-  static constexpr int numParameters() { return 2; }
-
-private:
-  double density_;
-  double specific_heat_capacity_;
   double conductivity_;
 };
 
@@ -125,11 +97,11 @@ public:
   }
 
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1&, const T2&, const T3& temperature_gradient) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
   {
     return MaterialResponse{.density                = density_,
                             .specific_heat_capacity = specific_heat_capacity_,
-                            .heat_flux              = -1.0 * (conductivity_)*temperature_gradient};
+                            .heat_flux              = -1.0 * conductivity_ * du_dx};
   }
 
 private:
@@ -152,7 +124,7 @@ struct ConstantSource {
    * @brief Evaluation function for the constant thermal source model
    *
    * @tparam T1 type of the position vector
-   * @tparam T2 type of the temperature 
+   * @tparam T2 type of the temperature
    * @tparam T3 type of the temperature gradient
    * @tparam dim The dimension of the problem
    * @return The thermal source value

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -36,6 +36,13 @@ struct MaterialResponse {
   T3 heat_flux;
 };
 
+/**
+ * @brief Template deduction guide for the material response
+ *
+ * @tparam T1 Density type
+ * @tparam T2 Specific heat capacity type
+ * @tparam T3 Heat flux type
+ */
 template <typename T1, typename T2, typename T3>
 MaterialResponse(T1, T2, T3) -> MaterialResponse<T1, T2, T3>;
 

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -116,7 +116,9 @@ public:
    *
    * @tparam T1 type of the temperature (e.g. tensor or dual type)
    * @tparam T2 type of the temperature gradient (e.g. tensor or dual type)
+   * @tparam T3 type of the parameter field (e.g. tensor or dual type)
    * @param temperature_gradient Gradient of the temperature (du_dx)
+   * @param parameter The user-defined parameter used to calculate the thermal conductivity
    * @return The thermal flux of the material model
    */
   template <typename T1, typename T2, typename T3>
@@ -151,6 +153,11 @@ public:
     return specific_heat_capacity_;
   }
 
+  /**
+   * @brief The number of parameters associated with this material model
+   *
+   * @return The number of material model parameters
+   */
   static constexpr int numParameters() { return 1; }
 
 private:

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -133,7 +133,7 @@ public:
    * @return The density
    */
   template <int dim, typename T1>
-  SERAC_HOST_DEVICE T1 density(const tensor<double, dim>& /* x */, const T1& parameter) const
+  SERAC_HOST_DEVICE auto density(const tensor<double, dim>& /* x */, const T1& parameter) const
   {
     return density_ + 0.0 * parameter;
   }

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -112,13 +112,6 @@ public:
   }
 
   /**
-   * @brief Return the number of parameters in the model
-   *
-   * @return Number of parameters in the model
-   */
-  constexpr int numParams() const { return 1; }
-
-  /**
    * @brief Function defining the thermal flux (constitutive response)
    *
    * @tparam T1 type of the temperature (e.g. tensor or dual type)
@@ -127,9 +120,10 @@ public:
    * @return The thermal flux of the material model
    */
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE T2 operator()(const T1& /* temperature */, const T2& temperature_gradient, const T3&) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* temperature */, const T2& temperature_gradient,
+                                    const T3& parameter) const
   {
-    return -1.0 * temperature_gradient;
+    return -1.0 * (conductivity_ + 0.01 * parameter) * temperature_gradient;
   }
 
   /**
@@ -141,7 +135,7 @@ public:
   template <int dim, typename T1>
   SERAC_HOST_DEVICE T1 density(const tensor<double, dim>& /* x */, const T1& parameter) const
   {
-    return density_ + 0.01 * parameter;
+    return density_ + 0.0 * parameter;
   }
 
   /**

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -143,14 +143,6 @@ private:
   tensor<double, dim, dim> conductivity_;
 };
 
-template <typename T>
-struct HeatSource {
-  T source;
-};
-
-template <typename T>
-HeatSource(T) -> HeatSource<T>;
-
 /// Constant thermal source model
 struct ConstantSource {
   /// The constant source
@@ -159,8 +151,9 @@ struct ConstantSource {
   /**
    * @brief Evaluation function for the constant thermal source model
    *
-   * @tparam T1 type of the temperature
-   * @tparam T2 type of the temperature gradient
+   * @tparam T1 type of the position vector
+   * @tparam T2 type of the temperature 
+   * @tparam T3 type of the temperature gradient
    * @tparam dim The dimension of the problem
    * @return The thermal source value
    */
@@ -168,17 +161,9 @@ struct ConstantSource {
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const double /* t */, const T2& /* u */,
                                     const T3& /* du_dx */) const
   {
-    return HeatSource{.source = source_};
+    return source_;
   }
 };
-
-template <typename T>
-struct FluxBoundary {
-  T flux;
-};
-
-template <typename T>
-FluxBoundary(T) -> FluxBoundary<T>;
 
 /// Constant thermal flux boundary model
 struct ConstantFlux {
@@ -188,15 +173,16 @@ struct ConstantFlux {
   /**
    * @brief Evaluation function for the thermal flux on a boundary
    *
-   * @tparam T1 Type of the normal vector
-   * @tparam T2 Type of the temperature
+   * @tparam T1 Type of the position vector
+   * @tparam T2 Type of the normal vector
+   * @tparam T3 Type of the temperature on the boundary
    * @tparam dim The dimension of the problem
    * @return The flux applied to the boundary
    */
   template <typename T1, typename T2, typename T3>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* n */, const T3& /* u */) const
   {
-    return FluxBoundary{.flux = flux_};
+    return flux_;
   }
 };
 

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -74,18 +74,19 @@ public:
    * @tparam T1 Spatial position type
    * @tparam T2 Temperature type
    * @tparam T3 Temperature gradient type
-   * @param[in] du_dx Temperature gradient
+   * @param[in] temperature_gradient Temperature gradient
    * @return The calculated material response (density, specific heat capacity, thermal flux) for a linear
    * isotropic material
    */
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */,
+                                    const T3& temperature_gradient) const
   {
-    using FluxType = decltype(conductivity_ * du_dx);
+    using FluxType = decltype(conductivity_ * temperature_gradient);
 
     return MaterialResponse<double, double, FluxType>{.density                = density_,
                                                       .specific_heat_capacity = specific_heat_capacity_,
-                                                      .heat_flux              = -1.0 * conductivity_ * du_dx};
+                                                      .heat_flux = -1.0 * conductivity_ * temperature_gradient};
   }
 
 private:
@@ -133,18 +134,19 @@ public:
    * @tparam T1 Spatial position type
    * @tparam T2 Temperature type
    * @tparam T3 Temperature gradient type
-   * @param[in] du_dx Temperature gradient
+   * @param[in] temperature_gradient Temperature gradient
    * @return The calculated material response (density, specific heat capacity, thermal flux) for a linear
    * anisotropic material
    */
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* u */, const T3& du_dx) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */,
+                                    const T3& temperature_gradient) const
   {
-    using FluxType = decltype(conductivity_ * du_dx);
+    using FluxType = decltype(conductivity_ * temperature_gradient);
 
     return MaterialResponse<double, double, FluxType>{.density                = density_,
                                                       .specific_heat_capacity = specific_heat_capacity_,
-                                                      .heat_flux              = -1.0 * conductivity_ * du_dx};
+                                                      .heat_flux = -1.0 * conductivity_ * temperature_gradient};
   }
 
 private:
@@ -173,8 +175,8 @@ struct ConstantSource {
    * @return The thermal source value
    */
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const double /* t */, const T2& /* u */,
-                                    const T3& /* du_dx */) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const double /* time */, const T2& /* temperature */,
+                                    const T3& /* temperature_gradient */) const
   {
     return source_;
   }
@@ -195,7 +197,7 @@ struct ConstantFlux {
    * @return The flux applied to the boundary
    */
   template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* n */, const T3& /* u */) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* normal */, const T3& /* temperature */) const
   {
     return flux_;
   }

--- a/src/serac/physics/materials/thermal_functional_material.hpp
+++ b/src/serac/physics/materials/thermal_functional_material.hpp
@@ -92,7 +92,7 @@ private:
 class ParameterizedLinearIsotropicConductor {
 public:
   /**
-   * @brief Construct a new Linear Isotropic Conductor object
+   * @brief Construct a new Parameterized Linear Isotropic Conductor object
    *
    * @param density Density of the material (mass/volume)
    * @param specific_heat_capacity Specific heat capacity of the material (energy / (mass * temp))
@@ -112,6 +112,13 @@ public:
   }
 
   /**
+   * @brief Return the number of parameters in the model
+   *
+   * @return Number of parameters in the model
+   */
+  constexpr int numParams() const { return 1; }
+
+  /**
    * @brief Function defining the thermal flux (constitutive response)
    *
    * @tparam T1 type of the temperature (e.g. tensor or dual type)
@@ -124,8 +131,6 @@ public:
   {
     return -1.0 * temperature_gradient;
   }
-
-  constexpr int numParams() const { return 1; }
 
   /**
    * @brief The density (mass per volume) of the material model

--- a/src/serac/physics/solid.hpp
+++ b/src/serac/physics/solid.hpp
@@ -385,8 +385,6 @@ public:
    *
    * @note Before this call, a forward and adjoint solve (with the appropriate QoI-based adjoint load) must be
    * completed. If this does not occur, the returned linear form will be incorrect.
-   *
-   * @note T
    */
   virtual FiniteElementDual& shearModulusSensitivity(mfem::ParFiniteElementSpace* shear_space = nullptr);
 

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -241,7 +241,7 @@ public:
   template <typename MaterialType>
   void setMaterial(MaterialType material)
   {
-    static_assert(has_density<MaterialType, dim>::value,
+    static_assert(has_density<MaterialType, dim, 0>::value,
                   "Solid functional materials must have a public density(x) method.");
     static_assert(has_stress<MaterialType, dim>::value,
                   "Solid functional materials must have a public (du_dx) operator for Kirchoff stress evaluation.");

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -241,7 +241,7 @@ public:
   template <typename MaterialType>
   void setMaterial(MaterialType material)
   {
-    static_assert(has_density<MaterialType, dim, 0>::value,
+    static_assert(has_density<MaterialType, dim>::value,
                   "Solid functional materials must have a public density(x) method.");
     static_assert(has_stress<MaterialType, dim>::value,
                   "Solid functional materials must have a public (du_dx) operator for Kirchoff stress evaluation.");

--- a/src/serac/physics/state/finite_element_vector.cpp
+++ b/src/serac/physics/state/finite_element_vector.cpp
@@ -41,7 +41,7 @@ FiniteElementVector::FiniteElementVector(mfem::ParMesh& mesh, FiniteElementVecto
   true_vec_ = 0.0;
 }
 
-FiniteElementVector::FiniteElementVector(mfem::ParMesh& mesh, mfem::ParFiniteElementSpace& space,
+FiniteElementVector::FiniteElementVector(mfem::ParMesh& mesh, const mfem::ParFiniteElementSpace& space,
                                          const std::string& name)
     : mesh_(mesh),
       coll_(std::unique_ptr<mfem::FiniteElementCollection>(mfem::FiniteElementCollection::New(space.FEColl()->Name()))),

--- a/src/serac/physics/state/finite_element_vector.hpp
+++ b/src/serac/physics/state/finite_element_vector.hpp
@@ -91,7 +91,7 @@ public:
    * @param[in] space The space to use for the finite element state. This space is deep copied into the new FE state
    * @param[in] name The name of the field
    */
-  FiniteElementVector(mfem::ParMesh& mesh, mfem::ParFiniteElementSpace& space, const std::string& name = "");
+  FiniteElementVector(mfem::ParMesh& mesh, const mfem::ParFiniteElementSpace& space, const std::string& name = "");
 
   /**
    * @brief Delete the default copy constructor

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ blt_add_library(
 
 set(serial_solver_tests
     serac_solid_sensitivity.cpp
+    serac_thermal_functional_finite_diff.cpp
     )
 
 serac_add_tests( SOURCES ${serial_solver_tests}

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -172,6 +172,8 @@ TEST(thermal_functional, 2D_quad_dynamic) { functional_test_dynamic<2, 2>(2.0288
 TEST(thermal_functional, 3D_linear_dynamic) { functional_test_dynamic<1, 3>(2.82842712); }
 TEST(thermal_functional, 3D_quad_dynamic) { functional_test_dynamic<2, 3>(2.828427124); }
 
+#if 0
+
 TEST(thermal_functional, parameterized_material)
 {
   MPI_Barrier(MPI_COMM_WORLD);
@@ -262,6 +264,8 @@ TEST(thermal_functional, parameterized_material)
 
   EXPECT_NEAR(0.013659489, mfem::ParNormlp(sensitivity.trueVec(), 2, MPI_COMM_WORLD), 1.0e-6);
 }
+#endif
+
 
 }  // namespace serac
 

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -207,6 +207,7 @@ TEST(thermal_functional, parameterized_material)
       ThermalConductionFunctional<p, dim, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
       {&parameterized_state});
 
+  // Construct a potentially user-defined parameterized material and send it to the thermal module
   Thermal::ParameterizedLinearIsotropicConductor mat(1.0, 1.0, 1.0);
   thermal_solver.setMaterial(mat);
 
@@ -240,13 +241,16 @@ TEST(thermal_functional, parameterized_material)
   // Output the sidre-based plot files
   thermal_solver.outputState();
 
+  // Construct a dummy adjoint load (this would come from a QOI downstream)
   FiniteElementDual adjoint_load(
       StateManager::newDual(FiniteElementState::Options{.order = 1, .name = "adjoint_load"}));
 
   adjoint_load.trueVec() = 1.0;
 
+  // Solve the adjoint problem
   thermal_solver.solveAdjoint(adjoint_load);
 
+  // Compute the sensitivity given the adjoint solution
   auto& sensitivity = thermal_solver.computeSensitivity<parameter_index>();
 
   EXPECT_NEAR(6.3245553203, mfem::ParNormlp(sensitivity.trueVec(), 2, MPI_COMM_WORLD), 1.0e-6);

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -206,7 +206,7 @@ TEST(thermal_functional, parameterized_material)
   // We should extend this to single scalar trial spaces (global vector space?)
   ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(
       ThermalConductionFunctional<p, dim, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
-      {&parameterized_state});
+      {parameterized_state});
 
   // Construct a potentially user-defined parameterized material and send it to the thermal module
   Thermal::ParameterizedLinearIsotropicConductor mat(1.0, 1.0, 1.0);

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -198,7 +198,6 @@ TEST(thermal_functional, parameterized_material)
   constexpr int parameter_index = 0;
 
   // Construct a functional-based thermal conduction solver
-  // We should extend this to single scalar trial spaces (global vector space?)
   ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(
       ThermalConductionFunctional<p, dim, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
       {parameterized_state});
@@ -247,7 +246,6 @@ TEST(thermal_functional, parameterized_material)
   thermal_solver.solveAdjoint(adjoint_load);
 
   // Compute the sensitivity given the adjoint solution
-  // TODO Should we own this? Should LiDO?
   auto& sensitivity = thermal_solver.computeSensitivity<parameter_index>();
 
   EXPECT_NEAR(0.5086485, mfem::ParNormlp(sensitivity.trueVec(), 2, MPI_COMM_WORLD), 1.0e-6);

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -43,7 +43,7 @@ void functional_test_static(double expected_temp_norm)
   std::set<int> ess_bdr = {1};
 
   // Construct a functional-based thermal conduction solver
-  ThermalConductionFunctional<p, dim> thermal_solver(ThermalConductionFunctional<p, dim>::defaultQuasistaticOptions(),
+  ThermalConductionFunctional<p, dim, H1<p>> thermal_solver(ThermalConductionFunctional<p, dim, H1<p>>::defaultQuasistaticOptions(),
                                                      "thermal_functional");
 
   tensor<double, dim, dim> cond;

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -72,7 +72,7 @@ void functional_test_static(double expected_temp_norm)
   thermal_solver.setSource(source);
 
   // Set the flux term to zero for testing code paths
-  Thermal::FluxBoundary flux_bc{0.0};
+  Thermal::ConstantFlux flux_bc{0.0};
   thermal_solver.setFluxBCs(flux_bc);
 
   // Finalize the data structures
@@ -139,7 +139,7 @@ void functional_test_dynamic(double expected_temp_norm)
   thermal_solver.setSource(source);
 
   // Set the flux term to zero for testing code paths
-  Thermal::FluxBoundary flux_bc{0.0};
+  Thermal::ConstantFlux flux_bc{0.0};
   thermal_solver.setFluxBCs(flux_bc);
 
   // Finalize the data structures
@@ -234,7 +234,7 @@ TEST(thermal_functional, parameterized_material)
   thermal_solver.setSource(source);
 
   // Set the flux term to zero for testing code paths
-  Thermal::FluxBoundary flux_bc{0.0};
+  Thermal::ConstantFlux flux_bc{0.0};
   thermal_solver.setFluxBCs(flux_bc);
 
   // Finalize the data structures

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -203,6 +203,7 @@ TEST(thermal_functional, parameterized_material)
   constexpr int parameter_index = 0;
 
   // Construct a functional-based thermal conduction solver
+  // We should extend this to single scalar trial spaces (global vector space?)
   ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(
       ThermalConductionFunctional<p, dim, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
       {&parameterized_state});
@@ -251,9 +252,10 @@ TEST(thermal_functional, parameterized_material)
   thermal_solver.solveAdjoint(adjoint_load);
 
   // Compute the sensitivity given the adjoint solution
+  // TODO Should we own this? Should LiDO?
   auto& sensitivity = thermal_solver.computeSensitivity<parameter_index>();
 
-  EXPECT_NEAR(6.3245553203, mfem::ParNormlp(sensitivity.trueVec(), 2, MPI_COMM_WORLD), 1.0e-6);
+  EXPECT_NEAR(0.013659489, mfem::ParNormlp(sensitivity.trueVec(), 2, MPI_COMM_WORLD), 1.0e-6);
 }
 
 }  // namespace serac

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -195,18 +195,23 @@ TEST(thermal_functional, parameterized_material)
   // Define a boundary attribute set
   std::set<int> ess_bdr = {1};
 
-  FiniteElementState parameterized_state(
-      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_field"}));
+  FiniteElementState parameterized_state_1(
+      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_field_1"}));
 
-  parameterized_state = 1.0;
+  parameterized_state_1 = 1.0;
+
+  FiniteElementState parameterized_state_2(
+      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_field_2"}));
+
+  parameterized_state_2 = 1.0;
 
   constexpr int parameter_index = 0;
 
   // Construct a functional-based thermal conduction solver
   // We should extend this to single scalar trial spaces (global vector space?)
-  ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(
-      ThermalConductionFunctional<p, dim, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
-      {parameterized_state});
+  ThermalConductionFunctional<p, dim, H1<1>, H1<1>> thermal_solver(
+      ThermalConductionFunctional<p, dim, H1<1>, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
+      {parameterized_state_1, parameterized_state_2});
 
   // Construct a potentially user-defined parameterized material and send it to the thermal module
   Thermal::ParameterizedLinearIsotropicConductor mat(1.0, 1.0, 1.0);

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -44,8 +44,7 @@ void functional_test_static(double expected_temp_norm)
   std::set<int> ess_bdr = {1};
 
   // Construct a functional-based thermal conduction solver
-  ThermalConductionFunctional<p, dim> thermal_solver(ThermalConductionFunctional<p, dim>::defaultQuasistaticOptions(),
-                                                     "thermal_functional");
+  ThermalConductionFunctional<p, dim> thermal_solver(Thermal::defaultQuasistaticOptions(), "thermal_functional");
 
   tensor<double, dim, dim> cond;
 
@@ -115,8 +114,7 @@ void functional_test_dynamic(double expected_temp_norm)
   std::set<int> ess_bdr = {1};
 
   // Construct a functional-based thermal conduction solver
-  ThermalConductionFunctional<p, dim> thermal_solver(ThermalConductionFunctional<p, dim>::defaultDynamicOptions(),
-                                                     "thermal_functional");
+  ThermalConductionFunctional<p, dim> thermal_solver(Thermal::defaultDynamicOptions(), "thermal_functional");
 
   // Define an isotropic conductor material model
   Thermal::LinearIsotropicConductor mat(0.5, 0.5, 0.5);
@@ -206,9 +204,8 @@ TEST(thermal_functional, parameterized_material)
   // Note that we now include an extra template parameter indicating the finite element space for the parameterized
   // field, in this case the thermal conductivity. We also pass an array of finite element states for each of the
   // requested parameterized fields.
-  ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(
-      ThermalConductionFunctional<p, dim, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
-      {user_defined_conductivity});
+  ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(Thermal::defaultQuasistaticOptions(), "thermal_functional",
+                                                            {user_defined_conductivity});
 
   // Construct a potentially user-defined parameterized material and send it to the thermal module
   Thermal::ParameterizedLinearIsotropicConductor mat;

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -43,7 +43,7 @@ void functional_test_static(double expected_temp_norm)
   std::set<int> ess_bdr = {1};
 
   // Construct a functional-based thermal conduction solver
-  ThermalConductionFunctional<p, dim, H1<p>> thermal_solver(ThermalConductionFunctional<p, dim, H1<p>>::defaultQuasistaticOptions(),
+  ThermalConductionFunctional<p, dim> thermal_solver(ThermalConductionFunctional<p, dim>::defaultQuasistaticOptions(),
                                                      "thermal_functional");
 
   tensor<double, dim, dim> cond;

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -201,8 +201,8 @@ TEST(thermal_functional, parameterized_material)
   constexpr int parameter_index = 0;
 
   // Construct a functional-based thermal conduction solver
-  ThermalConductionFunctional<p, dim, L2<0>> thermal_solver(
-      ThermalConductionFunctional<p, dim, L2<0>>::defaultQuasistaticOptions(), "thermal_functional",
+  ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(
+      ThermalConductionFunctional<p, dim, H1<1>>::defaultQuasistaticOptions(), "thermal_functional",
       {&parameterized_state});
 
   Thermal::ParameterizedLinearIsotropicConductor mat(1.0, 1.0, 1.0);

--- a/src/serac/physics/tests/serac_thermal_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional.cpp
@@ -251,10 +251,10 @@ TEST(thermal_functional, parameterized_material)
   // Solve the adjoint problem
   thermal_solver.solveAdjoint(adjoint_load);
 
-  // Compute the sensitivity (d QOI/d residual * d residual/d parameter) given the current adjoint solution
+  // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
   auto& sensitivity = thermal_solver.computeSensitivity<conductivity_parameter_index>();
 
-  EXPECT_NEAR(0.5086485, mfem::ParNormlp(sensitivity.trueVec(), 2, MPI_COMM_WORLD), 1.0e-6);
+  EXPECT_NEAR(1.6540980, mfem::ParNormlp(sensitivity.trueVec(), 2, MPI_COMM_WORLD), 1.0e-6);
 }
 
 }  // namespace serac

--- a/src/serac/physics/tests/serac_thermal_functional_finite_diff.cpp
+++ b/src/serac/physics/tests/serac_thermal_functional_finite_diff.cpp
@@ -1,0 +1,173 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "serac/physics/thermal_conduction_functional.hpp"
+#include "serac/physics/materials/thermal_functional_material.hpp"
+#include "serac/physics/materials/parameterized_thermal_functional_material.hpp"
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+#include "mfem.hpp"
+
+#include "serac/serac_config.hpp"
+#include "serac/mesh/mesh_utils.hpp"
+#include "serac/physics/state/state_manager.hpp"
+
+namespace serac {
+
+TEST(thermal_functional_finite_diff, finite_difference)
+{
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  int serial_refinement   = 1;
+  int parallel_refinement = 0;
+
+  // Create DataStore
+  axom::sidre::DataStore datastore;
+  serac::StateManager::initialize(datastore, "thermal_functional_parameterized_sensitivities");
+
+  // Construct the appropriate dimension mesh and give it to the data store
+  std::string filename = SERAC_REPO_DIR "/data/meshes/square.mesh";
+
+  auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+  serac::StateManager::setMesh(std::move(mesh));
+
+  constexpr int p   = 1;
+  constexpr int dim = 2;
+
+  // Define a boundary attribute set
+  std::set<int> ess_bdr = {1, 2};
+
+  // Construct and initialized the user-defined conductivity to be used as a differentiable parameter in
+  // the thermal conduction physics module.
+  FiniteElementState user_defined_conductivity(
+      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_conductivity"}));
+
+  double conductivity_value = 1.2;
+
+  user_defined_conductivity = conductivity_value;
+
+  // We must know the index of the parameter finite element state in our parameter pack to take sensitivities.
+  // As we only have one parameter in this example, the index is zero.
+  constexpr int conductivity_parameter_index = 0;
+
+  // Construct a functional-based thermal conduction solver
+  //
+  // Note that we now include an extra template parameter indicating the finite element space for the parameterized
+  // field, in this case the thermal conductivity. We also pass an array of finite element states for each of the
+  // requested parameterized fields.
+  ThermalConductionFunctional<p, dim, H1<1>> thermal_solver(Thermal::defaultQuasistaticOptions(), "thermal_functional",
+                                                            {user_defined_conductivity});
+
+  // Construct a potentially user-defined parameterized material and send it to the thermal module
+  Thermal::ParameterizedLinearIsotropicConductor mat;
+  thermal_solver.setMaterial(mat);
+
+  // Define the function for the initial temperature and boundary condition
+  auto bdr_temp = [](const mfem::Vector& x, double) -> double {
+    if (x[0] < 0.5 || x[1] < 0.5) {
+      return 1.0;
+    }
+    return 0.0;
+  };
+
+  // Set the initial temperature and boundary condition
+  thermal_solver.setTemperatureBCs(ess_bdr, bdr_temp);
+  thermal_solver.setTemperature(bdr_temp);
+
+  // Define a constant source term
+  Thermal::ConstantSource source{1.0};
+  thermal_solver.setSource(source);
+
+  // Set the flux term to zero for testing code paths
+  Thermal::ConstantFlux flux_bc{0.0};
+  thermal_solver.setFluxBCs(flux_bc);
+
+  // Finalize the data structures
+  thermal_solver.completeSetup();
+
+  // Perform the quasi-static solve
+  double dt = 1.0;
+  thermal_solver.advanceTimestep(dt);
+
+  // Output the sidre-based plot files
+  thermal_solver.outputState();
+
+  // Make up an adjoint load which can also be viewed as a
+  // sensitivity of some qoi with respect to displacement
+  mfem::ParLinearForm adjoint_load_form(&thermal_solver.temperature().space());
+  adjoint_load_form = 1.0;
+
+  // Construct a dummy adjoint load (this would come from a QOI downstream).
+  // This adjoint load is equivalent to a discrete L1 norm on the temperature.
+  serac::FiniteElementDual              adjoint_load(*mesh, thermal_solver.temperature().space(), "adjoint_load");
+  std::unique_ptr<mfem::HypreParVector> assembled_vector(adjoint_load_form.ParallelAssemble());
+  adjoint_load.trueVec() = *assembled_vector;
+  adjoint_load.distributeSharedDofs();
+
+  // Solve the adjoint problem
+  thermal_solver.solveAdjoint(adjoint_load);
+
+  // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
+  [[maybe_unused]] auto& sensitivity = thermal_solver.computeSensitivity<conductivity_parameter_index>();
+
+  // Perform finite difference on each conduction value
+  // to check if computed qoi sensitivity is consistent
+  // with finite difference on the temperature
+  double eps = 1.0e-4;
+  for (int i = 0; i < user_defined_conductivity.gridFunc().Size(); ++i) {
+    // Perturb the conductivity
+    user_defined_conductivity.trueVec()(i) = conductivity_value + eps;
+    user_defined_conductivity.distributeSharedDofs();
+
+    thermal_solver.advanceTimestep(dt);
+    mfem::ParGridFunction temperature_plus = thermal_solver.temperature().gridFunc();
+
+    user_defined_conductivity.trueVec()(i) = conductivity_value - eps;
+    user_defined_conductivity.distributeSharedDofs();
+
+    thermal_solver.advanceTimestep(dt);
+    mfem::ParGridFunction temperature_minus = thermal_solver.temperature().gridFunc();
+
+    // Reset to the original conductivity value
+    user_defined_conductivity.trueVec()(i) = conductivity_value;
+    user_defined_conductivity.distributeSharedDofs();
+
+    // Finite difference to compute sensitivity of temperature with respect to conductivity
+    mfem::ParGridFunction dtemp_dconductivity(&thermal_solver.temperature().space());
+    for (int i2 = 0; i2 < temperature_plus.Size(); ++i2) {
+      dtemp_dconductivity(i2) = (temperature_plus(i2) - temperature_minus(i2)) / (2.0 * eps);
+    }
+
+    // Compute numerical value of sensitivity of qoi with respect to conductivity
+    // by taking the inner product between adjoint load and displacement sensitivity
+    double dqoi_dconductivity = adjoint_load_form(dtemp_dconductivity);
+
+    // See if these are similar
+    SLIC_INFO(axom::fmt::format("dqoi_dconductivity: {}", dqoi_dconductivity));
+    SLIC_INFO(axom::fmt::format("sensitivity: {}", sensitivity.trueVec()(i)));
+    EXPECT_NEAR((sensitivity.trueVec()(i) - dqoi_dconductivity) / dqoi_dconductivity, 0.0, 1.0e-3);
+  }
+}
+
+}  // namespace serac
+
+//------------------------------------------------------------------------------
+#include "axom/slic/core/SimpleLogger.hpp"
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  MPI_Init(&argc, &argv);
+
+  axom::slic::SimpleLogger logger;
+
+  int result = RUN_ALL_TESTS();
+  MPI_Finalize();
+
+  return result;
+}

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -251,7 +251,7 @@ public:
           using FluxType = decltype(du_dx);
           FluxType flux;
 
-          auto source = serac::zero{};
+          auto source = 0.0 * u;
 
           if constexpr (is_parameterized<MaterialType>::value) {
             static_assert(material.numParameters() == sizeof...(params),

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -253,7 +253,7 @@ public:
             // Get the value and the gradient from the input tuple
             auto [u, du_dx] = temperature;
             auto source     = serac::zero{};
-            ;
+
             auto flux = -1.0 * material(u, du_dx, serac::get<0>(params)...);
 
             // Return the source and the flux as a tuple
@@ -528,11 +528,10 @@ public:
   virtual const serac::FiniteElementState& solveAdjoint(FiniteElementDual& adjoint_load,
                                                         FiniteElementDual* dual_with_essential_boundary = nullptr)
   {
-    adjoint_load.initializeTrueVec();
-
     // note: The assignment operator must be called after the copy constructor because
     // the copy constructor only sets the partitioning, it does not copy the actual vector
     // values
+
     mfem::HypreParVector adjoint_load_vector(adjoint_load.trueVec());
     adjoint_load_vector = adjoint_load.trueVec();
 

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -141,7 +141,7 @@ public:
     std::array<mfem::ParFiniteElementSpace*, sizeof...(parameter_space) + 1> trial_spaces;
     trial_spaces[0] = &temperature_.space();
 
-    for (long unsigned int i = 0; i < sizeof...(parameter_space) + 1; ++i) {
+    for (long unsigned int i = 0; i < sizeof...(parameter_space); ++i) {
       trial_spaces[i + 1] = &(parameter_states_[i]->space());
     }
 

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -427,13 +427,13 @@ public:
           [this](const mfem::Vector& u, mfem::Vector& r) {
             functional_call_args_[0] = u;
 
-            r = K_functional_->evaluate_index(functional_call_args_);
+            r = (*K_functional_)(functional_call_args_);
           },
 
           [this](const mfem::Vector& u) -> mfem::Operator& {
             functional_call_args_[0] = u;
 
-            auto [r, drdu] = K_functional_->evaluate_index(functional_call_args_, Index<0>{});
+            auto [r, drdu] = (*K_functional_)(functional_call_args_, Index<0>{});
             J_             = assemble(drdu);
             return *J_;
           });
@@ -448,11 +448,11 @@ public:
 
             functional_call_args_[0] = u_;
 
-            auto M_residual = M_functional_->evaluate_index(functional_call_args_);
+            auto M_residual = (*M_functional_)(functional_call_args_);
 
             functional_call_args_[0] = K_arg;
 
-            auto K_residual = K_functional_->evaluate_index(functional_call_args_);
+            auto K_residual = (*K_functional_)(functional_call_args_);
 
             functional_call_args_[0] = u_;
 
@@ -467,12 +467,12 @@ public:
 
               functional_call_args_[0] = u_;
 
-              auto M = serac::get<1>(M_functional_->evaluate_index(functional_call_args_, Index<0>{}));
+              auto M = serac::get<1>((*M_functional_)(functional_call_args_, Index<0>{}));
               std::unique_ptr<mfem::HypreParMatrix> m_mat(assemble(M));
 
               functional_call_args_[0] = K_arg;
 
-              auto K = serac::get<1>(K_functional_->evaluate_index(functional_call_args_, Index<0>{}));
+              auto K = serac::get<1>((*K_functional_)(functional_call_args_, Index<0>{}));
 
               functional_call_args_[0] = u_;
 
@@ -514,7 +514,7 @@ public:
 
     functional_call_args_[0] = temperature_.trueVec();
 
-    auto [r, drdu] = K_functional_->evaluate_index(functional_call_args_, Index<0>{});
+    auto [r, drdu] = (*K_functional_)(functional_call_args_, Index<0>{});
     auto jacobian  = assemble(drdu);
     auto J_T       = std::unique_ptr<mfem::HypreParMatrix>(jacobian->Transpose());
 
@@ -545,7 +545,7 @@ public:
   {
     functional_call_args_[0] = adjoint_temperature_.trueVec();
 
-    auto [r, drdparam] = K_functional_->evaluate_index(functional_call_args_, Index<parameter_field>{});
+    auto [r, drdparam] = (*K_functional_)(functional_call_args_, Index<parameter_field>{});
 
     functional_call_args_[0] = temperature_.trueVec();
 

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -575,7 +575,7 @@ public:
   {
     functional_call_args_[0] = temperature_.trueVec();
 
-    auto [r, drdparam] = (*K_functional_)(functional_call_args_, Index<parameter_field>{});
+    auto [r, drdparam] = (*K_functional_)(functional_call_args_, Index<parameter_field + 1>{});
 
     auto drdparam_mat = assemble(drdparam);
 

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -243,7 +243,7 @@ public:
                     "thermal material.");
     }
 
-    auto parameterized_material = parameterize_material(material);
+    auto parameterized_material = parameterizeMaterial(material);
 
     K_functional_->AddDomainIntegral(
         Dimension<dim>{},
@@ -309,7 +309,7 @@ public:
                     "thermal source.");
     }
 
-    auto parameterized_source = parameterize_source(source_function);
+    auto parameterized_source = parameterizeSource(source_function);
 
     K_functional_->AddDomainIntegral(
         Dimension<dim>{},
@@ -344,7 +344,7 @@ public:
                     "thermal flux boundary.");
     }
 
-    auto parameterized_flux = parameterize_flux(flux_function);
+    auto parameterized_flux = parameterizeFlux(flux_function);
 
     K_functional_->AddBoundaryIntegral(
         Dimension<dim - 1>{},

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -266,7 +266,7 @@ public:
     } else {
       K_functional_->AddDomainIntegral(
           Dimension<dim>{},
-          [material](auto, auto temperature, auto... params) {
+          [material](auto, auto temperature, auto...) {
             // Get the value and the gradient from the input tuple
             auto [u, du_dx] = temperature;
             auto source     = serac::zero{};

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -573,15 +573,13 @@ public:
   template <int parameter_field>
   FiniteElementDual& computeSensitivity()
   {
-    functional_call_args_[0] = adjoint_temperature_.trueVec();
+    functional_call_args_[0] = temperature_.trueVec();
 
     auto [r, drdparam] = (*K_functional_)(functional_call_args_, Index<parameter_field>{});
 
-    functional_call_args_[0] = temperature_.trueVec();
+    auto drdparam_mat = assemble(drdparam);
 
-    mfem::Vector& sensitivity_vector = parameter_sensitivities_[parameter_field]->trueVec();
-
-    sensitivity_vector = drdparam(parameter_states_[parameter_field]->trueVec());
+    drdparam_mat->MultTranspose(adjoint_temperature_.trueVec(), parameter_sensitivities_[parameter_field]->trueVec());
 
     parameter_sensitivities_[parameter_field]->distributeSharedDofs();
 

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -469,12 +469,7 @@ public:
   virtual const serac::FiniteElementState& solveAdjoint(FiniteElementDual& adjoint_load,
                                                         FiniteElementDual* dual_with_essential_boundary = nullptr)
   {
-    // note: The assignment operator must be called after the copy constructor because
-    // the copy constructor only sets the partitioning, it does not copy the actual vector
-    // values
-
     mfem::HypreParVector adjoint_load_vector(adjoint_load.trueVec());
-    // adjoint_load_vector = adjoint_load.trueVec();
 
     auto& lin_solver = nonlin_solver_.LinearSolver();
 


### PR DESCRIPTION
This is the initial draft of a working thermal module with sensitivities for arbitrary parameterized user-defined materials, flux boundary, and volumetric heat sources. To use this, a user must define the parameterized material/flux/load data type, and implement the appropriate paren operators. It still needs cleaning and documentation, but any and all feedback is appreciated!