### PR TITLE
Use Gauss-Lobatto basis functions for L2 FE vectors

### DIFF
--- a/src/serac/physics/state/finite_element_vector.cpp
+++ b/src/serac/physics/state/finite_element_vector.cpp
@@ -30,7 +30,9 @@ FiniteElementVector::FiniteElementVector(mfem::ParMesh& mesh, FiniteElementVecto
                            axom::fmt::format("Vector dim >1 requested for an HDIV basis function."));
       break;
     case ElementType::L2:
-      coll_ = std::make_unique<mfem::L2_FECollection>(options.order, dim);
+      // Note that we use Gauss-Lobatto basis functions as this is what serac::Functional uses for finite element
+      // integrals
+      coll_ = std::make_unique<mfem::L2_FECollection>(options.order, dim, mfem::BasisType::GaussLobatto);
       break;
     default:
       SLIC_ERROR_ROOT(axom::fmt::format("Finite element vector requested for unavailable basis type."));


### PR DESCRIPTION
We should use Gauss-Lobatto basis functions for L2 fields as that is what `serac::Functional` uses for L2 integral calculations.