### PR TITLE
Typo in `blt_list_append`

### DIFF
--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -43,7 +43,7 @@ set(infrastructure_sources
     )
 
 set(infrastructure_depends axom axom::fmt axom::cli11 mfem)
-blt_list_append(TO infrastructure_depends ELEMENTS caliper adiak IF SERAC_ENABLE_PROFILING})
+blt_list_append(TO infrastructure_depends ELEMENTS caliper adiak IF SERAC_ENABLE_PROFILING)
 blt_list_append(TO infrastructure_depends ELEMENTS cuda IF ENABLE_CUDA)
 list(APPEND infrastructure_depends mpi)
 


### PR DESCRIPTION
Got to love that CMake doesn't verify proper syntax.