### PR TITLE
Revert HDF5 build type change

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -155,10 +155,10 @@ class Serac(CachedCMakePackage, CudaPackage):
 
     # Optional (require when="+profile")
     for dep in ["adiak", "caliper"]:
-        depends_on("{0} build_type=Debug".format(dep), when="+profiling+debug".format(dep))
-        depends_on("{0} build_type=Release".format(dep), when="+profiling~debug".format(dep))
-        depends_on("{0}+shared".format(dep), when="+profiling+shared".format(dep))
-        depends_on("{0}~shared".format(dep), when="+profiling~shared".format(dep))
+        depends_on("{0} build_type=Debug".format(dep), when="+profiling+debug")
+        depends_on("{0} build_type=Release".format(dep), when="+profiling~debug")
+        depends_on("{0}+shared".format(dep), when="+profiling+shared")
+        depends_on("{0}~shared".format(dep), when="+profiling~shared")
 
     # Required
     # NOTE: Don't put HDF5 in this list, for the following reasons:

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -161,9 +161,9 @@ class Serac(CachedCMakePackage, CudaPackage):
         depends_on("{0}~shared".format(dep), when="+profiling~shared".format(dep))
 
     # Required
-    # TODO: don't put hdf5 in this list, for the following reasons:
-    #  hdf5+shared causes Axom to not find hdf5
-    #  hdf5 build_type=Release causes netcdf-c to not find hdf5 on ubuntu 20
+    # NOTE: Don't put HDF5 in this list, for the following reasons:
+    #  "hdf5+shared" causes Axom to not find HDF5
+    #  "hdf5 build_type=Release" causes netcdf-c to not find HDF5 on Ubuntu 20
     for dep in ["axom", "conduit", "metis", "parmetis", "superlu-dist"]:
         depends_on("{0} build_type=Debug".format(dep), when="+debug")
         depends_on("{0} build_type=Release".format(dep), when="~debug")


### PR DESCRIPTION
Reverting this change due to the following two reasons:

- hdf5+shared causes Axom to not find hdf5
- hdf5 build_type=Release causes netcdf-c to not find hdf5 on ubuntu 20
