### PR TITLE
Add check that processors contain boundary elements

### DIFF
--- a/src/serac/numerics/functional/dof_numbering.hpp
+++ b/src/serac/numerics/functional/dof_numbering.hpp
@@ -101,7 +101,7 @@ bool isL2(const mfem::ParFiniteElementSpace& fes)
 bool compatibleWithFaceRestriction(const mfem::ParFiniteElementSpace& fes)
 {
   return !(isHcurl(fes) && fes.GetMesh()->Dimension() == 2) && !(isHcurl(fes) && fes.GetMesh()->Dimension() == 3) &&
-         !(isL2(fes));
+         !(isL2(fes)) && fes.GetMesh()->GetNBE() > 0;
 }
 
 /**


### PR DESCRIPTION
This ensures the local processor contains boundary elements before constructing the face restriction operators.