### PR TITLE
Add missing headers from install

### DIFF
--- a/src/serac/physics/CMakeLists.txt
+++ b/src/serac/physics/CMakeLists.txt
@@ -27,12 +27,13 @@ set(physics_sources
 
 set(physics_headers
     base_physics.hpp
+    common.hpp
     solid.hpp
     solid_functional.hpp
     thermal_conduction.hpp
     thermal_conduction_functional.hpp
-    thermal_solid.hpp
     thermal_mechanics_functional.hpp
+    thermal_solid.hpp
     )
 
 set(physics_dependencies

--- a/src/serac/physics/materials/CMakeLists.txt
+++ b/src/serac/physics/materials/CMakeLists.txt
@@ -15,14 +15,17 @@ set(materials_sources
     )
 
 set(materials_headers
-    hyperelastic_material.hpp
-    thermal_expansion_material.hpp
-    solid_utils.hpp
-    thermal_functional_material.hpp
-    parameterized_thermal_functional_material.hpp    
-    solid_functional_material.hpp
-    parameterized_solid_functional_material.hpp
     functional_material_utils.hpp
+    green_saint_venant_thermoelastic.hpp
+    hyperelastic_material.hpp
+    liquid_crystal_elastomer.hpp
+    material_verification_tools.hpp
+    parameterized_solid_functional_material.hpp
+    parameterized_thermal_functional_material.hpp
+    solid_functional_material.hpp
+    solid_utils.hpp
+    thermal_expansion_material.hpp
+    thermal_functional_material.hpp
     )
 
 set(materials_depends


### PR DESCRIPTION
This is definitely required and was causing a build failure in a downstream customer:

```
physics/common.hpp
```

I noticed these were not being installed. If they shouldn't be installed please tell me before I merge it:

```
physics/materials/green_saint_venant_thermoelastic.hpp
physics/materials/liquid_crystal_elastomer.hpp
physics/materials/material_verification_tools.hpp
```