### PR TITLE
Refactor `solveAdjoint` interface to be compatible with systems of equations

### DIFF
--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -221,10 +221,10 @@ public:
 
   /**
    * @brief Solve the adjoint problem
-   * @pre It is expected that the forward analysis is complete and the current state is valid
-   * @note If the essential boundary state is not specified, homogeneous essential boundary conditions are applied
+   * @pre It is expected that the forward analysis is complete and the current states are valid
+   * @note If the essential boundary dual is not specified, homogeneous essential boundary conditions are applied
    *
-   * @return The computed adjoint finite element state
+   * @return The computed adjoint finite element states
    */
   virtual const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
       std::unordered_map<std::string, const serac::FiniteElementDual&> /* adjoint_loads */,

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -222,13 +222,14 @@ public:
   /**
    * @brief Solve the adjoint problem
    * @pre It is expected that the forward analysis is complete and the current states are valid
-   * @note If the essential boundary dual is not specified, homogeneous essential boundary conditions are applied
+   * @note If the essential boundary state for the adjoint is not specified, homogeneous essential boundary conditions
+   * are applied
    *
    * @return The computed adjoint finite element states
    */
   virtual const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
       std::unordered_map<std::string, const serac::FiniteElementDual&> /* adjoint_loads */,
-      std::unordered_map<std::string, const serac::FiniteElementDual&> /* duals_with_essential_boundary */)
+      std::unordered_map<std::string, const serac::FiniteElementState&> /* adjoint_with_essential_boundary */)
   {
     SLIC_ERROR_ROOT(axom::fmt::format("Adjoint analysis not defined for physics module {}", name_));
 

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -226,13 +226,14 @@ public:
    *
    * @return The computed adjoint finite element state
    */
-  virtual const serac::FiniteElementState& solveAdjoint(FiniteElementDual& /*adjoint_load */,
-                                                        FiniteElementDual* /* dual_with_essential_boundary */ = nullptr)
+  virtual const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
+      std::unordered_map<std::string, const serac::FiniteElementDual&> /* adjoint_loads */,
+      std::unordered_map<std::string, const serac::FiniteElementDual&> /* duals_with_essential_boundary */)
   {
     SLIC_ERROR_ROOT(axom::fmt::format("Adjoint analysis not defined for physics module {}", name_));
 
     // Return a dummy state value to quiet the compiler. This will never get used.
-    return *states_[0];
+    return {};
   }
 
   /**

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -569,7 +569,8 @@ public:
       // If the essential adjoint load container does not have a temperature dual but it has a non-zero size, the
       // user has supplied an incorrectly-named dual vector.
       SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
-                    "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint boundary condition named \"temperature\".");
+                    "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint "
+                    "boundary condition named \"temperature\".");
     }
 
     for (const auto& bc : bcs_.essentials()) {

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -528,7 +528,7 @@ public:
    *
    * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
    * indexed by their name
-   * @param duals_with_essential_boundary An unordered map containing finite element duals representing the
+   * @param adjoint_with_essential_boundary An unordered map containing finite element states representing the
    * non-homogeneous essential boundary condition data for the adjoint problem indexed by their name
    * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
    * "adjoint_temperature"

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -530,6 +530,21 @@ public:
    * boundary condition data for the adjoint problem
    * @return The computed adjoint finite element state
    */
+
+  /**
+   * @brief Solve the adjoint problem
+   * @pre It is expected that the forward analysis is complete and the current temperature state is valid
+   * @pre The adjoint load maps are expected to contain a single entry named "temperature"
+   * @note If the essential boundary dual is not specified, homogeneous essential boundary conditions are applied to
+   * the adjoint system
+   *
+   * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
+   * indexed by their name
+   * @param duals_with_essential_boundary A unordered map containing finite element duals representing the
+   * non-homogenous essential boundary condition data for the adjoint problem indexed their name
+   * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
+   * "adjoint_temperature"
+   */
   const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
       std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
       std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary = {}) override

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -522,18 +522,6 @@ public:
   /**
    * @brief Solve the adjoint problem
    * @pre It is expected that the forward analysis is complete and the current temperature state is valid
-   * @note If the essential boundary state is not specified, homogeneous essential boundary conditions are applied
-   *
-   * @param[in] adjoint_load The dual state that contains the right hand side of the adjoint system (d quantity of
-   * interest/d temperature)
-   * @param[in] dual_with_essential_boundary A optional finite element dual containing the non-homogenous essential
-   * boundary condition data for the adjoint problem
-   * @return The computed adjoint finite element state
-   */
-
-  /**
-   * @brief Solve the adjoint problem
-   * @pre It is expected that the forward analysis is complete and the current temperature state is valid
    * @pre The adjoint load maps are expected to contain a single entry named "temperature"
    * @note If the essential boundary dual is not specified, homogeneous essential boundary conditions are applied to
    * the adjoint system

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -528,14 +528,14 @@ public:
    *
    * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
    * indexed by their name
-   * @param duals_with_essential_boundary A unordered map containing finite element duals representing the
-   * non-homogenous essential boundary condition data for the adjoint problem indexed their name
+   * @param adjoint_with_essential_boundary A unordered map containing finite element duals representing the
+   * non-homogeneous essential boundary condition data for the adjoint problem indexed their name
    * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
    * "adjoint_temperature"
    */
   const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
-      std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
-      std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary = {}) override
+      std::unordered_map<std::string, const serac::FiniteElementDual&>  adjoint_loads,
+      std::unordered_map<std::string, const serac::FiniteElementState&> adjoint_with_essential_boundary = {}) override
   {
     SLIC_ERROR_ROOT_IF(adjoint_loads.size() != 1,
                        "Adjoint load container is not the expected size of 1 in the heat transfer module.");
@@ -561,14 +561,14 @@ public:
     auto J_T       = std::unique_ptr<mfem::HypreParMatrix>(jacobian->Transpose());
 
     // If we have a non-homogeneous essential boundary condition, extract it from the given state
-    auto essential_adjoint_temp = duals_with_essential_boundary.find("temperature");
+    auto essential_adjoint_temp = adjoint_with_essential_boundary.find("temperature");
 
-    if (essential_adjoint_temp != duals_with_essential_boundary.end()) {
+    if (essential_adjoint_temp != adjoint_with_essential_boundary.end()) {
       adjoint_essential = essential_adjoint_temp->second;
     } else {
       // If the essential adjoint load container does not have a temperature dual but it has a non-zero size, the
       // user has supplied an incorrectly-named dual vector.
-      SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
+      SLIC_ERROR_IF(adjoint_with_essential_boundary.size() != 0,
                     "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint "
                     "boundary condition named \"temperature\".");
     }

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -569,7 +569,7 @@ public:
       // If the essential adjoint load container does not have a temperature dual but it has a non-zero size, the
       // user has supplied an incorrectly-named dual vector.
       SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
-                    "Essential adjoint boundary condition given for an unexpected primal field.");
+                    "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint boundary condition named \"temperature\".");
     }
 
     for (const auto& bc : bcs_.essentials()) {

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -528,8 +528,8 @@ public:
    *
    * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
    * indexed by their name
-   * @param duals_with_essential_boundary A unordered map containing finite element duals representing the
-   * non-homogenous essential boundary condition data for the adjoint problem indexed their name
+   * @param duals_with_essential_boundary An unordered map containing finite element duals representing the
+   * non-homogenous essential boundary condition data for the adjoint problem indexed by their name
    * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
    * "adjoint_temperature"
    */

--- a/src/serac/physics/solid_legacy.cpp
+++ b/src/serac/physics/solid_legacy.cpp
@@ -550,7 +550,7 @@ const std::unordered_map<std::string, const serac::FiniteElementState&> SolidLeg
   if (essential_adjoint_disp != duals_with_essential_boundary.end()) {
     adjoint_essential = essential_adjoint_disp->second;
   } else {
-    // If the essential adjoint load container does not have a temperature dual but it has a non-zero size, the
+    // If the essential adjoint load container does not have a displacement dual but it has a non-zero size, the
     // user has supplied an incorrectly-named dual vector.
     SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
                   "Essential adjoint boundary condition given for an unexpected primal field.");

--- a/src/serac/physics/solid_legacy.cpp
+++ b/src/serac/physics/solid_legacy.cpp
@@ -512,8 +512,8 @@ FiniteElementDual& SolidLegacy::bulkModulusSensitivity(mfem::ParFiniteElementSpa
 }
 
 const std::unordered_map<std::string, const serac::FiniteElementState&> SolidLegacy::solveAdjoint(
-    std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
-    std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary)
+    std::unordered_map<std::string, const serac::FiniteElementDual&>  adjoint_loads,
+    std::unordered_map<std::string, const serac::FiniteElementState&> adjoint_with_essential_boundary)
 {
   SLIC_ERROR_ROOT_IF(!is_quasistatic_, "Adjoint analysis only vaild for quasistatic problems.");
   SLIC_ERROR_ROOT_IF(previous_solve_ == PreviousSolve::None, "Adjoint analysis only valid following a forward solve.");
@@ -545,14 +545,14 @@ const std::unordered_map<std::string, const serac::FiniteElementState&> SolidLeg
   adjoint_essential = 0.0;
 
   // If we have a non-homogeneous essential boundary condition, extract it from the given state
-  auto essential_adjoint_disp = duals_with_essential_boundary.find("displacement");
+  auto essential_adjoint_disp = adjoint_with_essential_boundary.find("displacement");
 
-  if (essential_adjoint_disp != duals_with_essential_boundary.end()) {
+  if (essential_adjoint_disp != adjoint_with_essential_boundary.end()) {
     adjoint_essential = essential_adjoint_disp->second;
   } else {
     // If the essential adjoint load container does not have a displacement dual but it has a non-zero size, the
     // user has supplied an incorrectly-named dual vector.
-    SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
+    SLIC_ERROR_IF(adjoint_with_essential_boundary.size() != 0,
                   "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint "
                   "boundary condition named \"displacement\"");
   }

--- a/src/serac/physics/solid_legacy.cpp
+++ b/src/serac/physics/solid_legacy.cpp
@@ -553,7 +553,8 @@ const std::unordered_map<std::string, const serac::FiniteElementState&> SolidLeg
     // If the essential adjoint load container does not have a displacement dual but it has a non-zero size, the
     // user has supplied an incorrectly-named dual vector.
     SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
-                  "Essential adjoint boundary condition given for an unexpected primal field.");
+                  "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint "
+                  "boundary condition named \"displacement\"");
   }
 
   for (const auto& bc : bcs_.essentials()) {

--- a/src/serac/physics/solid_legacy.cpp
+++ b/src/serac/physics/solid_legacy.cpp
@@ -511,8 +511,9 @@ FiniteElementDual& SolidLegacy::bulkModulusSensitivity(mfem::ParFiniteElementSpa
   return *bulk_sensitivity_;
 }
 
-const FiniteElementState& SolidLegacy::solveAdjoint(FiniteElementDual& adjoint_load,
-                                                    FiniteElementDual* dual_with_essential_boundary)
+const std::unordered_map<std::string, const serac::FiniteElementState&> SolidLegacy::solveAdjoint(
+    std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
+    std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary)
 {
   SLIC_ERROR_ROOT_IF(!is_quasistatic_, "Adjoint analysis only vaild for quasistatic problems.");
   SLIC_ERROR_ROOT_IF(previous_solve_ == PreviousSolve::None, "Adjoint analysis only valid following a forward solve.");
@@ -522,10 +523,17 @@ const FiniteElementState& SolidLegacy::solveAdjoint(FiniteElementDual& adjoint_l
     mesh_.NewNodes(*reference_nodes_);
   }
 
+  SLIC_ERROR_ROOT_IF(adjoint_loads.size() != 1,
+                     "Adjoint load container is not the expected size of 1 in the solid mechanics module.");
+
+  auto disp_adjoint_load = adjoint_loads.find("displacement");
+
+  SLIC_ERROR_ROOT_IF(disp_adjoint_load == adjoint_loads.end(), "Adjoint load for \"displacement\" not found.");
+
   // note: The assignment operator must be called after the copy constructor because
   // the copy constructor only sets the partitioning, it does not copy the actual vector
   // values
-  mfem::HypreParVector adjoint_load_vector(adjoint_load);
+  mfem::HypreParVector adjoint_load_vector(disp_adjoint_load->second);
 
   auto& lin_solver = nonlin_solver_.LinearSolver();
 
@@ -533,12 +541,19 @@ const FiniteElementState& SolidLegacy::solveAdjoint(FiniteElementDual& adjoint_l
   auto  J_T = std::unique_ptr<mfem::HypreParMatrix>(J.Transpose());
 
   // By default, use a homogeneous essential boundary condition
-  mfem::HypreParVector adjoint_essential(adjoint_load);
+  mfem::HypreParVector adjoint_essential(disp_adjoint_load->second);
   adjoint_essential = 0.0;
 
   // If we have a non-homogeneous essential boundary condition, extract it from the given state
-  if (dual_with_essential_boundary) {
-    adjoint_essential = *dual_with_essential_boundary;
+  auto essential_adjoint_disp = duals_with_essential_boundary.find("displacement");
+
+  if (essential_adjoint_disp != duals_with_essential_boundary.end()) {
+    adjoint_essential = essential_adjoint_disp->second;
+  } else {
+    // If the essential adjoint load container does not have a temperature dual but it has a non-zero size, the
+    // user has supplied an incorrectly-named dual vector.
+    SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
+                  "Essential adjoint boundary condition given for an unexpected primal field.");
   }
 
   for (const auto& bc : bcs_.essentials()) {
@@ -557,7 +572,7 @@ const FiniteElementState& SolidLegacy::solveAdjoint(FiniteElementDual& adjoint_l
 
   previous_solve_ = PreviousSolve::Adjoint;
 
-  return adjoint_displacement_;
+  return {{"adjoint_displacement", adjoint_displacement_}};
 }
 
 void SolidLegacy::InputOptions::defineInputFileSchema(axom::inlet::Container& container)

--- a/src/serac/physics/solid_legacy.hpp
+++ b/src/serac/physics/solid_legacy.hpp
@@ -407,14 +407,14 @@ public:
    *
    * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
    * indexed by their name
-   * @param duals_with_essential_boundary A unordered map containing finite element duals representing the
-   * non-homogenous essential boundary condition data for the adjoint problem indexed their name
+   * @param adjoint_with_essential_boundary A unordered map containing finite element state representing the
+   * non-homogeneous essential boundary condition data for the adjoint problem indexed their name
    * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
    * "adjoint_displacement"
    */
   const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
-      std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
-      std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary = {}) override;
+      std::unordered_map<std::string, const serac::FiniteElementDual&>  adjoint_loads,
+      std::unordered_map<std::string, const serac::FiniteElementState&> adjoint_with_essential_boundary = {}) override;
 
   /**
    * @brief Compute the implicit sensitivity of the quantity of interest used in defining the load for the adjoint

--- a/src/serac/physics/solid_legacy.hpp
+++ b/src/serac/physics/solid_legacy.hpp
@@ -407,7 +407,7 @@ public:
    *
    * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
    * indexed by their name
-   * @param adjoint_with_essential_boundary A unordered map containing finite element state representing the
+   * @param adjoint_with_essential_boundary A unordered map containing finite element states representing the
    * non-homogeneous essential boundary condition data for the adjoint problem indexed their name
    * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
    * "adjoint_displacement"

--- a/src/serac/physics/solid_legacy.hpp
+++ b/src/serac/physics/solid_legacy.hpp
@@ -400,13 +400,17 @@ public:
 
   /**
    * @brief Solve the adjoint problem
-   * @note It is expected that the forward analysis is complete and the current displacement state is valid
-   * @note If the essential boundary state is not specified, homogeneous essential boundary conditions are applied
+   * @pre It is expected that the forward analysis is complete and the current displacement state is valid
+   * @pre The adjoint load maps are expected to contain a single entry named "displacement"
+   * @note If the essential boundary dual is not specified, homogeneous essential boundary conditions are applied to
+   * the adjoint system
    *
-   * @param[in] adjoint_load The dual state that contains the right hand side of the adjoint system
-   * @param[in] dual_with_essential_boundary A optional finite element dual containing the non-homogenous essential
-   * boundary condition data for the adjoint problem
-   * @return The computed adjoint finite element state
+   * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
+   * indexed by their name
+   * @param duals_with_essential_boundary A unordered map containing finite element duals representing the
+   * non-homogenous essential boundary condition data for the adjoint problem indexed their name
+   * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
+   * "adjoint_displacement"
    */
   const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
       std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,

--- a/src/serac/physics/solid_legacy.hpp
+++ b/src/serac/physics/solid_legacy.hpp
@@ -408,8 +408,9 @@ public:
    * boundary condition data for the adjoint problem
    * @return The computed adjoint finite element state
    */
-  virtual const serac::FiniteElementState& solveAdjoint(
-      FiniteElementDual& adjoint_load, FiniteElementDual* dual_with_essential_boundary = nullptr) override;
+  const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
+      std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
+      std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary = {}) override;
 
   /**
    * @brief Compute the implicit sensitivity of the quantity of interest used in defining the load for the adjoint

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -766,7 +766,8 @@ public:
       // If the essential adjoint load container does not have a displacement dual but it has a non-zero size, the
       // user has supplied an incorrectly-named dual vector.
       SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
-                    "Essential adjoint boundary condition given for an unexpected primal field.");
+                    "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint "
+                    "boundary condition named \"displacement\"");
     }
 
     for (const auto& bc : bcs_.essentials()) {

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -745,7 +745,7 @@ public:
     if (essential_adjoint_disp != duals_with_essential_boundary.end()) {
       adjoint_essential = essential_adjoint_disp->second;
     } else {
-      // If the essential adjoint load container does not have a temperature dual but it has a non-zero size, the
+      // If the essential adjoint load container does not have a displacement dual but it has a non-zero size, the
       // user has supplied an incorrectly-named dual vector.
       SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
                     "Essential adjoint boundary condition given for an unexpected primal field.");

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -700,13 +700,16 @@ public:
   /**
    * @brief Solve the adjoint problem
    * @pre It is expected that the forward analysis is complete and the current displacement state is valid
-   * @note If the essential boundary state is not specified, homogeneous essential boundary conditions are applied
+   * @pre The adjoint load maps are expected to contain a single entry named "displacement"
+   * @note If the essential boundary dual is not specified, homogeneous essential boundary conditions are applied to
+   * the adjoint system
    *
-   * @param[in] adjoint_load The dual state that contains the right hand side of the adjoint system (d quantity of
-   * interest/d displacement)
-   * @param[in] dual_with_essential_boundary A optional finite element dual containing the non-homogenous essential
-   * boundary condition data for the adjoint problem
-   * @return The computed adjoint finite element state
+   * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
+   * indexed by their name
+   * @param duals_with_essential_boundary A unordered map containing finite element duals representing the
+   * non-homogenous essential boundary condition data for the adjoint problem indexed their name
+   * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
+   * "adjoint_displacement"
    */
   const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
       std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -724,14 +724,14 @@ public:
    *
    * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
    * indexed by their name
-   * @param duals_with_essential_boundary A unordered map containing finite element duals representing the
-   * non-homogenous essential boundary condition data for the adjoint problem indexed their name
+   * @param adjoint_with_essential_boundary A unordered map containing finite element duals representing the
+   * non-homogeneous essential boundary condition data for the adjoint problem indexed their name
    * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
    * "adjoint_displacement"
    */
   const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
-      std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
-      std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary = {}) override
+      std::unordered_map<std::string, const serac::FiniteElementDual&>  adjoint_loads,
+      std::unordered_map<std::string, const serac::FiniteElementState&> adjoint_with_essential_boundary = {}) override
   {
     SLIC_ERROR_ROOT_IF(adjoint_loads.size() != 1,
                        "Adjoint load container is not the expected size of 1 in the solid mechanics module.");
@@ -758,14 +758,14 @@ public:
     auto J_T      = std::unique_ptr<mfem::HypreParMatrix>(jacobian->Transpose());
 
     // If we have a non-homogeneous essential boundary condition, extract it from the given state
-    auto essential_adjoint_disp = duals_with_essential_boundary.find("displacement");
+    auto essential_adjoint_disp = adjoint_with_essential_boundary.find("displacement");
 
-    if (essential_adjoint_disp != duals_with_essential_boundary.end()) {
+    if (essential_adjoint_disp != adjoint_with_essential_boundary.end()) {
       adjoint_essential = essential_adjoint_disp->second;
     } else {
       // If the essential adjoint load container does not have a displacement dual but it has a non-zero size, the
       // user has supplied an incorrectly-named dual vector.
-      SLIC_ERROR_IF(duals_with_essential_boundary.size() != 0,
+      SLIC_ERROR_IF(adjoint_with_essential_boundary.size() != 0,
                     "Essential adjoint boundary condition given for an unexpected primal field. Expected adjoint "
                     "boundary condition named \"displacement\"");
     }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -713,7 +713,7 @@ public:
    */
   const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
       std::unordered_map<std::string, const serac::FiniteElementDual&> adjoint_loads,
-      std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary = {})
+      std::unordered_map<std::string, const serac::FiniteElementDual&> duals_with_essential_boundary = {}) override
   {
     SLIC_ERROR_ROOT_IF(adjoint_loads.size() != 1,
                        "Adjoint load container is not the expected size of 1 in the solid mechanics module.");

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -724,7 +724,7 @@ public:
    *
    * @param adjoint_loads An unordered map containing finite element duals representing the RHS of the adjoint equations
    * indexed by their name
-   * @param adjoint_with_essential_boundary A unordered map containing finite element duals representing the
+   * @param adjoint_with_essential_boundary A unordered map containing finite element states representing the
    * non-homogeneous essential boundary condition data for the adjoint problem indexed their name
    * @return An unordered map of the adjoint solutions indexed by their name. It has a single entry named
    * "adjoint_displacement"

--- a/src/serac/physics/tests/parameterized_thermal.cpp
+++ b/src/serac/physics/tests/parameterized_thermal.cpp
@@ -103,7 +103,7 @@ TEST(Thermal, ParameterizedMaterial)
   adjoint_load = 1.0;
 
   // Solve the adjoint problem
-  thermal_solver.solveAdjoint(adjoint_load);
+  thermal_solver.solveAdjoint({{"temperature", adjoint_load}});
 
   // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
   auto& sensitivity = thermal_solver.computeSensitivity(conductivity_parameter_index);

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
   auto                     dqoi_du = get<1>(qoi(DifferentiateWRT<0>{}, simulation.displacement()));
   adjoint_load                     = *assemble(dqoi_du);
 
-  simulation.solveAdjoint(adjoint_load);
+  simulation.solveAdjoint({{"displacement", adjoint_load}});
 
   auto& dqoi_dalpha = simulation.computeSensitivity(1);
 

--- a/src/serac/physics/tests/solid_finite_diff.cpp
+++ b/src/serac/physics/tests/solid_finite_diff.cpp
@@ -114,7 +114,7 @@ TEST(SolidMechanics, FiniteDifferenceParameter)
   adjoint_load = *assembled_vector;
 
   // Solve the adjoint problem
-  solid_solver.solveAdjoint(adjoint_load);
+  solid_solver.solveAdjoint({{"displacement", adjoint_load}});
 
   // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
   [[maybe_unused]] auto& sensitivity = solid_solver.computeSensitivity(bulk_parameter_index);
@@ -240,7 +240,7 @@ TEST(SolidMechanics, FiniteDifferenceShape)
   adjoint_load = *assembled_vector;
 
   // Solve the adjoint problem
-  solid_solver.solveAdjoint(adjoint_load);
+  solid_solver.solveAdjoint({{"displacement", adjoint_load}});
 
   // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
   [[maybe_unused]] auto& sensitivity = solid_solver.computeShapeSensitivity();

--- a/src/serac/physics/tests/solid_legacy_adjoint.cpp
+++ b/src/serac/physics/tests/solid_legacy_adjoint.cpp
@@ -94,8 +94,8 @@ TEST(SolidLegacy, Adjoint)
   adjoint_load.Assemble();
   assembled_adjoint_load = *adjoint_load.ParallelAssemble();
 
-  auto&  adjoint_state_1 = solid_solver.solveAdjoint(assembled_adjoint_load);
-  double adjoint_norm_1  = norm(adjoint_state_1);
+  auto&  adjoint_state_1 = solid_solver.solveAdjoint({{"displacement", assembled_adjoint_load}});
+  double adjoint_norm_1  = norm(adjoint_state_1.at("adjoint_displacement"));
 
   SLIC_INFO_ROOT(axom::fmt::format("Adjoint norm (homogeneous BCs): {}", adjoint_norm_1));
 
@@ -138,8 +138,9 @@ TEST(SolidLegacy, Adjoint)
   // Set the essential boundary to a non-zero value
   adjoint_essential = 0.5;
 
-  auto&  adjoint_state_2 = solid_solver.solveAdjoint(assembled_adjoint_load, &adjoint_essential);
-  double adjoint_norm_2  = norm(adjoint_state_2);
+  auto& adjoint_state_2 =
+      solid_solver.solveAdjoint({{"displacement", assembled_adjoint_load}}, {{"displacement", adjoint_essential}});
+  double adjoint_norm_2 = norm(adjoint_state_2.at("adjoint_displacement"));
 
   SLIC_INFO_ROOT(axom::fmt::format("Adjoint norm (non-homogeneous BCs): {}", adjoint_norm_2));
 

--- a/src/serac/physics/tests/solid_legacy_adjoint.cpp
+++ b/src/serac/physics/tests/solid_legacy_adjoint.cpp
@@ -133,7 +133,7 @@ TEST(SolidLegacy, Adjoint)
   // Do another adjoint solve with a non-homogeneous BC
   // Also test the state manager option for finite element duals
   auto adjoint_essential =
-      StateManager::newDual(FiniteElementVector::Options{.vector_dim = dim, .name = "adjoint_essential_load"});
+      StateManager::newState(FiniteElementVector::Options{.vector_dim = dim, .name = "adjoint_essential_load"});
 
   // Set the essential boundary to a non-zero value
   adjoint_essential = 0.5;

--- a/src/serac/physics/tests/solid_legacy_sensitivity.cpp
+++ b/src/serac/physics/tests/solid_legacy_sensitivity.cpp
@@ -96,7 +96,7 @@ TEST(SolidLegacy, FiniteDiff)
   assembledAdjointLoad                     = *assembledVector;
   delete assembledVector;
 
-  solid.solveAdjoint(assembledAdjointLoad);
+  solid.solveAdjoint({{"displacement", assembledAdjointLoad}});
 
   // Ask for bulk modulus sensitivity
   serac::FiniteElementDual const& bulkModulusSensitivity  = solid.bulkModulusSensitivity(&l2fespace_scalar);
@@ -241,7 +241,7 @@ TEST(SolidLegacy, MultipleDesignSpaces)
     // Create a dummy adjoint load and compute the sensitivities
     serac::FiniteElementDual adjointLoad(h1fespace_vector, "adjoint_load");
     adjointLoad = 1.1;
-    solid.solveAdjoint(adjointLoad);
+    solid.solveAdjoint({{"displacement", adjointLoad}});
     solid.shearModulusSensitivity(shearModulus.ParFESpace());
     solid.shearModulusSensitivity(bulkModulus.ParFESpace());
   }

--- a/src/serac/physics/tests/thermal_finite_diff.cpp
+++ b/src/serac/physics/tests/thermal_finite_diff.cpp
@@ -99,7 +99,7 @@ TEST(Thermal, FiniteDifference)
   adjoint_load = *assembled_vector;
 
   // Solve the adjoint problem
-  thermal_solver.solveAdjoint(adjoint_load);
+  thermal_solver.solveAdjoint({{"temperature", adjoint_load}});
 
   // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
   [[maybe_unused]] auto& sensitivity = thermal_solver.computeSensitivity(conductivity_parameter_index);
@@ -214,7 +214,7 @@ TEST(HeatTransfer, FiniteDifferenceShape)
   adjoint_load = *assembled_vector;
 
   // Solve the adjoint problem
-  thermal_solver.solveAdjoint(adjoint_load);
+  thermal_solver.solveAdjoint({{"temperature", adjoint_load}});
 
   // Compute the sensitivity (d QOI/ d state * d state/d parameter) given the current adjoint solution
   [[maybe_unused]] auto& sensitivity = thermal_solver.computeShapeSensitivity();


### PR DESCRIPTION
The previous interface assumed only one primal field in the adjoint solve. This new interface allows for block systems of equations.

Note @kswartz92 , this will change your wrapper interface slightly. 