### PR TITLE
Allow Spack to choose HDF5 1.8.23 while it's available

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -1,4 +1,4 @@
-# Copyright 2013-2021 Lawrence Livermore National Security, LLC and other
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level LICENSE file for details.
 #
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
@@ -109,7 +109,7 @@ class Serac(CachedCMakePackage, CudaPackage):
     # Note: Certain combinations of CMake and Conduit do not like +mpi
     #  and cause FindHDF5.cmake to fail and only return mpi information
     #  (includes, libs, etc) instead of hdf5 info
-    depends_on("hdf5@1.8.21+hl~mpi")
+    depends_on("hdf5@1.8.21:+hl~mpi")
 
     depends_on("camp@2022.03.2:")
 


### PR DESCRIPTION
Building TPLs on Fedora Linux 37 requires a [bugfix that's in HDF5 1.8.23](https://github.com/spack/spack/pull/38541). This patch enables serac to build with versions 1.8.21 or later. In LiDO, I customize the HDF5 package to add version 1.8.23 until upstream picks it up.
