### PR TITLE
Force at least one linear solve per nonlinear solve

### DIFF
--- a/src/serac/numerics/CMakeLists.txt
+++ b/src/serac/numerics/CMakeLists.txt
@@ -14,6 +14,7 @@ set(numerics_headers
     equation_solver.hpp
     expr_template_impl.hpp
     expr_template_ops.hpp
+    newton_solver.hpp
     odes.hpp
     quadrature_data.hpp
     solver_config.hpp
@@ -23,6 +24,7 @@ set(numerics_headers
 
 set(numerics_sources
     equation_solver.cpp
+    newton_solver.cpp
     quadrature_data.cpp
     odes.cpp
     )

--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -8,6 +8,7 @@
 
 #include "serac/infrastructure/logger.hpp"
 #include "serac/infrastructure/terminator.hpp"
+#include "serac/numerics/newton_solver.hpp"
 
 namespace serac::mfem_ext {
 
@@ -156,7 +157,7 @@ std::unique_ptr<mfem::NewtonSolver> EquationSolver::BuildNewtonSolver(MPI_Comm  
   std::unique_ptr<mfem::NewtonSolver> newton_solver;
 
   if (nonlin_options.nonlin_solver == NonlinearSolver::MFEMNewton) {
-    newton_solver = std::make_unique<mfem::NewtonSolver>(comm);
+    newton_solver = std::make_unique<serac::mfem_ext::NewtonSolver>(comm);
   }
   // KINSOL
   else {

--- a/src/serac/numerics/newton_solver.cpp
+++ b/src/serac/numerics/newton_solver.cpp
@@ -1,0 +1,105 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "serac/numerics/newton_solver.hpp"
+#include "serac/infrastructure/logger.hpp"
+
+namespace serac::mfem_ext {
+
+void NewtonSolver::Mult(const mfem::Vector& b, mfem::Vector& x) const
+{
+  MFEM_ASSERT(oper != NULL, "the Operator is not set (use SetOperator).");
+  MFEM_ASSERT(prec != NULL, "the Solver is not set (use SetSolver).");
+
+  int        it;
+  double     norm0, norm, norm_goal;
+  const bool have_b = (b.Size() == Height());
+
+  if (!iterative_mode) {
+    x = 0.0;
+  }
+
+  ProcessNewState(x);
+
+  oper->Mult(x, r);
+  if (have_b) {
+    r -= b;
+  }
+
+  norm0 = norm = Norm(r);
+  if (print_options.first_and_last && !print_options.iterations) {
+    mfem::out << "Newton iteration " << std::setw(2) << 0 << " : ||r|| = " << norm << "...\n";
+  }
+  norm_goal = std::max(rel_tol * norm, abs_tol);
+
+  prec->iterative_mode = false;
+
+  // x_{i+1} = x_i - [DF(x_i)]^{-1} [F(x_i)-b]
+  for (it = 0; true; it++) {
+    SLIC_ERROR_ROOT_IF(!mfem::IsFinite(norm), axom::fmt::format("norm = {}", norm));
+    if (print_options.iterations) {
+      mfem::out << "Newton iteration " << std::setw(2) << it << " : ||r|| = " << norm;
+      if (it > 0) {
+        mfem::out << ", ||r||/||r_0|| = " << norm / norm0;
+      }
+      mfem::out << '\n';
+    }
+    Monitor(it, norm, r, x);
+
+    if (norm <= norm_goal) {
+      // Ensure that at least 1 linear solve occurs for each Newton solve
+      if (it > 0 || !force_linear_solve_) {
+        converged = true;
+        break;
+      }
+    }
+
+    if (it >= max_iter) {
+      converged = false;
+      break;
+    }
+
+    grad = &oper->GetGradient(x);
+    prec->SetOperator(*grad);
+
+    if (lin_rtol_type) {
+      AdaptiveLinRtolPreSolve(x, it, norm);
+    }
+
+    prec->Mult(r, c);  // c = [DF(x_i)]^{-1} [F(x_i)-b]
+
+    if (lin_rtol_type) {
+      AdaptiveLinRtolPostSolve(c, r, it, norm);
+    }
+
+    const double c_scale = ComputeScalingFactor(x, b);
+    if (c_scale == 0.0) {
+      converged = false;
+      break;
+    }
+    add(x, -c_scale, c, x);
+
+    ProcessNewState(x);
+
+    oper->Mult(x, r);
+    if (have_b) {
+      r -= b;
+    }
+    norm = Norm(r);
+  }
+
+  final_iter = it;
+  final_norm = norm;
+
+  if (print_options.summary || (!converged && print_options.warnings) || print_options.first_and_last) {
+    mfem::out << "Newton: Number of iterations: " << final_iter << '\n' << "   ||r|| = " << final_norm << '\n';
+  }
+  if (!converged && (print_options.summary || print_options.warnings)) {
+    mfem::out << "Newton: No convergence!\n";
+  }
+}
+
+}  // namespace serac::mfem_ext

--- a/src/serac/numerics/newton_solver.hpp
+++ b/src/serac/numerics/newton_solver.hpp
@@ -7,14 +7,14 @@
 /**
  * @file newton_solver.hpp
  *
- * @brief This file contains the declaration of an modified version of MFEM's newton solver
+ * @brief This file contains the declaration of an modified version of MFEM's native newton solver
  */
 
 #include "mfem.hpp"
 
 namespace serac::mfem_ext {
 
-/// Newton's method for solving F(x)=b for a given operator F.
+/// Newton's method for solving F(x)=b for a given nonlinear operator F.
 /** This is a slightly modified version of MFEM's native Newton
  * solver. By default, it forces one linear solve as opposed to only performing a
  * residual calculation if the initial residual is low.

--- a/src/serac/numerics/newton_solver.hpp
+++ b/src/serac/numerics/newton_solver.hpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2019-2022, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file newton_solver.hpp
+ *
+ * @brief This file contains the declaration of an modified version of MFEM's newton solver
+ */
+
+#include "mfem.hpp"
+
+namespace serac::mfem_ext {
+
+/// Newton's method for solving F(x)=b for a given operator F.
+/** This is a slightly modified version of MFEM's native Newton
+ * solver. By default, it forces one linear solve as opposed to only performing a
+ * residual calculation if the initial residual is low.
+ */
+class NewtonSolver : public mfem::NewtonSolver {
+public:
+  /**
+   * @brief Construct a new Newton Solver object
+   *
+   * @param communicator The MPI communicator for the global reductions in the solver
+   * @param force_linear_solve Flag to force the newton solver to perform at least one linear solve
+   */
+  NewtonSolver(MPI_Comm communicator, bool force_linear_solve = true)
+      : mfem::NewtonSolver(communicator), force_linear_solve_(force_linear_solve)
+  {
+  }
+
+  /// Solve the nonlinear system with right-hand side @a b.
+  /** If `b.Size() != Height()`, then @a b is assumed to be zero. */
+  void Mult(const mfem::Vector& b, mfem::Vector& x) const override;
+
+protected:
+  /// @brief Flag denoting whether to force a single linear solve even if the residual is low at iteration zero
+  bool force_linear_solve_;
+};
+
+}  // namespace serac::mfem_ext


### PR DESCRIPTION
This creates a modified version of the native `mfem::NewtonSolver` that optionally forces at least one linear solve per nonlinear solve. This is needed for downstream optimization customers to avoid the optimizer thinking it has hit a flat response of the parameter fields.