### PR TITLE
toss3 spack config: correct libunwind version

### DIFF
--- a/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
+++ b/scripts/spack/configs/toss_3_x86_64_ib/packages.yaml
@@ -108,7 +108,7 @@ packages:
   libunwind:
     buildable: false
     externals:
-    - spec: libunwind@8.0.1
+    - spec: libunwind@1.2
       prefix: /usr
   libx11:
     buildable: false


### PR DESCRIPTION
This commit corrects the GNU libunwind version used in the TOSS3
x86_64_ib configuration. The existing version erroneously uses the
shared library's soname to determine the version number; however, the
soversion of GNU libunwind has been 8 for quite some time -- since GNU
libunwind version 1.0.1 (see
https://abi-laboratory.pro/index.php?view=timeline&l=libunwind for
details).

The correct version can be introspected by looking at
`/usr/include/libunwind.h` on a TOSS3 machine. Because Red Hat targets multiple
architectures, this file is split into multiple headers, so the
version information is in /usr/include/libunwind-common.h, which
defines the macros `UNW_VERSION_MAJOR` and `UNW_VERSION_MINOR` to `1` and `2`,
respectively; `UNW_VERSION_EXTRA` is blank, so the GNU libunwind
version installed on quartz (and presumably other TOSS3 x86_64_ib
systems) is 1.2, rather than 8.0.1.