### PR TITLE
Fix the boundary condition essential dof list applications

### DIFF
--- a/src/serac/infrastructure/tests/serac_error_handling.cpp
+++ b/src/serac/infrastructure/tests/serac_error_handling.cpp
@@ -61,10 +61,6 @@ TEST(serac_error_handling, bc_project_requires_state)
   auto              coef = std::make_shared<mfem::ConstantCoefficient>();
   BoundaryCondition bc(coef, 0, std::set<int>{1}, num_attrs);
   EXPECT_THROW(bc.project(), SlicErrorException);
-
-  FiniteElementState state(*mesh);
-  bc.setDofs(state);
-  EXPECT_NO_THROW(bc.project());
 }
 
 TEST(serac_error_handling, bc_one_component_vector_coef)

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -41,11 +41,6 @@ BasePhysics::BasePhysics(int n, int p, mfem::ParMesh* pmesh) : BasePhysics(pmesh
   gf_initialized_.assign(static_cast<std::size_t>(n), StateManager::isRestart());
 }
 
-void BasePhysics::setTrueDofs(const mfem::Array<int>& true_dofs, serac::GeneralCoefficient ess_bdr_coef, int component)
-{
-  bcs_.addEssentialTrueDofs(true_dofs, ess_bdr_coef, component);
-}
-
 const std::vector<std::reference_wrapper<serac::FiniteElementState> >& BasePhysics::getState() const { return state_; }
 
 void BasePhysics::setTime(const double time)

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -54,16 +54,6 @@ public:
   BasePhysics(BasePhysics&& other) = default;
 
   /**
-   * @brief Set a list of true degrees of freedom from a coefficient
-   *
-   * @param[in] true_dofs The true degrees of freedom to set with a Dirichlet condition
-   * @param[in] ess_bdr_coef The coefficient that evaluates to the Dirichlet condition
-   * @param[in] component The component to set (-1 implies all components are set)
-   */
-  virtual void setTrueDofs(const mfem::Array<int>& true_dofs, serac::GeneralCoefficient ess_bdr_coef,
-                           const int component = -1);
-
-  /**
    * @brief Get the list of state variable grid functions
    *
    * @return the current vector of finite element states

--- a/src/serac/physics/boundary_conditions/boundary_condition.cpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition.cpp
@@ -18,12 +18,15 @@ BoundaryCondition::BoundaryCondition(GeneralCoefficient coef, const std::optiona
     SLIC_ERROR_ROOT_IF(component_, "A vector coefficient must be applied to all components");
   }
 
-  setDofs();
-
   markers_ = 0;
   for (const int attr : attrs) {
     SLIC_ASSERT_MSG(attr <= num_attrs, "Attribute specified larger than what is found in the mesh.");
     markers_[attr - 1] = 1;
+  }
+
+  // If a finite element state is provided, set the dofs from the associated finite element space
+  if (state) {
+    setDofs();
   }
 }
 
@@ -39,21 +42,21 @@ BoundaryCondition::BoundaryCondition(GeneralCoefficient coef, const std::optiona
 
 void BoundaryCondition::setTrueDofs(const mfem::Array<int> true_dofs)
 {
-  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");  
+  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");
   true_dofs_ = true_dofs;
   state_->space().GetRestrictionMatrix()->BooleanMultTranspose(*true_dofs_, *local_dofs_);
 }
 
 void BoundaryCondition::setLocalDofs(const mfem::Array<int> local_dofs)
 {
-  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");    
+  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");
   local_dofs_ = local_dofs;
   state_->space().GetRestrictionMatrix()->BooleanMult(*local_dofs_, *true_dofs_);
 }
 
 void BoundaryCondition::setDofs()
 {
-  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");    
+  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");
   true_dofs_.emplace(0);
   local_dofs_.emplace(0);
 

--- a/src/serac/physics/boundary_conditions/boundary_condition.cpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition.cpp
@@ -11,12 +11,15 @@
 namespace serac {
 
 BoundaryCondition::BoundaryCondition(GeneralCoefficient coef, const std::optional<int> component,
-                                     const std::set<int>& attrs, const int num_attrs)
-    : coef_(coef), component_(component), markers_(num_attrs)
+                                     const std::set<int>& attrs, const int num_attrs, FiniteElementState* state)
+    : coef_(coef), component_(component), markers_(num_attrs), state_(state)
 {
   if (get_if<std::shared_ptr<mfem::VectorCoefficient>>(&coef_)) {
     SLIC_ERROR_ROOT_IF(component_, "A vector coefficient must be applied to all components");
   }
+
+  setDofs();
+
   markers_ = 0;
   for (const int attr : attrs) {
     SLIC_ASSERT_MSG(attr <= num_attrs, "Attribute specified larger than what is found in the mesh.");
@@ -25,8 +28,8 @@ BoundaryCondition::BoundaryCondition(GeneralCoefficient coef, const std::optiona
 }
 
 BoundaryCondition::BoundaryCondition(GeneralCoefficient coef, const std::optional<int> component,
-                                     const mfem::Array<int>& true_dofs)
-    : coef_(coef), component_(component), markers_(0)
+                                     const mfem::Array<int>& true_dofs, FiniteElementState* state)
+    : coef_(coef), component_(component), markers_(0), state_(state)
 {
   if (get_if<std::shared_ptr<mfem::VectorCoefficient>>(&coef_)) {
     SLIC_ERROR_IF(component_, "A vector coefficient must be applied to all components");
@@ -36,38 +39,41 @@ BoundaryCondition::BoundaryCondition(GeneralCoefficient coef, const std::optiona
 
 void BoundaryCondition::setTrueDofs(const mfem::Array<int> true_dofs)
 {
+  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");  
   true_dofs_ = true_dofs;
   state_->space().GetRestrictionMatrix()->BooleanMultTranspose(*true_dofs_, *local_dofs_);
 }
 
 void BoundaryCondition::setLocalDofs(const mfem::Array<int> local_dofs)
 {
+  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");    
   local_dofs_ = local_dofs;
   state_->space().GetRestrictionMatrix()->BooleanMult(*local_dofs_, *true_dofs_);
 }
 
-void BoundaryCondition::setDofs(FiniteElementState& state)
+void BoundaryCondition::setDofs()
 {
+  SLIC_ERROR_ROOT_IF(!state_, "A finite element state must exist to set the boundary condition DOFs.");    
   true_dofs_.emplace(0);
   local_dofs_.emplace(0);
-  state_ = &state;
+
   if (component_) {
     mfem::Array<int> dof_markers;
 
-    state.space().GetEssentialTrueDofs(markers_, *true_dofs_, *component_);
-    state.space().GetEssentialVDofs(markers_, dof_markers, *component_);
+    state_->space().GetEssentialTrueDofs(markers_, *true_dofs_, *component_);
+    state_->space().GetEssentialVDofs(markers_, dof_markers, *component_);
 
     // The VDof call actually returns a marker array, so we need to transform it to a list of indices
-    state.space().MarkerToList(dof_markers, *local_dofs_);
+    state_->space().MarkerToList(dof_markers, *local_dofs_);
 
   } else {
     mfem::Array<int> dof_markers;
 
-    state.space().GetEssentialTrueDofs(markers_, *true_dofs_, -1);
-    state.space().GetEssentialVDofs(markers_, *local_dofs_, -1);
+    state_->space().GetEssentialTrueDofs(markers_, *true_dofs_, -1);
+    state_->space().GetEssentialVDofs(markers_, *local_dofs_, -1);
 
     // The VDof call actually returns a marker array, so we need to transform it to a list of indices
-    state.space().MarkerToList(dof_markers, *local_dofs_);
+    state_->space().MarkerToList(dof_markers, *local_dofs_);
   }
 }
 

--- a/src/serac/physics/boundary_conditions/boundary_condition.hpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition.hpp
@@ -36,9 +36,10 @@ public:
    * should be -1 for all components
    * @param[in] attrs The set of boundary condition attributes in the mesh that the BC applies to
    * @param[in] num_attrs The total number of boundary attributes for the mesh
+   * @param[in] state The finite element state on which this BC is applied
    */
   BoundaryCondition(GeneralCoefficient coef, const std::optional<int> component, const std::set<int>& attrs,
-                    const int num_attrs = 0);
+                    const int num_attrs = 0, FiniteElementState* state = nullptr);
 
   /**
    * @brief Minimal constructor for setting the true DOFs directly
@@ -46,8 +47,9 @@ public:
    * @param[in] component The zero-indexed vector component if the BC applies to just one component,
    * should be -1 for all components
    * @param[in] true_dofs The indices of the relevant DOFs
+   * @param[in] state The finite element state on which this BC is applied
    */
-  BoundaryCondition(GeneralCoefficient coef, const std::optional<int> component, const mfem::Array<int>& true_dofs);
+  BoundaryCondition(GeneralCoefficient coef, const std::optional<int> component, const mfem::Array<int>& true_dofs, FiniteElementState* state = nullptr);
 
   /**
    * @brief Determines whether a boundary condition is associated with a tag
@@ -148,15 +150,6 @@ public:
    * @note True and local dofs are described in the <a href="https://mfem.org/pri-dual-vec/">MFEM documentation</a>
    */
   void setLocalDofs(const mfem::Array<int> local_dofs);
-
-  /**
-   * @brief Uses mfem::ParFiniteElementSpace::GetEssentialTrueDofs to
-   * determine the DOFs for the boundary condition
-   * @param[in] state The finite element state for which the DOFs should be obtained
-   *
-   * @note This will set both the true and local dof values.
-   */
-  void setDofs(FiniteElementState& state);
 
   /**
    * @brief Returns the DOF indices for an essential boundary condition
@@ -266,6 +259,14 @@ public:
   void setTime(const double time);
 
 private:
+  /**
+   * @brief Uses mfem::ParFiniteElementSpace::GetEssentialTrueDofs to
+   * determine the DOFs for the boundary condition from the stored marker list
+   *
+   * @note This will set both the true and local dof values.
+   */
+  void setDofs();
+
   /**
    * @brief A coefficient containing either a mfem::Coefficient or an mfem::VectorCoefficient
    */

--- a/src/serac/physics/boundary_conditions/boundary_condition.hpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition.hpp
@@ -49,7 +49,8 @@ public:
    * @param[in] true_dofs The indices of the relevant DOFs
    * @param[in] state The finite element state on which this BC is applied
    */
-  BoundaryCondition(GeneralCoefficient coef, const std::optional<int> component, const mfem::Array<int>& true_dofs, FiniteElementState* state = nullptr);
+  BoundaryCondition(GeneralCoefficient coef, const std::optional<int> component, const mfem::Array<int>& true_dofs,
+                    FiniteElementState* state = nullptr);
 
   /**
    * @brief Determines whether a boundary condition is associated with a tag

--- a/src/serac/physics/boundary_conditions/boundary_condition_manager.cpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition_manager.cpp
@@ -31,16 +31,15 @@ void BoundaryConditionManager::addEssential(const std::set<int>& ess_bdr, serac:
 }
 
 void BoundaryConditionManager::addNatural(const std::set<int>& nat_bdr, serac::GeneralCoefficient nat_bdr_coef,
-                                             const std::optional<int> component)
+                                          const std::optional<int> component)
 {
   nat_bdr_.emplace_back(nat_bdr_coef, component, nat_bdr, num_attrs_);
   all_dofs_valid_ = false;
 }
 
-void BoundaryConditionManager::addEssentialTrueDofs(const mfem::Array<int>&   true_dofs,
-                                                    serac::GeneralCoefficient ess_bdr_coef,
-                                                    serac::FiniteElementState& state,
-                                                    std::optional<int>        component)
+void BoundaryConditionManager::addEssentialTrueDofs(const mfem::Array<int>&    true_dofs,
+                                                    serac::GeneralCoefficient  ess_bdr_coef,
+                                                    serac::FiniteElementState& state, std::optional<int> component)
 {
   ess_bdr_.emplace_back(ess_bdr_coef, component, true_dofs, &state);
   all_dofs_valid_ = false;

--- a/src/serac/physics/boundary_conditions/boundary_condition_manager.cpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition_manager.cpp
@@ -25,15 +25,13 @@ void BoundaryConditionManager::addEssential(const std::set<int>& ess_bdr, serac:
     SLIC_WARNING_ROOT("Multiple definition of essential boundary! Using first definition given.");
   }
 
-  BoundaryCondition bc(ess_bdr_coef, component, filtered_attrs, num_attrs_);
-  bc.setDofs(state);
-  ess_bdr_.emplace_back(std::move(bc));
+  ess_bdr_.emplace_back(ess_bdr_coef, component, filtered_attrs, num_attrs_, &state);
   attrs_in_use_.insert(ess_bdr.begin(), ess_bdr.end());
   all_dofs_valid_ = false;
 }
 
 void BoundaryConditionManager::addNatural(const std::set<int>& nat_bdr, serac::GeneralCoefficient nat_bdr_coef,
-                                          const std::optional<int> component)
+                                             const std::optional<int> component)
 {
   nat_bdr_.emplace_back(nat_bdr_coef, component, nat_bdr, num_attrs_);
   all_dofs_valid_ = false;
@@ -41,9 +39,10 @@ void BoundaryConditionManager::addNatural(const std::set<int>& nat_bdr, serac::G
 
 void BoundaryConditionManager::addEssentialTrueDofs(const mfem::Array<int>&   true_dofs,
                                                     serac::GeneralCoefficient ess_bdr_coef,
+                                                    serac::FiniteElementState& state,
                                                     std::optional<int>        component)
 {
-  ess_bdr_.emplace_back(ess_bdr_coef, component, true_dofs);
+  ess_bdr_.emplace_back(ess_bdr_coef, component, true_dofs, &state);
   all_dofs_valid_ = false;
 }
 

--- a/src/serac/physics/boundary_conditions/boundary_condition_manager.hpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition_manager.hpp
@@ -207,9 +207,10 @@ public:
    *
    * @param[in] true_dofs The true degrees of freedom to set with a Dirichlet condition
    * @param[in] ess_bdr_coef The coefficient that evaluates to the Dirichlet condition
+   * @param[in] state The finite element state where the essential boundary is being applied
    * @param[in] component The component to set (-1 implies all components are set)
    */
-  void addEssentialTrueDofs(const mfem::Array<int>& true_dofs, serac::GeneralCoefficient ess_bdr_coef,
+  void addEssentialTrueDofs(const mfem::Array<int>& true_dofs, serac::GeneralCoefficient ess_bdr_coef, serac::FiniteElementState& state,
                             std::optional<int> component = {});
 
   /**

--- a/src/serac/physics/boundary_conditions/boundary_condition_manager.hpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition_manager.hpp
@@ -210,8 +210,8 @@ public:
    * @param[in] state The finite element state where the essential boundary is being applied
    * @param[in] component The component to set (-1 implies all components are set)
    */
-  void addEssentialTrueDofs(const mfem::Array<int>& true_dofs, serac::GeneralCoefficient ess_bdr_coef, serac::FiniteElementState& state,
-                            std::optional<int> component = {});
+  void addEssentialTrueDofs(const mfem::Array<int>& true_dofs, serac::GeneralCoefficient ess_bdr_coef,
+                            serac::FiniteElementState& state, std::optional<int> component = {});
 
   /**
    * @brief Returns all the true degrees of freedom associated with all the essential BCs

--- a/src/serac/physics/boundary_conditions/tests/serac_boundary_cond.cpp
+++ b/src/serac/physics/boundary_conditions/tests/serac_boundary_cond.cpp
@@ -96,11 +96,12 @@ TEST(boundary_cond_helper, element_attribute_dof_list_scalar)
   auto mesh = mfem::Mesh::MakeCartesian3D(4, 4, 4, mfem::Element::HEXAHEDRON);
   mesh.SetAttribute(1, attribute);
   mesh.SetAttribute(31, attribute);
+  mesh.SetAttributes();
 
   mfem::ParMesh pmesh(MPI_COMM_WORLD, mesh);
   int           sdim = pmesh.SpaceDimension();
 
-  mfem::Array<int> elem_attr_is_ess(pmesh.bdr_attributes.Max());
+  mfem::Array<int> elem_attr_is_ess(pmesh.attributes.Max());
   elem_attr_is_ess                = 0;
   elem_attr_is_ess[attribute - 1] = 1;
 
@@ -163,6 +164,7 @@ TEST(boundary_cond_helper, element_attribute_dof_list_vector)
   auto mesh = mfem::Mesh::MakeCartesian3D(4, 4, 4, mfem::Element::HEXAHEDRON);
   mesh.SetAttribute(2, attribute);
   mesh.SetAttribute(3, attribute);
+  mesh.SetAttributes();
 
   mfem::ParMesh pmesh(MPI_COMM_WORLD, mesh);
   int           sdim = pmesh.SpaceDimension();


### PR DESCRIPTION
When a user asks for essential boundary conditions, it was possible to not include a finite element space. This created a seg fault as the boolean restrictions from the underlying finite element space are needed to calculate the appropriate degree-of-freedom arrays.