### PR TITLE
testing CI jobs from external pull requests

### DIFF
--- a/.gitlab/build_lassen.yml
+++ b/.gitlab/build_lassen.yml
@@ -12,6 +12,8 @@
     - when: on_success
   before_script:
     # python3.8 is needed on lassen to avoid trampling on the x86 clingo wheel
+    - mkdir this_is_a_test
+    - ls
     - module load python/3.8
     # CMake >= 3.17 is needed for FindCUDAToolkit with caliper
     # We could also extract the CMake executable location from the hostconfig in common_build_functions


### PR DESCRIPTION
I was reading about some potential security issues with github actions over the weekend and wondered if the gitlab runners were susceptible. One of the "attacks" involved CI jobs being triggered automatically from pull requests created by unauthorized users, so I thought I'd try it and see what happens.