### PR TITLE
Use the correct integration rule for runtime spaces

### DIFF
--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -281,7 +281,7 @@ public:
     }
 
     const mfem::FiniteElement&   el = *test_space_->GetFE(0);
-    const mfem::IntegrationRule& ir = mfem::IntRules.Get(el.GetGeomType(), el.GetOrder() * 2);
+    const mfem::IntegrationRule& ir = mfem::IntRules.Get(el.GetGeomType(), (Q - 1) * 2);
 
     constexpr auto flags = mfem::GeometricFactors::COORDINATES | mfem::GeometricFactors::JACOBIANS;
 
@@ -316,8 +316,7 @@ public:
       SLIC_ERROR_ROOT_IF(domain.GetBdrElementType(e) != supported_types[dim], "Mesh contains unsupported element type");
     }
 
-    const mfem::FiniteElement&   el = *test_space_->GetFE(0);
-    const mfem::IntegrationRule& ir = mfem::IntRules.Get(supported_types[dim], el.GetOrder() * 2);
+    const mfem::IntegrationRule& ir = mfem::IntRules.Get(supported_types[dim], (Q - 1) * 2);
     constexpr auto flags = mfem::FaceGeometricFactors::COORDINATES | mfem::FaceGeometricFactors::DETERMINANTS |
                            mfem::FaceGeometricFactors::NORMALS;
 

--- a/src/serac/numerics/functional/functional_qoi.inl
+++ b/src/serac/numerics/functional/functional_qoi.inl
@@ -169,7 +169,7 @@ public:
     }
 
     const mfem::FiniteElement&   el = *trial_space_[0]->GetFE(0);
-    const mfem::IntegrationRule& ir = mfem::IntRules.Get(el.GetGeomType(), el.GetOrder() * 2);
+    const mfem::IntegrationRule& ir = mfem::IntRules.Get(el.GetGeomType(), (Q - 1) * 2);
 
     constexpr auto flags = mfem::GeometricFactors::COORDINATES | mfem::GeometricFactors::JACOBIANS;
     auto           geom  = domain.GetGeometricFactors(ir, flags);
@@ -203,8 +203,7 @@ public:
       SLIC_ERROR_ROOT_IF(domain.GetBdrElementType(e) != supported_types[dim], "Mesh contains unsupported element type");
     }
 
-    const mfem::FiniteElement&   el = *trial_space_[0]->GetBE(0);
-    const mfem::IntegrationRule& ir = mfem::IntRules.Get(supported_types[dim], el.GetOrder() * 2);
+    const mfem::IntegrationRule& ir = mfem::IntRules.Get(supported_types[dim], (Q - 1) * 2);
     constexpr auto flags = mfem::FaceGeometricFactors::COORDINATES | mfem::FaceGeometricFactors::DETERMINANTS |
                            mfem::FaceGeometricFactors::NORMALS;
 

--- a/src/serac/numerics/functional/tests/functional_qoi.cpp
+++ b/src/serac/numerics/functional/tests/functional_qoi.cpp
@@ -528,7 +528,9 @@ TEST(QoI, ShapeAndParameter)
   std::unique_ptr<mfem::HypreParVector> parameter(parameter_fe_space->NewTrueDofVector());
   *parameter = 0.1;
 
-  serac_qoi->operator()(*shape, *parameter);
+  double val = serac_qoi->operator()(*shape, *parameter);
+
+  EXPECT_NEAR(val, 0.8, 1.0e-14);
 }
 
 // clang-format off

--- a/src/serac/numerics/functional/tests/functional_qoi.cpp
+++ b/src/serac/numerics/functional/tests/functional_qoi.cpp
@@ -497,6 +497,40 @@ TEST(QoI, UsingL2)
   check_gradient(f, *U0, *U1);
 }
 
+TEST(QoI, ShapeAndParameter)
+{
+  static constexpr int dim{3};
+  using shape_space     = H1<2, dim>;
+  using parameter_space = H1<1>;
+
+  using qoi_type = serac::Functional<double(shape_space, parameter_space)>;
+
+  mfem::ParMesh& mesh = *mesh3D;
+
+  auto [shape_fe_space, shape_fe_coll]         = generateParFiniteElementSpace<shape_space>(&mesh);
+  auto [parameter_fe_space, parameter_fe_coll] = generateParFiniteElementSpace<parameter_space>(&mesh);
+
+  std::array<const mfem::ParFiniteElementSpace*, 2> trial_fes = {shape_fe_space.get(), parameter_fe_space.get()};
+
+  auto serac_qoi = std::make_unique<qoi_type>(trial_fes);
+  serac_qoi->AddDomainIntegral(
+      serac::Dimension<dim>{}, serac::DependsOn<0, 1>{},
+      [](auto, auto X, auto param) {
+        auto dp_dx = serac::get<1>(X);
+        auto I     = serac::Identity<dim>();
+        return serac::get<0>(param) * serac::det(dp_dx + I);
+      },
+      mesh);
+
+  std::unique_ptr<mfem::HypreParVector> shape(shape_fe_space->NewTrueDofVector());
+  *shape = 1.0;
+
+  std::unique_ptr<mfem::HypreParVector> parameter(parameter_fe_space->NewTrueDofVector());
+  *parameter = 0.1;
+
+  serac_qoi->operator()(*shape, *parameter);
+}
+
 // clang-format off
 TEST(Measure, 2DLinear   ) { qoi_test(*mesh2D, H1<1>{}, Dimension<2>{}, WhichTest::Measure); }
 TEST(Measure, 2DQuadratic) { qoi_test(*mesh2D, H1<2>{}, Dimension<2>{}, WhichTest::Measure); }


### PR DESCRIPTION
This fixes a bug where the runtime (MFEM) integration rule was calculated incorrectly for multiple trial spaces of different order. It also adds a test based on @kswartz92 's reproducer.