### PR TITLE
Remove the mesh morphing from the `SolidFunctional` module

### DIFF
--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -683,12 +683,6 @@ protected:
   /// @brief A flag denoting whether to compute geometric nonlinearities in the residual
   GeometricNonlinearities geom_nonlin_;
 
-  /// @brief Pointer to the reference mesh data
-  std::unique_ptr<mfem::ParGridFunction> reference_nodes_;
-
-  /// @brief Pointer to the deformed mesh data
-  std::unique_ptr<mfem::ParGridFunction> deformed_nodes_;
-
   /// @brief Coefficient containing the essential boundary values
   std::shared_ptr<mfem::VectorCoefficient> disp_bdr_coef_;
 

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -99,7 +99,7 @@ public:
    */
   SolidFunctional(
       const SolverOptions& options, GeometricNonlinearities geom_nonlin = GeometricNonlinearities::On,
-      FinalMeshOption keep_deformation = FinalMeshOption::Deformed, const std::string& name = "",
+      const std::string&                                                                 name             = "",
       std::array<std::reference_wrapper<FiniteElementState>, sizeof...(parameter_space)> parameter_states = {})
       : BasePhysics(2, order, name),
         velocity_(StateManager::newState(FiniteElementState::Options{
@@ -114,8 +114,7 @@ public:
               nonlin_solver_, bcs_),
         c0_(0.0),
         c1_(0.0),
-        geom_nonlin_(geom_nonlin),
-        keep_deformation_(keep_deformation)
+        geom_nonlin_(geom_nonlin)
   {
     SLIC_ERROR_ROOT_IF(mesh_.Dimension() != dim,
                        axom::fmt::format("Compile time dimension and runtime mesh dimension mismatch"));
@@ -142,13 +141,6 @@ public:
 
     state_.push_back(velocity_);
     state_.push_back(displacement_);
-
-    // Initialize the mesh node pointers
-    reference_nodes_ = std::make_unique<mfem::ParGridFunction>(&displacement_.space());
-    mesh_.EnsureNodes();
-    mesh_.GetNodes(*reference_nodes_);
-
-    deformed_nodes_ = std::make_unique<mfem::ParGridFunction>(*reference_nodes_);
 
     displacement_ = 0.0;
     velocity_     = 0.0;
@@ -190,26 +182,7 @@ public:
   }
 
   /// @brief Destroy the Solid Functional object
-  ~SolidFunctional()
-  {
-    // Update the mesh with the new deformed nodes if requested
-    if (keep_deformation_ == FinalMeshOption::Deformed) {
-      *reference_nodes_ += displacement_.gridFunction();
-    }
-
-    // Build a new grid function to store the mesh nodes post-destruction
-    // NOTE: MFEM will manage the memory of these objects
-
-    auto mesh_fe_coll  = new mfem::H1_FECollection(order_, mesh_.Dimension());
-    auto mesh_fe_space = new mfem::ParFiniteElementSpace(displacement_.space(), &mesh_, mesh_fe_coll);
-    auto mesh_nodes    = new mfem::ParGridFunction(mesh_fe_space);
-    mesh_nodes->MakeOwner(mesh_fe_coll);
-
-    *mesh_nodes = *reference_nodes_;
-
-    // Set the mesh to the newly created nodes object and pass ownership
-    mesh_.NewNodes(*mesh_nodes, true);
-  }
+  ~SolidFunctional() {}
 
   /**
    * @brief Create a shared ptr to a quadrature data buffer for the given material type
@@ -508,11 +481,6 @@ public:
   {
     SLIC_ERROR_ROOT_IF(!residual_, "completeSetup() must be called prior to advanceTimestep(dt) in SolidFunctional.");
 
-    // Set the mesh nodes to the reference configuration
-    if (geom_nonlin_ == GeometricNonlinearities::On) {
-      mesh_.NewNodes(*reference_nodes_);
-    }
-
     // bcs_.setTime(time_);
 
     if (is_quasistatic_) {
@@ -535,14 +503,6 @@ public:
       residual_->update_qdata = false;
     }
 
-    if (geom_nonlin_ == GeometricNonlinearities::On) {
-      // Update the mesh with the new deformed nodes
-      deformed_nodes_->Set(1.0, displacement_.gridFunction());
-      deformed_nodes_->Add(1.0, *reference_nodes_);
-
-      mesh_.NewNodes(*deformed_nodes_);
-    }
-
     cycle_ += 1;
   }
 
@@ -560,11 +520,6 @@ public:
   virtual const serac::FiniteElementState& solveAdjoint(FiniteElementDual& adjoint_load,
                                                         FiniteElementDual* dual_with_essential_boundary = nullptr)
   {
-    if (geom_nonlin_ == GeometricNonlinearities::On) {
-      // Set the mesh nodes to the reference configuration
-      mesh_.NewNodes(*reference_nodes_);
-    }
-
     mfem::HypreParVector adjoint_load_vector(adjoint_load);
 
     // Add the sign correction to move the term to the RHS
@@ -595,11 +550,6 @@ public:
     lin_solver.SetOperator(*J_T);
     lin_solver.Mult(adjoint_load_vector, adjoint_displacement_);
 
-    if (geom_nonlin_ == GeometricNonlinearities::On) {
-      // Update the mesh with the new deformed nodes
-      mesh_.NewNodes(*deformed_nodes_);
-    }
-
     return adjoint_displacement_;
   }
 
@@ -615,22 +565,12 @@ public:
   template <int parameter_field>
   FiniteElementDual& computeSensitivity()
   {
-    if (geom_nonlin_ == GeometricNonlinearities::On) {
-      // Set the mesh nodes to the reference configuration
-      mesh_.NewNodes(*reference_nodes_);
-    }
-
     auto drdparam = serac::get<DERIVATIVE>((*residual_)(DifferentiateWRT<parameter_field + 2>{}, displacement_, zero_,
                                                         parameter_states_[parameter_indices]...));
 
     auto drdparam_mat = assemble(drdparam);
 
     drdparam_mat->MultTranspose(adjoint_displacement_, *parameter_sensitivities_[parameter_field]);
-
-    if (geom_nonlin_ == GeometricNonlinearities::On) {
-      // Set the mesh nodes back to the reference configuration
-      mesh_.NewNodes(*deformed_nodes_);
-    }
 
     return *parameter_sensitivities_[parameter_field];
   }
@@ -667,15 +607,6 @@ public:
 
   /// @brief getter for nodal forces (before zeroing-out essential dofs)
   const serac::FiniteElementDual& nodalForces() { return nodal_forces_; };
-
-  /// @brief Reset the mesh, displacement, and velocity to the reference (stress-free) configuration
-  void resetToReferenceConfiguration()
-  {
-    displacement_ = 0.0;
-    velocity_     = 0.0;
-
-    mesh_.NewNodes(*reference_nodes_);
-  }
 
 protected:
   /// The compile-time finite element trial space for displacement and velocity (H1 of order p)
@@ -754,9 +685,6 @@ protected:
 
   /// @brief Pointer to the reference mesh data
   std::unique_ptr<mfem::ParGridFunction> reference_nodes_;
-
-  /// @brief Flag to indicate the final mesh node state post-destruction
-  FinalMeshOption keep_deformation_;
 
   /// @brief Pointer to the deformed mesh data
   std::unique_ptr<mfem::ParGridFunction> deformed_nodes_;

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -93,7 +93,6 @@ public:
    *
    * @param options The options for the linear, nonlinear, and ODE solves
    * @param geom_nonlin Flag to include geometric nonlinearities
-   * @param keep_deformation Flag to keep the deformation in the underlying mesh post-destruction
    * @param name An optional name for the physics module instance
    * @param parameter_states An array of FiniteElementStates containing the user-specified parameter fields
    */

--- a/src/serac/physics/tests/serac_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_solid_functional.cpp
@@ -51,8 +51,7 @@ void functional_solid_test_static(double expected_disp_norm)
   options.nonlinear.abs_tol = 1.0e-16;
 
   // Construct a functional-based solid mechanics solver
-  SolidFunctional<p, dim> solid_solver(options, GeometricNonlinearities::On, FinalMeshOption::Reference,
-                                       "solid_functional");
+  SolidFunctional<p, dim> solid_solver(options, GeometricNonlinearities::On, "solid_functional");
 
   solid_mechanics::NeoHookean<dim> mat{1.0, 1.0, 1.0};
   solid_solver.setMaterial(mat);
@@ -115,8 +114,7 @@ void functional_solid_test_static_J2()
   options.linear         = linear_options;
 
   // Construct a functional-based solid mechanics solver
-  SolidFunctional<p, dim> solid_solver(options, GeometricNonlinearities::Off, FinalMeshOption::Reference,
-                                       "solid_functional");
+  SolidFunctional<p, dim> solid_solver(options, GeometricNonlinearities::Off, "solid_functional");
 
   solid_mechanics::J2 mat{
       10000,  // Young's modulus
@@ -191,7 +189,7 @@ void functional_solid_test_dynamic(double expected_disp_norm)
 
   // Construct a functional-based solid mechanics solver
   SolidFunctional<p, dim> solid_solver(default_dynamic_options, GeometricNonlinearities::Off,
-                                       FinalMeshOption::Reference, "solid_functional_dynamic");
+                                       "solid_functional_dynamic");
 
   solid_mechanics::LinearIsotropic<dim> mat{1.0, 1.0, 1.0};
   solid_solver.setMaterial(mat);
@@ -252,8 +250,7 @@ void functional_solid_test_boundary(double expected_disp_norm, TestType test_mod
   serac::StateManager::setMesh(std::move(mesh));
 
   // Construct a functional-based solid mechanics solver
-  SolidFunctional<p, dim> solid_solver(default_static_options, GeometricNonlinearities::Off, FinalMeshOption::Reference,
-                                       "solid_functional");
+  SolidFunctional<p, dim> solid_solver(default_static_options, GeometricNonlinearities::Off, "solid_functional");
 
   solid_mechanics::LinearIsotropic<dim> mat{1.0, 1.0, 1.0};
   solid_solver.setMaterial(mat);
@@ -335,7 +332,7 @@ void functional_parameterized_solid_test(double expected_disp_norm)
 
   // Construct a functional-based solid mechanics solver
   SolidFunctional<p, dim, Parameters<H1<1>, H1<1>>> solid_solver(
-      default_static_options, GeometricNonlinearities::On, FinalMeshOption::Reference, "solid_functional",
+      default_static_options, GeometricNonlinearities::On, "solid_functional",
       {user_defined_bulk_modulus, user_defined_shear_modulus});
 
   solid_mechanics::ParameterizedNeoHookeanSolid<dim> mat{1.0, 0.0, 0.0};
@@ -375,12 +372,12 @@ void functional_parameterized_solid_test(double expected_disp_norm)
   EXPECT_NEAR(expected_disp_norm, norm(solid_solver.displacement()), 1.0e-6);
 }
 
-TEST(SolidFunctional, 2DLinearStatic) { functional_solid_test_static<1, 2>(1.5110743593501033); }
-TEST(SolidFunctional, 2DQuadStatic) { functional_solid_test_static<2, 2>(2.1864070695817928); }
-TEST(SolidFunctional, 2DQuadParameterizedStatic) { functional_parameterized_solid_test<2, 2>(2.1864070695817928); }
+TEST(SolidFunctional, 2DLinearStatic) { functional_solid_test_static<1, 2>(1.5110529858788075); }
+TEST(SolidFunctional, 2DQuadStatic) { functional_solid_test_static<2, 2>(2.1864815661936112); }
+TEST(SolidFunctional, 2DQuadParameterizedStatic) { functional_parameterized_solid_test<2, 2>(2.1864815661936112); }
 
-TEST(SolidFunctional, 3DLinearStatic) { functional_solid_test_static<1, 3>(1.3708718127987922); }
-TEST(SolidFunctional, 3DQuadStatic) { functional_solid_test_static<2, 3>(1.9497254957351946); }
+TEST(SolidFunctional, 3DLinearStatic) { functional_solid_test_static<1, 3>(1.3708614483662795); }
+TEST(SolidFunctional, 3DQuadStatic) { functional_solid_test_static<2, 3>(1.9497651636266995); }
 
 TEST(SolidFunctional, 3DQuadStaticJ2) { functional_solid_test_static_J2(); }
 

--- a/src/serac/physics/tests/serac_solid_functional_boundary.cpp
+++ b/src/serac/physics/tests/serac_solid_functional_boundary.cpp
@@ -42,7 +42,7 @@ TEST(SolidFunctional, BoundaryCondition)
   serac::StateManager::setMesh(std::move(mesh));
 
   // Construct a functional-based solid mechanics solver
-  SolidFunctional<p, dim> solid_solver(default_static_options, GeometricNonlinearities::Off, FinalMeshOption::Reference,
+  SolidFunctional<p, dim> solid_solver(default_static_options, GeometricNonlinearities::Off,
                                        "solid_functional_boundary");
 
   solid_mechanics::LinearIsotropic<dim> mat{1.0, 1.0, 1.0};

--- a/src/serac/physics/tests/serac_solid_functional_finite_diff.cpp
+++ b/src/serac/physics/tests/serac_solid_functional_finite_diff.cpp
@@ -59,7 +59,7 @@ TEST(SolidFunctionalFiniteDiff, FiniteDifference)
 
   // Construct a functional-based solid solver
   SolidFunctional<p, dim, Parameters<H1<1>, H1<1> > > solid_solver(
-      default_static_options, GeometricNonlinearities::On, FinalMeshOption::Reference, "solid_functional",
+      default_static_options, GeometricNonlinearities::On, "solid_functional",
       {user_defined_bulk_modulus, user_defined_shear_modulus});
 
   // We must know the index of the parameter finite element state in our parameter pack to take sensitivities.

--- a/src/serac/physics/tests/serac_thermal_solid_functional.cpp
+++ b/src/serac/physics/tests/serac_thermal_solid_functional.cpp
@@ -52,8 +52,7 @@ void functional_test_static(double expected_norm)
   // The material model needs to be implemented before this
   // module can be used.
   ThermalSolidFunctional<p, dim> thermal_solid_solver(thermal_options, solid_mechanics_options,
-                                                      GeometricNonlinearities::On, FinalMeshOption::Deformed,
-                                                      "thermal_solid_functional");
+                                                      GeometricNonlinearities::On, "thermal_solid_functional");
 
   double u = 0.0;
   EXPECT_NEAR(u, expected_norm, 1.0e-6);

--- a/src/serac/physics/thermal_solid_functional.hpp
+++ b/src/serac/physics/thermal_solid_functional.hpp
@@ -34,7 +34,6 @@ public:
    * @param thermal_options The options for the linear, nonlinear, and ODE solves of the thermal operator
    * @param solid_options The options for the linear, nonlinear, and ODE solves of the thermal operator
    * @param geom_nonlin Flag to include geometric nonlinearities
-   * @param keep_deformation Flag to keep the deformation in the underlying mesh post-destruction
    * @param name An optional name for the physics module instance
    */
   ThermalSolidFunctional(const SolverOptions& thermal_options, const SolverOptions& solid_options,

--- a/src/serac/physics/thermal_solid_functional.hpp
+++ b/src/serac/physics/thermal_solid_functional.hpp
@@ -39,7 +39,7 @@ public:
    */
   ThermalSolidFunctional(const SolverOptions& thermal_options, const SolverOptions& solid_options,
                          GeometricNonlinearities geom_nonlin = GeometricNonlinearities::On,
-                         FinalMeshOption keep_deformation = FinalMeshOption::Deformed, const std::string& name = "")
+                         const std::string&      name        = "")
       : BasePhysics(3, order, name),
         temperature_(
             StateManager::newState(FiniteElementState::Options{.order      = order,
@@ -51,7 +51,7 @@ public:
         displacement_(StateManager::newState(FiniteElementState::Options{
             .order = order, .vector_dim = mesh_.Dimension(), .name = detail::addPrefix(name, "displacement")})),
         thermal_functional_(thermal_options, name + "thermal"),
-        solid_functional_(solid_options, geom_nonlin, keep_deformation, name + "mechanical")
+        solid_functional_(solid_options, geom_nonlin, name + "mechanical")
   {
     SLIC_ERROR_ROOT_IF(mesh_.Dimension() != dim,
                        axom::fmt::format("Compile time dimension and runtime mesh dimension mismatch"));


### PR DESCRIPTION
To ensure consistency between physics modules, this PR removes the mesh mutation from the `SolidFunctional` module. This is OK for output as both ParaView and Sidre provide displace operators.

Resolves https://github.com/LLNL/serac/issues/760