### PR TITLE
docfix: "+caliper" variant is now "+profiling"

### DIFF
--- a/src/docs/sphinx/quickstart.rst
+++ b/src/docs/sphinx/quickstart.rst
@@ -145,7 +145,7 @@ Some helpful uberenv options include :
 
 * ``--spec=+debug`` (build the MFEM and Hypre libraries with debug symbols)
 * ``--spec=+glvis`` (build the optional glvis visualization library)
-* ``--spec=+caliper`` (build the `Caliper performance profiling library <https://github.com/LLNL/Caliper>`_)
+* ``--spec=+profiling`` (build the `Caliper performance profiling library <https://github.com/LLNL/Caliper>`_)
 * ``--spec=+devtools`` (also build the devtools with one command)
 * ``--spec=%clang@10.0.0`` (build with a specific compiler as defined in the ``compiler.yaml`` file)
 * ``--spack-config-dir=<Path to spack configuration directory>`` (use specific Spack configuration files)

--- a/src/docs/sphinx/quickstart.rst
+++ b/src/docs/sphinx/quickstart.rst
@@ -145,7 +145,7 @@ Some helpful uberenv options include :
 
 * ``--spec=+debug`` (build the MFEM and Hypre libraries with debug symbols)
 * ``--spec=+glvis`` (build the optional glvis visualization library)
-* ``--spec=+profiling`` (build the `Caliper performance profiling library <https://github.com/LLNL/Caliper>`_)
+* ``--spec=+profiling`` (build the Adiak and Caliper libraries)
 * ``--spec=+devtools`` (also build the devtools with one command)
 * ``--spec=%clang@10.0.0`` (build with a specific compiler as defined in the ``compiler.yaml`` file)
 * ``--spack-config-dir=<Path to spack configuration directory>`` (use specific Spack configuration files)


### PR DESCRIPTION
This commit updates the quickstart documentation regarding building
Serac with Caliper support by replacing the `--spec=+caliper` Serac
Spack package variant with the updated `--spec=+profiling` variant.