### PR TITLE
Simplify finite element state creation

### DIFF
--- a/src/serac/physics/state/finite_element_vector.cpp
+++ b/src/serac/physics/state/finite_element_vector.cpp
@@ -16,20 +16,20 @@ FiniteElementVector::FiniteElementVector(mfem::ParMesh& mesh, FiniteElementVecto
   const auto ordering = mfem::Ordering::byNODES;
 
   switch (options.element_type) {
-    case Family::H1:
+    case ElementType::H1:
       coll_ = std::make_unique<mfem::H1_FECollection>(options.order, dim);
       break;
-    case Family::HCURL:
+    case ElementType::HCURL:
       coll_ = std::make_unique<mfem::ND_FECollection>(options.order, dim);
       SLIC_WARNING_ROOT_IF(options.vector_dim != 1,
                            axom::fmt::format("Vector dim >1 requested for an HCURL basis function."));
       break;
-    case Family::HDIV:
+    case ElementType::HDIV:
       coll_ = std::make_unique<mfem::RT_FECollection>(options.order, dim);
       SLIC_WARNING_ROOT_IF(options.vector_dim != 1,
                            axom::fmt::format("Vector dim >1 requested for an HDIV basis function."));
       break;
-    case Family::L2:
+    case ElementType::L2:
       coll_ = std::make_unique<mfem::L2_FECollection>(options.order, dim);
       break;
     default:

--- a/src/serac/physics/state/finite_element_vector.cpp
+++ b/src/serac/physics/state/finite_element_vector.cpp
@@ -10,13 +10,35 @@
 namespace serac {
 
 FiniteElementVector::FiniteElementVector(mfem::ParMesh& mesh, FiniteElementVector::Options&& options)
-    : mesh_(mesh),
-      coll_(options.coll ? std::move(options.coll)
-                         : std::make_unique<mfem::H1_FECollection>(options.order, mesh.Dimension())),
-      space_(std::make_unique<mfem::ParFiniteElementSpace>(&mesh, coll_.get(), options.vector_dim,
-                                                           mfem::Ordering::byNODES)),
-      name_(options.name)
+    : mesh_(mesh), name_(options.name)
 {
+  const int  dim      = mesh.Dimension();
+  const auto ordering = mfem::Ordering::byNODES;
+
+  switch (options.element_type) {
+    case Family::H1:
+      coll_ = std::make_unique<mfem::H1_FECollection>(options.order, dim);
+      break;
+    case Family::HCURL:
+      coll_ = std::make_unique<mfem::ND_FECollection>(options.order, dim);
+      SLIC_WARNING_ROOT_IF(options.vector_dim != 1,
+                           axom::fmt::format("Vector dim >1 requested for an HCURL basis function."));
+      break;
+    case Family::HDIV:
+      coll_ = std::make_unique<mfem::RT_FECollection>(options.order, dim);
+      SLIC_WARNING_ROOT_IF(options.vector_dim != 1,
+                           axom::fmt::format("Vector dim >1 requested for an HDIV basis function."));
+      break;
+    case Family::L2:
+      coll_ = std::make_unique<mfem::L2_FECollection>(options.order, dim);
+      break;
+    default:
+      SLIC_ERROR_ROOT(axom::fmt::format("Finite element vector requested for unavailable basis type."));
+      break;
+  }
+
+  space_ = std::make_unique<mfem::ParFiniteElementSpace>(&mesh, coll_.get(), options.vector_dim, ordering);
+
   // Construct a hypre par vector based on the new finite element space
   HypreParVector new_vector(space_.get());
 

--- a/src/serac/physics/state/finite_element_vector.hpp
+++ b/src/serac/physics/state/finite_element_vector.hpp
@@ -18,7 +18,6 @@
 #include "mfem.hpp"
 
 #include "serac/infrastructure/variant.hpp"
-#include "serac/numerics/functional/functional.hpp"
 
 namespace serac {
 
@@ -26,6 +25,17 @@ namespace serac {
  * @brief A sum type for encapsulating either a scalar or vector coeffient
  */
 using GeneralCoefficient = variant<std::shared_ptr<mfem::Coefficient>, std::shared_ptr<mfem::VectorCoefficient>>;
+
+/// @brief The type of a finite element basis function
+/// @note This class is used instead of the Family class from functional do to incompatibilities with Vector expression
+/// templates and the dual number class.
+enum class ElementType
+{
+  H1,     ///< Nodal scalar valued basis functions
+  HCURL,  ///< Nedelec (continuous tangent) vector-valued basis functions
+  HDIV,   ///< Raviart-Thomas (continuous normal) vector-valued basis functions
+  L2      ///< Discontinuous scalar valued basis functions
+};
 
 /**
  * @brief Class for encapsulating the data associated with a vector derived
@@ -58,7 +68,7 @@ public:
      *
      * Options are H1, HCURL, HDIV, or L2.
      */
-    Family element_type = Family::H1;
+    ElementType element_type = ElementType::H1;
 
     /**
      * @brief The name of the field encapsulated by the state object
@@ -73,7 +83,7 @@ public:
    * the dimension of the FESpace, the type of basis functions, and the name of the field
    */
   FiniteElementVector(mfem::ParMesh& mesh,
-                      Options&&      options = {.order = 1, .vector_dim = 1, .element_type = Family::H1, .name = ""});
+                      Options&& options = {.order = 1, .vector_dim = 1, .element_type = ElementType::H1, .name = ""});
 
   /**
    * @brief Minimal constructor for a FiniteElementVector given a finite element space

--- a/src/serac/physics/state/finite_element_vector.hpp
+++ b/src/serac/physics/state/finite_element_vector.hpp
@@ -64,7 +64,7 @@ public:
     int vector_dim = 1;
 
     /**
-     * @brief Enum deoniting type of basis functions to use
+     * @brief Enum denoting type of basis functions to use
      *
      * Options are H1, HCURL, HDIV, or L2.
      */

--- a/src/serac/physics/state/finite_element_vector.hpp
+++ b/src/serac/physics/state/finite_element_vector.hpp
@@ -18,6 +18,7 @@
 #include "mfem.hpp"
 
 #include "serac/infrastructure/variant.hpp"
+#include "serac/numerics/functional/functional.hpp"
 
 namespace serac {
 
@@ -51,10 +52,14 @@ public:
      * Defaults to scalar valued spaces.
      */
     int vector_dim = 1;
+
     /**
-     * @brief The FECollection to use - defaults to an H1_FECollection
+     * @brief Enum deoniting type of basis functions to use
+     *
+     * Options are H1, HCURL, HDIV, or L2.
      */
-    std::unique_ptr<mfem::FiniteElementCollection> coll = {};
+    Family element_type = Family::H1;
+
     /**
      * @brief The name of the field encapsulated by the state object
      */
@@ -65,10 +70,10 @@ public:
    * @brief Main constructor for building a new finite element vector
    * @param[in] mesh The problem mesh (object does not take ownership)
    * @param[in] options The options specified, namely those relating to the order of the problem,
-   * the dimension of the FESpace, the type of FEColl, the DOF ordering that should be used,
-   * and the name of the field
+   * the dimension of the FESpace, the type of basis functions, and the name of the field
    */
-  FiniteElementVector(mfem::ParMesh& mesh, Options&& options = {.order = 1, .vector_dim = 1, .coll = {}, .name = ""});
+  FiniteElementVector(mfem::ParMesh& mesh,
+                      Options&&      options = {.order = 1, .vector_dim = 1, .element_type = Family::H1, .name = ""});
 
   /**
    * @brief Minimal constructor for a FiniteElementVector given a finite element space

--- a/src/serac/physics/state/finite_element_vector.hpp
+++ b/src/serac/physics/state/finite_element_vector.hpp
@@ -27,14 +27,14 @@ namespace serac {
 using GeneralCoefficient = variant<std::shared_ptr<mfem::Coefficient>, std::shared_ptr<mfem::VectorCoefficient>>;
 
 /// @brief The type of a finite element basis function
-/// @note This class is used instead of the Family class from functional do to incompatibilities with Vector expression
-/// templates and the dual number class.
+/// @note TODO This class is used instead of the Family class from functional due to incompatibilities with Vector
+/// expression templates and the dual number class.
 enum class ElementType
 {
-  H1,     ///< Nodal scalar valued basis functions
+  H1,     ///< Nodal scalar-valued basis functions
   HCURL,  ///< Nedelec (continuous tangent) vector-valued basis functions
   HDIV,   ///< Raviart-Thomas (continuous normal) vector-valued basis functions
-  L2      ///< Discontinuous scalar valued basis functions
+  L2      ///< Discontinuous scalar-valued basis functions
 };
 
 /**

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -102,16 +102,13 @@ int main(int argc, char* argv[])
 
   simulation.setMaterial(DependsOn<0, 1>{}, material);
 
-  auto temperature_fec = std::unique_ptr<mfem::FiniteElementCollection>(new mfem::H1_FECollection(p, dim));
-  FiniteElementState temperature(StateManager::newState(
-      FiniteElementState::Options{.order = p, .coll = std::move(temperature_fec), .name = "theta"}));
+  FiniteElementState temperature(StateManager::newState(FiniteElementState::Options{.order = p, .name = "theta"}));
   temperature = theta_ref;
   simulation.setParameter(0, temperature);
 
   double             alpha0    = 1.0e-3;
   auto               alpha_fec = std::unique_ptr<mfem::FiniteElementCollection>(new mfem::H1_FECollection(p, dim));
-  FiniteElementState alpha(
-      StateManager::newState(FiniteElementState::Options{.order = p, .coll = std::move(alpha_fec), .name = "alpha"}));
+  FiniteElementState alpha(StateManager::newState(FiniteElementState::Options{.order = p, .name = "alpha"}));
   alpha = alpha0;
   simulation.setParameter(1, alpha);
 


### PR DESCRIPTION
This replaces the unique pointer to a finite element collection with an enum denoting the basis function selection in the construction of a `FiniteElementVector`.

Note that a new basis function enum class was needed due to resolution conflicts between `dual.hpp` and `expr_template_ops.hpp`, which both define templated `operator*` methods. 

Resolves https://github.com/LLNL/serac/issues/872