### PR TITLE
Turn off readthedocs pdf generation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,7 +10,8 @@ sphinx:
   configuration: src/docs/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
-formats: all
+# TODO this was turned off due to build failures in the pdf generation. See https://github.com/LLNL/serac/issues/901
+# formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -1397,7 +1397,7 @@ FORMULA_TRANSPARENT    = YES
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-USE_MATHJAX            = NO
+USE_MATHJAX            = YES
 
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -1530,7 +1530,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of


### PR DESCRIPTION
Readthedocs recently required requested pdf generation failures to kill the entire docs build. It looks like the pdf generation framework can't currently handle our math LaTeX commands. We should look into this in the future. See https://github.com/LLNL/serac/issues/901 .

This also turns on MathJax instead of LaTeX for the sphinx docs for better output.