### PR TITLE
fix failing thermomechanics test

### DIFF
--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -60,7 +60,7 @@ auto greenStrain(const tensor<T, dim, dim>& grad_u)
 
 /// @brief St. Venant Kirchhoff hyperelastic model
 struct StVenantKirchhoff {
-  using State = Empty;
+  using State = Empty;  ///< this material has no internal variables
 
   /**
    * @brief stress calculation for a St. Venant Kirchhoff material model

--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -63,25 +63,16 @@ struct StVenantKirchhoff {
   using State = Empty;
 
   /**
-   * @brief Evaluate constitutive variables for thermomechanics
+   * @brief stress calculation for a St. Venant Kirchhoff material model
    *
-   * @tparam T1 Type of the displacement gradient components (number-like)
-   * @tparam T2 Type of the temperature (number-like)
-   * @tparam T3 Type of the temperature gradient components (number-like)
+   * @tparam T Type of the displacement gradient components (number-like)
    *
    * @param[in] grad_u Displacement gradient
-   * @param[in] theta Temperature
-   * @param[in] grad_theta Temperature gradient
-   * @param[in,out] state State variables for this material
    *
-   * @return[out] tuple of constitutive outputs. Contains the
-   * Cauchy stress, the volumetric heat capacity in the reference
-   * configuration, the heat generated per unit volume during the time
-   * step (units of energy), and the referential heat flux (units of
-   * energy per unit time and per unit area).
+   * @return The Cauchy stress
    */
-  template <typename T1, int dim>
-  auto operator()(State&, const tensor<T1, dim, dim>& grad_u) const
+  template <typename T, int dim>
+  auto operator()(State&, const tensor<T, dim, dim>& grad_u) const
   {
     static constexpr auto I = Identity<dim>();
     auto                  F = grad_u + I;

--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -95,10 +95,9 @@ struct StVenantKirchhoff {
     return sigma;
   }
 
-  double density; ///< density
-  double K;       ///< Bulk modulus
-  double G;       ///< Shear modulus
-
+  double density;  ///< density
+  double K;        ///< Bulk modulus
+  double G;        ///< Shear modulus
 };
 
 /**

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -779,6 +779,11 @@ public:
       *parameters_[parameter_index].previous_state = *parameters_[parameter_index].state;
     }
 
+    for (int i = 0; i < constrained_dofs.Size(); i++) {
+      int j = constrained_dofs[i];
+      dr_[j] = du_[j];
+    }
+
     auto& lin_solver = nonlin_solver_->linearSolver();
 
     lin_solver.SetOperator(*J_);

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -780,7 +780,7 @@ public:
     }
 
     for (int i = 0; i < constrained_dofs.Size(); i++) {
-      int j = constrained_dofs[i];
+      int j  = constrained_dofs[i];
       dr_[j] = du_[j];
     }
 

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ set(test_dependencies serac_physics serac_mesh gtest)
 blt_list_append( TO test_dependencies ELEMENTS caliper adiak IF ${SERAC_ENABLE_PROFILING} )
 
 set(serial_solver_tests
+    beam_bending.cpp
     thermal_finite_diff.cpp
     thermal_statics_patch.cpp
     thermal_dynamics_patch.cpp

--- a/src/serac/physics/tests/beam_bending.cpp
+++ b/src/serac/physics/tests/beam_bending.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) 2019-2023, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "serac/physics/solid_mechanics.hpp"
+
+#include <functional>
+#include <fstream>
+#include <set>
+#include <string>
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include <gtest/gtest.h>
+#include "mfem.hpp"
+
+#include "serac/mesh/mesh_utils.hpp"
+#include "serac/physics/state/state_manager.hpp"
+#include "serac/physics/materials/solid_material.hpp"
+#include "serac/serac_config.hpp"
+
+namespace serac {
+
+TEST(BeamBending, TwoDimensional) {
+
+  constexpr int p = 1;
+  constexpr int dim = 2;
+
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  // Create DataStore
+  axom::sidre::DataStore datastore;
+  serac::StateManager::initialize(datastore, "beam_bending_data");
+
+  // Construct the appropriate dimension mesh and give it to the data store
+  std::string filename = SERAC_REPO_DIR "/data/meshes/beam-quad.mesh";
+
+  auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), 0, 0);
+  serac::StateManager::setMesh(std::move(mesh));
+
+  // _solver_params_start
+  serac::LinearSolverOptions linear_options{.linear_solver  = LinearSolver::GMRES,
+                                            .preconditioner = Preconditioner::HypreAMG,
+                                            .relative_tol   = 1.0e-6,
+                                            .absolute_tol   = 1.0e-14,
+                                            .max_iterations = 500,
+                                            .print_level    = 1};
+
+#ifdef MFEM_USE_SUNDIALS
+  serac::NonlinearSolverOptions nonlinear_options{.nonlin_solver  = NonlinearSolver::KINFullStep,
+                                                  .relative_tol   = 1.0e-12,
+                                                  .absolute_tol   = 1.0e-12,
+                                                  .max_iterations = 5000,
+                                                  .print_level    = 1};
+#else
+  serac::NonlinearSolverOptions nonlinear_options{.nonlin_solver  = NonlinearSolver::Newton,
+                                                  .relative_tol   = 1.0e-12,
+                                                  .absolute_tol   = 1.0e-12,
+                                                  .max_iterations = 5000,
+                                                  .print_level    = 1};
+#endif
+
+  SolidMechanics<p, dim> solid_solver(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
+                                      GeometricNonlinearities::On, "solid_mechanics");
+  // _solver_params_end
+
+  double K = 1.91666666666667;
+  double G = 1.0;
+  solid_mechanics::StVenantKirchhoff mat{1.0, K, G};
+  solid_solver.setMaterial(mat);
+
+  // Define the function for the initial displacement and boundary condition
+  auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
+
+  // Define a boundary attribute set and specify initial / boundary conditions
+  std::set<int> ess_bdr = {1};
+  solid_solver.setDisplacementBCs(ess_bdr, bc);
+  solid_solver.setDisplacement(bc);
+
+  solid_solver.setPiolaTraction([](const auto& x, const tensor<double, dim>& n, const double) {
+    return -0.01 * n * (x[1] > 0.99);
+  });
+
+  // Finalize the data structures
+  solid_solver.completeSetup();
+
+  // Perform the quasi-static solve
+  double dt = 1.0;
+  solid_solver.advanceTimestep(dt);
+
+  // Output the sidre-based plot files
+  solid_solver.outputState("paraview_output");
+}
+
+}  // namespace serac
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  MPI_Init(&argc, &argv);
+
+  axom::slic::SimpleLogger logger;
+
+  int result = RUN_ALL_TESTS();
+  MPI_Finalize();
+
+  return result;
+}

--- a/src/serac/physics/tests/beam_bending.cpp
+++ b/src/serac/physics/tests/beam_bending.cpp
@@ -22,9 +22,9 @@
 
 namespace serac {
 
-TEST(BeamBending, TwoDimensional) {
-
-  constexpr int p = 1;
+TEST(BeamBending, TwoDimensional)
+{
+  constexpr int p   = 1;
   constexpr int dim = 2;
 
   MPI_Barrier(MPI_COMM_WORLD);
@@ -65,8 +65,8 @@ TEST(BeamBending, TwoDimensional) {
                                       GeometricNonlinearities::On, "solid_mechanics");
   // _solver_params_end
 
-  double K = 1.91666666666667;
-  double G = 1.0;
+  double                             K = 1.91666666666667;
+  double                             G = 1.0;
   solid_mechanics::StVenantKirchhoff mat{1.0, K, G};
   solid_solver.setMaterial(mat);
 
@@ -78,9 +78,8 @@ TEST(BeamBending, TwoDimensional) {
   solid_solver.setDisplacementBCs(ess_bdr, bc);
   solid_solver.setDisplacement(bc);
 
-  solid_solver.setPiolaTraction([](const auto& x, const tensor<double, dim>& n, const double) {
-    return -0.01 * n * (x[1] > 0.99);
-  });
+  solid_solver.setPiolaTraction(
+      [](const auto& x, const tensor<double, dim>& n, const double) { return -0.01 * n * (x[1] > 0.99); });
 
   // Finalize the data structures
   solid_solver.completeSetup();

--- a/src/serac/physics/tests/beam_bending.cpp
+++ b/src/serac/physics/tests/beam_bending.cpp
@@ -39,7 +39,6 @@ TEST(BeamBending, TwoDimensional)
   auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), 0, 0);
   serac::StateManager::setMesh(std::move(mesh));
 
-  // _solver_params_start
   serac::LinearSolverOptions linear_options{.linear_solver  = LinearSolver::GMRES,
                                             .preconditioner = Preconditioner::HypreAMG,
                                             .relative_tol   = 1.0e-6,
@@ -63,7 +62,6 @@ TEST(BeamBending, TwoDimensional)
 
   SolidMechanics<p, dim> solid_solver(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
                                       GeometricNonlinearities::On, "solid_mechanics");
-  // _solver_params_end
 
   double                             K = 1.91666666666667;
   double                             G = 1.0;

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -179,7 +179,7 @@ TEST(Thermomechanics, ParameterizedMaterial)
 
   double epsilon = 1.0e-5;
   auto   dalpha  = alpha.CreateCompatibleVector();
-  dalpha = 1.0;
+  dalpha         = 1.0;
   alpha += epsilon * dalpha;
 
   // rerun the simulation to the beginning,

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -133,6 +133,8 @@ TEST(Thermomechanics, ParameterizedMaterial)
   temperature = theta_ref + 1.0;
   simulation.advanceTimestep(dt);
 
+  simulation.outputState("paraview");
+
   // define quantities of interest
   auto& mesh = serac::StateManager::mesh();
 
@@ -175,16 +177,16 @@ TEST(Thermomechanics, ParameterizedMaterial)
 
   auto& dqoi_dalpha = simulation.computeSensitivity(1);
 
-  double epsilon = 1.0e-6;
+  double epsilon = 1.0e-5;
   auto   dalpha  = alpha.CreateCompatibleVector();
-  dalpha.Randomize(0);
+  dalpha = 1.0;
   alpha += epsilon * dalpha;
 
   // rerun the simulation to the beginning,
   // but this time use perturbed values of alpha
-  simulation.setDisplacement(zero_vector);
-
   simulation.advanceTimestep(dt);
+
+  simulation.outputState("paraview");
 
   double final_qoi = qoi(simulation.displacement());
 
@@ -196,7 +198,7 @@ TEST(Thermomechanics, ParameterizedMaterial)
       axom::fmt::format("directional derivative of QoI by adjoint-state method: {}", adjoint_qoi_derivative));
   SLIC_INFO_ROOT(axom::fmt::format("directional derivative of QoI by finite-difference:    {}", fd_qoi_derivative));
 
-  EXPECT_NEAR(0.0, (fd_qoi_derivative - adjoint_qoi_derivative) / fd_qoi_derivative, 5.0e-6);
+  EXPECT_NEAR(0.0, (fd_qoi_derivative - adjoint_qoi_derivative) / fd_qoi_derivative, 3.0e-5);
 }
 
 // output:
@@ -205,8 +207,8 @@ TEST(Thermomechanics, ParameterizedMaterial)
 // exact area of the top surface: 0.441786
 // average vertical displacement: 0.001999
 // expected average vertical displacement: 0.002
-// directional derivative of QoI by adjoint-state method: 0.028289
-// directional derivative of QoI by finite-difference: 0.0282891
+// directional derivative of QoI by adjoint-state method: 0.8812734293294495
+// directional derivative of QoI by finite-difference:    0.8812609461498273
 
 int main(int argc, char* argv[])
 {


### PR DESCRIPTION
the relevant fix is the small change to solid_mechanics.hpp, where our extrapolated initial guess for the Newton solver wasn't respecting the essential boundary conditions. Was there a related issue for this failing test?

I'm also adding the reproducer file from #940 to facilitate future debugging of that issue.