### PR TITLE
Add missing header geometry

### DIFF
--- a/src/serac/numerics/functional/CMakeLists.txt
+++ b/src/serac/numerics/functional/CMakeLists.txt
@@ -13,6 +13,7 @@ set(functional_headers
     boundary_integral_kernels.hpp
     dof_numbering.hpp
     element_restriction.hpp
+    geometry.hpp
     geometric_factors.hpp
     domain_integral_kernels.hpp
     dual.hpp


### PR DESCRIPTION
noticed this issue while testing my recent LiDO TPL build

```
In file included from /usr/WS2/meemee/lido-2.0/lido_libs/toss_4_x86_64_ib/2023_08_01_11_56_12/linux-rhel8-ivybridge/gcc-10.3.1/smith-0.0.20_lido-ldt56w4fkhfbaa5snn6xjfnljvq4sz65/include/serac/numerics/functional/quadrature.hpp:16,
                 from /usr/WS2/meemee/lido-2.0/lido_libs/toss_4_x86_64_ib/2023_08_01_11_56_12/linux-rhel8-ivybridge/gcc-10.3.1/smith-0.0.20_lido-ldt56w4fkhfbaa5snn6xjfnljvq4sz65/include/serac/numerics/functional/functional.hpp:19,
                 from /usr/workspace/meemee/lido-2.0/repo/src/operators/serac/SeracHelper.hpp:21,
                 from /usr/workspace/meemee/lido-2.0/repo/examples/UncertainThreePoint.cpp:45:
/usr/WS2/meemee/lido-2.0/lido_libs/toss_4_x86_64_ib/2023_08_01_11_56_12/linux-rhel8-ivybridge/gcc-10.3.1/smith-0.0.20_lido-ldt56w4fkhfbaa5snn6xjfnljvq4sz65/include/serac/numerics/functional/polynomials.hpp:16:10: fatal error: geometry.hpp: No such file or directory
   16 | #include "geometry.hpp"
      |          ^~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [examples/CMakeFiles/UncertainThreePoint.dir/build.make:76: examples/CMakeFiles/UncertainThreePoint.dir/UncertainThreePoint.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:4248: examples/CMakeFiles/UncertainThreePoint.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
In file included from /usr/WS2/meemee/lido-2.0/lido_libs/toss_4_x86_64_ib/2023_08_01_11_56_12/linux-rhel8-ivybridge/gcc-10.3.1/smith-0.0.20_lido-ldt56w4fkhfbaa5snn6xjfnljvq4sz65/include/serac/numerics/functional/quadrature.hpp:16,
                 from /usr/WS2/meemee/lido-2.0/lido_libs/toss_4_x86_64_ib/2023_08_01_11_56_12/linux-rhel8-ivybridge/gcc-10.3.1/smith-0.0.20_lido-ldt56w4fkhfbaa5snn6xjfnljvq4sz65/include/serac/numerics/functional/functional.hpp:19,
                 from /usr/workspace/meemee/lido-2.0/repo/src/operators/serac/SeracHelper.hpp:21,
                 from /usr/workspace/meemee/lido-2.0/repo/tests/operators/serac/SeracQuasiStatic.test.cpp:34:
/usr/WS2/meemee/lido-2.0/lido_libs/toss_4_x86_64_ib/2023_08_01_11_56_12/linux-rhel8-ivybridge/gcc-10.3.1/smith-0.0.20_lido-ldt56w4fkhfbaa5snn6xjfnljvq4sz65/include/serac/numerics/functional/polynomials.hpp:16:10: fatal error: geometry.hpp: No such file or directory
   16 | #include "geometry.hpp"
      |          ^~~~~~~~~~~~~~
compilation terminated.
make[2]: *** [tests/operators/serac/CMakeFiles/SeracQuasiStatic.test.dir/build.make:76: tests/operators/serac/CMakeFiles/SeracQuasiStatic.test.dir/SeracQuasiStatic.test.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:3937: tests/operators/serac/CMakeFiles/SeracQuasiStatic.test.dir/all] Error 2
```