### PR TITLE
Add missing <optional> header

### DIFF
--- a/src/serac/infrastructure/input.hpp
+++ b/src/serac/infrastructure/input.hpp
@@ -14,6 +14,7 @@
 
 #include <string>
 #include <variant>
+#include <optional>
 
 #include "mfem.hpp"
 #include "axom/inlet.hpp"


### PR DESCRIPTION
Required when compiling with GCC 11.2.0

Fixes error "‘optional’ in namespace ‘std’ does not name a template
type; did you forget to ‘#include <optional>’?"