### PR TITLE
Fix the `generateParFiniteElementSpace` memory leak

### DIFF
--- a/src/serac/numerics/functional/tests/functional_basic_h1_vector.cpp
+++ b/src/serac/numerics/functional/tests/functional_basic_h1_vector.cpp
@@ -42,13 +42,13 @@ void weird_mixed_test()
 
   auto mesh = mesh::refineAndDistribute(buildMeshFromFile(meshfile), 1);
 
-  auto trial_fes = generateParFiniteElementSpace<trial_space>(mesh.get());
-  auto test_fes  = generateParFiniteElementSpace<test_space>(mesh.get());
+  auto [trial_fes, trial_col] = generateParFiniteElementSpace<trial_space>(mesh.get());
+  auto [test_fes, test_col]   = generateParFiniteElementSpace<test_space>(mesh.get());
 
   mfem::Vector U(trial_fes->TrueVSize());
   U.Randomize();
 
-  Functional<test_space(trial_space)> residual(test_fes, {trial_fes});
+  Functional<test_space(trial_space)> residual(test_fes.get(), {trial_fes.get()});
 
   auto d11 =
       1.0 * make_tensor<dim + 1, dim, dim + 2, dim>([](int i, int j, int k, int l) { return i - j + 2 * k - 3 * l; });
@@ -77,9 +77,6 @@ void weird_mixed_test()
       *mesh);
 
   check_gradient(residual, U);
-
-  delete test_fes;
-  delete trial_fes;
 }
 
 template <int p, int dim>
@@ -99,13 +96,13 @@ void elasticity_test()
 
   auto mesh = mesh::refineAndDistribute(buildMeshFromFile(meshfile), 1);
 
-  auto trial_fes = generateParFiniteElementSpace<trial_space>(mesh.get());
-  auto test_fes  = generateParFiniteElementSpace<test_space>(mesh.get());
+  auto [trial_fes, trial_col] = generateParFiniteElementSpace<trial_space>(mesh.get());
+  auto [test_fes, test_col]   = generateParFiniteElementSpace<test_space>(mesh.get());
 
   mfem::Vector U(trial_fes->TrueVSize());
   U.Randomize();
 
-  Functional<test_space(trial_space)> residual(test_fes, {trial_fes});
+  Functional<test_space(trial_space)> residual(test_fes.get(), {trial_fes.get()});
 
   [[maybe_unused]] auto d00 = make_tensor<dim, dim>([](int i, int j) { return i + 2 * j + 1; });
   [[maybe_unused]] auto d01 = make_tensor<dim, dim, dim>([](int i, int j, int k) { return i + 2 * j - k + 1; });
@@ -135,9 +132,6 @@ void elasticity_test()
       *mesh);
 
   check_gradient(residual, U);
-
-  delete test_fes;
-  delete trial_fes;
 }
 
 TEST(basic, weird_mixed_test_2D) { weird_mixed_test<1, 2>(); }

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -302,6 +302,9 @@ protected:
     /// The trial spaces used for the Functional object
     std::unique_ptr<mfem::ParFiniteElementSpace> trial_space;
 
+    /// The collections needed for the parameter finite element space
+    std::unique_ptr<mfem::FiniteElementCollection> trial_collection;
+
     /// The finite element states representing user-defined and owned parameter fields
     serac::FiniteElementState* state;
 

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -144,8 +144,10 @@ public:
     if constexpr (sizeof...(parameter_space) > 0) {
       tuple<parameter_space...> types{};
       for_constexpr<sizeof...(parameter_space)>([&](auto i) {
-        parameters_[i].trial_space = std::unique_ptr<mfem::ParFiniteElementSpace>(
-            generateParFiniteElementSpace<typename std::remove_reference<decltype(get<i>(types))>::type>(&mesh_));
+        auto [fes, fec] =
+            generateParFiniteElementSpace<typename std::remove_reference<decltype(get<i>(types))>::type>(&mesh_);
+        parameters_[i].trial_space       = std::move(fes);
+        parameters_[i].trial_collection  = std::move(fec);
         trial_spaces[i + NUM_STATE_VARS] = parameters_[i].trial_space.get();
       });
     }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -156,8 +156,10 @@ public:
     if constexpr (sizeof...(parameter_space) > 0) {
       tuple<parameter_space...> types{};
       for_constexpr<sizeof...(parameter_space)>([&](auto i) {
-        parameters_[i].trial_space = std::unique_ptr<mfem::ParFiniteElementSpace>(
-            generateParFiniteElementSpace<typename std::remove_reference<decltype(get<i>(types))>::type>(&mesh_));
+        auto [fes, fec] =
+            generateParFiniteElementSpace<typename std::remove_reference<decltype(get<i>(types))>::type>(&mesh_);
+        parameters_[i].trial_space       = std::move(fes);
+        parameters_[i].trial_collection  = std::move(fec);
         trial_spaces[i + NUM_STATE_VARS] = parameters_[i].trial_space.get();
       });
     }


### PR DESCRIPTION
Before this fix, the `FiniteElementCollection` constructed by the `generateParFiniteElementSpace` method would be leaked. This fix returns both the `ParFiniteElementSpace` and the associated `FiniteElementCollection` as unique pointers to ensure no memory is leaked.