### PR TITLE
Add a default argument to the `BasePhysics::solveAdjoint` method

### DIFF
--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -229,7 +229,7 @@ public:
    */
   virtual const std::unordered_map<std::string, const serac::FiniteElementState&> solveAdjoint(
       std::unordered_map<std::string, const serac::FiniteElementDual&> /* adjoint_loads */,
-      std::unordered_map<std::string, const serac::FiniteElementState&> /* adjoint_with_essential_boundary */)
+      std::unordered_map<std::string, const serac::FiniteElementState&> /* adjoint_with_essential_boundary */ = {})
   {
     SLIC_ERROR_ROOT(axom::fmt::format("Adjoint analysis not defined for physics module {}", name_));
 


### PR DESCRIPTION
This is needed for generic `BasePhysics` wrappers, specifically LiDO.