### PR TITLE
Update Caliper and Adiak spack packages

### DIFF
--- a/scripts/spack/packages/adiak/package.py
+++ b/scripts/spack/packages/adiak/package.py
@@ -1,45 +1,51 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
-from spack import *
+from spack.package import *
 
 
 class Adiak(CMakePackage):
     """Adiak collects metadata about HPC application runs and provides it
-       to tools."""
+    to tools."""
 
     homepage = "https://github.com/LLNL/Adiak"
-    url      = "https://github.com/LLNL/Adiak/releases/download/v0.1/adiak-v0.1.1.tar.gz"
-    git      = "https://github.com/LLNL/Adiak"
+    url = "https://github.com/LLNL/Adiak/releases/download/v0.1/adiak-v0.1.1.tar.gz"
+    git = "https://github.com/LLNL/Adiak"
 
-    maintainers = ["daboehme", "mplegendre"]
+    maintainers("daboehme", "mplegendre")
 
-    variant('mpi', default=True, description='Build with MPI support')
-    variant('shared', default=True, description='Build dynamic libraries')
+    variant("mpi", default=True, description="Build with MPI support")
+    variant("shared", default=True, description="Build dynamic libraries")
 
-    version('0.3.0-alpha', commit='054d2693a977ed0e1f16c665b4966bb90924779e',
-            submodules=True)
-    version('0.2.1', commit='950e3bfb91519ecb7b7ee7fa3063bfab23c0e2c9',
-            submodules=True, preferred=True)
-    version('0.1.1', sha256='438e4652e15e206cd0019423d829fd4f2329323ff0c8861d9586bae051d9624b')
+    version(
+        "0.2.2", commit="3aedd494c81c01df1183af28bc09bade2fabfcd3", submodules=True, preferred=True
+    )
+    version(
+        "0.3.0-alpha",
+        commit="054d2693a977ed0e1f16c665b4966bb90924779e",
+        submodules=True,
+        deprecated=True,
+    )
+    version("0.2.1", commit="950e3bfb91519ecb7b7ee7fa3063bfab23c0e2c9", submodules=True)
+    version("0.1.1", sha256="438e4652e15e206cd0019423d829fd4f2329323ff0c8861d9586bae051d9624b")
 
-    depends_on('mpi', when='+mpi')
+    depends_on("mpi", when="+mpi")
 
     def cmake_args(self):
         args = []
-        if self.spec.satisfies('+mpi'):
-            args.append('-DMPI_CXX_COMPILER=%s' % self.spec['mpi'].mpicxx)
-            args.append('-DMPI_C_COMPILER=%s' % self.spec['mpi'].mpicc)
-            args.append('-DENABLE_MPI=ON')
+        if self.spec.satisfies("+mpi"):
+            args.append("-DMPI_CXX_COMPILER=%s" % self.spec["mpi"].mpicxx)
+            args.append("-DMPI_C_COMPILER=%s" % self.spec["mpi"].mpicc)
+            args.append("-DENABLE_MPI=ON")
         else:
-            args.append('-DENABLE_MPI=OFF')
+            args.append("-DENABLE_MPI=OFF")
 
-        if (self.spec.satisfies('+shared')):
-            args.append('-DBUILD_SHARED_LIBS=ON')
+        if self.spec.satisfies("+shared"):
+            args.append("-DBUILD_SHARED_LIBS=ON")
         else:
-            args.append('-DBUILD_SHARED_LIBS=OFF')
+            args.append("-DBUILD_SHARED_LIBS=OFF")
 
-        args.append('-DENABLE_TESTS=OFF')
+        args.append("-DENABLE_TESTS=OFF")
         return args

--- a/scripts/spack/packages/caliper/package.py
+++ b/scripts/spack/packages/caliper/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2022 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -6,12 +6,10 @@
 import os
 import sys
 
-from llnl.util import tty
-
-from spack import *
+from spack.package import *
 
 
-class Caliper(CMakePackage, CudaPackage):
+class Caliper(CMakePackage, CudaPackage, ROCmPackage):
     """Caliper is a program instrumentation and performance measurement
     framework. It is designed as a performance analysis toolbox in a
     library, allowing one to bake performance analysis capabilities
@@ -19,175 +17,162 @@ class Caliper(CMakePackage, CudaPackage):
     """
 
     homepage = "https://github.com/LLNL/Caliper"
-    git      = "https://github.com/LLNL/Caliper.git"
-    url      = "https://github.com/LLNL/Caliper/archive/v2.7.0.tar.gz"
-    tags     = ['e4s', 'radiuss']
+    git = "https://github.com/LLNL/Caliper.git"
+    url = "https://github.com/LLNL/Caliper/archive/v2.9.1.tar.gz"
+    tags = ["e4s", "radiuss"]
 
-    maintainers = ["daboehme"]
+    maintainers("daboehme")
 
     test_requires_compiler = True
 
-    version('master', branch='master')
-    version('2.7.0', sha256='b3bf290ec2692284c6b4f54cc0c507b5700c536571d3e1a66e56626618024b2b')
-    version('2.6.0', sha256='6efcd3e4845cc9a6169e0d934840766b12182c6d09aa3ceca4ae776e23b6360f')
-    version('2.5.0', sha256='d553e60697d61c53de369b9ca464eb30710bda90fba9671201543b64eeac943c')
-    version('2.4.0', tag='v2.4.0')
-    version('2.3.0', tag='v2.3.0')
-    version('2.2.0', tag='v2.2.0')
-    version('2.1.1', tag='v2.1.1')
-    version('2.0.1', tag='v2.0.1')
-    version('1.9.1', tag='v1.9.1')
-    version('1.9.0', tag='v1.9.0')
-    version('1.8.0', tag='v1.8.0')
-    version('1.7.0', tag='v1.7.0')
+    version("master", branch="master")
+    version("2.9.1", sha256="4771d630de505eff9227e0ec498d0da33ae6f9c34df23cb201b56181b8759e9e")
+    version("2.9.0", sha256="507ea74be64a2dfd111b292c24c4f55f459257528ba51a5242313fa50978371f")
+    version("2.8.0", sha256="17807b364b5ac4b05997ead41bd173e773f9a26ff573ff2fe61e0e70eab496e4")
+    version("2.7.0", sha256="b3bf290ec2692284c6b4f54cc0c507b5700c536571d3e1a66e56626618024b2b")
+    version("2.6.0", sha256="6efcd3e4845cc9a6169e0d934840766b12182c6d09aa3ceca4ae776e23b6360f")
+    version("2.5.0", sha256="d553e60697d61c53de369b9ca464eb30710bda90fba9671201543b64eeac943c")
+    version("2.4.0", tag="v2.4.0")
+    version("2.3.0", tag="v2.3.0")
+    version("2.2.0", tag="v2.2.0")
+    version("2.1.1", tag="v2.1.1")
+    version("2.0.1", tag="v2.0.1")
+    version("1.9.1", tag="v1.9.1")
+    version("1.9.0", tag="v1.9.0")
+    version("1.8.0", tag="v1.8.0")
+    version("1.7.0", tag="v1.7.0")
 
-    is_linux = sys.platform.startswith('linux')
-    variant('shared', default=True,
-            description='Build shared libraries')
-    variant('adiak', default=True,
-            description='Enable Adiak support')
-    variant('mpi', default=True,
-            description='Enable MPI wrappers')
+    is_linux = sys.platform.startswith("linux")
+    variant("shared", default=True, description="Build shared libraries")
+    variant("adiak", default=True, description="Enable Adiak support")
+    variant("mpi", default=True, description="Enable MPI wrappers")
     # libunwind has some issues on Mac
-    variant('libunwind', default=sys.platform != 'darwin',
-            description='Enable stack unwind support')
-    variant('libdw', default=is_linux,
-            description='Enable DWARF symbol lookup')
+    variant(
+        "libunwind", default=sys.platform != "darwin", description="Enable stack unwind support"
+    )
+    variant("libdw", default=is_linux, description="Enable DWARF symbol lookup")
     # pthread_self() signature is incompatible with PAPI_thread_init() on Mac
-    variant('papi', default=sys.platform != 'darwin',
-            description='Enable PAPI service')
-    variant('libpfm', default=False,
-            description='Enable libpfm (perf_events) service')
+    variant("papi", default=sys.platform != "darwin", description="Enable PAPI service")
+    variant("libpfm", default=False, description="Enable libpfm (perf_events) service")
     # Gotcha is Linux-only
-    variant('gotcha', default=is_linux,
-            description='Enable GOTCHA support')
-    variant('sampler', default=is_linux,
-            description='Enable sampling support on Linux')
-    variant('sosflow', default=False,
-            description='Enable SOSflow support')
-    variant('fortran', default=False,
-            description='Enable Fortran support')
+    variant("gotcha", default=is_linux, description="Enable GOTCHA support")
+    variant("sampler", default=is_linux, description="Enable sampling support on Linux")
+    variant("sosflow", default=False, description="Enable SOSflow support")
+    variant("fortran", default=False, description="Enable Fortran support")
 
-    depends_on('adiak@0.1:0', when='@2.2: +adiak')
+    depends_on("adiak@0.1:0", when="@2.2: +adiak")
 
-    depends_on('papi@5.3:5', when='@:2.2 +papi')
-    depends_on('papi@5.3:6', when='@2.3: +papi')
+    depends_on("papi@5.3:5", when="@:2.2 +papi")
+    depends_on("papi@5.3:6", when="@2.3: +papi")
 
-    depends_on('libpfm4@4.8:4', when='+libpfm')
+    depends_on("libpfm4@4.8:4", when="+libpfm")
 
-    depends_on('mpi', when='+mpi')
-    depends_on('unwind@1.2:1', when='+libunwind')
-    depends_on('elfutils', when='+libdw')
+    depends_on("mpi", when="+mpi")
+    depends_on("unwind@1.2:1", when="+libunwind")
+    depends_on("elfutils", when="+libdw")
 
-    depends_on('sosflow@spack', when='@1.0:1+sosflow')
+    depends_on("sosflow@spack", when="@1.0:1+sosflow")
 
-    depends_on('cmake',  type='build')
-    depends_on('python', type='build')
+    depends_on("cmake", type="build")
+    depends_on("python", type="build")
 
     # sosflow support not yet in 2.0
-    conflicts('+sosflow', '@2.0.0:2.5')
-    conflicts('+adiak', '@:2.1')
-    conflicts('+libdw', '@:2.4')
+    conflicts("+sosflow", "@2.0.0:2.9")
+    conflicts("+adiak", "@:2.1")
+    conflicts("+libdw", "@:2.4")
+    conflicts("+rocm", "@:2.7")
+    conflicts("+rocm+cuda")
 
-    patch('for_aarch64.patch', when='target=aarch64:')
-    # SERAC EDIT START
-    patch('no_static_cupti.patch', when='+cuda~shared')
-    # SERAC EDIT END
+    patch("for_aarch64.patch", when="target=aarch64:")
+    patch("sampler-service-missing-libunwind-include-dir.patch", when="@2.9.0 +libunwind +sampler")
 
     def cmake_args(self):
         spec = self.spec
 
         args = [
-            ('-DPYTHON_EXECUTABLE=%s' %
-                spec['python'].command.path),
-            '-DBUILD_TESTING=Off',
-            '-DBUILD_DOCS=Off',
-            '-DBUILD_SHARED_LIBS=%s' % ('On' if '+shared'  in spec else 'Off'),
-            '-DWITH_ADIAK=%s'    % ('On' if '+adiak'    in spec else 'Off'),
-            '-DWITH_GOTCHA=%s'   % ('On' if '+gotcha'   in spec else 'Off'),
-            '-DWITH_PAPI=%s'     % ('On' if '+papi'     in spec else 'Off'),
-            '-DWITH_LIBDW=%s'    % ('On' if '+libdw'    in spec else 'Off'),
-            '-DWITH_LIBPFM=%s'   % ('On' if '+libpfm'   in spec else 'Off'),
-            '-DWITH_SOSFLOW=%s'  % ('On' if '+sosflow'  in spec else 'Off'),
-            '-DWITH_SAMPLER=%s'  % ('On' if '+sampler'  in spec else 'Off'),
-            '-DWITH_MPI=%s'      % ('On' if '+mpi'      in spec else 'Off'),
-            '-DWITH_FORTRAN=%s'  % ('On' if '+fortran'  in spec else 'Off')
+            ("-DPYTHON_EXECUTABLE=%s" % spec["python"].command.path),
+            "-DBUILD_TESTING=Off",
+            "-DBUILD_DOCS=Off",
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("WITH_ADIAK", "adiak"),
+            self.define_from_variant("WITH_GOTCHA", "gotcha"),
+            self.define_from_variant("WITH_PAPI", "papi"),
+            self.define_from_variant("WITH_LIBDW", "libdw"),
+            self.define_from_variant("WITH_LIBPFM", "libpfm"),
+            self.define_from_variant("WITH_SOSFLOW", "sosflow"),
+            self.define_from_variant("WITH_SAMPLER", "sampler"),
+            self.define_from_variant("WITH_MPI", "mpi"),
+            self.define_from_variant("WITH_FORTRAN", "fortran"),
+            self.define_from_variant("WITH_CUPTI", "cuda"),
+            self.define_from_variant("WITH_NVTX", "cuda"),
+            self.define_from_variant("WITH_ROCTRACER", "rocm"),
+            self.define_from_variant("WITH_ROCTX", "rocm"),
         ]
 
-        if '+papi' in spec:
-            args.append('-DPAPI_PREFIX=%s'    % spec['papi'].prefix)
-        if '+libdw' in spec:
-            args.append('-DLIBDW_PREFIX=%s'   % spec['elfutils'].prefix)
-        if '+libpfm' in spec:
-            args.append('-DLIBPFM_INSTALL=%s' % spec['libpfm4'].prefix)
-        if '+sosflow' in spec:
-            args.append('-DSOS_PREFIX=%s'     % spec['sosflow'].prefix)
+        if "+papi" in spec:
+            args.append("-DPAPI_PREFIX=%s" % spec["papi"].prefix)
+        if "+libdw" in spec:
+            args.append("-DLIBDW_PREFIX=%s" % spec["elfutils"].prefix)
+        if "+libpfm" in spec:
+            args.append("-DLIBPFM_INSTALL=%s" % spec["libpfm4"].prefix)
+        if "+sosflow" in spec:
+            args.append("-DSOS_PREFIX=%s" % spec["sosflow"].prefix)
 
         # -DWITH_CALLPATH was renamed -DWITH_LIBUNWIND in 2.5
-        callpath_flag = 'LIBUNWIND' if spec.satisfies('@2.5:') else 'CALLPATH'
-        if '+libunwind' in spec:
-            args.append('-DLIBUNWIND_PREFIX=%s' % spec['unwind'].prefix)
-            args.append('-DWITH_%s=On'  % callpath_flag)
+        callpath_flag = "LIBUNWIND" if spec.satisfies("@2.5:") else "CALLPATH"
+        if "+libunwind" in spec:
+            args.append("-DLIBUNWIND_PREFIX=%s" % spec["unwind"].prefix)
+            args.append("-DWITH_%s=On" % callpath_flag)
         else:
-            args.append('-DWITH_%s=Off' % callpath_flag)
+            args.append("-DWITH_%s=Off" % callpath_flag)
 
-        if '+mpi' in spec:
-            args.append('-DMPI_C_COMPILER=%s' % spec['mpi'].mpicc)
-            args.append('-DMPI_CXX_COMPILER=%s' % spec['mpi'].mpicxx)
+        if "+mpi" in spec:
+            args.append("-DMPI_C_COMPILER=%s" % spec["mpi"].mpicc)
+            args.append("-DMPI_CXX_COMPILER=%s" % spec["mpi"].mpicxx)
 
-        if '+cuda' in spec:
-            args.append('-DCUDA_TOOLKIT_ROOT_DIR=%s' % spec['cuda'].prefix)
+        if "+cuda" in spec:
+            args.append("-DCUDA_TOOLKIT_ROOT_DIR=%s" % spec["cuda"].prefix)
             # technically only works with cuda 10.2+, otherwise cupti is in
             # ${CUDA_TOOLKIT_ROOT_DIR}/extras/CUPTI
-            args.append('-DCUPTI_PREFIX=%s' % spec['cuda'].prefix)
-            args.append('-DWITH_NVTX=On')
-            args.append('-DWITH_CUPTI=On')
-        else:
-            args.append('-DWITH_NVTX=Off')
-            args.append('-DWITH_CUPTI=Off')
+            args.append("-DCUPTI_PREFIX=%s" % spec["cuda"].prefix)
+
+        if "+rocm" in spec:
+            args.append("-DCMAKE_CXX_COMPILER={0}".format(spec["hip"].hipcc))
+            args.append("-DROCM_PREFIX=%s" % spec["hsa-rocr-dev"].prefix)
 
         return args
 
-    @run_after('install')
+    @run_after("install")
     def cache_test_sources(self):
         """Copy the example source files after the package is installed to an
         install test subdirectory for use during `spack test run`."""
-        self.cache_extra_test_sources([join_path('examples', 'apps')])
+        self.cache_extra_test_sources([join_path("examples", "apps")])
 
-    def run_cxx_example_test(self):
-        """Run stand alone test: cxx_example"""
+    def test_cxx_example(self):
+        """build and run cxx-example"""
 
-        test_dir = self.test_suite.current_test_cache_dir.examples.apps
-        exe = 'cxx-example'
-        source_file = 'cxx-example.cpp'
+        exe = "cxx-example"
+        source_file = "{0}.cpp".format(exe)
 
-        if not os.path.isfile(join_path(test_dir, source_file)):
-            tty.warn('Skipping caliper test:'
-                     '{0} does not exist'.format(source_file))
-            return
+        source_path = find_required_file(
+            self.test_suite.current_test_cache_dir, source_file, expected=1, recursive=True
+        )
 
-        if os.path.exists(self.prefix.lib):
-            lib_dir = self.prefix.lib
-        else:
-            lib_dir = self.prefix.lib64
+        lib_dir = self.prefix.lib if os.path.exists(self.prefix.lib) else self.prefix.lib64
 
-        options = ['-L{0}'.format(lib_dir),
-                   '-I{0}'.format(self.prefix.include),
-                   '{0}'.format(join_path(test_dir, source_file)),
-                   '-o', exe, '-std=c++11', '-lcaliper', '-lstdc++']
+        cxx = which(os.environ["CXX"])
+        test_dir = os.path.dirname(source_path)
+        with working_dir(test_dir):
+            cxx(
+                "-L{0}".format(lib_dir),
+                "-I{0}".format(self.prefix.include),
+                source_path,
+                "-o",
+                exe,
+                "-std=c++11",
+                "-lcaliper",
+                "-lstdc++",
+            )
 
-        if not self.run_test(exe=os.environ['CXX'],
-                             options=options,
-                             purpose='test: compile {0} example'.format(exe),
-                             work_dir=test_dir):
-            tty.warn('Skipping caliper test: failed to compile example')
-            return
-
-        if not self.run_test(exe,
-                             purpose='test: run {0} example'.format(exe),
-                             work_dir=test_dir):
-            tty.warn('Skipping caliper test: failed to run example')
-
-    def test(self):
-        self.run_cxx_example_test()
-
+            cxx_example = which(exe)
+            cxx_example()


### PR DESCRIPTION
* Add versions 2.8.0, 2.9.0 and 2.9.1 of Caliper (update to a release in Jan 24, 2023).
* Add version 0.2.2 of Adiak that is newer than the 0.3.0-alpha tag.