### PR TITLE
Don't change the mesh when geometric nonlinearities are off

### DIFF
--- a/data/input_files/tests/solid/qs_linear.lua
+++ b/data/input_files/tests/solid/qs_linear.lua
@@ -1,5 +1,5 @@
 -- Comparison information
-expected_displacement_l2norm = 2.9787340
+expected_displacement_l2norm = 2.79954039
 epsilon = 0.0001
 
 -- Simulation time parameters

--- a/src/serac/physics/solid.cpp
+++ b/src/serac/physics/solid.cpp
@@ -443,8 +443,10 @@ FiniteElementDual& Solid::shearModulusSensitivity(mfem::ParFiniteElementSpace* s
 {
   checkSensitivityMode();
 
-  // Set the mesh nodes to the reference configuration
-  mesh_.NewNodes(*reference_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    // Set the mesh nodes to the reference configuration
+    mesh_.NewNodes(*reference_nodes_);
+  }
 
   LinearElasticMaterial* linear_mat = dynamic_cast<LinearElasticMaterial*>(material_.get());
 
@@ -472,8 +474,10 @@ FiniteElementDual& Solid::shearModulusSensitivity(mfem::ParFiniteElementSpace* s
   // Distribute the shared dofs in the dual state
   shear_sensitivity_->distributeSharedDofs();
 
-  // Set the mesh nodes back to the reference configuration
-  mesh_.NewNodes(*deformed_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    // Set the mesh nodes back to the reference configuration
+    mesh_.NewNodes(*deformed_nodes_);
+  }
 
   return *shear_sensitivity_;
 }
@@ -482,8 +486,10 @@ FiniteElementDual& Solid::bulkModulusSensitivity(mfem::ParFiniteElementSpace* bu
 {
   checkSensitivityMode();
 
-  // Set the mesh nodes to the reference configuration
-  mesh_.NewNodes(*reference_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    // Set the mesh nodes to the reference configuration
+    mesh_.NewNodes(*reference_nodes_);
+  }
 
   LinearElasticMaterial* linear_mat = dynamic_cast<LinearElasticMaterial*>(material_.get());
 
@@ -510,8 +516,10 @@ FiniteElementDual& Solid::bulkModulusSensitivity(mfem::ParFiniteElementSpace* bu
   // Distribute the shared dofs in the dual state
   bulk_sensitivity_->distributeSharedDofs();
 
-  // Set the mesh nodes back to the reference configuration
-  mesh_.NewNodes(*deformed_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    // Set the mesh nodes back to the reference configuration
+    mesh_.NewNodes(*deformed_nodes_);
+  }
 
   return *bulk_sensitivity_;
 }
@@ -522,8 +530,10 @@ const FiniteElementState& Solid::solveAdjoint(FiniteElementDual& adjoint_load,
   SLIC_ERROR_ROOT_IF(!is_quasistatic_, "Adjoint analysis only vaild for quasistatic problems.");
   SLIC_ERROR_ROOT_IF(previous_solve_ == PreviousSolve::None, "Adjoint analysis only valid following a forward solve.");
 
-  // Set the mesh nodes to the reference configuration
-  mesh_.NewNodes(*reference_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    // Set the mesh nodes to the reference configuration
+    mesh_.NewNodes(*reference_nodes_);
+  }
 
   adjoint_load.initializeTrueVec();
 
@@ -558,11 +568,10 @@ const FiniteElementState& Solid::solveAdjoint(FiniteElementDual& adjoint_load,
 
   adjoint_displacement_.distributeSharedDofs();
 
-  // Update the mesh with the new deformed nodes
-  deformed_nodes_->Set(1.0, displacement_.gridFunc());
-  deformed_nodes_->Add(1.0, *reference_nodes_);
-
-  mesh_.NewNodes(*deformed_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    // Update the mesh with the new deformed nodes
+    mesh_.NewNodes(*deformed_nodes_);
+  }
 
   // Reset the equation solver to use the full nonlinear residual operator
   nonlin_solver_.SetOperator(*residual_);

--- a/src/serac/physics/solid.cpp
+++ b/src/serac/physics/solid.cpp
@@ -153,7 +153,7 @@ Solid::Solid(const Solid::InputOptions& options, const std::string& name)
 Solid::~Solid()
 {
   // Update the mesh with the new deformed nodes if requested
-  if (keep_deformation_ == FinalMeshOption::Deformed) {
+  if (keep_deformation_ == FinalMeshOption::Deformed && geom_nonlin_ == GeometricNonlinearities::On) {
     *reference_nodes_ += displacement_.gridFunc();
   }
 
@@ -395,7 +395,10 @@ void Solid::advanceTimestep(double& dt)
   displacement_.initializeTrueVec();
 
   // Set the mesh nodes to the reference configuration
-  mesh_.NewNodes(*reference_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    mesh_.NewNodes(*reference_nodes_);
+  }
+
   bcs_.setTime(time_);
 
   if (is_quasistatic_) {
@@ -410,11 +413,12 @@ void Solid::advanceTimestep(double& dt)
   velocity_.distributeSharedDofs();
   displacement_.distributeSharedDofs();
 
-  // Update the mesh with the new deformed nodes
-  deformed_nodes_->Set(1.0, displacement_.gridFunc());
-  deformed_nodes_->Add(1.0, *reference_nodes_);
-
-  mesh_.NewNodes(*deformed_nodes_);
+  if (geom_nonlin_ == GeometricNonlinearities::On) {
+    // Update the mesh with the new deformed nodes
+    deformed_nodes_->Set(1.0, displacement_.gridFunc());
+    deformed_nodes_->Add(1.0, *reference_nodes_);
+    mesh_.NewNodes(*deformed_nodes_);
+  }
 
   cycle_ += 1;
 

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -230,7 +230,9 @@ public:
     displacement_.initializeTrueVec();
 
     // Set the mesh nodes to the reference configuration
-    mesh_.NewNodes(*reference_nodes_);
+    if (geom_nonlin_ == GeometricNonlinearities::On) {
+      mesh_.NewNodes(*reference_nodes_);
+    }
 
     bcs_.setTime(time_);
 
@@ -246,11 +248,13 @@ public:
     velocity_.distributeSharedDofs();
     displacement_.distributeSharedDofs();
 
-    // Update the mesh with the new deformed nodes
-    deformed_nodes_->Set(1.0, displacement_.gridFunc());
-    deformed_nodes_->Add(1.0, *reference_nodes_);
+    if (geom_nonlin_ == GeometricNonlinearities::On) {
+      // Update the mesh with the new deformed nodes
+      deformed_nodes_->Set(1.0, displacement_.gridFunc());
+      deformed_nodes_->Add(1.0, *reference_nodes_);
 
-    mesh_.NewNodes(*deformed_nodes_);
+      mesh_.NewNodes(*deformed_nodes_);
+    }
 
     cycle_ += 1;
   }

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -601,6 +601,11 @@ public:
   virtual const serac::FiniteElementState& solveAdjoint(FiniteElementDual& adjoint_load,
                                                         FiniteElementDual* dual_with_essential_boundary = nullptr)
   {
+    if (geom_nonlin_ == GeometricNonlinearities::On) {
+      // Set the mesh nodes to the reference configuration
+      mesh_.NewNodes(*reference_nodes_);
+    }
+
     mfem::HypreParVector adjoint_load_vector(adjoint_load.trueVec());
 
     // Add the sign correction to move the term to the RHS
@@ -637,6 +642,11 @@ public:
     // Reset the equation solver to use the full nonlinear residual operator
     nonlin_solver_.SetOperator(*residual_);
 
+    if (geom_nonlin_ == GeometricNonlinearities::On) {
+      // Update the mesh with the new deformed nodes
+      mesh_.NewNodes(*deformed_nodes_);
+    }
+
     return adjoint_displacement_;
   }
 
@@ -652,6 +662,11 @@ public:
   template <int parameter_field>
   FiniteElementDual& computeSensitivity()
   {
+    if (geom_nonlin_ == GeometricNonlinearities::On) {
+      // Set the mesh nodes to the reference configuration
+      mesh_.NewNodes(*reference_nodes_);
+    }
+
     functional_call_args_[0] = displacement_.trueVec();
 
     auto [r, drdparam] = (*K_functional_)(functional_call_args_, Index<parameter_field + 1>{});
@@ -661,6 +676,11 @@ public:
     drdparam_mat->MultTranspose(adjoint_displacement_.trueVec(), parameter_sensitivities_[parameter_field]->trueVec());
 
     parameter_sensitivities_[parameter_field]->distributeSharedDofs();
+
+    if (geom_nonlin_ == GeometricNonlinearities::On) {
+      // Set the mesh nodes back to the reference configuration
+      mesh_.NewNodes(*deformed_nodes_);
+    }
 
     return *parameter_sensitivities_[parameter_field];
   }

--- a/src/serac/physics/tests/serac_solid_adjoint.cpp
+++ b/src/serac/physics/tests/serac_solid_adjoint.cpp
@@ -111,7 +111,7 @@ TEST(SolidSolver, Adjoint)
 
   SLIC_INFO_ROOT(axom::fmt::format("Shear sensitivity vector norm: {}", shear_norm));
 
-  EXPECT_NEAR(shear_norm, 0.005673835517459125, 1.0e-8);
+  EXPECT_NEAR(shear_norm, 0.005673803147, 1.0e-8);
 
   auto& bulk_sensitivity = solid_solver.bulkModulusSensitivity(&l2_fe_space);
 

--- a/src/serac/physics/tests/serac_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_solid_functional.cpp
@@ -373,14 +373,14 @@ TEST(SolidFunctional, 2DQuadParameterizedStatic) { functional_parameterized_soli
 TEST(SolidFunctional, 3DLinearStatic) { functional_solid_test_static<1, 3>(1.37084852); }
 TEST(SolidFunctional, 3DQuadStatic) { functional_solid_test_static<2, 3>(1.949532747); }
 
-TEST(SolidFunctional, 2DLinearDynamic) { functional_solid_test_dynamic<1, 2>(1.525641434); }
-TEST(SolidFunctional, 2DQuadDynamic) { functional_solid_test_dynamic<2, 2>(1.5325754040); }
+TEST(SolidFunctional, 2DLinearDynamic) { functional_solid_test_dynamic<1, 2>(1.52116682); }
+TEST(SolidFunctional, 2DQuadDynamic) { functional_solid_test_dynamic<2, 2>(1.52777214); }
 
-TEST(SolidFunctional, 3DLinearDynamic) { functional_solid_test_dynamic<1, 3>(1.52490653); }
-TEST(SolidFunctional, 3DQuadDynamic) { functional_solid_test_dynamic<2, 3>(1.53140614); }
+TEST(SolidFunctional, 3DLinearDynamic) { functional_solid_test_dynamic<1, 3>(1.520679017); }
+TEST(SolidFunctional, 3DQuadDynamic) { functional_solid_test_dynamic<2, 3>(1.527009514); }
 
-TEST(SolidFunctional, 2DLinearPressure) { functional_solid_test_boundary<1, 2>(0.065134188, TestType::Pressure); }
-TEST(SolidFunctional, 2DLinearTraction) { functional_solid_test_boundary<1, 2>(0.126610139, TestType::Traction); }
+TEST(SolidFunctional, 2DLinearPressure) { functional_solid_test_boundary<1, 2>(0.065326222, TestType::Pressure); }
+TEST(SolidFunctional, 2DLinearTraction) { functional_solid_test_boundary<1, 2>(0.126593590, TestType::Traction); }
 
 }  // namespace serac
 

--- a/src/serac/physics/tests/serac_thermal_expansion.cpp
+++ b/src/serac/physics/tests/serac_thermal_expansion.cpp
@@ -89,7 +89,7 @@ TEST(SolidSolver, ThermalExpansion)
   solid_solver.outputState();
 
   // Check the norm of the displacement error
-  EXPECT_NEAR(0.11536897, norm(solid_solver.displacement()), 1.0e-4);
+  EXPECT_NEAR(0.1, norm(solid_solver.displacement()), 1.0e-4);
 
   MPI_Barrier(MPI_COMM_WORLD);
 }


### PR DESCRIPTION
This changes the behavior of the `GeometricNonlinearities::Off` option in the `Solid` and `SolidFunctional` modules. Originally, the mesh was still perturbed at the end of the timestep. However after discussions with @kswartz92 (any by proxy @sethwatts ), we thought that keeping the mesh unperturbed in this case is a better option.