### PR TITLE
Add parameterizations and sensitivities to `SolidFunctional`

### DIFF
--- a/src/serac/physics/materials/CMakeLists.txt
+++ b/src/serac/physics/materials/CMakeLists.txt
@@ -17,6 +17,7 @@ set(materials_headers
     thermal_functional_material.hpp
     parameterized_thermal_functional_material.hpp    
     solid_functional_material.hpp
+    parameterized_solid_functional_material.hpp
     functional_material_utils.hpp
     )
 

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -34,17 +34,18 @@ struct TriviallyParameterizedMaterial {
   /**
    * @brief Material response wrapper for an unparameterized material in a parameterized context
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Temperature type
-   * @tparam T3 Temperature gradient type
-   * @tparam S Unused parameter pack type
+   * @tparam PositionType Spatial position type
+   * @tparam StateType State type
+   * @tparam StateGradType State gradient type
+   * @tparam ParamTypes Unused parameter pack type
    * @param x Spatial position
-   * @param u Temperature
-   * @param du_dx Temperature gradient
+   * @param u State
+   * @param du_dx State gradient
    * @return Material response of the unparameterized material
    */
-  template <typename T1, typename T2, typename T3, typename... S>
-  SERAC_HOST_DEVICE auto operator()(const T1& x, const T2& u, const T3& du_dx, S...) const
+  template <typename PositionType, typename StateType, typename StateGradType, typename... ParamTypes>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& x, const StateType& u, const StateGradType& du_dx,
+                                    ParamTypes...) const
   {
     return mat(x, u, du_dx);
   }
@@ -56,22 +57,22 @@ struct TriviallyParameterizedMaterial {
 /**
  * @brief Template deduction guide for the trivially parameterized material
  *
- * @tparam T The unparameterized material type
+ * @tparam MaterialType The unparameterized material type
  */
-template <typename T>
-TriviallyParameterizedMaterial(T) -> TriviallyParameterizedMaterial<T>;
+template <typename MaterialType>
+TriviallyParameterizedMaterial(MaterialType) -> TriviallyParameterizedMaterial<MaterialType>;
 
 /**
  * @brief Convert an unparameterized material to one which accepts parameter values in the paren operator
  *
- * @tparam T The unparameterized material type
+ * @tparam MaterialType The unparameterized material type
  * @param material The unparameterized material
  * @return The parameterized material
  */
-template <typename T>
-auto parameterizeMaterial(T& material)
+template <typename MaterialType>
+auto parameterizeMaterial(MaterialType& material)
 {
-  if constexpr (is_parameterized<T>::value) {
+  if constexpr (is_parameterized<MaterialType>::value) {
     return material;
   } else {
     return TriviallyParameterizedMaterial{material};
@@ -88,18 +89,19 @@ struct TriviallyParameterizedSource {
   /**
    * @brief Wrapper for an unparameterized source in a parameterized context
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Temperature type
-   * @tparam T3 Temperature gradient type
-   * @tparam S Unused parameter pack type
+   * @tparam PositionType Spatial position type
+   * @tparam StateType State type
+   * @tparam StateGradType State gradient type
+   * @tparam ParamTypes Unused parameter pack type
    * @param x Spatial position
    * @param t Time
-   * @param u Temperature
-   * @param du_dx Temperature gradient
+   * @param u State
+   * @param du_dx State gradient
    * @return Volumetric source for the unparameterized source
    */
-  template <typename T1, typename T2, typename T3, typename... S>
-  SERAC_HOST_DEVICE auto operator()(const T1& x, double t, const T2& u, const T3& du_dx, S...) const
+  template <typename PositionType, typename StateType, typename StateGradType, typename... ParamTypes>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& x, double t, const StateType& u, const StateGradType& du_dx,
+                                    ParamTypes...) const
   {
     return source(x, t, u, du_dx);
   }
@@ -111,22 +113,22 @@ struct TriviallyParameterizedSource {
 /**
  * @brief Template deduction guide for the trivially parameterized source
  *
- * @tparam T The unparameterized source type
+ * @tparam SourceType The unparameterized source type
  */
-template <typename T>
-TriviallyParameterizedSource(T) -> TriviallyParameterizedSource<T>;
+template <typename SourceType>
+TriviallyParameterizedSource(SourceType) -> TriviallyParameterizedSource<SourceType>;
 
 /**
  * @brief Convert an unparameterized source to one which accepts parameter values in the paren operator
  *
- * @tparam T The unparameterized source type
+ * @tparam SourceType The unparameterized source type
  * @param source The unparameterized source
  * @return The parameterized source
  */
-template <typename T>
-auto parameterizeSource(T& source)
+template <typename SourceType>
+auto parameterizeSource(SourceType& source)
 {
-  if constexpr (is_parameterized<T>::value) {
+  if constexpr (is_parameterized<SourceType>::value) {
     return source;
   } else {
     return TriviallyParameterizedSource{source};
@@ -144,17 +146,17 @@ struct TriviallyParameterizedFlux {
    * @brief The wrapper for an unparameterized boundary flux object to be called using the parameterized
    * call signature
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Normal vector type
-   * @tparam T3 Temperature type
-   * @tparam S Unused parameter pack type
+   * @tparam PositionType Spatial position type
+   * @tparam NormalType Normal vector type
+   * @tparam StateType State type
+   * @tparam ParamTypes Unused parameter pack type
    * @param x Spatial position
    * @param n Normal vector
-   * @param u Temperature
+   * @param u State
    * @return Computed boundary flux to be applied
    */
-  template <typename T1, typename T2, typename T3, typename... S>
-  SERAC_HOST_DEVICE auto operator()(const T1& x, const T2& n, const T3& u, S...) const
+  template <typename PositionType, typename NormalType, typename StateType, typename... ParamTypes>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& x, const NormalType& n, const StateType& u, ParamTypes...) const
   {
     return flux(x, n, u);
   }
@@ -174,14 +176,14 @@ TriviallyParameterizedFlux(T) -> TriviallyParameterizedFlux<T>;
 /**
  * @brief Convert an unparameterized flux to one which accepts parameter values in the paren operator
  *
- * @tparam T The unparameterized flux type
+ * @tparam FluxType The unparameterized flux type
  * @param flux The unparameterized flux
  * @return The parameterized flux
  */
-template <typename T>
-auto parameterizeFlux(T& flux)
+template <typename FluxType>
+auto parameterizeFlux(FluxType& flux)
 {
-  if constexpr (is_parameterized<T>::value) {
+  if constexpr (is_parameterized<FluxType>::value) {
     return flux;
   } else {
     return TriviallyParameterizedFlux{flux};
@@ -198,16 +200,14 @@ struct TriviallyParameterizedPressure {
   /**
    * @brief Wrapper for an unparameterized source in a parameterized context
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Temperature type
-   * @tparam T3 Temperature gradient type
-   * @tparam S Unused parameter pack type
+   * @tparam PositionType Spatial position type
+   * @tparam ParamTypes Unused parameter pack type
    * @param x Spatial position
    * @param t Time
    * @return Volumetric source for the unparameterized source
    */
-  template <typename T1, typename... S>
-  SERAC_HOST_DEVICE auto operator()(const T1& x, double t, S...) const
+  template <typename PositionType, typename... ParamTypes>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& x, double t, ParamTypes...) const
   {
     return pressure(x, t);
   }
@@ -219,22 +219,22 @@ struct TriviallyParameterizedPressure {
 /**
  * @brief Template deduction guide for the trivially parameterized source
  *
- * @tparam T The unparameterized source type
+ * @tparam PressureType The unparameterized source type
  */
-template <typename T>
-TriviallyParameterizedPressure(T) -> TriviallyParameterizedPressure<T>;
+template <typename PressureType>
+TriviallyParameterizedPressure(PressureType) -> TriviallyParameterizedPressure<PressureType>;
 
 /**
  * @brief Convert an unparameterized pressure to one which accepts parameter values in the paren operator
  *
- * @tparam T The unparameterized pressure type
+ * @tparam PressureType The unparameterized pressure type
  * @param pressure The unparameterized pressure
  * @return The parameterized pressure
  */
-template <typename T>
-auto parameterizePressure(T& pressure)
+template <typename PressureType>
+auto parameterizePressure(PressureType& pressure)
 {
-  if constexpr (is_parameterized<T>::value) {
+  if constexpr (is_parameterized<PressureType>::value) {
     return pressure;
   } else {
     return TriviallyParameterizedPressure{pressure};

--- a/src/serac/physics/materials/functional_material_utils.hpp
+++ b/src/serac/physics/materials/functional_material_utils.hpp
@@ -225,11 +225,11 @@ template <typename T>
 TriviallyParameterizedPressure(T) -> TriviallyParameterizedPressure<T>;
 
 /**
- * @brief Convert an unparameterized source to one which accepts parameter values in the paren operator
+ * @brief Convert an unparameterized pressure to one which accepts parameter values in the paren operator
  *
- * @tparam T The unparameterized source type
- * @param source The unparameterized source
- * @return The parameterized source
+ * @tparam T The unparameterized pressure type
+ * @param pressure The unparameterized pressure
+ * @return The parameterized pressure
  */
 template <typename T>
 auto parameterizePressure(T& pressure)

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -43,19 +43,21 @@ public:
   /**
    * @brief Material response call for a linear isotropic solid
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Displacement type
-   * @tparam T3 Displacement gradient type
-   * @tparam T4 Bulk modulus type
-   * @tparam T5 Shear modulus type
+   * @tparam PositionType Spatial position type
+   * @tparam DisplacementType Displacement type
+   * @tparam DispGradType Displacement gradient type
+   * @tparam BulkType Bulk modulus type
+   * @tparam ShearType Shear modulus type
    * @param du_dX Displacement gradient with respect to the reference configuration (du_dX)
    * @param bulk_parameter The parameterized bulk modulus
    * @param shear_parameter The parameterized shear modulus
-   * @return The calculated material response (density, kirchoff stress) for the material
+   * @return The calculated material response (density, Kirchoff stress) for the material
    */
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX,
-                                    const T4& bulk_parameter, const T5& shear_parameter) const
+  template <typename PositionType, typename DisplacementType, typename DispGradType, typename BulkType,
+            typename ShearType>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& /* x */, const DisplacementType& /* displacement */,
+                                    const DispGradType& du_dX, const BulkType& bulk_parameter,
+                                    const ShearType& shear_parameter) const
   {
     auto bulk_modulus  = bulk_parameter + bulk_modulus_offset_;
     auto shear_modulus = shear_parameter + shear_modulus_offset_;
@@ -113,19 +115,21 @@ public:
   /**
    * @brief Material response call for a neo-Hookean solid
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Displacement type
-   * @tparam T3 Displacement gradient type
-   * @tparam T4 Bulk modulus type
-   * @tparam T5 Shear modulus type
+   * @tparam PositionType Spatial position type
+   * @tparam DisplacementType Displacement type
+   * @tparam DispGradType Displacement gradient type
+   * @tparam BulkType Bulk modulus type
+   * @tparam ShearType Shear modulus type
    * @param du_dX Displacement gradient with respect to the reference configuration (du_dX)
    * @param bulk_parameter The parameterized bulk modulus
    * @param shear_parameter The parameterized shear modulus
    * @return The calculated material response (density, kirchoff stress) for the material
    */
-  template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX,
-                                    const T4& bulk_parameter, const T5& shear_parameter) const
+  template <typename PositionType, typename DisplacementType, typename DispGradType, typename BulkType,
+            typename ShearType>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& /* x */, const DisplacementType& /* displacement */,
+                                    const DispGradType& du_dX, const BulkType& bulk_parameter,
+                                    const ShearType& shear_parameter) const
   {
     auto bulk_modulus  = bulk_parameter + bulk_modulus_offset_;
     auto shear_modulus = shear_parameter + shear_modulus_offset_;

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -33,7 +33,8 @@ public:
    * @param shear_modulus_offset Shear modulus offset of the material
    * @param bulk_modulus_offset Bulk modulus offset of the material
    */
-  ParameterizedLinearIsotropicSolid(double density = 1.0, double shear_modulus_offset = 1.0, double bulk_modulus_offset = 1.0)
+  ParameterizedLinearIsotropicSolid(double density = 1.0, double shear_modulus_offset = 1.0,
+                                    double bulk_modulus_offset = 1.0)
       : density_(density), bulk_modulus_offset_(bulk_modulus_offset), shear_modulus_offset_(shear_modulus_offset)
   {
     SLIC_ERROR_ROOT_IF(density_ < 0.0, "Density must be positive in the linear isotropic elasticity material model.");
@@ -49,9 +50,10 @@ public:
    * @return The calculated material response (density, kirchoff stress) for the material
    */
   template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX, const T4& bulk_parameter, const T5& shear_parameter) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX,
+                                    const T4& bulk_parameter, const T5& shear_parameter) const
   {
-    auto bulk_modulus = bulk_parameter + bulk_modulus_offset_;
+    auto bulk_modulus  = bulk_parameter + bulk_modulus_offset_;
     auto shear_modulus = shear_parameter + shear_modulus_offset_;
 
     auto I      = Identity<dim>();
@@ -97,7 +99,8 @@ public:
    * @param shear_modulus_offset Shear modulus of the material
    * @param bulk_modulus_offset Bulk modulus of the material
    */
-  ParameterizedNeoHookeanSolid(double density = 1.0, double shear_modulus_offset = 1.0, double bulk_modulus_offset = 1.0)
+  ParameterizedNeoHookeanSolid(double density = 1.0, double shear_modulus_offset = 1.0,
+                               double bulk_modulus_offset = 1.0)
       : density_(density), bulk_modulus_offset_(bulk_modulus_offset), shear_modulus_offset_(shear_modulus_offset)
   {
     SLIC_ERROR_ROOT_IF(density_ < 0.0, "Density must be positive in the neo-Hookean material model.");
@@ -113,9 +116,10 @@ public:
    * @return The calculated material response (density, kirchoff stress) for the material
    */
   template <typename T1, typename T2, typename T3, typename T4, typename T5>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX, const T4& bulk_parameter, const T5& shear_parameter) const
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX,
+                                    const T4& bulk_parameter, const T5& shear_parameter) const
   {
-    auto bulk_modulus = bulk_parameter + bulk_modulus_offset_;
+    auto bulk_modulus  = bulk_parameter + bulk_modulus_offset_;
     auto shear_modulus = shear_parameter + shear_modulus_offset_;
 
     auto I         = Identity<dim>();

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -64,6 +64,13 @@ public:
     return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
   }
 
+  /**
+   * @brief The number of parameters in the model
+   *
+   * @return The number of parameters in the model
+   */
+  static constexpr int numParameters() { return 2; }
+
 private:
   /// Density
   double density_;
@@ -105,7 +112,7 @@ public:
    * @param du_dX displacement gradient with respect to the reference configuration (du_dX)
    * @return The calculated material response (density, kirchoff stress) for the material
    */
-  template <typename T1, typename T2, typename T3>
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX, const T4& bulk_parameter, const T5& shear_parameter) const
   {
     auto bulk_modulus = bulk_parameter + bulk_modulus_offset_;
@@ -121,12 +128,19 @@ public:
     // be removed by either putting the dual implementation of the global namespace or implementing a pure
     // double version there. More investigation into argument-dependent lookup is needed.
     using std::log;
-    auto stress = lambda * log(J) * I + shear_modulus_ * B_minus_I;
+    auto stress = lambda * log(J) * I + shear_modulus * B_minus_I;
 
     using StressType = decltype(stress);
 
     return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
   }
+
+  /**
+   * @brief The number of parameters in the model
+   *
+   * @return The number of parameters in the model
+   */
+  static constexpr int numParameters() { return 2; }
 
 private:
   /// Density

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -46,7 +46,11 @@ public:
    * @tparam T1 Spatial position type
    * @tparam T2 Displacement type
    * @tparam T3 Displacement gradient type
-   * @param du_dX displacement gradient with respect to the reference configuration (du_dX)
+   * @tparam T4 Bulk modulus type
+   * @tparam T5 Shear modulus type
+   * @param du_dX Displacement gradient with respect to the reference configuration (du_dX)
+   * @param bulk_parameter The parameterized bulk modulus
+   * @param shear_parameter The parameterized shear modulus
    * @return The calculated material response (density, kirchoff stress) for the material
    */
   template <typename T1, typename T2, typename T3, typename T4, typename T5>
@@ -112,7 +116,11 @@ public:
    * @tparam T1 Spatial position type
    * @tparam T2 Displacement type
    * @tparam T3 Displacement gradient type
-   * @param du_dX displacement gradient with respect to the reference configuration (du_dX)
+   * @tparam T4 Bulk modulus type
+   * @tparam T5 Shear modulus type
+   * @param du_dX Displacement gradient with respect to the reference configuration (du_dX)
+   * @param bulk_parameter The parameterized bulk modulus
+   * @param shear_parameter The parameterized shear modulus
    * @return The calculated material response (density, kirchoff stress) for the material
    */
   template <typename T1, typename T2, typename T3, typename T4, typename T5>

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -1,0 +1,142 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file solid_functional_material.hpp
+ *
+ * @brief The material and load types for the solid functional physics module
+ */
+
+#pragma once
+
+#include "serac/numerics/functional/functional.hpp"
+#include "serac/physics/materials/solid_functional_material.hpp"
+
+/// SolidFunctional helper data types
+namespace serac::solid_util {
+
+/**
+ * @brief Linear isotropic elasticity material model
+ *
+ * @tparam dim Spatial dimension of the mesh
+ */
+template <int dim>
+class ParameterizedLinearIsotropicSolid {
+public:
+  /**
+   * @brief Construct a new Linear Isotropic Elasticity object
+   *
+   * @param density Density of the material
+   * @param shear_modulus_offset Shear modulus offset of the material
+   * @param bulk_modulus_offset Bulk modulus offset of the material
+   */
+  ParameterizedLinearIsotropicSolid(double density = 1.0, double shear_modulus_offset = 1.0, double bulk_modulus_offset = 1.0)
+      : density_(density), bulk_modulus_offset_(bulk_modulus_offset), shear_modulus_offset_(shear_modulus_offset)
+  {
+    SLIC_ERROR_ROOT_IF(density_ < 0.0, "Density must be positive in the linear isotropic elasticity material model.");
+  }
+
+  /**
+   * @brief Material response call for a linear isotropic solid
+   *
+   * @tparam T1 Spatial position type
+   * @tparam T2 Displacement type
+   * @tparam T3 Displacement gradient type
+   * @param du_dX displacement gradient with respect to the reference configuration (du_dX)
+   * @return The calculated material response (density, kirchoff stress) for the material
+   */
+  template <typename T1, typename T2, typename T3, typename T4, typename T5>
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX, const T4& bulk_parameter, const T5& shear_parameter) const
+  {
+    auto bulk_modulus = bulk_parameter + bulk_modulus_offset_;
+    auto shear_modulus = shear_parameter + shear_modulus_offset_;
+
+    auto I      = Identity<dim>();
+    auto lambda = bulk_modulus - (2.0 / dim) * shear_modulus;
+    auto strain = 0.5 * (du_dX + transpose(du_dX));
+    auto stress = lambda * tr(strain) * I + 2.0 * shear_modulus * strain;
+
+    using StressType = decltype(stress);
+
+    return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
+  }
+
+private:
+  /// Density
+  double density_;
+
+  /// Bulk modulus
+  double bulk_modulus_offset_;
+
+  /// Shear modulus
+  double shear_modulus_offset_;
+};
+
+/**
+ * @brief Neo-Hookean material model
+ *
+ * @tparam dim The spatial dimension of the mesh
+ */
+template <int dim>
+class ParameterizedNeoHookeanSolid {
+public:
+  /**
+   * @brief Construct a new Neo-Hookean object
+   *
+   * @param density Density of the material
+   * @param shear_modulus_offset Shear modulus of the material
+   * @param bulk_modulus_offset Bulk modulus of the material
+   */
+  ParameterizedNeoHookeanSolid(double density = 1.0, double shear_modulus_offset = 1.0, double bulk_modulus_offset = 1.0)
+      : density_(density), bulk_modulus_offset_(bulk_modulus_offset), shear_modulus_offset_(shear_modulus_offset)
+  {
+    SLIC_ERROR_ROOT_IF(density_ < 0.0, "Density must be positive in the neo-Hookean material model.");
+  }
+
+  /**
+   * @brief Material response call for a neo-Hookean solid
+   *
+   * @tparam T1 Spatial position type
+   * @tparam T2 Displacement type
+   * @tparam T3 Displacement gradient type
+   * @param du_dX displacement gradient with respect to the reference configuration (du_dX)
+   * @return The calculated material response (density, kirchoff stress) for the material
+   */
+  template <typename T1, typename T2, typename T3>
+  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX, const T4& bulk_parameter, const T5& shear_parameter) const
+  {
+    auto bulk_modulus = bulk_parameter + bulk_modulus_offset_;
+    auto shear_modulus = shear_parameter + shear_modulus_offset_;
+
+    auto I         = Identity<dim>();
+    auto lambda    = bulk_modulus - (2.0 / dim) * shear_modulus;
+    auto B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
+
+    auto J = det(du_dX + I);
+
+    // TODO this resolve to the correct std implementation of log when J resolves to a pure double. It can
+    // be removed by either putting the dual implementation of the global namespace or implementing a pure
+    // double version there. More investigation into argument-dependent lookup is needed.
+    using std::log;
+    auto stress = lambda * log(J) * I + shear_modulus_ * B_minus_I;
+
+    using StressType = decltype(stress);
+
+    return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
+  }
+
+private:
+  /// Density
+  double density_;
+
+  /// Bulk modulus in the stress free configuration
+  double bulk_modulus_offset_;
+
+  /// Shear modulus in the stress free configuration
+  double shear_modulus_offset_;
+};
+
+}  // namespace serac::solid_util

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -144,7 +144,9 @@ public:
     using std::log;
     auto stress = lambda * log(J) * I + shear_modulus * B_minus_I;
 
-    return MaterialResponse{.density = density_, .stress = stress};
+    // TODO For some reason, clang can't handle CTAD here. We should investigate why.
+    using StressType = decltype(stress);
+    return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
   }
 
   /**

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -67,9 +67,7 @@ public:
     auto strain = 0.5 * (du_dX + transpose(du_dX));
     auto stress = lambda * tr(strain) * I + 2.0 * shear_modulus * strain;
 
-    using StressType = decltype(stress);
-
-    return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
+    return MaterialResponse{.density = density_, .stress = stress};
   }
 
   /**

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -144,9 +144,7 @@ public:
     using std::log;
     auto stress = lambda * log(J) * I + shear_modulus * B_minus_I;
 
-    using StressType = decltype(stress);
-
-    return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
+    return MaterialResponse{.density = density_, .stress = stress};
   }
 
   /**

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -18,7 +18,7 @@
 namespace serac::solid_util {
 
 /**
- * @brief Response data type for thermal conduction simulations
+ * @brief Response data type for solid mechanics simulations
  *
  * @tparam T1 Density type
  * @tparam T2 Stress type (i.e. second order tensor)

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -20,26 +20,26 @@ namespace serac::solid_util {
 /**
  * @brief Response data type for solid mechanics simulations
  *
- * @tparam T1 Density type
- * @tparam T2 Stress type (i.e. second order tensor)
+ * @tparam DensityType Density type
+ * @tparam StressType Stress type (i.e. second order tensor)
  */
-template <typename T1, typename T2>
+template <typename DensityType, typename StressType>
 struct MaterialResponse {
   /// Density of the material (mass/volume)
-  T1 density;
+  DensityType density;
 
   /// Kirchoff stress (det(deformation gradient) * Cauchy stress) for the constitutive model
-  T2 stress;
+  StressType stress;
 };
 
 /**
  * @brief Template deduction guide for the material response
  *
- * @tparam T1 Density type
- * @tparam T2 Stress type
+ * @tparam DensityType Density type
+ * @tparam StressType Stress type (i.e. second order tensor)
  */
-template <typename T1, typename T2>
-MaterialResponse(T1, T2) -> MaterialResponse<T1, T2>;
+template <typename DensityType, typename StressType>
+MaterialResponse(DensityType, StressType) -> MaterialResponse<DensityType, StressType>;
 
 /**
  * @brief Linear isotropic elasticity material model
@@ -78,20 +78,21 @@ public:
   /**
    * @brief Material response call for a linear isotropic solid
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Displacement type
-   * @tparam T3 Displacement gradient type
+   * @tparam PositionType Spatial position type
+   * @tparam DisplacementType Displacement type
+   * @tparam DispGradType Displacement gradient type
    * @param du_dX displacement gradient with respect to the reference configuration (du_dX)
-   * @return The calculated material response (density, kirchoff stress) for the material
+   * @return The calculated material response (density, Kirchoff stress) for the material
    */
-  template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX) const
+  template <typename PositionType, typename DisplacementType, typename DispGradType>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& /* x */, const DisplacementType& /* displacement */,
+                                    const DispGradType& du_dX) const
   {
     auto I      = Identity<dim>();
     auto lambda = bulk_modulus_ - (2.0 / dim) * shear_modulus_;
     auto strain = 0.5 * (du_dX + transpose(du_dX));
     auto stress = lambda * tr(strain) * I + 2.0 * shear_modulus_ * strain;
-    return MaterialResponse<double, T3>{.density = density_, .stress = stress};
+    return MaterialResponse<double, DispGradType>{.density = density_, .stress = stress};
   }
 
 private:
@@ -139,14 +140,15 @@ public:
   /**
    * @brief Material response call for a neo-Hookean solid
    *
-   * @tparam T1 Spatial position type
-   * @tparam T2 Displacement type
-   * @tparam T3 Displacement gradient type
+   * @tparam PositionType Spatial position type
+   * @tparam DisplacementType Displacement type
+   * @tparam DispGradType Displacement gradient type
    * @param du_dX displacement gradient with respect to the reference configuration (du_dX)
-   * @return The calculated material response (density, kirchoff stress) for the material
+   * @return The calculated material response (density, Kirchoff stress) for the material
    */
-  template <typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* displacement */, const T3& du_dX) const
+  template <typename PositionType, typename DisplacementType, typename DispGradType>
+  SERAC_HOST_DEVICE auto operator()(const PositionType& /* x */, const DisplacementType& /* displacement */,
+                                    const DispGradType& du_dX) const
   {
     auto I         = Identity<dim>();
     auto lambda    = bulk_modulus_ - (2.0 / dim) * shear_modulus_;
@@ -159,7 +161,7 @@ public:
     // double version there. More investigation into argument-dependent lookup is needed.
     using std::log;
     auto stress = lambda * log(J) * I + shear_modulus_ * B_minus_I;
-    return MaterialResponse<double, T3>{.density = density_, .stress = stress};
+    return MaterialResponse<double, DispGradType>{.density = density_, .stress = stress};
   }
 
 private:
@@ -182,14 +184,15 @@ struct ConstantBodyForce {
   /**
    * @brief Evaluation function for the constant body force model
    *
-   * @tparam T1 type of the displacement
-   * @tparam T2 type of the displacement gradient
+   * @tparam DisplacementType Displacement type
+   * @tparam DispGradType Displacement gradient type
    * @tparam dim The dimension of the problem
    * @return The body force value
    */
-  template <typename T1, typename T2>
+  template <typename DisplacementType, typename DispGradType>
   SERAC_HOST_DEVICE tensor<double, dim> operator()(const tensor<double, dim>& /* x */, const double /* t */,
-                                                   const T1& /* u */, const T2& /* du_dX */) const
+                                                   const DisplacementType& /* displacement */,
+                                                   const DispGradType& /* du_dX */) const
   {
     return force_;
   }

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -91,7 +91,7 @@ public:
     auto lambda = bulk_modulus_ - (2.0 / dim) * shear_modulus_;
     auto strain = 0.5 * (displacement_grad + transpose(displacement_grad));
     auto stress = lambda * tr(strain) * I + 2.0 * shear_modulus_ * strain;
-    return MaterialResponse{.density = density_, .stress = stress};
+    return MaterialResponse<double, DispGradType>{.density = density_, .stress = stress};
   }
 
 private:

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -76,6 +76,7 @@ public:
    * @param geom_nonlin Flag to include geometric nonlinearities
    * @param keep_deformation Flag to keep the deformation in the underlying mesh post-destruction
    * @param name An optional name for the physics module instance
+   * @param parameter_states An array of FiniteElementStates containing the user-specified parameter fields
    */
   SolidFunctional(
       const solid_util::SolverOptions& options, GeometricNonlinearities geom_nonlin = GeometricNonlinearities::On,

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -490,7 +490,7 @@ public:
         [this](const mfem::Vector& u, mfem::Vector& r) {
           functional_call_args_[0] = u;
 
-          r = (*K_functional_)(u);
+          r = (*K_functional_)(functional_call_args_);
           r.SetSubVector(bcs_.allEssentialDofs(), 0.0);
         },
 
@@ -595,10 +595,10 @@ protected:
   FiniteElementState adjoint_displacement_;
 
   /// Mass functional object
-  std::unique_ptr<Functional<test(trial)>> M_functional_;
+  std::unique_ptr<Functional<test(trial, parameter_space...)>> M_functional_;
 
   /// Stiffness functional object
-  std::unique_ptr<Functional<test(trial)>> K_functional_;
+  std::unique_ptr<Functional<test(trial, parameter_space...)>> K_functional_;
 
   /// The finite element states representing user-defined parameter fields
   std::array<std::reference_wrapper<FiniteElementState>, sizeof...(parameter_space)> parameter_states_;

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -585,7 +585,7 @@ public:
    * @note If the essential boundary state is not specified, homogeneous essential boundary conditions are applied
    *
    * @param[in] adjoint_load The dual state that contains the right hand side of the adjoint system (d quantity of
-   * interest/d temperature)
+   * interest/d displacement)
    * @param[in] dual_with_essential_boundary A optional finite element dual containing the non-homogenous essential
    * boundary condition data for the adjoint problem
    * @return The computed adjoint finite element state
@@ -685,7 +685,7 @@ protected:
   /// The sensitivities (dual vectors) with repect to each of the input parameter fields
   std::array<std::unique_ptr<FiniteElementDual>, sizeof...(parameter_space)> parameter_sensitivities_;
 
-  /// The set of input trial space vectors (temperature + parameters) used to call the underlying functional
+  /// The set of input trial space vectors (displacement + parameters) used to call the underlying functional
   std::vector<std::reference_wrapper<const mfem::Vector>> functional_call_args_;
 
   /**

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -24,6 +24,38 @@
 
 namespace serac {
 
+namespace solid_util {
+/// A timestep and boundary condition enforcement method for a dynamic solver
+struct TimesteppingOptions {
+  /// The timestepping method to be applied
+  TimestepMethod timestepper;
+
+  /// The essential boundary enforcement method to use
+  DirichletEnforcementMethod enforcement_method;
+};
+
+/**
+ * @brief A configuration variant for the various solves
+ * For quasistatic solves, leave the @a dyn_options parameter null. @a T_nonlin_options and @a T_lin_options
+ * define the solver parameters for the nonlinear residual and linear stiffness solves. For
+ * dynamic problems, @a dyn_options defines the timestepping scheme while @a T_lin_options and @a T_nonlin_options
+ * define the nonlinear residual and linear stiffness solve options as before.
+ */
+struct SolverOptions {
+  /// The linear solver options
+  LinearSolverOptions H_lin_options;
+
+  /// The nonlinear solver options
+  NonlinearSolverOptions H_nonlin_options;
+
+  /**
+   * @brief The optional ODE solver parameters
+   * @note If this is not defined, a quasi-static solve is performed
+   */
+  std::optional<TimesteppingOptions> dyn_options = std::nullopt;
+};
+}  // namespace solid_util
+
 /**
  * @brief The nonlinear solid solver class
  *
@@ -34,39 +66,9 @@ namespace serac {
  * @tparam order The order of the discretization of the displacement and velocity fields
  * @tparam dim The spatial dimension of the mesh
  */
-template <int order, int dim>
+template <int order, int dim, typename... parameter_space>
 class SolidFunctional : public BasePhysics {
 public:
-  /// A timestep and boundary condition enforcement method for a dynamic solver
-  struct TimesteppingOptions {
-    /// The timestepping method to be applied
-    TimestepMethod timestepper;
-
-    /// The essential boundary enforcement method to use
-    DirichletEnforcementMethod enforcement_method;
-  };
-
-  /**
-   * @brief A configuration variant for the various solves
-   * For quasistatic solves, leave the @a dyn_options parameter null. @a T_nonlin_options and @a T_lin_options
-   * define the solver parameters for the nonlinear residual and linear stiffness solves. For
-   * dynamic problems, @a dyn_options defines the timestepping scheme while @a T_lin_options and @a T_nonlin_options
-   * define the nonlinear residual and linear stiffness solve options as before.
-   */
-  struct SolverOptions {
-    /// The linear solver options
-    LinearSolverOptions H_lin_options;
-
-    /// The nonlinear solver options
-    NonlinearSolverOptions H_nonlin_options;
-
-    /**
-     * @brief The optional ODE solver parameters
-     * @note If this is not defined, a quasi-static solve is performed
-     */
-    std::optional<TimesteppingOptions> dyn_options = std::nullopt;
-  };
-
   /**
    * @brief Construct a new Solid Functional object
    *
@@ -75,15 +77,18 @@ public:
    * @param keep_deformation Flag to keep the deformation in the underlying mesh post-destruction
    * @param name An optional name for the physics module instance
    */
-  SolidFunctional(const SolverOptions& options, GeometricNonlinearities geom_nonlin = GeometricNonlinearities::On,
-                  FinalMeshOption keep_deformation = FinalMeshOption::Deformed, const std::string& name = "")
+  SolidFunctional(
+      const solid_util::SolverOptions& options, GeometricNonlinearities geom_nonlin = GeometricNonlinearities::On,
+      FinalMeshOption keep_deformation = FinalMeshOption::Deformed, const std::string& name = "",
+      std::array<std::reference_wrapper<FiniteElementState>, sizeof...(parameter_space)> parameter_states = {})
       : BasePhysics(2, order),
         velocity_(StateManager::newState(FiniteElementState::Options{
             .order = order, .vector_dim = mesh_.Dimension(), .name = detail::addPrefix(name, "velocity")})),
         displacement_(StateManager::newState(FiniteElementState::Options{
             .order = order, .vector_dim = mesh_.Dimension(), .name = detail::addPrefix(name, "displacement")})),
-        M_functional_(&displacement_.space(), {&displacement_.space()}),
-        K_functional_(&displacement_.space(), {&displacement_.space()}),
+        adjoint_displacement_(StateManager::newState(FiniteElementState::Options{
+            .order = order, .vector_dim = mesh_.Dimension(), .name = detail::addPrefix(name, "adjoint_displacement")})),
+        parameter_states_(parameter_states),
         ode2_(displacement_.space().TrueVSize(), {.c0 = c0_, .c1 = c1_, .u = u_, .du_dt = du_dt_, .d2u_dt2 = previous_},
               nonlin_solver_, bcs_),
         geom_nonlin_(geom_nonlin),
@@ -91,6 +96,22 @@ public:
   {
     SLIC_ERROR_ROOT_IF(mesh_.Dimension() != dim,
                        axom::fmt::format("Compile time dimension and runtime mesh dimension mismatch"));
+
+    // Create a pack of the primal field and parameter finite element spaces
+    std::array<mfem::ParFiniteElementSpace*, sizeof...(parameter_space) + 1> trial_spaces;
+    trial_spaces[0] = &displacement_.space();
+
+    functional_call_args_.emplace_back(displacement_.trueVec());
+
+    for (size_t i = 0; i < sizeof...(parameter_space); ++i) {
+      trial_spaces[i + 1]         = &(parameter_states_[i].get().space());
+      parameter_sensitivities_[i] = std::make_unique<FiniteElementDual>(mesh_, parameter_states_[i].get().space());
+      functional_call_args_.emplace_back(parameter_states_[i].get().trueVec());
+    }
+
+    M_functional_ = std::make_unique<Functional<test(trial, parameter_space...)>>(&displacement_.space(), trial_spaces);
+
+    K_functional_ = std::make_unique<Functional<test(trial, parameter_space...)>>(&displacement_.space(), trial_spaces);
 
     state_.push_back(velocity_);
     state_.push_back(displacement_);
@@ -241,20 +262,25 @@ public:
   template <typename MaterialType>
   void setMaterial(MaterialType material)
   {
-    static_assert(has_density<MaterialType, dim>::value,
-                  "Solid functional materials must have a public density(x) method.");
-    static_assert(has_stress<MaterialType, dim>::value,
-                  "Solid functional materials must have a public (du_dx) operator for Kirchoff stress evaluation.");
+    if constexpr (is_parameterized<MaterialType>::value) {
+      static_assert(material.numParameters() == sizeof...(parameter_space),
+                    "Number of parameters in solid does not equal the number of parameters in the "
+                    "solid material.");
+    }
 
-    K_functional_.AddDomainIntegral(
+    auto parameterized_material = parameterizeMaterial(material);
+
+    K_functional_->AddDomainIntegral(
         Dimension<dim>{},
-        [this, material](auto, auto displacement) {
+        [this, parameterized_material](auto x, auto displacement, auto... params) {
           // Get the value and the gradient from the input tuple
           auto [u, du_dX] = displacement;
 
           auto source = zero{};
 
-          auto flux = material(du_dX);
+          auto response = parameterized_material(x, u, du_dX, serac::get<0>(params)...);
+
+          auto flux = response.stress;
 
           if (geom_nonlin_ == GeometricNonlinearities::On) {
             auto deformation_grad = du_dX + I_;
@@ -265,17 +291,19 @@ public:
         },
         mesh_);
 
-    M_functional_.AddDomainIntegral(
+    M_functional_->AddDomainIntegral(
         Dimension<dim>{},
-        [this, material](auto x, auto displacement) {
+        [this, parameterized_material](auto x, auto displacement, auto... params) {
           auto [u, du_dX] = displacement;
+
+          auto response = parameterized_material(x, u, du_dX, serac::get<0>(params)...);
 
           auto flux = 0.0 * du_dX;
 
           double geom_factor = (geom_nonlin_ == GeometricNonlinearities::On ? 1.0 : 0.0);
 
           auto deformation_grad = du_dX + I_;
-          auto source           = material.density(x) * u * (1.0 + geom_factor * (det(deformation_grad) - 1.0));
+          auto source           = response.density * u * (1.0 + geom_factor * (det(deformation_grad) - 1.0));
 
           return serac::tuple{source, flux};
         },
@@ -319,12 +347,17 @@ public:
   template <typename BodyForceType>
   void addBodyForce(BodyForceType body_force_function)
   {
-    static_assert(has_body_force<BodyForceType, dim>::value,
-                  "Body forces must have a public (x, t, u, du_dx) operator for force evaluation.");
+    if constexpr (is_parameterized<BodyForceType>::value) {
+      static_assert(body_force_function.numParameters() == sizeof...(parameter_space),
+                    "Number of parameters in solid not equal the number of parameters in the "
+                    "body force.");
+    }
 
-    K_functional_.AddDomainIntegral(
+    auto parameterized_body_force = parameterizeSource(body_force_function);
+
+    K_functional_->AddDomainIntegral(
         Dimension<dim>{},
-        [body_force_function, this](auto x, auto displacement) {
+        [parameterized_body_force, this](auto x, auto displacement, auto... params) {
           // Get the value and the gradient from the input tuple
           auto [u, du_dX] = displacement;
 
@@ -334,7 +367,8 @@ public:
 
           auto deformation_grad = du_dX + I_;
 
-          auto source = body_force_function(x, time_, u, du_dX) * (1.0 + geom_factor * (det(deformation_grad) - 1.0));
+          auto source = parameterized_body_force(x, time_, u, du_dX, serac::get<0>(params)...) *
+                        (1.0 + geom_factor * (det(deformation_grad) - 1.0));
           return serac::tuple{source, flux};
         },
         mesh_);
@@ -352,15 +386,23 @@ public:
   template <typename TractionType>
   void setTractionBCs(TractionType traction_function, bool compute_on_reference = true)
   {
-    static_assert(has_traction_boundary<TractionType, dim>::value,
-                  "Traction must have a public (x, n, t) operator for traction evaluation.");
+    if constexpr (is_parameterized<TractionType>::value) {
+      static_assert(traction_function.numParameters() == sizeof...(parameter_space),
+                    "Number of parameters in solid does not equal the number of parameters in the "
+                    "traction boundary.");
+    }
+
+    auto parameterized_traction = parameterizeFlux(traction_function);
 
     // TODO fix this when we can get gradients from boundary integrals
     SLIC_ERROR_IF(!compute_on_reference, "SolidFunctional cannot compute traction BCs in deformed configuration");
 
-    K_functional_.AddBoundaryIntegral(
+    K_functional_->AddBoundaryIntegral(
         Dimension<dim - 1>{},
-        [this, traction_function](auto x, auto n, auto) { return -1.0 * traction_function(x, n, time_); }, mesh_);
+        [this, parameterized_traction](auto x, auto n, auto, auto... params) {
+          return -1.0 * parameterized_traction(x, n, time_, params...);
+        },
+        mesh_);
   }
 
   /**
@@ -375,15 +417,23 @@ public:
   template <typename PressureType>
   void setPressureBCs(PressureType pressure_function, bool compute_on_reference = true)
   {
-    static_assert(has_pressure_boundary<PressureType, dim>::value,
-                  "Pressure must have a public (x, t) operator for pressure evaluation.");
+    if constexpr (is_parameterized<PressureType>::value) {
+      static_assert(pressure_function.numParameters() == sizeof...(parameter_space),
+                    "Number of parameters in solid does not equal the number of parameters in the "
+                    "pressure boundary.");
+    }
+
+    auto parameterized_pressure = parameterizePressure(pressure_function);
 
     // TODO fix this when we can get gradients from boundary integrals
     SLIC_ERROR_IF(!compute_on_reference, "SolidFunctional cannot compute pressure BCs in deformed configuration");
 
-    K_functional_.AddBoundaryIntegral(
+    K_functional_->AddBoundaryIntegral(
         Dimension<dim - 1>{},
-        [this, pressure_function](auto x, auto n, auto) { return pressure_function(x, time_) * n; }, mesh_);
+        [this, parameterized_pressure](auto x, auto n, auto, auto... params) {
+          return parameterized_pressure(x, time_, params...) * n;
+        },
+        mesh_);
   }
 
   /**
@@ -395,6 +445,16 @@ public:
 
   /// @overload
   serac::FiniteElementState& displacement() { return displacement_; };
+
+  /**
+   * @brief Get the adjoint displacement state
+   *
+   * @return A reference to the current adjoint displacement finite element state
+   */
+  const serac::FiniteElementState& adjointDisplacement() const { return adjoint_displacement_; };
+
+  /// @overload
+  serac::FiniteElementState& adjointDisplacement() { return adjoint_displacement_; };
 
   /**
    * @brief Get the velocity state
@@ -428,13 +488,17 @@ public:
 
         // residual function
         [this](const mfem::Vector& u, mfem::Vector& r) {
-          r = K_functional_(u);
+          functional_call_args_[0] = u;
+
+          r = (*K_functional_)(u);
           r.SetSubVector(bcs_.allEssentialDofs(), 0.0);
         },
 
         // gradient of residual function
         [this](const mfem::Vector& u) -> mfem::Operator& {
-          auto [r, drdu] = K_functional_(differentiate_wrt(u));
+          functional_call_args_[0] = u;
+
+          auto [r, drdu] = (*K_functional_)(functional_call_args_, Index<0>{});
           J_             = assemble(drdu);
           bcs_.eliminateAllEssentialDofsFromMatrix(*J_);
           return *J_;
@@ -471,23 +535,37 @@ public:
           displacement_.space().TrueVSize(),
 
           [this](const mfem::Vector& d2u_dt2, mfem::Vector& r) {
+            functional_call_args_[0] = d2u_dt2;
+
+            auto M_residual = (*M_functional_)(functional_call_args_);
+
             mfem::Vector K_arg(u_.Size());
             add(1.0, u_, c0_, d2u_dt2, K_arg);
+            functional_call_args_[0] = K_arg;
 
-            add(M_functional_(d2u_dt2), K_functional_(K_arg), r);
+            auto K_residual = (*K_functional_)(functional_call_args_);
 
+            functional_call_args_[0] = u_;
+
+            add(M_residual, K_residual, r);
             r.SetSubVector(bcs_.allEssentialDofs(), 0.0);
           },
 
           [this](const mfem::Vector& d2u_dt2) -> mfem::Operator& {
+            functional_call_args_[0] = d2u_dt2;
+
+            auto M = serac::get<1>((*M_functional_)(functional_call_args_, Index<0>{}));
+            std::unique_ptr<mfem::HypreParMatrix> m_mat(assemble(M));
+
             // J = M + c0 * H(u_predicted)
             mfem::Vector K_arg(u_.Size());
             add(1.0, u_, c0_, d2u_dt2, K_arg);
+            functional_call_args_[0] = K_arg;
 
-            auto                                  M = serac::get<1>(M_functional_(differentiate_wrt(u_)));
-            std::unique_ptr<mfem::HypreParMatrix> m_mat(assemble(M));
+            auto K = serac::get<1>((*K_functional_)(functional_call_args_, Index<0>{}));
 
-            auto                                  K = serac::get<1>(K_functional_(differentiate_wrt(K_arg)));
+            functional_call_args_[0] = u_;
+
             std::unique_ptr<mfem::HypreParMatrix> k_mat(assemble(K));
 
             J_.reset(mfem::Add(1.0, *m_mat, c0_, *k_mat));
@@ -513,11 +591,23 @@ protected:
   /// The displacement finite element state
   FiniteElementState displacement_;
 
+  /// The displacement finite element state
+  FiniteElementState adjoint_displacement_;
+
   /// Mass functional object
-  Functional<test(trial)> M_functional_;
+  std::unique_ptr<Functional<test(trial)>> M_functional_;
 
   /// Stiffness functional object
-  Functional<test(trial)> K_functional_;
+  std::unique_ptr<Functional<test(trial)>> K_functional_;
+
+  /// The finite element states representing user-defined parameter fields
+  std::array<std::reference_wrapper<FiniteElementState>, sizeof...(parameter_space)> parameter_states_;
+
+  /// The sensitivities (dual vectors) with repect to each of the input parameter fields
+  std::array<std::unique_ptr<FiniteElementDual>, sizeof...(parameter_space)> parameter_sensitivities_;
+
+  /// The set of input trial space vectors (temperature + parameters) used to call the underlying functional
+  std::vector<std::reference_wrapper<const mfem::Vector>> functional_call_args_;
 
   /**
    * @brief mfem::Operator that describes the nonlinear residual

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -104,7 +104,7 @@ public:
 
     functional_call_args_.emplace_back(displacement_.trueVec());
 
-    if constexpr (sizeof...(parameter_space)) {
+    if constexpr (sizeof...(parameter_space) > 0) {
       for (size_t i = 0; i < sizeof...(parameter_space); ++i) {
         trial_spaces[i + 1]         = &(parameter_states_[i].get().space());
         parameter_sensitivities_[i] = std::make_unique<FiniteElementDual>(mesh_, parameter_states_[i].get().space());

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -104,10 +104,12 @@ public:
 
     functional_call_args_.emplace_back(displacement_.trueVec());
 
-    for (size_t i = 0; i < sizeof...(parameter_space); ++i) {
-      trial_spaces[i + 1]         = &(parameter_states_[i].get().space());
-      parameter_sensitivities_[i] = std::make_unique<FiniteElementDual>(mesh_, parameter_states_[i].get().space());
-      functional_call_args_.emplace_back(parameter_states_[i].get().trueVec());
+    if constexpr (sizeof...(parameter_space)) {
+      for (size_t i = 0; i < sizeof...(parameter_space); ++i) {
+        trial_spaces[i + 1]         = &(parameter_states_[i].get().space());
+        parameter_sensitivities_[i] = std::make_unique<FiniteElementDual>(mesh_, parameter_states_[i].get().space());
+        functional_call_args_.emplace_back(parameter_states_[i].get().trueVec());
+      }
     }
 
     M_functional_ = std::make_unique<Functional<test(trial, parameter_space...)>>(&displacement_.space(), trial_spaces);

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ blt_add_library(
 set(serial_solver_tests
     serac_solid_sensitivity.cpp
     serac_thermal_functional_finite_diff.cpp
+    serac_solid_functional_finite_diff.cpp
     )
 
 serac_add_tests( SOURCES ${serial_solver_tests}

--- a/src/serac/physics/tests/serac_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_solid_functional.cpp
@@ -57,17 +57,17 @@ void functional_solid_test_static(double expected_disp_norm)
 
   const typename solid_util::SolverOptions default_static = {default_linear_options, default_nonlinear_options};
 
-  // Construct a functional-based thermal conduction solver
+  // Construct a functional-based solid mechanics solver
   SolidFunctional<p, dim> solid_solver(default_static, GeometricNonlinearities::On, FinalMeshOption::Reference,
                                        "solid_functional");
 
   solid_util::NeoHookeanSolid<dim> mat(1.0, 1.0, 1.0);
   solid_solver.setMaterial(mat);
 
-  // Define the function for the initial temperature and boundary condition
+  // Define the function for the initial displacement and boundary condition
   auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
 
-  // Set the initial temperature and boundary condition
+  // Set the initial displacement and boundary condition
   solid_solver.setDisplacementBCs(ess_bdr, bc);
   solid_solver.setDisplacement(bc);
 
@@ -138,17 +138,17 @@ void functional_solid_test_dynamic(double expected_disp_norm)
   const typename solid_util::SolverOptions default_dynamic = {default_linear_options, default_nonlinear_options,
                                                               default_timestep};
 
-  // Construct a functional-based thermal conduction solver
+  // Construct a functional-based solid mechanics solver
   SolidFunctional<p, dim> solid_solver(default_dynamic, GeometricNonlinearities::Off, FinalMeshOption::Reference,
                                        "solid_functional_dynamic");
 
   solid_util::LinearIsotropicSolid<dim> mat(1.0, 1.0, 1.0);
   solid_solver.setMaterial(mat);
 
-  // Define the function for the initial temperature and boundary condition
+  // Define the function for the initial displacement and boundary condition
   auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
 
-  // Set the initial temperature and boundary condition
+  // Set the initial displacement and boundary condition
   solid_solver.setDisplacementBCs(ess_bdr, bc);
   solid_solver.setDisplacement(bc);
 
@@ -222,17 +222,17 @@ void functional_solid_test_boundary(double expected_disp_norm, TestType test_mod
 
   const typename solid_util::SolverOptions default_static = {default_linear_options, default_nonlinear_options};
 
-  // Construct a functional-based thermal conduction solver
+  // Construct a functional-based solid mechanics solver
   SolidFunctional<p, dim> solid_solver(default_static, GeometricNonlinearities::Off, FinalMeshOption::Reference,
                                        "solid_functional");
 
   solid_util::LinearIsotropicSolid<dim> mat(1.0, 1.0, 1.0);
   solid_solver.setMaterial(mat);
 
-  // Define the function for the initial temperature and boundary condition
+  // Define the function for the initial displacement and boundary condition
   auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
 
-  // Set the initial temperature and boundary condition
+  // Set the initial displacement and boundary condition
   solid_solver.setDisplacementBCs(ess_bdr, bc);
   solid_solver.setDisplacement(bc);
 
@@ -314,8 +314,8 @@ void functional_parameterized_solid_test(double expected_disp_norm)
 
   const typename solid_util::SolverOptions default_static = {default_linear_options, default_nonlinear_options};
 
-  // Construct and initialized the user-defined conductivity to be used as a differentiable parameter in
-  // the thermal conduction physics module.
+  // Construct and initialized the user-defined moduli to be used as a differentiable parameter in
+  // the solid mechanics physics module.
   FiniteElementState user_defined_shear_modulus(
       StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_shear"}));
 
@@ -326,7 +326,7 @@ void functional_parameterized_solid_test(double expected_disp_norm)
 
   user_defined_bulk_modulus = 1.0;
 
-  // Construct a functional-based thermal conduction solver
+  // Construct a functional-based solid mechanics solver
   SolidFunctional<p, dim, H1<1>, H1<1>> solid_solver(default_static, GeometricNonlinearities::On,
                                                      FinalMeshOption::Reference, "solid_functional",
                                                      {user_defined_bulk_modulus, user_defined_shear_modulus});
@@ -334,10 +334,10 @@ void functional_parameterized_solid_test(double expected_disp_norm)
   solid_util::ParameterizedNeoHookeanSolid<dim> mat(1.0, 0.0, 0.0);
   solid_solver.setMaterial(mat);
 
-  // Define the function for the initial temperature and boundary condition
+  // Define the function for the initial displacement and boundary condition
   auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
 
-  // Set the initial temperature and boundary condition
+  // Set the initial displacement and boundary condition
   solid_solver.setDisplacementBCs(ess_bdr, bc);
   solid_solver.setDisplacement(bc);
 

--- a/src/serac/physics/tests/serac_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_solid_functional.cpp
@@ -54,8 +54,7 @@ void functional_solid_test_static(double expected_disp_norm)
   const NonlinearSolverOptions default_nonlinear_options = {
       .rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 10, .print_level = 1};
 
-  const typename SolidFunctional<p, dim>::SolverOptions default_static = {default_linear_options,
-                                                                          default_nonlinear_options};
+  const typename solid_util::SolverOptions default_static = {default_linear_options, default_nonlinear_options};
 
   // Construct a functional-based thermal conduction solver
   SolidFunctional<p, dim> solid_solver(default_static, GeometricNonlinearities::On, FinalMeshOption::Reference,
@@ -132,11 +131,11 @@ void functional_solid_test_dynamic(double expected_disp_norm)
   const NonlinearSolverOptions default_nonlinear_options = {
       .rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 10, .print_level = 1};
 
-  const typename SolidFunctional<p, dim>::TimesteppingOptions default_timestep = {
-      TimestepMethod::AverageAcceleration, DirichletEnforcementMethod::RateControl};
+  const typename solid_util::TimesteppingOptions default_timestep = {TimestepMethod::AverageAcceleration,
+                                                                     DirichletEnforcementMethod::RateControl};
 
-  const typename SolidFunctional<p, dim>::SolverOptions default_dynamic = {default_linear_options,
-                                                                           default_nonlinear_options, default_timestep};
+  const typename solid_util::SolverOptions default_dynamic = {default_linear_options, default_nonlinear_options,
+                                                              default_timestep};
 
   // Construct a functional-based thermal conduction solver
   SolidFunctional<p, dim> solid_solver(default_dynamic, GeometricNonlinearities::Off, FinalMeshOption::Reference,
@@ -220,8 +219,7 @@ void functional_solid_test_boundary(double expected_disp_norm, TestType test_mod
   const NonlinearSolverOptions default_nonlinear_options = {
       .rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 10, .print_level = 1};
 
-  const typename SolidFunctional<p, dim>::SolverOptions default_static = {default_linear_options,
-                                                                          default_nonlinear_options};
+  const typename solid_util::SolverOptions default_static = {default_linear_options, default_nonlinear_options};
 
   // Construct a functional-based thermal conduction solver
   SolidFunctional<p, dim> solid_solver(default_static, GeometricNonlinearities::Off, FinalMeshOption::Reference,

--- a/src/serac/physics/tests/serac_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_solid_functional.cpp
@@ -16,6 +16,7 @@
 #include "serac/physics/state/state_manager.hpp"
 #include "serac/physics/solid_functional.hpp"
 #include "serac/physics/materials/solid_functional_material.hpp"
+#include "serac/physics/materials/parameterized_solid_functional_material.hpp"
 
 namespace serac {
 
@@ -276,8 +277,98 @@ void functional_solid_test_boundary(double expected_disp_norm, TestType test_mod
   EXPECT_NEAR(expected_disp_norm, norm(solid_solver.displacement()), 1.0e-6);
 }
 
+template <int p, int dim>
+void functional_parameterized_solid_test(double expected_disp_norm)
+{
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  int serial_refinement   = 0;
+  int parallel_refinement = 0;
+
+  // Create DataStore
+  axom::sidre::DataStore datastore;
+  serac::StateManager::initialize(datastore, "solid_functional_parameterized_solve");
+
+  static_assert(dim == 2 || dim == 3, "Dimension must be 2 or 3 for solid functional parameterized test");
+
+  // Construct the appropriate dimension mesh and give it to the data store
+  std::string filename =
+      (dim == 2) ? SERAC_REPO_DIR "/data/meshes/beam-quad.mesh" : SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
+
+  auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+  serac::StateManager::setMesh(std::move(mesh));
+
+  // Define a boundary attribute set
+  std::set<int> ess_bdr = {1};
+
+  // define the solver configurations
+  const IterativeSolverOptions default_linear_options = {.rel_tol     = 1.0e-6,
+                                                         .abs_tol     = 1.0e-10,
+                                                         .print_level = 0,
+                                                         .max_iter    = 500,
+                                                         .lin_solver  = LinearSolver::GMRES,
+                                                         .prec        = HypreBoomerAMGPrec{}};
+
+  const NonlinearSolverOptions default_nonlinear_options = {
+      .rel_tol = 1.0e-4, .abs_tol = 1.0e-8, .max_iter = 10, .print_level = 1};
+
+  const typename solid_util::SolverOptions default_static = {default_linear_options, default_nonlinear_options};
+
+  // Construct and initialized the user-defined conductivity to be used as a differentiable parameter in
+  // the thermal conduction physics module.
+  FiniteElementState user_defined_shear_modulus(
+      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_shear"}));
+
+  user_defined_shear_modulus = 1.0;
+
+  FiniteElementState user_defined_bulk_modulus(
+      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_bulk"}));
+
+  user_defined_bulk_modulus = 1.0;
+
+  // Construct a functional-based thermal conduction solver
+  SolidFunctional<p, dim, H1<1>, H1<1>> solid_solver(default_static, GeometricNonlinearities::On, FinalMeshOption::Reference,
+                                       "solid_functional", {user_defined_bulk_modulus, user_defined_shear_modulus});
+
+  solid_util::ParameterizedNeoHookeanSolid<dim> mat(1.0, 0.0, 0.0);
+  solid_solver.setMaterial(mat);
+
+  // Define the function for the initial temperature and boundary condition
+  auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
+
+  // Set the initial temperature and boundary condition
+  solid_solver.setDisplacementBCs(ess_bdr, bc);
+  solid_solver.setDisplacement(bc);
+
+  tensor<double, dim> constant_force;
+
+  constant_force[0] = 0.0;
+  constant_force[1] = 5.0e-4;
+
+  if (dim == 3) {
+    constant_force[2] = 0.0;
+  }
+
+  solid_util::ConstantBodyForce<dim> force{constant_force};
+  solid_solver.addBodyForce(force);
+
+  // Finalize the data structures
+  solid_solver.completeSetup();
+
+  // Perform the quasi-static solve
+  double dt = 1.0;
+  solid_solver.advanceTimestep(dt);
+
+  // Output the sidre-based plot files
+  solid_solver.outputState();
+
+  // Check the final displacement norm
+  EXPECT_NEAR(expected_disp_norm, norm(solid_solver.displacement()), 1.0e-6);
+}
+
 TEST(solid_functional, 2D_linear_static) { functional_solid_test_static<1, 2>(1.511052595); }
 TEST(solid_functional, 2D_quad_static) { functional_solid_test_static<2, 2>(2.18604855); }
+TEST(solid_functional, 2D_quad_parameterized_static) { functional_parameterized_solid_test<2, 2>(2.18604855); }
 
 TEST(solid_functional, 3D_linear_static) { functional_solid_test_static<1, 3>(1.37084852); }
 TEST(solid_functional, 3D_quad_static) { functional_solid_test_static<2, 3>(1.949532747); }

--- a/src/serac/physics/tests/serac_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_solid_functional.cpp
@@ -327,8 +327,9 @@ void functional_parameterized_solid_test(double expected_disp_norm)
   user_defined_bulk_modulus = 1.0;
 
   // Construct a functional-based thermal conduction solver
-  SolidFunctional<p, dim, H1<1>, H1<1>> solid_solver(default_static, GeometricNonlinearities::On, FinalMeshOption::Reference,
-                                       "solid_functional", {user_defined_bulk_modulus, user_defined_shear_modulus});
+  SolidFunctional<p, dim, H1<1>, H1<1>> solid_solver(default_static, GeometricNonlinearities::On,
+                                                     FinalMeshOption::Reference, "solid_functional",
+                                                     {user_defined_bulk_modulus, user_defined_shear_modulus});
 
   solid_util::ParameterizedNeoHookeanSolid<dim> mat(1.0, 0.0, 0.0);
   solid_solver.setMaterial(mat);

--- a/src/serac/physics/tests/serac_solid_functional_finite_diff.cpp
+++ b/src/serac/physics/tests/serac_solid_functional_finite_diff.cpp
@@ -1,0 +1,188 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "serac/physics/solid_functional.hpp"
+#include "serac/physics/materials/solid_functional_material.hpp"
+#include "serac/physics/materials/parameterized_solid_functional_material.hpp"
+
+#include <fstream>
+
+#include <gtest/gtest.h>
+#include "mfem.hpp"
+
+#include "serac/serac_config.hpp"
+#include "serac/mesh/mesh_utils.hpp"
+#include "serac/physics/state/state_manager.hpp"
+
+namespace serac {
+
+TEST(solid_functional_finite_diff, finite_difference)
+{
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  int serial_refinement   = 1;
+  int parallel_refinement = 0;
+
+  // Create DataStore
+  axom::sidre::DataStore datastore;
+  serac::StateManager::initialize(datastore, "solid_functional_parameterized_sensitivities");
+
+  // Construct the appropriate dimension mesh and give it to the data store
+  std::string filename = SERAC_REPO_DIR "/data/meshes/beam-quad.mesh";
+
+  auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+  serac::StateManager::setMesh(std::move(mesh));
+
+  constexpr int p   = 1;
+  constexpr int dim = 2;
+
+  // Define a boundary attribute set
+  std::set<int> ess_bdr = {1};
+
+  // define the solver configurations
+  const IterativeSolverOptions default_linear_options = {.rel_tol     = 1.0e-8,
+                                                         .abs_tol     = 1.0e-14,
+                                                         .print_level = 0,
+                                                         .max_iter    = 500,
+                                                         .lin_solver  = LinearSolver::GMRES,
+                                                         .prec        = HypreBoomerAMGPrec{}};
+
+  const NonlinearSolverOptions default_nonlinear_options = {
+      .rel_tol = 1.0e-6, .abs_tol = 1.0e-12, .max_iter = 10, .print_level = 1};
+
+  const typename solid_util::SolverOptions default_static = {default_linear_options, default_nonlinear_options};
+
+  // Construct and initialized the user-defined moduli to be used as a differentiable parameter in
+  // the solid physics module.
+  FiniteElementState user_defined_shear_modulus(
+      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_shear"}));
+
+  double shear_modulus_value = 1.0;
+
+  user_defined_shear_modulus = shear_modulus_value;
+
+  FiniteElementState user_defined_bulk_modulus(
+      StateManager::newState(FiniteElementState::Options{.order = 1, .name = "parameterized_bulk"}));
+
+  double bulk_modulus_value = 1.0;
+
+  user_defined_bulk_modulus = bulk_modulus_value;
+
+  // Construct a functional-based solid solver
+  SolidFunctional<p, dim, H1<1>, H1<1>> solid_solver(default_static, GeometricNonlinearities::On,
+                                                     FinalMeshOption::Reference, "solid_functional",
+                                                     {user_defined_bulk_modulus, user_defined_shear_modulus});
+
+  // We must know the index of the parameter finite element state in our parameter pack to take sensitivities.
+  // As we only have one parameter in this example, the index is zero.
+  constexpr int bulk_parameter_index = 0;
+
+  solid_util::ParameterizedNeoHookeanSolid<dim> mat(1.0, 0.0, 0.0);
+  solid_solver.setMaterial(mat);
+
+  // Define the function for the initial displacement and boundary condition
+  auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
+
+  // Set the initial displacement and boundary condition
+  solid_solver.setDisplacementBCs(ess_bdr, bc);
+  solid_solver.setDisplacement(bc);
+
+  tensor<double, dim> constant_force;
+
+  constant_force[0] = 0.0;
+  constant_force[1] = 1.0e-3;
+
+  if (dim == 3) {
+    constant_force[2] = 0.0;
+  }
+
+  solid_util::ConstantBodyForce<dim> force{constant_force};
+  solid_solver.addBodyForce(force);
+
+  // Finalize the data structures
+  solid_solver.completeSetup();
+
+  // Perform the quasi-static solve
+  double dt = 1.0;
+  solid_solver.advanceTimestep(dt);
+
+  // Output the sidre-based plot files
+  solid_solver.outputState();
+
+  // Make up an adjoint load which can also be viewed as a
+  // sensitivity of some qoi with respect to displacement
+  mfem::ParLinearForm adjoint_load_form(&solid_solver.displacement().space());
+  adjoint_load_form = 1.0;
+
+  // Construct a dummy adjoint load (this would come from a QOI downstream).
+  // This adjoint load is equivalent to a discrete L1 norm on the displacement.
+  serac::FiniteElementDual              adjoint_load(*mesh, solid_solver.displacement().space(), "adjoint_load");
+  std::unique_ptr<mfem::HypreParVector> assembled_vector(adjoint_load_form.ParallelAssemble());
+  adjoint_load.trueVec() = *assembled_vector;
+  adjoint_load.distributeSharedDofs();
+
+  // Solve the adjoint problem
+  solid_solver.solveAdjoint(adjoint_load);
+
+  // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
+  [[maybe_unused]] auto& sensitivity = solid_solver.computeSensitivity<bulk_parameter_index>();
+
+  // Perform finite difference on each bulk modulus value
+  // to check if computed qoi sensitivity is consistent
+  // with finite difference on the displacement
+  double eps = 1.0e-6;
+  for (int i = 0; i < user_defined_bulk_modulus.gridFunc().Size(); ++i) {
+    // Perturb the bulk modulus
+    user_defined_bulk_modulus.trueVec()(i) = bulk_modulus_value + eps;
+    user_defined_bulk_modulus.distributeSharedDofs();
+
+    solid_solver.advanceTimestep(dt);
+    mfem::ParGridFunction displacement_plus = solid_solver.displacement().gridFunc();
+
+    user_defined_bulk_modulus.trueVec()(i) = bulk_modulus_value - eps;
+    user_defined_bulk_modulus.distributeSharedDofs();
+
+    solid_solver.advanceTimestep(dt);
+    mfem::ParGridFunction displacement_minus = solid_solver.displacement().gridFunc();
+
+    // Reset to the original bulk modulus value
+    user_defined_bulk_modulus.trueVec()(i) = bulk_modulus_value;
+    user_defined_bulk_modulus.distributeSharedDofs();
+
+    // Finite difference to compute sensitivity of displacement with respect to bulk modulus
+    mfem::ParGridFunction ddisp_dbulk(&solid_solver.displacement().space());
+    for (int i2 = 0; i2 < displacement_plus.Size(); ++i2) {
+      ddisp_dbulk(i2) = (displacement_plus(i2) - displacement_minus(i2)) / (2.0 * eps);
+    }
+
+    // Compute numerical value of sensitivity of qoi with respect to bulk modulus
+    // by taking the inner product between adjoint load and displacement sensitivity
+    double dqoi_dbulk = adjoint_load_form(ddisp_dbulk);
+
+    // See if these are similar
+    SLIC_INFO(axom::fmt::format("dqoi_dbulk: {}", dqoi_dbulk));
+    SLIC_INFO(axom::fmt::format("sensitivity: {}", sensitivity.trueVec()(i)));
+    EXPECT_NEAR((sensitivity.trueVec()(i) - dqoi_dbulk) / std::max(dqoi_dbulk, 1.0e-2), 0.0, 5.0e-3);
+  }
+}
+
+}  // namespace serac
+
+//------------------------------------------------------------------------------
+#include "axom/slic/core/SimpleLogger.hpp"
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  MPI_Init(&argc, &argv);
+
+  axom::slic::SimpleLogger logger;
+
+  int result = RUN_ALL_TESTS();
+  MPI_Finalize();
+
+  return result;
+}

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -153,7 +153,7 @@ public:
 
     functional_call_args_.emplace_back(temperature_.trueVec());
 
-    if constexpr (sizeof...(parameter_space)) {
+    if constexpr (sizeof...(parameter_space) > 0) {
       for (size_t i = 0; i < sizeof...(parameter_space); ++i) {
         trial_spaces[i + 1]         = &(parameter_states_[i].get().space());
         parameter_sensitivities_[i] = std::make_unique<FiniteElementDual>(mesh_, parameter_states_[i].get().space());


### PR DESCRIPTION
This adds arbitrary parameterizations of load and materials to the `SolidFunctional` physics model. Included are two parameterized models: linear elastic and neo-Hookean responses with user-parameterized bulk and shear modulus. The interface could easily be extended to include both new material models as well as new parameterizations ready for sensitivity analysis.