### PR TITLE
Add newer tagged versions of RAJA that will compile on Fedora 37

### DIFF
--- a/scripts/spack/packages/raja/package.py
+++ b/scripts/spack/packages/raja/package.py
@@ -20,6 +20,8 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     version('develop', branch='develop', submodules=False)
     version('main',  branch='main',  submodules=False)
+    version("2022.10.5", tag="v2022.10.5", submodules=False)
+    version("2022.10.4", tag="v2022.10.4", submodules=False)
     version('2022.03.0', tag='v2022.03.0', submodules=False)
     version('0.14.0', tag='v0.14.0', submodules='True')
     version('0.13.0', tag='v0.13.0', submodules='True')
@@ -46,7 +48,7 @@ class Raja(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     # BEGIN SERAC EDIT
     # Patch for cuda and hip includes when not running on device
-    patch('arch_impl.patch', when='@2022.03.0:')
+    patch('arch_impl.patch', when='@2022.03.0')
     # END SERAC EDIT
 
     variant('openmp', default=True, description='Build OpenMP backend')


### PR DESCRIPTION
Regrettably, my previous pull request (#951) left out another necessary change.  The native gcc on Fedora 37 is gcc-12.3.1, and when it compiles RAJA 2022.03.0, there are numerous error messages stemming from the `avx512_int32.hpp` header file like these two:
```
  >> 424     /home/lidouser/current/lido/lido_libs/linux_fedora_37/2023_07_07_09_50_46/linux-fedora37-skylake_avx512/gcc-12.3.1/raja-2022.03.0
             -htujoqw3uo3ah3sawse7meqqw5bs65wc/include/RAJA/policy/tensor/arch/avx512/avx512_int32.hpp:213:33: error: cannot convert a value o
             f type 'RAJA::expt::Register<int, RAJA::expt::avx512_register>::register_type' to vector type '__m256i' which has different size
     425       213 |                                 _mm512_i64scatter_epi32(ptr,
     426           |               
     427     /home/epperly2/current/lido/lido_libs/linux_fedora_37/2023_07_07_09_50_46/linux-fedora37-skylake_avx512/gcc-12.3.1/raja-2022.03.0
             -htujoqw3uo3ah3sawse7meqqw5bs65wc/include/RAJA/policy/tensor/arch/avx512/avx512_int32.hpp: In member function 'const RAJA::expt::
             Register<int, RAJA::expt::avx512_register>::self_type& RAJA::expt::Register<int, RAJA::expt::avx512_register>::store_strided_n(el
             ement_type*, camp::idx_t, camp::idx_t) const':
  >> 428     /home/epperly2/current/lido/lido_libs/linux_fedora_37/2023_07_07_09_50_46/linux-fedora37-skylake_avx512/gcc-12.3.1/raja-2022.03.0
             -htujoqw3uo3ah3sawse7meqqw5bs65wc/include/RAJA/policy/tensor/arch/avx512/avx512_int32.hpp:228:33: error: cannot convert a value o
             f type 'RAJA::expt::Register<int, RAJA::expt::avx512_register>::register_type' to vector type '__m256i' which has different size
     429       228 |                                 _mm512_mask_i64scatter_epi32(ptr,
     430           |                                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This pair of errors shows up when compiling several source flies.

Adding version `2022.10.5` resolves this issue on Fedora 37.
