### PR TITLE
Adding diag operation for square rank 2 tensors

### DIFF
--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1065,15 +1065,15 @@ SERAC_HOST_DEVICE constexpr auto dev(const tensor<T, n, n>& A)
 }
 
 /**
- * @brief Returns a matrix (rank-2 tensor) containing the diagonal entries of the input matrix
+ * @brief Returns a square matrix (rank-2 tensor) containing the diagonal entries of the input square matrix
  * with zeros in the off-diagonal positions
- * @param[in] A The input matrix
+ * @param[in] A The input square matrix
  * This operation is used to compute a term in the constitutive response of a linear, cubic solid material
  */
 template <typename T, int n>
 SERAC_HOST_DEVICE constexpr auto diag(const tensor<T, n, n>& A)
 {
-  auto D = make_tensor<n, n>([](int, int) { return 0.0; });
+  auto D = make_tensor<n, n>([](int, int) {return 0.0;});
   for (int i = 0; i < n; i++) {
     D[i][i] = A[i][i];
   }

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1065,6 +1065,22 @@ SERAC_HOST_DEVICE constexpr auto dev(const tensor<T, n, n>& A)
 }
 
 /**
+ * @brief Returns a matrix (rank-2 tensor) containing the diagonal entries of the input matrix
+ * with zeros in the off-diagonal positions
+ * @param[in] A The input matrix
+ * This operation is used to compute a term in the constitutive response of a linear, cubic solid material
+ */
+template <typename T, int n>
+SERAC_HOST_DEVICE constexpr auto diag(const tensor<T, n, n>& A)
+{
+  auto D = make_tensor<n, n>([](int, int) { return 0.0; });
+  for (int i = 0; i < n; i++) {
+    D[i][i] = A[i][i];
+  }
+  return D;
+}
+
+/**
  * @brief Obtains the identity matrix of the specified dimension
  * @return I_dim
  */

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1071,9 +1071,9 @@ SERAC_HOST_DEVICE constexpr auto dev(const tensor<T, n, n>& A)
  * This operation is used to compute a term in the constitutive response of a linear, cubic solid material
  */
 template <typename T, int n>
-SERAC_HOST_DEVICE constexpr auto diag(const tensor<T, n, n>& A)
+SERAC_HOST_DEVICE constexpr auto diagonal_matrix(const tensor<T, n, n>& A)
 {
-  auto D = make_tensor<n, n>([](int, int) {return 0.0;});
+  tensor<T, n, n> D{};
   for (int i = 0; i < n; i++) {
     D[i][i] = A[i][i];
   }

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -43,7 +43,7 @@ TEST(Tensor, BasicOperations)
   EXPECT_LT(abs(squared_norm(dev(A) - devA)), tolerance);
 
   tensor<double, 3, 3> diagA = {{{0, 0, 0}, {0, 3, 0}, {0, 0, 6}}};
-  EXPECT_LT(abs(squared_norm(diag(A) - diagA)), tolerance);
+  EXPECT_LT(abs(squared_norm(diagonal_matrix(A) - diagA)), tolerance);
 
   tensor<double, 3, 3> invAp1 = {{{-4, -1, 3}, {-1.5, 0.5, 0.5}, {2, 0, -1}}};
   EXPECT_LT(abs(squared_norm(inv(A + I) - invAp1)), tolerance);

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -42,6 +42,9 @@ TEST(Tensor, BasicOperations)
   tensor<double, 3, 3> devA = {{{-3, 2, 4}, {1, 0, 5}, {2, 4, 3}}};
   EXPECT_LT(abs(squared_norm(dev(A) - devA)), tolerance);
 
+  tensor<double, 3, 3> diagA = {{{0, 0, 0}, {0, 3, 0}, {0, 0, 6}}};
+  EXPECT_LT(abs(squared_norm(diag(A) - diagA)), tolerance);
+
   tensor<double, 3, 3> invAp1 = {{{-4, -1, 3}, {-1.5, 0.5, 0.5}, {2, 0, -1}}};
   EXPECT_LT(abs(squared_norm(inv(A + I) - invAp1)), tolerance);
 


### PR DESCRIPTION
This operation returns a matrix with the same diagonal entries as the input matrix, with zeros in the off-diagonal positions. It is needed for a linear, cubic solid material model. 