### PR TITLE
tolerance.json support

### DIFF
--- a/scripts/testing/tolerance_test.py
+++ b/scripts/testing/tolerance_test.py
@@ -47,7 +47,6 @@ Example usages for --tolerance:
 
 Example usage for --tolerance-file:
     --tolerance-file=tolerance_low.json
-    (Note: <name>.json file must be in tests/integration/tolerances directory)
 
 Example JSON file for --tolerance-file:
     {

--- a/scripts/testing/tolerance_test.py
+++ b/scripts/testing/tolerance_test.py
@@ -38,16 +38,36 @@ def ensure_file(path):
         sys.exit(1)
 
 def parse_args():
-    parser = argparse.ArgumentParser(description="Compare two Serac summary files")
-    group = parser.add_mutually_exclusive_group(required=True)
+    usage = """
+Compare two Serac summary files.
+
+Example usages for --tolerance:
+    --tolerance=0.001 // used for all field values
+    --tolerance=default:0.001,velocity:0.1,displacement:0.234 // default is for all non-specified tolerances
+
+Example usage for --tolerance-file:
+    --tolerance-file=tolerance_low.json
+    (Note: <name>.json file must be in tests/integration/tolerances directory)
+
+Example JSON file for --tolerance-file:
+    {
+        \"default\": 0.0001,   // default is for all non-specified tolerances
+        \"velocity\": 0.001,   // specific field value tolerance
+        \"displacement\":0.01
+    }
+"""
+
+    parser = argparse.ArgumentParser(description=usage,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    tolerance_group = parser.add_mutually_exclusive_group(required=True)
 
     parser.add_argument("--baseline", type=str, required=True,
                         help="Path to baseline summary file")
     parser.add_argument("--test", type=str, required=True,
                         help="Path to test summary file")
-    group.add_argument("--tolerance", type=str,
+    tolerance_group.add_argument("--tolerance", type=str,
                         help="Allowed tolerance amount for individual values")
-    group.add_argument("--tolerance-file", type=str,
+    tolerance_group.add_argument("--tolerance-file", type=str,
                         help="JSON file specifying tolerance amount for specific values")
 
     args = parser.parse_args()
@@ -79,7 +99,7 @@ def parse_tolerance_query(query):
     if ":" not in query:
         tolerance_dict = { "default": float(query) }
     else:
-        query_list = query.split("::")
+        query_list = query.split(",")
         for q in query_list:
             q = q.split(":")
             tolerance_dict[q[0]] = float(q[1])

--- a/src/docs/sphinx/dev_guide/testing.rst
+++ b/src/docs/sphinx/dev_guide/testing.rst
@@ -48,6 +48,7 @@ Requirements:
      
      # Personal Machine (currently runs subset of tests)
      $ ./ats.sh
+
    Append ``--help`` to the command to see the current options.
 
 #. **View results.**

--- a/src/docs/sphinx/dev_guide/testing.rst
+++ b/src/docs/sphinx/dev_guide/testing.rst
@@ -48,7 +48,7 @@ Requirements:
      
      # Personal Machine (currently runs subset of tests)
      $ ./ats.sh
-
+   Append `--help` to the command to see the current options.
 #. **View results.**
    ATS gives a running summary and the final results.  ATS also outputs the following
    helpful files in the platform and timestamp specific created log directory:
@@ -84,3 +84,19 @@ easier in ``tests/test.ats``.
       :end-before: _serac_tolerance_test_end
       :language: text
       :dedent: 4
+
+Example usages for --tolerance:
+    --tolerance=0.001 // used for all field values
+    --tolerance=default:0.001,velocity:0.1,displacement:0.234 // default is for all non-specified tolerances
+
+Example usage for --tolerance-file:
+    --tolerance-file=tolerance_low.json
+    (Note: <name>.json file must be in tests/integration/tolerances directory)
+
+Example JSON file for --tolerance-file:
+    {
+        "default": 0.0001,   // default is for all non-specified tolerances
+        "velocity": 0.001,   // specific field value tolerance
+        "displacement":0.01
+    }
+

--- a/src/docs/sphinx/dev_guide/testing.rst
+++ b/src/docs/sphinx/dev_guide/testing.rst
@@ -49,6 +49,7 @@ Requirements:
      # Personal Machine (currently runs subset of tests)
      $ ./ats.sh
    Append ``--help`` to the command to see the current options.
+
 #. **View results.**
    ATS gives a running summary and the final results.  ATS also outputs the following
    helpful files in the platform and timestamp specific created log directory:

--- a/src/docs/sphinx/dev_guide/testing.rst
+++ b/src/docs/sphinx/dev_guide/testing.rst
@@ -48,7 +48,7 @@ Requirements:
      
      # Personal Machine (currently runs subset of tests)
      $ ./ats.sh
-   Append `--help` to the command to see the current options.
+   Append ``--help`` to the command to see the current options.
 #. **View results.**
    ATS gives a running summary and the final results.  ATS also outputs the following
    helpful files in the platform and timestamp specific created log directory:
@@ -84,19 +84,4 @@ easier in ``tests/test.ats``.
       :end-before: _serac_tolerance_test_end
       :language: text
       :dedent: 4
-
-Example usages for --tolerance:
-    --tolerance=0.001 // used for all field values
-    --tolerance=default:0.001,velocity:0.1,displacement:0.234 // default is for all non-specified tolerances
-
-Example usage for --tolerance-file:
-    --tolerance-file=tolerance_low.json
-    (Note: <name>.json file must be in tests/integration/tolerances directory)
-
-Example JSON file for --tolerance-file:
-    {
-        "default": 0.0001,   // default is for all non-specified tolerances
-        "velocity": 0.001,   // specific field value tolerance
-        "displacement":0.01
-    }
 


### PR DESCRIPTION
In `tolerance_test.py`, you can now use a tolerance.json file or one single tolerance value to specify tolerance values for fields. There is also error checking in case there is no default value or no value for each field.

I still need to add things on the `tests/integration` side as well as implementing a string parser for the `--tolerance` option.

fixes #601