### PR TITLE
Use Cauchy stress instead of Kirchhoff stress for solid mechanics material models

### DIFF
--- a/src/serac/physics/materials/green_saint_venant_thermoelastic.hpp
+++ b/src/serac/physics/materials/green_saint_venant_thermoelastic.hpp
@@ -62,9 +62,9 @@ struct GreenSaintVenantThermoelasticMaterial {
     const auto            trEg = tr(Eg);
 
     // stress
-    const auto S  = 2.0 * G * dev(Eg) + K * (trEg - 3.0 * alpha * (theta - theta_ref)) * I;
-    const auto P  = dot(F, S);
-    const auto TK = dot(P, transpose(F)) / det(F);
+    const auto S     = 2.0 * G * dev(Eg) + K * (trEg - 3.0 * alpha * (theta - theta_ref)) * I;
+    const auto P     = dot(F, S);
+    const auto sigma = dot(P, transpose(F)) / det(F);
 
     // internal heat source
     const auto s0 = -3 * K * alpha * theta * (trEg - state.strain_trace);
@@ -74,7 +74,7 @@ struct GreenSaintVenantThermoelasticMaterial {
 
     state.strain_trace = get_value(trEg);
 
-    return serac::tuple{TK, C, s0, q0};
+    return serac::tuple{sigma, C, s0, q0};
   }
 
   /**
@@ -147,9 +147,9 @@ struct ParameterizedGreenSaintVenantThermoelasticMaterial {
     auto                  alpha = alpha0 * scale;
 
     // stress
-    const auto S  = 2.0 * G * dev(Eg) + K * (trEg - 3.0 * alpha * (theta - theta_ref)) * I;
-    const auto P  = dot(F, S);
-    const auto TK = (dot(P, transpose(F))) / det(F);
+    const auto S     = 2.0 * G * dev(Eg) + K * (trEg - 3.0 * alpha * (theta - theta_ref)) * I;
+    const auto P     = dot(F, S);
+    const auto sigma = (dot(P, transpose(F))) / det(F);
 
     // internal heat source
     const auto s0 = -3 * K * alpha * theta * (trEg - state.strain_trace);
@@ -159,7 +159,7 @@ struct ParameterizedGreenSaintVenantThermoelasticMaterial {
 
     state.strain_trace = get_value(trEg);
 
-    return serac::tuple{TK, C, s0, q0};
+    return serac::tuple{sigma, C, s0, q0};
   }
 
   /**

--- a/src/serac/physics/materials/green_saint_venant_thermoelastic.hpp
+++ b/src/serac/physics/materials/green_saint_venant_thermoelastic.hpp
@@ -46,7 +46,7 @@ struct GreenSaintVenantThermoelasticMaterial {
    * @param[in,out] state State variables for this material
    *
    * @return[out] tuple of constitutive outputs. Contains the
-   * Kirchhoff stress, the volumetric heat capacity in the reference
+   * Cauchy stress, the volumetric heat capacity in the reference
    * configuration, the heat generated per unit volume during the time
    * step (units of energy), and the referential heat flux (units of
    * energy per unit time and per unit area).
@@ -64,7 +64,7 @@ struct GreenSaintVenantThermoelasticMaterial {
     // stress
     const auto S  = 2.0 * G * dev(Eg) + K * (trEg - 3.0 * alpha * (theta - theta_ref)) * I;
     const auto P  = dot(F, S);
-    const auto TK = dot(P, transpose(F));
+    const auto TK = dot(P, transpose(F)) / det(F);
 
     // internal heat source
     const auto s0 = -3 * K * alpha * theta * (trEg - state.strain_trace);
@@ -128,7 +128,7 @@ struct ParameterizedGreenSaintVenantThermoelasticMaterial {
    * @param[in,out] state State variables for this material
    *
    * @return[out] tuple of constitutive outputs. Contains the
-   * Kirchhoff stress, the volumetric heat capacity in the reference
+   * Cauchy stress, the volumetric heat capacity in the reference
    * configuration, the heat generated per unit volume during the time
    * step (units of energy), and the referential heat flux (units of
    * energy per unit time and per unit area).
@@ -149,7 +149,7 @@ struct ParameterizedGreenSaintVenantThermoelasticMaterial {
     // stress
     const auto S  = 2.0 * G * dev(Eg) + K * (trEg - 3.0 * alpha * (theta - theta_ref)) * I;
     const auto P  = dot(F, S);
-    const auto TK = dot(P, transpose(F));
+    const auto TK = (dot(P, transpose(F))) / det(F);
 
     // internal heat source
     const auto s0 = -3 * K * alpha * theta * (trEg - state.strain_trace);

--- a/src/serac/physics/materials/liquid_crystal_elastomer.hpp
+++ b/src/serac/physics/materials/liquid_crystal_elastomer.hpp
@@ -75,7 +75,7 @@ struct LiquidCrystalElastomer {
    * @param[in] displacement_grad displacement gradient with respect to the reference configuration
    * @param[in] temperature the temperature
    * @param[in] gamma the polar angle used to define the liquid crystal orientation vector
-   * @return The calculated material response (density, Kirchoff stress) for the material
+   * @return The calculated material response (Cauchy stress) for the material
    */
   template <typename DispGradType, typename TemperatureType, typename AngleType>
   SERAC_HOST_DEVICE auto operator()(State& state, const tensor<DispGradType, dim, dim>& displacement_grad,
@@ -107,12 +107,12 @@ struct LiquidCrystalElastomer {
     // Note to Jorge-Luis: the paper is omits a prefactor of 1/J in the
     // Cauchy stress equation because they assume J = 1 strictly
     // (the incompressible limit). It needs to be retained for this
-    // compressible model (and then cancelled out when converting to
-    // Kirchhoff stress).
+    // compressible model.
     auto         stress = (3 * shear_modulus_ / N_b_squared_) * (mu - mu0);
     const double lambda = bulk_modulus_ - (2.0 / 3.0) * shear_modulus_;
     using std::log;
-    stress = stress + lambda * log(J) * I;
+    stress += lambda * log(J) * I;
+    stress /= det(J);
 
     // update state variables
     state.deformation_gradient = get_value(F);

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -89,7 +89,7 @@ struct ParameterizedNeoHookeanSolid {
     auto           G         = G0 + get<0>(DeltaG);
     auto           lambda    = K - (2.0 / dim) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    auto J = det(I + du_dX);
+    auto           J         = det(I + du_dX);
     return (lambda * log(J) * I + G * B_minus_I) / J;
   }
 

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -89,7 +89,8 @@ struct ParameterizedNeoHookeanSolid {
     auto           G         = G0 + get<0>(DeltaG);
     auto           lambda    = K - (2.0 / dim) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    return (lambda * log(det(I + du_dX)) * I + G * B_minus_I) / det(I + du_dX);
+    auto J = det(I + du_dX);
+    return (lambda * log(J) * I + G * B_minus_I) / J;
   }
 
   /**

--- a/src/serac/physics/materials/parameterized_solid_functional_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_functional_material.hpp
@@ -34,7 +34,7 @@ struct ParameterizedLinearIsotropic {
    * @param du_dX Displacement gradient with respect to the reference configuration (displacement_grad)
    * @param DeltaK The bulk modulus offset
    * @param DeltaG The shear modulus offset
-   * @return The calculated material response (density, Kirchoff stress) for the material
+   * @return The calculated material response (Cauchy stress) for the material
    */
   template <typename DisplacementType, typename DispGradType, typename BulkType, typename ShearType>
   SERAC_HOST_DEVICE auto operator()(const DispGradType& du_dX, const BulkType& DeltaK, const ShearType& DeltaG) const
@@ -77,7 +77,7 @@ struct ParameterizedNeoHookeanSolid {
    * @param du_dX Displacement gradient with respect to the reference configuration (displacement_grad)
    * @param DeltaK The bulk modulus offset
    * @param DeltaG The shear modulus offset
-   * @return The calculated material response (density, kirchoff stress) for the material
+   * @return The calculated material response (Cauchy stress) for the material
    */
   template <typename DispGradType, typename BulkType, typename ShearType>
   SERAC_HOST_DEVICE auto operator()(State& /*state*/, const DispGradType& du_dX, const BulkType& DeltaK,
@@ -89,7 +89,7 @@ struct ParameterizedNeoHookeanSolid {
     auto           G         = G0 + get<0>(DeltaG);
     auto           lambda    = K - (2.0 / dim) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    return lambda * log(det(I + du_dX)) * I + G * B_minus_I;
+    return (lambda * log(det(I + du_dX)) * I + G * B_minus_I) / det(I + du_dX);
   }
 
   /**

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -33,7 +33,7 @@ struct LinearIsotropic {
    * @tparam T Number-like type for the displacement gradient components
    * @tparam dim Dimensionality of space
    * @param du_dX Displacement gradient with respect to the reference configuration
-   * @return The Kirchhoff stress
+   * @return The Cauchy stress
    */
   template <typename T, int dim>
   SERAC_HOST_DEVICE auto operator()(State& /* state */, const tensor<T, dim, dim>& du_dX) const
@@ -65,7 +65,7 @@ struct NeoHookean {
    * @tparam T Number-like type for the displacement gradient components
    * @tparam dim Dimensionality of space
    * @param du_dX displacement gradient with respect to the reference configuration (displacement_grad)
-   * @return The Kirchhoff stress
+   * @return The Cauchy stress
    */
   template <typename T, int dim>
   SERAC_HOST_DEVICE auto operator()(State& /* state */, const tensor<T, dim, dim>& du_dX) const
@@ -74,7 +74,7 @@ struct NeoHookean {
     constexpr auto I         = Identity<dim>();
     auto           lambda    = K - (2.0 / 3.0) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    return lambda * log(det(I + du_dX)) * I + G * B_minus_I;
+    return (lambda * log(det(I + du_dX)) * I + G * B_minus_I) / det(I + du_dX);
   }
 
   double density;  ///< mass density

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -74,7 +74,7 @@ struct NeoHookean {
     constexpr auto I         = Identity<dim>();
     auto           lambda    = K - (2.0 / 3.0) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    auto J = det(I + du_dX);
+    auto           J         = det(I + du_dX);
     return (lambda * log(J) * I + G * B_minus_I) / J;
   }
 

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -74,7 +74,8 @@ struct NeoHookean {
     constexpr auto I         = Identity<dim>();
     auto           lambda    = K - (2.0 / 3.0) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    return (lambda * log(det(I + du_dX)) * I + G * B_minus_I) / det(I + du_dX);
+    auto J = det(I + du_dX);
+    return (lambda * log(J) * I + G * B_minus_I) / J;
   }
 
   double density;  ///< mass density

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -348,7 +348,7 @@ public:
 
           // Compute the displacement gradient with respect to the shape-adjusted coordinate.
 
-          // Note that the current configuration x' = X + u + p, where X is the original reference
+          // Note that the current configuration x = X + u + p, where X is the original reference
           // configuration, u is the displacement, and p is the shape displacement. We need the gradient with
           // respect to the perturbed reference configuration X' = X + p for the material model. Therefore, we calculate
           // du/dX' = du/dX * dX/dX' = du/dX * (dX'/dX)^-1 = du/dX * (I + dp/dX)^-1
@@ -357,17 +357,17 @@ public:
 
           auto stress = material(state, du_dX_prime, params...);
 
-          // This deformation gradient is the volumetric transform to get us back to the original
-          // reference configuration dx'/dX = I + du/dX + dp/dX. If we are not including geometric
+          // dx_dX is the volumetric transform to get us back to the original
+          // reference configuration (dx/dX = I + du/dX + dp/dX). If we are not including geometric
           // nonlinearities, we ignore the du/dX factor.
 
-          auto deformation_grad = 0.0 * du_dX + dp_dX + I;
+          auto dx_dX = 0.0 * du_dX + dp_dX + I;
 
           if (geom_nonlin_ == GeometricNonlinearities::On) {
-            deformation_grad = deformation_grad + du_dX;
+            dx_dX += du_dX;
           }
 
-          auto flux = dot(stress, transpose(inv(deformation_grad))) * det(deformation_grad);
+          auto flux = dot(stress, transpose(inv(dx_dX))) * det(dx_dX);
 
           // This transpose on the stress in the following line is a
           // hack to fix a bug in the residual operator. The stress

--- a/src/serac/physics/solid_functional.hpp
+++ b/src/serac/physics/solid_functional.hpp
@@ -21,7 +21,6 @@
 #include "serac/numerics/functional/functional.hpp"
 #include "serac/physics/state/state_manager.hpp"
 #include "serac/physics/solid.hpp"
-#include "serac/physics/materials/functional_material_utils.hpp"
 
 namespace serac {
 
@@ -368,16 +367,15 @@ public:
             deformation_grad = deformation_grad + du_dX;
           }
 
-          // Note that the jacobian needs the fixup for the shape displacement.
-          // The material returns Kirchoff stress, which contains det(du / dX'). We want
-          // The final Jacobian to be det(du / dX), so we compute
-          // det(du / dX) = det(du / dX') * det(dX' / dX) = det(du / dX') * det(I + dp / dX)
-          auto flux = dot(stress, transpose(inv(deformation_grad))) * det(I + dp_dX);
+          auto flux = dot(stress, transpose(inv(deformation_grad))) * det(deformation_grad);
 
           // This transpose on the stress in the following line is a
           // hack to fix a bug in the residual operator. The stress
           // should be transposed in the contraction of the Piola
           // stress with the shape function gradients.
+          //
+          // Note that the mass part of the return is integrated in the perturbed reference
+          // configuration, hence the det(I + dp_dx) = det(dX'/dX)
           //
           // TODO: fix the residual implementation and remove this transpose.
           return serac::tuple{material.density * d2u_dt2 * det(I + dp_dX), transpose(flux)};


### PR DESCRIPTION
This hopefully clarifies the residual calculation calls. It is also more common for lab material libraries to use Cauchy stress vs. reference configuration stress measures.