### PR TITLE
`FiniteElementVector` copy constructor bugfix

### DIFF
--- a/src/serac/physics/state/finite_element_vector.hpp
+++ b/src/serac/physics/state/finite_element_vector.hpp
@@ -97,7 +97,10 @@ public:
    *
    * @param[in] rhs The input vector used for construction
    */
-  FiniteElementVector(const FiniteElementVector& rhs) : FiniteElementVector(*rhs.space_, rhs.name_) {}
+  FiniteElementVector(const FiniteElementVector& rhs) : FiniteElementVector(*rhs.space_, rhs.name_)
+  {
+    HypreParVector::operator=(rhs);
+  }
 
   /**
    * @brief Move construct a new Finite Element Vector object


### PR DESCRIPTION
In the `FiniteElementVector` copy constructor, the underlying vector data was not being copied.