### PR TITLE
Handle new axom repo in codevelop mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,7 @@ install(TARGETS              serac
 if (SERAC_ENABLE_CODEVELOP)
     # This really shouldn't be needed but it keeps getting dropped from axom.
     # It certainly shouldn't go here either.
-    target_include_directories(axom SYSTEM PUBLIC
+    target_include_directories(axom SYSTEM INTERFACE
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/axom/src>
     )
 


### PR DESCRIPTION
This doesn't build because an `axom::array` constructor was removed but this gets past the CMake issues.

I will solve the code issue after we update Axom but it can't be fixed until then.

If you want to fix the build issues locally to use a newer Axom in codevelop, just remove the `{` and `}` in this file:

```
/usr/WS2/white238/serac/repo/src/serac/numerics/functional/element_restriction.cpp:384:50: error: call to constructor of 'axom::Array<DoF, 2, axom::MemorySpace::Host>' is ambiguous
    axom::Array<DoF, 2, axom::MemorySpace::Host> output({n, dofs_per_face});
                                                 ^      ~~~~~~~~~~~~~~~~~~
```