### PR TITLE
Patched Reactions Dual Construction in SolidMechanics

### DIFF
--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -126,7 +126,7 @@ public:
                                                                .vector_dim = mesh_.Dimension(),
                                                                .name = detail::addPrefix(name, "adjoint_displacement")},
                                    sidre_datacoll_id_)),
-        reactions_(StateManager::newDual(displacement_.space(), "reactions")),
+        reactions_(StateManager::newDual(displacement_.space(), detail::addPrefix(name, "reactions"))),
         ode2_(displacement_.space().TrueVSize(),
               {.time = ode_time_point_, .c0 = c0_, .c1 = c1_, .u = u_, .du_dt = du_dt_, .d2u_dt2 = previous_},
               nonlin_solver_, bcs_),


### PR DESCRIPTION
This MR prepends the name of the SolidMechanics object to the "reactions" dual for consistency with the other named states in the state manager.