### PR TITLE
Re-enable paraview output

### DIFF
--- a/src/docs/sphinx/user_guide/command_line_options.rst
+++ b/src/docs/sphinx/user_guide/command_line_options.rst
@@ -37,3 +37,7 @@ Below is the documentation for Serac's command line options:
      - -o
      - Path
      - Directory to put outputted files
+   * - --paraview
+     - -p
+     - N/A
+     - Enable paraview output

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -119,6 +119,13 @@ int main(int argc, char* argv[])
   }
   axom::utilities::filesystem::makeDirsForPath(output_directory);
 
+  search = cli_opts.find("paraview-directory");
+  std::optional<std::string> paraview_output_dir = {};
+  if (search != cli_opts.end()) {
+    paraview_output_dir = search->second;
+    axom::utilities::filesystem::makeDirsForPath(*paraview_output_dir);
+  }
+
   // Check if a restart was requested
   std::optional<int> restart_cycle;
   if (auto cycle = cli_opts.find("restart-cycle"); cycle != cli_opts.end()) {
@@ -229,7 +236,7 @@ int main(int argc, char* argv[])
     main_physics->advanceTimestep(dt_real);
 
     // Output a visualization file
-    main_physics->outputState();
+    main_physics->outputState(paraview_output_dir);
 
     // Save curve data to Sidre datastore to be output later
     main_physics->saveSummary(datastore, t);

--- a/src/drivers/serac.cpp
+++ b/src/drivers/serac.cpp
@@ -120,6 +120,7 @@ int main(int argc, char* argv[])
   axom::utilities::filesystem::makeDirsForPath(output_directory);
 
   search = cli_opts.find("paraview-directory");
+
   std::optional<std::string> paraview_output_dir = {};
   if (search != cli_opts.end()) {
     paraview_output_dir = search->second;

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -30,10 +30,10 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
                "Writes Sphinx documentation for input file, then exits");
   std::string output_directory;
   app.add_option("-o, --output-directory", output_directory, "Directory to put outputted files");
+  bool enable_paraview{false};
+  app.add_flag("-p, --paraview", enable_paraview, "Enable paraview output");
   bool version{false};
   app.add_flag("-v, --version", version, "Print version and providence information, then exits");
-  bool enable_paraview{false};
-  app.add_option("-p, --paraview", enable_paraview, "Enable paraview output");
 
   // Parse the arguments and check if they are good
   try {

--- a/src/serac/infrastructure/cli.cpp
+++ b/src/serac/infrastructure/cli.cpp
@@ -32,6 +32,8 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
   app.add_option("-o, --output-directory", output_directory, "Directory to put outputted files");
   bool version{false};
   app.add_flag("-v, --version", version, "Print version and providence information, then exits");
+  bool enable_paraview{false};
+  app.add_option("-p, --paraview", enable_paraview, "Enable paraview output");
 
   // Parse the arguments and check if they are good
   try {
@@ -71,6 +73,9 @@ std::unordered_map<std::string, std::string> defineAndParse(int argc, char* argv
       output_directory = serac::input::getInputFileName(input_file_path);
     }
     cli_opts.insert({"output-directory", output_directory});
+    if (enable_paraview) {
+      cli_opts.insert({"paraview-directory", output_directory + "_paraview"});
+    }
   }
 
   return cli_opts;

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -68,7 +68,7 @@ void BasePhysics::outputState(std::optional<std::string> paraview_output_dir) co
         output_name = "default";
       }
 
-      paraview_dc_            = std::make_unique<mfem::ParaViewDataCollection>(output_name, &state_.front().get().mesh());
+      paraview_dc_ = std::make_unique<mfem::ParaViewDataCollection>(output_name, &state_.front().get().mesh());
       int max_order_in_fields = 0;
 
       // Find the maximum polynomial order in the physics module's states

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -63,7 +63,12 @@ void BasePhysics::outputState(std::optional<std::string> paraview_output_dir) co
   if (paraview_output_dir) {
     // Check to see if the paraview data collection exists. If not, create it.
     if (!paraview_dc_) {
-      paraview_dc_            = std::make_unique<mfem::ParaViewDataCollection>(name_, &state_.front().get().mesh());
+      std::string output_name = name_;
+      if (output_name == "") {
+        output_name = "default";
+      }
+
+      paraview_dc_            = std::make_unique<mfem::ParaViewDataCollection>(output_name, &state_.front().get().mesh());
       int max_order_in_fields = 0;
 
       // Find the maximum polynomial order in the physics module's states

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -62,23 +62,29 @@ void BasePhysics::outputState(std::optional<std::string> paraview_output_dir) co
   // Optionally output a paraview datacollection for visualization
   if (paraview_output_dir) {
     // Check to see if the paraview data collection exists. If not, create it.
-
     if (!paraview_dc_) {
       paraview_dc_            = std::make_unique<mfem::ParaViewDataCollection>(name_, &state_.front().get().mesh());
       int max_order_in_fields = 0;
+
+      // Find the maximum polynomial order in the physics module's states
       for (FiniteElementState& state : state_) {
         paraview_dc_->RegisterField(state.name(), &state.gridFunction());
         max_order_in_fields = std::max(max_order_in_fields, state.space().GetOrder(0));
       }
+
+      // Set the options for the paraview output files
       paraview_dc_->SetLevelsOfDetail(max_order_in_fields);
       paraview_dc_->SetHighOrderOutput(true);
       paraview_dc_->SetDataFormat(mfem::VTKFormat::BINARY);
       paraview_dc_->SetCompression(true);
     }
 
+    // Set the current time, cycle, and requested paraview directory
     paraview_dc_->SetCycle(cycle_);
     paraview_dc_->SetTime(time_);
     paraview_dc_->SetPrefixPath(*paraview_output_dir);
+
+    // Write the paraview file
     paraview_dc_->Save();
   }
 }

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -20,8 +20,9 @@
 
 namespace serac {
 
-BasePhysics::BasePhysics(mfem::ParMesh* pmesh)
-    : sidre_datacoll_id_(StateManager::collectionID(pmesh)),
+BasePhysics::BasePhysics(std::string name, mfem::ParMesh* pmesh)
+    : name_(name),
+      sidre_datacoll_id_(StateManager::collectionID(pmesh)),
       mesh_(StateManager::mesh(sidre_datacoll_id_)),
       comm_(mesh_.GetComm()),
       time_(0.0),
@@ -30,10 +31,9 @@ BasePhysics::BasePhysics(mfem::ParMesh* pmesh)
 {
   std::tie(mpi_size_, mpi_rank_) = getMPIInfo(comm_);
   order_                         = 1;
-  root_name_                     = "serac";
 }
 
-BasePhysics::BasePhysics(int n, int p, mfem::ParMesh* pmesh) : BasePhysics(pmesh)
+BasePhysics::BasePhysics(int n, int p, std::string name, mfem::ParMesh* pmesh) : BasePhysics(name, pmesh)
 {
   order_ = p;
   // If this is a restart run, things have already been initialized
@@ -54,7 +54,34 @@ void BasePhysics::setCycle(const int cycle) { cycle_ = cycle; }
 
 int BasePhysics::cycle() const { return cycle_; }
 
-void BasePhysics::outputState() const { StateManager::save(time_, cycle_, sidre_datacoll_id_); }
+void BasePhysics::outputState(std::optional<std::string> paraview_output_dir) const
+{
+  // First, save the restart/Sidre file
+  StateManager::save(time_, cycle_, sidre_datacoll_id_);
+
+  // Optionally output a paraview datacollection for visualization
+  if (paraview_output_dir) {
+    // Check to see if the paraview data collection exists. If not, create it.
+
+    if (!paraview_dc_) {
+      paraview_dc_            = std::make_unique<mfem::ParaViewDataCollection>(name_, &state_.front().get().mesh());
+      int max_order_in_fields = 0;
+      for (FiniteElementState& state : state_) {
+        paraview_dc_->RegisterField(state.name(), &state.gridFunction());
+        max_order_in_fields = std::max(max_order_in_fields, state.space().GetOrder(0));
+      }
+      paraview_dc_->SetLevelsOfDetail(max_order_in_fields);
+      paraview_dc_->SetHighOrderOutput(true);
+      paraview_dc_->SetDataFormat(mfem::VTKFormat::BINARY);
+      paraview_dc_->SetCompression(true);
+    }
+
+    paraview_dc_->SetCycle(cycle_);
+    paraview_dc_->SetTime(time_);
+    paraview_dc_->SetPrefixPath(*paraview_output_dir);
+    paraview_dc_->Save();
+  }
+}
 
 void BasePhysics::initializeSummary(axom::sidre::DataStore& datastore, double t_final, double dt) const
 {

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -106,7 +106,8 @@ public:
   virtual void advanceTimestep(double& dt) = 0;
 
   /**
-   * @brief Output the current state of the PDE fields
+   * @brief Output the current state of the PDE fields in Sidre format and optionally in Paraview format
+   *  if \p paraview_output_dir is given.
    *
    * @param[in] paraview_output_dir Optional output directory for paraview visualization files
    */

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -32,9 +32,10 @@ public:
   /**
    * @brief Empty constructor
    * @param[in] pmesh An optional mesh reference, must be provided to configure the module
+   * @param[in] name Name of the physics module instance
    * when a mesh other than the primary mesh is used
    */
-  BasePhysics(mfem::ParMesh* pmesh = nullptr);
+  BasePhysics(std::string name_, mfem::ParMesh* pmesh = nullptr);
 
   /**
    * @brief Constructor that creates n entries in state_ of order p
@@ -42,9 +43,10 @@ public:
    * @param[in] n Number of state variables
    * @param[in] p Order of the solver
    * @param[in] pmesh An optional mesh reference, must be provided to configure the module
+   * @param[in] name Name of the physics module instance
    * when a mesh other than the default mesh is used
    */
-  BasePhysics(int n, int p, mfem::ParMesh* pmesh = nullptr);
+  BasePhysics(int n, int p, std::string name_, mfem::ParMesh* pmesh = nullptr);
 
   /**
    * @brief Construct a new Base Physics object (copy constructor)
@@ -105,8 +107,10 @@ public:
 
   /**
    * @brief Output the current state of the PDE fields
+   *
+   * @param[in] paraview_output_dir[in] Optional output directory for paraview visualization files
    */
-  virtual void outputState() const;
+  virtual void outputState(std::optional<std::string> paraview_output_dir = {}) const;
 
   /**
    * @brief Initializes the Sidre structure for simulation summary data
@@ -136,7 +140,10 @@ public:
   const mfem::ParMesh& mesh() const { return mesh_; }
 
 protected:
-  /// @brief ID of the corresponding MFEMSidreDataCollection
+  /// @brief Name of the physics module
+  std::string name_ = {};
+
+  /// @brief ID of the corresponding MFEMSidreDataCollection (denoting a mesh)
   std::string sidre_datacoll_id_ = {};
 
   /**
@@ -163,16 +170,6 @@ protected:
    *@brief Whether the simulation is time-independent
    */
   bool is_quasistatic_ = true;
-
-  /**
-   * @brief Root output name
-   */
-  std::string root_name_;
-
-  /**
-   * @brief Directory to output files
-   */
-  std::string output_directory_;
 
   /**
    * @brief Number of significant figures to output for floating-point
@@ -205,9 +202,9 @@ protected:
   int order_;
 
   /**
-   * @brief DataCollection pointer
+   * @brief DataCollection pointer for optional paraview output
    */
-  std::unique_ptr<mfem::DataCollection> dc_;
+  mutable std::unique_ptr<mfem::ParaViewDataCollection> paraview_dc_;
 
   /**
    * @brief State variable initialization indicator

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -35,7 +35,7 @@ public:
    * @param[in] name Name of the physics module instance
    * when a mesh other than the primary mesh is used
    */
-  BasePhysics(std::string name_, mfem::ParMesh* pmesh = nullptr);
+  BasePhysics(std::string name, mfem::ParMesh* pmesh = nullptr);
 
   /**
    * @brief Constructor that creates n entries in state_ of order p
@@ -46,7 +46,7 @@ public:
    * @param[in] name Name of the physics module instance
    * when a mesh other than the default mesh is used
    */
-  BasePhysics(int n, int p, std::string name_, mfem::ParMesh* pmesh = nullptr);
+  BasePhysics(int n, int p, std::string name, mfem::ParMesh* pmesh = nullptr);
 
   /**
    * @brief Construct a new Base Physics object (copy constructor)
@@ -108,7 +108,7 @@ public:
   /**
    * @brief Output the current state of the PDE fields
    *
-   * @param[in] paraview_output_dir[in] Optional output directory for paraview visualization files
+   * @param[in] paraview_output_dir Optional output directory for paraview visualization files
    */
   virtual void outputState(std::optional<std::string> paraview_output_dir = {}) const;
 

--- a/src/serac/physics/solid.cpp
+++ b/src/serac/physics/solid.cpp
@@ -24,7 +24,7 @@ constexpr int NUM_FIELDS = 3;
 
 Solid::Solid(int order, const SolverOptions& options, GeometricNonlinearities geom_nonlin,
              FinalMeshOption keep_deformation, const std::string& name, mfem::ParMesh* pmesh)
-    : BasePhysics(NUM_FIELDS, order, pmesh),
+    : BasePhysics(NUM_FIELDS, order, name, pmesh),
       velocity_(StateManager::mesh(sidre_datacoll_id_),
                 FiniteElementState::Options{
                     .order = order, .vector_dim = mesh_.Dimension(), .name = detail::addPrefix(name, "velocity")}),

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -82,7 +82,7 @@ public:
       const solid_util::SolverOptions& options, GeometricNonlinearities geom_nonlin = GeometricNonlinearities::On,
       FinalMeshOption keep_deformation = FinalMeshOption::Deformed, const std::string& name = "",
       std::array<std::reference_wrapper<FiniteElementState>, sizeof...(parameter_space)> parameter_states = {})
-      : BasePhysics(2, order),
+      : BasePhysics(2, order, name),
         velocity_(StateManager::newState(FiniteElementState::Options{
             .order = order, .vector_dim = mesh_.Dimension(), .name = detail::addPrefix(name, "velocity")})),
         displacement_(StateManager::newState(FiniteElementState::Options{

--- a/src/serac/physics/tests/serac_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_solid_functional.cpp
@@ -89,8 +89,8 @@ void functional_solid_test_static(double expected_disp_norm)
   double dt = 1.0;
   solid_solver.advanceTimestep(dt);
 
-  // Output the sidre-based plot files
-  solid_solver.outputState();
+  // Output the sidre-based and paraview plot files
+  solid_solver.outputState("paraview_output");
 
   // Check the final displacement norm
   EXPECT_NEAR(expected_disp_norm, norm(solid_solver.displacement()), 1.0e-6);

--- a/src/serac/physics/thermal_conduction.cpp
+++ b/src/serac/physics/thermal_conduction.cpp
@@ -18,7 +18,7 @@ constexpr int NUM_FIELDS = 1;
 
 ThermalConduction::ThermalConduction(int order, const SolverOptions& options, const std::string& name,
                                      mfem::ParMesh* pmesh)
-    : BasePhysics(NUM_FIELDS, order, pmesh),
+    : BasePhysics(NUM_FIELDS, order, name, pmesh),
       temperature_(StateManager::newState(FiniteElementState::Options{.order      = order,
                                                                       .vector_dim = 1,
                                                                       .ordering   = mfem::Ordering::byNODES,

--- a/src/serac/physics/thermal_conduction_functional.hpp
+++ b/src/serac/physics/thermal_conduction_functional.hpp
@@ -128,7 +128,7 @@ public:
   ThermalConductionFunctional(
       const Thermal::SolverOptions& options, const std::string& name = {},
       std::array<std::reference_wrapper<FiniteElementState>, sizeof...(parameter_space)> parameter_states = {})
-      : BasePhysics(2, order),
+      : BasePhysics(2, order, name),
         temperature_(
             StateManager::newState(FiniteElementState::Options{.order      = order,
                                                                .vector_dim = 1,

--- a/src/serac/physics/thermal_solid.cpp
+++ b/src/serac/physics/thermal_solid.cpp
@@ -15,7 +15,7 @@ constexpr int NUM_FIELDS = 3;
 
 ThermalSolid::ThermalSolid(int order, const ThermalConduction::SolverOptions& therm_options,
                            const Solid::SolverOptions& solid_options, const std::string& name, mfem::ParMesh* pmesh)
-    : BasePhysics(NUM_FIELDS, order, pmesh),
+    : BasePhysics(NUM_FIELDS, order, name, pmesh),
       // Note that the solid solver must be constructed before the thermal solver as it mutates the mesh node grid
       // function
       solid_solver_(order, solid_options, GeometricNonlinearities::On, FinalMeshOption::Deformed, name, pmesh),
@@ -36,7 +36,7 @@ ThermalSolid::ThermalSolid(int order, const ThermalConduction::SolverOptions& th
 
 ThermalSolid::ThermalSolid(const ThermalConduction::InputOptions& thermal_input, const Solid::InputOptions& solid_input,
                            const std::string& name)
-    : BasePhysics(NUM_FIELDS, std::max(thermal_input.order, solid_input.order)),
+    : BasePhysics(NUM_FIELDS, std::max(thermal_input.order, solid_input.order), name),
       // Note that the solid solver must be constructed before the thermal solver as it mutates the mesh node grid
       // function
       solid_solver_(solid_input, name),

--- a/src/serac/physics/thermal_solid_functional.hpp
+++ b/src/serac/physics/thermal_solid_functional.hpp
@@ -41,7 +41,7 @@ public:
                          const typename solid_util::SolverOptions& solid_options,
                          GeometricNonlinearities                   geom_nonlin = GeometricNonlinearities::On,
                          FinalMeshOption keep_deformation = FinalMeshOption::Deformed, const std::string& name = "")
-      : BasePhysics(3, order),
+      : BasePhysics(3, order, name),
         temperature_(
             StateManager::newState(FiniteElementState::Options{.order      = order,
                                                                .vector_dim = 1,


### PR DESCRIPTION
As ParaView is much more common than VisIt, this re-enables paraview output in addition to the sidre-based output needed for restarts. 

Closes https://github.com/LLNL/serac/issues/732 .