### PR TITLE
One line fix for Intel 19.1.2

### DIFF
--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -233,7 +233,8 @@ mfem::Vector FromInlet<mfem::Vector>::operator()(const axom::inlet::Container& b
 serac::input::BoundaryConditionInputOptions FromInlet<serac::input::BoundaryConditionInputOptions>::operator()(
     const axom::inlet::Container& base)
 {
-  serac::input::BoundaryConditionInputOptions result{.attrs={}, .coef_opts = base.get<serac::input::CoefficientInputOptions>()};
+  serac::input::BoundaryConditionInputOptions result{.attrs     = {},
+                                                     .coef_opts = base.get<serac::input::CoefficientInputOptions>()};
   // Build a set with just the values of the map
   auto bdr_attr_map = base["attrs"].get<std::unordered_map<int, int>>();
   for (const auto& [_, val] : bdr_attr_map) {

--- a/src/serac/infrastructure/input.cpp
+++ b/src/serac/infrastructure/input.cpp
@@ -233,7 +233,7 @@ mfem::Vector FromInlet<mfem::Vector>::operator()(const axom::inlet::Container& b
 serac::input::BoundaryConditionInputOptions FromInlet<serac::input::BoundaryConditionInputOptions>::operator()(
     const axom::inlet::Container& base)
 {
-  serac::input::BoundaryConditionInputOptions result{.coef_opts = base.get<serac::input::CoefficientInputOptions>()};
+  serac::input::BoundaryConditionInputOptions result{.attrs={}, .coef_opts = base.get<serac::input::CoefficientInputOptions>()};
   // Build a set with just the values of the map
   auto bdr_attr_map = base["attrs"].get<std::unordered_map<int, int>>();
   for (const auto& [_, val] : bdr_attr_map) {


### PR DESCRIPTION
I built the infrastructure directory as part of another project using Intel 19.1.2 and that compiler could not deal with partial struct initialization when a non-POD datatype was involved. This small change seemed to placate the compiler.