### PR TITLE
resolve issue #667

### DIFF
--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -141,9 +141,7 @@ public:
     using std::log;
     auto stress = lambda * log(J) * I + shear_modulus * B_minus_I;
 
-    // TODO For some reason, clang can't handle CTAD here. We should investigate why.
-    using StressType = decltype(stress);
-    return MaterialResponse<double, StressType>{.density = density_, .stress = stress};
+    return MaterialResponse{density_, stress};
   }
 
   /**

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -162,8 +162,7 @@ public:
     using std::log;
     auto stress = lambda * log(J) * I + shear_modulus_ * B_minus_I;
 
-    // TODO figure out why clang can't handle CTAD here.
-    return MaterialResponse<double, DispGradType>{.density = density_, .stress = stress};
+    return MaterialResponse{density_, stress};
   }
 
 private:


### PR DESCRIPTION
see: https://github.com/LLNL/serac/issues/667

clang was failing to compile the following code:

```cpp
return MaterialResponse{.density = density_, .stress = stress};
```

this feature using `.density = ...` in the constructor ("[designated initializers](https://en.cppreference.com/w/cpp/language/aggregate_initialization)") isn't technically supported until C++20 but some compilers allow it anyway. In this case, mixing that with CTAD led to a compilation error.
