### PR TITLE
Restore accidentally disabled traction patch tests

### DIFF
--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -175,11 +175,9 @@ auto KirchhoffToPiola(const tensor<T1, dim, dim>& kirchhoff_stress, const tensor
 template <typename T1, typename T2, int dim>
 auto CauchyToPiola(const tensor<T1, dim, dim>& cauchy_stress, const tensor<T2, dim, dim>& displacement_gradient)
 {
-  auto kirchhoff_stress = det(displacement_gradient + Identity<dim>())*cauchy_stress;
+  auto kirchhoff_stress = det(displacement_gradient + Identity<dim>()) * cauchy_stress;
   return KirchhoffToPiola(kirchhoff_stress, displacement_gradient);
 }
-
-
 
 /// Constant body force model
 template <int dim>

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -161,6 +161,26 @@ auto KirchhoffToPiola(const tensor<T1, dim, dim>& kirchhoff_stress, const tensor
   return transpose(linear_solve(displacement_gradient + Identity<dim>(), kirchhoff_stress));
 }
 
+/**
+ * @brief Transform the Cauchy stress to the Piola stress
+ *
+ * @tparam T1 number-like type of the displacement gradient components
+ * @tparam T1 number-like type of the Cauchy stress components
+ * @tparam dim number of spatial dimensions
+ *
+ * @param displacement_gradient Displacement gradient
+ * @param cauchy_stress Cauchy stress
+ * @return Piola stress
+ */
+template <typename T1, typename T2, int dim>
+auto CauchyToPiola(const tensor<T1, dim, dim>& cauchy_stress, const tensor<T2, dim, dim>& displacement_gradient)
+{
+  auto kirchhoff_stress = det(displacement_gradient + Identity<dim>())*cauchy_stress;
+  return KirchhoffToPiola(kirchhoff_stress, displacement_gradient);
+}
+
+
+
 /// Constant body force model
 template <int dim>
 struct ConstantBodyForce {

--- a/src/serac/physics/materials/solid_functional_material.hpp
+++ b/src/serac/physics/materials/solid_functional_material.hpp
@@ -164,8 +164,8 @@ auto KirchhoffToPiola(const tensor<T1, dim, dim>& kirchhoff_stress, const tensor
 /**
  * @brief Transform the Cauchy stress to the Piola stress
  *
- * @tparam T1 number-like type of the displacement gradient components
  * @tparam T1 number-like type of the Cauchy stress components
+ * @tparam T2 number-like type of the displacement gradient components
  * @tparam dim number of spatial dimensions
  *
  * @param displacement_gradient Displacement gradient

--- a/src/serac/physics/tests/test_solid_functional_statics.cpp
+++ b/src/serac/physics/tests/test_solid_functional_statics.cpp
@@ -90,8 +90,8 @@ public:
     // natural BCs
     typename Material::State state;
     auto H = make_tensor<dim, dim>([&](int i, int j) { return A(i,j); });
-    tensor<double, dim, dim> tau = material(state, H);
-    auto P = solid_mechanics::KirchhoffToPiola(tau, H);
+    tensor<double, dim, dim> sigma = material(state, H);
+    auto P = solid_mechanics::CauchyToPiola(sigma, H);
     auto traction = [P](auto, auto n0, auto) { return dot(P, n0); };
     sf.setPiolaTraction(traction);
   }
@@ -250,7 +250,7 @@ TEST(SolidFunctional, PatchTest2dQ1TractionBcs)
 {
   constexpr int p = 1;
   constexpr int dim   = 2;
-  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Essential);
+  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Mixed_essential_and_natural);
   EXPECT_LT(error, tol);
 }
 
@@ -258,7 +258,7 @@ TEST(SolidFunctional, PatchTest3dQ1TractionBcs)
 {
   constexpr int p = 1;
   constexpr int dim   = 3;
-  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Essential);
+  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Mixed_essential_and_natural);
   EXPECT_LT(error, tol);
 }
 
@@ -266,7 +266,7 @@ TEST(SolidFunctional, PatchTest2dQ2TractionBcs)
 {
   constexpr int p = 2;
   constexpr int dim   = 2;
-  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Essential);
+  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Mixed_essential_and_natural);
   EXPECT_LT(error, tol);
 }
 
@@ -274,7 +274,7 @@ TEST(SolidFunctional, PatchTest3dQ2TractionBcs)
 {
   constexpr int p = 2;
   constexpr int dim   = 3;
-  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Essential);
+  double error = solution_error<p, dim>(AffineSolution<dim>(), PatchBoundaryCondition::Mixed_essential_and_natural);
   EXPECT_LT(error, tol);
 }
 


### PR DESCRIPTION
Sam noticed that I had accidentally turned off the patch tests that used traction loading. This turns them back on.

To be more precise, I had refactored the patch tests so that there is an `enum` determining whether the tests apply purely essential BCs, or a mixture of natural and essential BCs. Due to a copy and paste error, the natural-and-essential test cases were actually duplicates of the essential BC tests.

The traction tests should have failed when Jamie changed the stress measure from Kirchhoff to Cauchy. I verified that they did in fact fail when activated. This is good, as we want the tests to be sufficiently sensitive to catch common finite deformation mistakes like this. I then updated the stress transformation and now they now pass again, as expected.