### PR TITLE
clarify q-function requirements for solid mechanics module

### DIFF
--- a/scripts/spack/configs/linux_ubuntu_22/compilers.yaml
+++ b/scripts/spack/configs/linux_ubuntu_22/compilers.yaml
@@ -1,9 +1,9 @@
 compilers:
 - compiler:
-    spec: gcc@11.3.0
+    spec: gcc@12.1.0
     paths:
-      cc: /usr/bin/gcc
-      cxx: /usr/bin/g++
+      cc: /usr/bin/gcc-12
+      cxx: /usr/bin/g++-12
       f77: /usr/bin/gfortran
       fc: /usr/bin/gfortran
     flags: 

--- a/scripts/spack/configs/linux_ubuntu_22/packages.yaml
+++ b/scripts/spack/configs/linux_ubuntu_22/packages.yaml
@@ -14,7 +14,7 @@ packages:
     buildable: false
   mpich:
     externals:
-    - spec: mpich@3.3.2%gcc
+    - spec: mpich@4.0%gcc
       prefix: /usr
 
   # Lock down versions of packages we depend on

--- a/src/docs/doxygen/mainpage.md
+++ b/src/docs/doxygen/mainpage.md
@@ -3,8 +3,8 @@
 #### Physics Simulation Modules ####
 
 * [Base physics](@ref serac::BasePhysics)
-* [Heat Transfer](@ref serac::HeatTransfer)
-* [Solid mechanics](@ref serac::SolidMechanics)
+* [Heat Transfer](classserac_1_1HeatTransfer_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_00b10147e2187ea0fff3ed4d400f86c2eb.html)
+* [Solid mechanics](classserac_1_1SolidMechanics_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_0a4b58643425b41433838b2828455c49.html)
 * [Thermomechanics](@ref serac::Thermomechanics)
 
 #### Simulation Utilities ####
@@ -23,7 +23,7 @@
 
 #### Functional Interface ####
 
-* <a style="font-weight:bold" href="classserac_1_1Functional_3_01test_07trial_08_4.html">Functional</a>
+* [Functional](classserac_1_1Functional_3_01test_07trials_8_8_8_08_00_01exec_01_4.html)
 * [Domain integral](@ref serac::DomainIntegral)
 * [Boundary integral](@ref serac::BoundaryIntegral)
 

--- a/src/docs/doxygen/mainpage.md
+++ b/src/docs/doxygen/mainpage.md
@@ -3,8 +3,8 @@
 #### Physics Simulation Modules ####
 
 * [Base physics](@ref serac::BasePhysics)
-* <a style="font-weight:bold" href="classserac_1_1HeatTransfer_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_00b10147e2187ea0fff3ed4d400f86c2eb.html">Heat Transfer</a>
-* <a style="font-weight:bold" href="classserac_1_1SolidMechanics_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_0a4b58643425b41433838b2828455c49.html">Solid Mechanics</a>
+* [**Heat Transfer**][1]
+* [**Solid Mechanics**][2]
 * [Thermomechanics](@ref serac::Thermomechanics)
 
 #### Simulation Utilities ####
@@ -23,7 +23,7 @@
 
 #### Functional Interface ####
 
-* <a style="font-weight:bold" href="classserac_1_1Functional_3_01test_07trials_8_8_8_08_00_01exec_01_4.html">Functional</a>
+* [**Functional**][3]
 * [Domain integral](@ref serac::DomainIntegral)
 * [Boundary integral](@ref serac::BoundaryIntegral)
 
@@ -36,3 +36,8 @@
 * <a style="font-weight:bold" href="logger_8hpp.html">Logging</a>
 * <a style="font-weight:bold" href="profiling_8hpp.html">Profiling</a>
 * <a style="font-weight:bold" href="terminator_8hpp.html">Terminator</a>
+
+<!-- Reference Links -->
+[1]: classserac_1_1HeatTransfer_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_00b10147e2187ea0fff3ed4d400f86c2eb.html
+[2]: classserac_1_1SolidMechanics_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_0a4b58643425b41433838b2828455c49.html
+[3]: classserac_1_1Functional_3_01test_07trials_8_8_8_08_00_01exec_01_4.html

--- a/src/docs/doxygen/mainpage.md
+++ b/src/docs/doxygen/mainpage.md
@@ -3,8 +3,8 @@
 #### Physics Simulation Modules ####
 
 * [Base physics](@ref serac::BasePhysics)
-* [Heat Transfer](classserac_1_1HeatTransfer_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_00b10147e2187ea0fff3ed4d400f86c2eb.html)
-* [Solid mechanics](classserac_1_1SolidMechanics_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_0a4b58643425b41433838b2828455c49.html)
+* <a style="font-weight:bold" href="classserac_1_1HeatTransfer_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_00b10147e2187ea0fff3ed4d400f86c2eb.html">Heat Transfer</a>
+* <a style="font-weight:bold" href="classserac_1_1SolidMechanics_3_01order_00_01dim_00_01Parameters_3_01parameter__space_8_8_8_01_4_0a4b58643425b41433838b2828455c49.html">Solid Mechanics</a>
 * [Thermomechanics](@ref serac::Thermomechanics)
 
 #### Simulation Utilities ####
@@ -23,7 +23,7 @@
 
 #### Functional Interface ####
 
-* [Functional](classserac_1_1Functional_3_01test_07trials_8_8_8_08_00_01exec_01_4.html)
+* <a style="font-weight:bold" href="classserac_1_1Functional_3_01test_07trials_8_8_8_08_00_01exec_01_4.html">Functional</a>
 * [Domain integral](@ref serac::DomainIntegral)
 * [Boundary integral](@ref serac::BoundaryIntegral)
 

--- a/src/docs/sphinx/dev_guide/tensor_dual.rst
+++ b/src/docs/sphinx/dev_guide/tensor_dual.rst
@@ -321,7 +321,7 @@ Now let's consider a function that has multiple inputs and multiple outputs:
       auto strain_rate = 0.5 * (L + transpose(L));
       auto stress = - p * I + 2 * mu * strain_rate;
       auto kinetic_energy_density = 0.5 * p * dot(v, v);
-      return std::tuple{stress, kinetic_energy_density};
+      return serac::tuple{stress, kinetic_energy_density};
    };
 
 Here, ``f`` calculates the stress, :math:`\sigma`, and local kinetic energy density, :math:`q`, of a fluid in terms of
@@ -343,16 +343,16 @@ pattern as before:
    tensor<double,3,3> L = ...;
 
    // promote the arguments to dual numbers with make_dual()
-   std::tuple dual_args = make_dual(p, v, L);
+   tuple dual_args = make_dual(serac::tuple{p, v, L});
 
    // then call the function with the dual arguments
-   auto outputs = std::apply(f, dual_args);
+   auto outputs = apply(f, dual_args);
 
-   // note: std::apply is a way to pass an n-tuple to a function that expects n arguments 
+   // note: serac::apply is a way to pass an n-tuple to a function that expects n arguments 
    // 
    // i.e. the two following lines have the same effect
    // f(p, v, L);
-   // std::apply(f, std::tuple{p, v, L});
+   // serac::apply(f, serac::tuple{p, v, L});
 
 Like before, ``outputs`` will now contain the actual output values, but also all gradient terms (6, in this case).
 To get the gradient tensors, we call the same ``get_gradient()`` function:
@@ -378,25 +378,25 @@ the derivative of the :math:`i^{th}` output with respect to the :math:`j^{th}` i
    \frac{\partial q}{\partial L}
    \end{bmatrix}
 
-The type returned by ``get_gradient()`` reflects this structure: returning a ``std::tuple`` of ``std::tuple``.
+The type returned by ``get_gradient()`` reflects this structure: returning a ``serac::tuple`` of ``serac::tuple``.
 So for this example, the return type will be of the form:
 
 .. code-block:: cpp
 
-  std::tuple<
-    std::tuple< df1_dx1_type, df1_dx2_type, df1_dx2_type >, 
-    std::tuple< df2_dx1_type, df2_dx2_type, df2_dx2_type >
+  serac::tuple<
+    serac::tuple< df1_dx1_type, df1_dx2_type, df1_dx2_type >, 
+    serac::tuple< df2_dx1_type, df2_dx2_type, df2_dx2_type >
   >;
 
-The individual blocks can be accessed by using ``std::get()``.
+The individual blocks can be accessed by using ``serac::get()``.
 
 Finally, if we look at the actual types contained in ``get_gradient(output)`` we see a few interesting details:
 
 .. code-block:: cpp
 
-   std::tuple<
-     std::tuple<tensor<double, 3, 3>, zero,              tensor<double, 3, 3, 3, 3> >, 
-     std::tuple<zero,                 tensor<double, 3>, zero                       > 
+   serac::tuple<
+     serac::tuple<tensor<double, 3, 3>, zero,              tensor<double, 3, 3, 3, 3> >, 
+     serac::tuple<double,               tensor<double, 3>, zero                       > 
    > gradients = get_gradient(outputs);
 
 First, the tensor shapes of the individual blocks are are in agreement with what we expect (e.g. 

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -140,10 +140,11 @@ class Functional;
 /**
  * @brief Intended to be like @p std::function for finite element kernels
  *
- * That is: you tell it the inputs (trial spaces) for a kernel, and the outputs (test space) like @p std::function
+ * That is: you tell it the inputs (trial spaces) for a kernel, and the outputs (test space) like @p std::function.
+ *
  * For example, this code represents a function that takes an integer argument and returns a double:
  * @code{.cpp}
- * std::function< double(double, int) > my_func;
+ * std::function< double(int) > my_func;
  * @endcode
  * And this represents a function that takes values from an Hcurl field and returns a
  * residual vector associated with an H1 field:

--- a/src/serac/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
@@ -95,14 +95,13 @@ TEST(TupleArithmeticUnitTests, TensorOutputWithTupleInput)
   EXPECT_NEAR(norm(df1 - df0) / norm(df0), 0.0, 2.0e-8);
 }
 
-
 TEST(TupleArithmeticUnitTests, ReadTheDocsExample)
 {
-  auto f = [=](auto p, auto v, auto L){
-     auto strain_rate = 0.5 * (L + transpose(L));
-     auto stress = - p * I + 2 * mu * strain_rate;
-     auto kinetic_energy_density = 0.5 * p * dot(v, v);
-     return tuple{stress, kinetic_energy_density};
+  auto f = [=](auto p, auto v, auto L) {
+    auto strain_rate            = 0.5 * (L + transpose(L));
+    auto stress                 = -p * I + 2 * mu * strain_rate;
+    auto kinetic_energy_density = 0.5 * p * dot(v, v);
+    return tuple{stress, kinetic_energy_density};
   };
 
   [[maybe_unused]] constexpr double p = 3.14;
@@ -122,13 +121,10 @@ TEST(TupleArithmeticUnitTests, ReadTheDocsExample)
   auto outputs = apply(f, dual_args);
 
   // verify that the derivative types are what we expect
-  [[maybe_unused]] tuple<
-    tuple<tensor<double, 3, 3>, zero,              tensor<double, 3, 3, 3, 3> >,
-    tuple<double,               tensor<double, 3>, zero                       >
-  > gradients = get_gradient(outputs);
-
+  [[maybe_unused]] tuple<tuple<tensor<double, 3, 3>, zero, tensor<double, 3, 3, 3, 3> >,
+                         tuple<double, tensor<double, 3>, zero> >
+      gradients = get_gradient(outputs);
 }
-
 
 int main(int argc, char* argv[])
 {

--- a/src/serac/numerics/functional/tuple_arithmetic.hpp
+++ b/src/serac/numerics/functional/tuple_arithmetic.hpp
@@ -188,11 +188,8 @@ SERAC_HOST_DEVICE constexpr auto make_dual(const tuple<T0, T1>& args)
 template <typename T0, typename T1, typename T2>
 SERAC_HOST_DEVICE constexpr auto make_dual(const tuple<T0, T1, T2>& args)
 {
-  return tuple{
-    make_dual_helper<0, 3>(get<0>(args)), 
-    make_dual_helper<1, 3>(get<1>(args)), 
-    make_dual_helper<2, 3>(get<2>(args))
-  };
+  return tuple{make_dual_helper<0, 3>(get<0>(args)), make_dual_helper<1, 3>(get<1>(args)),
+               make_dual_helper<2, 3>(get<2>(args))};
 }
 
 /**

--- a/src/serac/numerics/functional/tuple_arithmetic.hpp
+++ b/src/serac/numerics/functional/tuple_arithmetic.hpp
@@ -184,6 +184,17 @@ SERAC_HOST_DEVICE constexpr auto make_dual(const tuple<T0, T1>& args)
   return tuple{make_dual_helper<0, 2>(get<0>(args)), make_dual_helper<1, 2>(get<1>(args))};
 }
 
+/// @overload
+template <typename T0, typename T1, typename T2>
+SERAC_HOST_DEVICE constexpr auto make_dual(const tuple<T0, T1, T2>& args)
+{
+  return tuple{
+    make_dual_helper<0, 3>(get<0>(args)), 
+    make_dual_helper<1, 3>(get<1>(args)), 
+    make_dual_helper<2, 3>(get<2>(args))
+  };
+}
+
 /**
  * @brief a function that optionally (decided at compile time) converts a value to its dual type
  *

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -353,11 +353,12 @@ public:
    *    1. `MaterialType::State & state` an mutable reference to the internal variables for this quadrature point
    *    2. `tensor<T,dim,dim> du_dx` the displacement gradient at this quadrature point
    *    3. `tuple{value, derivative}`, a tuple of values and derivatives for each parameter field
-   *            specified in the `DependsOn<...>` argument. 
+   *            specified in the `DependsOn<...>` argument.
    *
    * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>, 3>`) 
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
+   * 3>`)
    *
    * @param qdata the buffer of material internal variables at each quadrature point
    *
@@ -472,11 +473,12 @@ public:
    * @pre body_force must be a object that can be called with the following arguments:
    *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
    *    2. `double t` the time (note: time will be handled differently in the future)
-   *    3. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative), 
-   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument. 
+   *    3. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative),
+   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument.
    * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>, 3>`) 
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
+   * 3>`)
    *
    */
   template <int... active_parameters, typename BodyForceType>
@@ -511,12 +513,13 @@ public:
    *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
    *    2. `tensor<T,dim> n` the outward-facing unit normal for the quadrature point
    *    3. `double t` the time (note: time will be handled differently in the future)
-   *    4. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative), 
-   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument. 
+   *    4. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative),
+   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument.
    *
    * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>, 3>`) 
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
+   * 3>`)
    *
    * @note: until mfem::GetFaceGeometricFactors implements their JACOBIANS option,
    * (or we implement a replacement kernel ourselves) we are not able to compute

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -350,9 +350,9 @@ public:
    * @tparam StateType the type that contains the internal variables for MaterialType
    * @param material A material that provides a function to evaluate stress
    * @pre body_force must be a object that can be called with the following arguments:
-   *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
-   *    2. `double t` the time (note: time will be handled differently in the future)
-   *    3+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces
+   *    1. `MaterialType::State & state` an mutable reference to the internal variables for this quadrature point
+   *    2. `tensor<T,dim,dim> du_dx` the displacement gradient at this quadrature point
+   *    3. `tuple{value, derivative}`, a tuple of values and derivatives for each parameter field
    *            specified in the `DependsOn<...>` argument. 
    *
    * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -349,6 +349,16 @@ public:
    * @tparam MaterialType The solid material type
    * @tparam StateType the type that contains the internal variables for MaterialType
    * @param material A material that provides a function to evaluate stress
+   * @pre body_force must be a object that can be called with the following arguments:
+   *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
+   *    2. `double t` the time (note: time will be handled differently in the future)
+   *    3+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces
+   *            specified in the `DependsOn<...>` argument. 
+   *
+   *    The actual types of these arguments will be `double`, `tensor<double, ... >` or tuples thereof
+   *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
+   *
    * @param qdata the buffer of material internal variables at each quadrature point
    *
    * @pre MaterialType must have a public member variable `density`
@@ -459,7 +469,15 @@ public:
    * @brief Set the body forcefunction
    *
    * @tparam BodyForceType The type of the body force load
-   * @param body_force A source function for a prescribed body load
+   * @pre body_force must be a object that can be called with the following arguments:
+   *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
+   *    2. `double t` the time (note: time will be handled differently in the future)
+   *    3+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces
+   *            specified in the `DependsOn<...>` argument. 
+   *
+   *    The actual types of these arguments will be `double`, `tensor<double, ... >` or tuples thereof
+   *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
    *
    * @pre BodyForceType must have the operator (x, time) defined as the body force
    */
@@ -491,7 +509,16 @@ public:
    * @tparam TractionType The type of the traction load
    * @param traction_function A function describing the traction applied to a boundary
    *
-   * @pre TractionType must have the operator (x, normal, time) to return the thermal flux value
+   * @pre TractionType must be a object that can be called with the following arguments:
+   *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
+   *    2. `tensor<T,dim> n` the outward-facing unit normal for the quadrature point
+   *    3. `double t` the time (note: time will be handled differently in the future)
+   *    4+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces
+   *            specified in the `DependsOn<...>` argument. 
+   *
+   *    The actual types of these arguments will be `double`, `tensor<double, ... >` or tuples thereof
+   *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
    *
    * @note: until mfem::GetFaceGeometricFactors implements their JACOBIANS option,
    * (or we implement a replacement kernel ourselves) we are not able to compute

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -357,7 +357,7 @@ public:
    *
    * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>, 3>`) 
    *
    * @param qdata the buffer of material internal variables at each quadrature point
    *
@@ -476,7 +476,7 @@ public:
    *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument. 
    * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>, 3>`) 
    *
    */
   template <int... active_parameters, typename BodyForceType>
@@ -516,7 +516,7 @@ public:
    *
    * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>, 3>`) 
    *
    * @note: until mfem::GetFaceGeometricFactors implements their JACOBIANS option,
    * (or we implement a replacement kernel ourselves) we are not able to compute

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -349,7 +349,7 @@ public:
    * @tparam MaterialType The solid material type
    * @tparam StateType the type that contains the internal variables for MaterialType
    * @param material A material that provides a function to evaluate stress
-   * @pre body_force must be a object that can be called with the following arguments:
+   * @pre material must be a object that can be called with the following arguments:
    *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
    *    2. `double t` the time (note: time will be handled differently in the future)
    *    3+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -355,7 +355,7 @@ public:
    *    3+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces
    *            specified in the `DependsOn<...>` argument. 
    *
-   *    The actual types of these arguments will be `double`, `tensor<double, ... >` or tuples thereof
+   * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
    *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
    *
@@ -472,14 +472,12 @@ public:
    * @pre body_force must be a object that can be called with the following arguments:
    *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
    *    2. `double t` the time (note: time will be handled differently in the future)
-   *    3+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces
-   *            specified in the `DependsOn<...>` argument. 
-   *
-   *    The actual types of these arguments will be `double`, `tensor<double, ... >` or tuples thereof
+   *    3. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative), 
+   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument. 
+   * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
    *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
    *
-   * @pre BodyForceType must have the operator (x, time) defined as the body force
    */
   template <int... active_parameters, typename BodyForceType>
   void addBodyForce(DependsOn<active_parameters...>, BodyForceType body_force)
@@ -513,10 +511,10 @@ public:
    *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
    *    2. `tensor<T,dim> n` the outward-facing unit normal for the quadrature point
    *    3. `double t` the time (note: time will be handled differently in the future)
-   *    4+. `tuple{value, derivative}`, a tuple of values and derivatives for each of the trial spaces
-   *            specified in the `DependsOn<...>` argument. 
+   *    4. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative), 
+   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument. 
    *
-   *    The actual types of these arguments will be `double`, `tensor<double, ... >` or tuples thereof
+   * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
    *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
    *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` -> `tensor<dual<...>, 3>`) 
    *


### PR DESCRIPTION
Also update the links on the doxygen main page to point to the actual physics modules, rather than empty forward declarations.