### PR TITLE
Add +asan variant to MFEM and Sundials Spack packages vendored into Serac

### DIFF
--- a/scripts/spack/packages/mfem/package.py
+++ b/scripts/spack/packages/mfem/package.py
@@ -164,45 +164,17 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     variant('miniapps', default=False,
             description='Build and install miniapps')
 
-    # SERAC EDIT BEGIN - add ASan variant for memory debugging
-    # Custom variant not yet in upstream Spack; see
-    # https://github.com/spack/spack/pull/30210 for inspiration. Eventually,
-    # this variant should be replaced with a feature in upstream Spack that
-    # enables targeted use of ASan flags. The motivation for this variant is
-    # to inject ASan flags in this package, but not in its dependents;
-    # injecting ASan flags into specs will propagate them to MFEM's
-    # dependencts, which can result in undesirable behavior (e.g., building
-    # CMake with ASan flags).
+    # SERAC EDIT BEGIN - add AddressSanitizer variant for memory debugging
     variant('asan', default=False, description='Add Address Sanitizer flags')
 
-    # ASan is only supported by GCC and (some) LLVM-derived
-    # compilers. There's no convenient spec syntax for negating sets
-    # of compilers -- in this case, the conflicts arise with compilers
-    # that aren't gcc, clang, or apple-clang.
-    #
-    # The preferred approach taken by upstream Spack as of upstream
-    # commit 24c01d5 is to raise an exception within a package stage
-    # (e.g., xios does so in its install stage, pfunit does so in its
-    # setup_build_environment stage, wrf does so in its configure
-    # stage, elemental does so in its cmake_args stage).
-    #
-    # The trouble with this approach in isolation is that the
-    # concretizer can't detect those conflicts, so the exception is
-    # raised after building all of a package's dependents. Some of the
-    # more likely conflicts are listed here to enable
-    # concretization-time conflict detection; the list of compilers in
-    # the loop is every compiler listed in the spack.compilers package
-    # (https://spack.readthedocs.io/en/latest/spack.compilers.html)
-    # except gcc, clang, and apple-clang, to err on the conservative side.
+    # AddressSanitizer (ASan) is only supported by GCC and (some) LLVM-derived
+    # compilers. Blacklist compilers not known to support ASan
     asan_compiler_blacklist = {
         'aocc', 'arm', 'cce', 'fj', 'intel', 'nag', 'nvhpc', 'oneapi', 'pgi',
         'xl', 'xl_r'
     }
 
-    # Whitelist of compilers known to support Address Sanitizer;
-    # used in conjunction with blacklist of compilers suspected
-    # not to support AddressSanitizer in this package's conflict
-    # directives.
+    # Whitelist of compilers known to support Address Sanitizer
     asan_compiler_whitelist = {'gcc', 'clang', 'apple-clang'}
 
     # ASan compiler blacklist and whitelist should be disjoint.
@@ -376,11 +348,6 @@ class Mfem(Package, CudaPackage, ROCmPackage):
         env.unset('MFEM_BUILD_DIR')
 
         # SERAC EDIT BEGIN - Add ASan variant for memory debugging
-        # Logic for custom variant not yet in upstream Spack; see
-        # https://github.com/spack/spack/pull/30210 for inspiration. Eventually,
-        # this variant should be replaced with a feature in upstream Spack that
-        # enables targeted use of ASan flags; when that replacement occurs, the
-        # code in this `if '+asan' in self.spec:` block should be deleted.
         if '+asan' in self.spec:
             for flag in ("CFLAGS", "CXXFLAGS", "LDFLAGS"):
                 env.append_flags(flag, "-fsanitize=address")

--- a/scripts/spack/packages/mfem/package.py
+++ b/scripts/spack/packages/mfem/package.py
@@ -164,6 +164,57 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     variant('miniapps', default=False,
             description='Build and install miniapps')
 
+    # SERAC EDIT BEGIN - add ASan variant for memory debugging
+    # Custom variant not yet in upstream Spack; see
+    # https://github.com/spack/spack/pull/30210 for inspiration. Eventually,
+    # this variant should be replaced with a feature in upstream Spack that
+    # enables targeted use of ASan flags. The motivation for this variant is
+    # to inject ASan flags in this package, but not in its dependents;
+    # injecting ASan flags into specs will propagate them to MFEM's
+    # dependencts, which can result in undesirable behavior (e.g., building
+    # CMake with ASan flags).
+    variant('asan', default=False, description='Add Address Sanitizer flags')
+
+    # ASan is only supported by GCC and (some) LLVM-derived
+    # compilers. There's no convenient spec syntax for negating sets
+    # of compilers -- in this case, the conflicts arise with compilers
+    # that aren't gcc, clang, or apple-clang.
+    #
+    # The preferred approach taken by upstream Spack as of upstream
+    # commit 24c01d5 is to raise an exception within a package stage
+    # (e.g., xios does so in its install stage, pfunit does so in its
+    # setup_build_environment stage, wrf does so in its configure
+    # stage, elemental does so in its cmake_args stage).
+    #
+    # The trouble with this approach in isolation is that the
+    # concretizer can't detect those conflicts, so the exception is
+    # raised after building all of a package's dependents. Some of the
+    # more likely conflicts are listed here to enable
+    # concretization-time conflict detection; the list of compilers in
+    # the loop is every compiler listed in the spack.compilers package
+    # (https://spack.readthedocs.io/en/latest/spack.compilers.html)
+    # except gcc, clang, and apple-clang, to err on the conservative side.
+    asan_compiler_blacklist = {
+        'aocc', 'arm', 'cce', 'fj', 'intel', 'nag', 'nvhpc', 'oneapi', 'pgi',
+        'xl', 'xl_r'
+    }
+
+    # Whitelist of compilers known to support Address Sanitizer;
+    # used in conjunction with blacklist of compilers suspected
+    # not to support AddressSanitizer in this package's conflict
+    # directives.
+    asan_compiler_whitelist = {'gcc', 'clang', 'apple-clang'}
+
+    # ASan compiler blacklist and whitelist should be disjoint.
+    assert len(asan_compiler_blacklist & asan_compiler_whitelist) == 0
+
+    for compiler_ in asan_compiler_blacklist:
+        conflicts("%{0}".format(compiler_),
+                  when="+asan",
+                  msg="{0} compilers do not support Address Sanitizer".format(
+                      compiler_))
+    # SERAC EDIT END
+
     conflicts('+shared', when='@:3.3.2')
     conflicts('~static~shared')
     conflicts('~threadsafe', when='@:3+openmp')
@@ -323,6 +374,22 @@ class Mfem(Package, CudaPackage, ROCmPackage):
     def setup_build_environment(self, env):
         env.unset('MFEM_DIR')
         env.unset('MFEM_BUILD_DIR')
+
+        # SERAC EDIT BEGIN - Add ASan variant for memory debugging
+        # Logic for custom variant not yet in upstream Spack; see
+        # https://github.com/spack/spack/pull/30210 for inspiration. Eventually,
+        # this variant should be replaced with a feature in upstream Spack that
+        # enables targeted use of ASan flags; when that replacement occurs, the
+        # code in this `if '+asan' in self.spec:` block should be deleted.
+        if '+asan' in self.spec:
+            for flag in ("CFLAGS", "CXXFLAGS", "LDFLAGS"):
+                env.append_flags(flag, "-fsanitize=address")
+
+            for flag in ("CFLAGS", "CXXFLAGS"):
+                env.append_flags(flag, "-fno-omit-frame-pointer")
+                if '+debug' in self.spec:
+                    env.append_flags(flag, "-fno-optimize-sibling-calls")
+        # SERAC EDIT END
 
     #
     # Note: Although MFEM does support CMake configuration, MFEM

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -91,6 +91,7 @@ class Serac(CachedCMakePackage, CudaPackage):
 
     depends_on("sundials@5.7.0~shared+hypre+monitoring~examples~examples-install",
                when="+sundials")
+    depends_on("sundials+asan", when="+sundials+asan")
 
     # Libraries that support +debug
     mfem_variants = "~shared+metis+superlu-dist+lapack+mpi"
@@ -107,6 +108,7 @@ class Serac(CachedCMakePackage, CudaPackage):
     depends_on("mfem+petsc", when="+petsc")
     depends_on("mfem+sundials", when="+sundials")
     depends_on("mfem+amgx", when="+cuda")
+    depends_on("mfem+asan", when="+asan")
     depends_on("netcdf-c@4.7.4~shared", when="+netcdf")
 
     # Needs to be first due to a bug with the Spack concretizer

--- a/scripts/spack/packages/sundials/package.py
+++ b/scripts/spack/packages/sundials/package.py
@@ -139,6 +139,57 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     variant('profiling', default=False, when='@6.0.0:',
             description='Build with profiling capabilities')
 
+    # SERAC EDIT BEGIN - Add ASan variant for memory debugging
+    # Custom variant not yet in upstream Spack; see
+    # https://github.com/spack/spack/pull/30210 for inspiration. Eventually,
+    # this variant should be replaced with a feature in upstream Spack that
+    # enables targeted use of ASan flags. The motivation for this variant is
+    # to inject ASan flags in this package, but not in its dependents;
+    # injecting ASan flags into specs will propagate them to MFEM's
+    # dependencts, which can result in undesirable behavior (e.g., building
+    # CMake with ASan flags).
+    variant('asan', default=False, description='Add Address Sanitizer flags')
+
+    # ASan is only supported by GCC and (some) LLVM-derived
+    # compilers. There's no convenient spec syntax for negating sets
+    # of compilers -- in this case, the conflicts arise with compilers
+    # that aren't gcc, clang, or apple-clang.
+    #
+    # The preferred approach taken by upstream Spack as of upstream
+    # commit 24c01d5 is to raise an exception within a package stage
+    # (e.g., xios does so in its install stage, pfunit does so in its
+    # setup_build_environment stage, wrf does so in its configure
+    # stage, elemental does so in its cmake_args stage).
+    #
+    # The trouble with this approach in isolation is that the
+    # concretizer can't detect those conflicts, so the exception is
+    # raised after building all of a package's dependents. Some of the
+    # more likely conflicts are listed here to enable
+    # concretization-time conflict detection; the list of compilers in
+    # the loop is every compiler listed in the spack.compilers package
+    # (https://spack.readthedocs.io/en/latest/spack.compilers.html)
+    # except gcc, clang, and apple-clang, to err on the conservative side.
+    asan_compiler_blacklist = {
+        'aocc', 'arm', 'cce', 'fj', 'intel', 'nag', 'nvhpc', 'oneapi', 'pgi',
+        'xl', 'xl_r'
+    }
+
+    # Whitelist of compilers known to support Address Sanitizer;
+    # used in conjunction with blacklist of compilers suspected
+    # not to support AddressSanitizer in this package's conflict
+    # directives.
+    asan_compiler_whitelist = {'gcc', 'clang', 'apple-clang'}
+
+    # ASan compiler blacklist and whitelist should be disjoint.
+    assert len(asan_compiler_blacklist & asan_compiler_whitelist) == 0
+
+    for compiler_ in asan_compiler_blacklist:
+        conflicts("%{0}".format(compiler_),
+                  when="+asan",
+                  msg="{0} compilers do not support Address Sanitizer".format(
+                      compiler_))
+    # SERAC EDIT END
+
     # ==========================================================================
     # Conflicts
     # ==========================================================================
@@ -238,6 +289,23 @@ class Sundials(CMakePackage, CudaPackage, ROCmPackage):
     # ==========================================================================
     # SUNDIALS Settings
     # ==========================================================================
+
+    # SERAC EDIT BEGIN - Add ASan variant for memory debugging
+    def setup_build_environment(self, env):
+        # Logic for custom variant not yet in upstream Spack; see
+        # https://github.com/spack/spack/pull/30210 for inspiration. Eventually,
+        # this variant should be replaced with a feature in upstream Spack that
+        # enables targeted use of ASan flags; when that replacement occurs, the
+        # code in this `if '+asan' in self.spec:` block should be deleted.
+        if '+asan' in self.spec:
+            for flag in ("CFLAGS", "CXXFLAGS", "LDFLAGS"):
+                env.append_flags(flag, "-fsanitize=address")
+
+            for flag in ("CFLAGS", "CXXFLAGS"):
+                env.append_flags(flag, "-fno-omit-frame-pointer")
+                if '+debug' in self.spec:
+                    env.append_flags(flag, "-fno-optimize-sibling-calls")
+    # SERAC EDIT END
 
     def cmake_args(self):
         spec = self.spec


### PR DESCRIPTION
This pull request adds an `+asan` variant to the MFEM and Sundials Spack packages vendored into Serac, as part of upstreaming some Spack package tweaks from LiDO to Serac.