### PR TITLE
Another L2 basis fix

### DIFF
--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -122,7 +122,8 @@ generateParFiniteElementSpace(mfem::ParMesh* mesh)
       fec = std::make_unique<mfem::RT_FECollection>(function_space::order, dim);
       break;
     case Family::L2:
-      fec = std::make_unique<mfem::L2_FECollection>(function_space::order, dim);
+      // We use GaussLobatto basis functions as this is what is used for the serac::Functional FE kernels
+      fec = std::make_unique<mfem::L2_FECollection>(function_space::order, dim, mfem::BasisType::GaussLobatto);
       break;
     default:
       return std::pair<std::unique_ptr<mfem::ParFiniteElementSpace>, std::unique_ptr<mfem::FiniteElementCollection>>(


### PR DESCRIPTION
The `generateParFiniteElementSpace` method was not using GaussLobatto basis functions for L2 spaces. As we are using GaussLobatto inside of functional, it needs to be fixed here for consistency.