### PR TITLE
WIP: Refactor serac to support RAJA

### DIFF
--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -122,7 +122,8 @@ endmacro(serac_convert_to_native_escaped_file_path)
 ##------------------------------------------------------------------------------
 ## serac_add_tests( SOURCES       [source1 [source2 ...]]
 ##                  DEPENDS_ON    [dep1 [dep2 ...]]
-##                  NUM_MPI_TASKS [num tasks])
+##                  NUM_MPI_TASKS [num tasks]
+##                  )
 ##
 ## Creates an executable per given source and then adds the test to CTest
 ##------------------------------------------------------------------------------

--- a/src/serac/numerics/functional/boundary_integral_kernels.hpp
+++ b/src/serac/numerics/functional/boundary_integral_kernels.hpp
@@ -153,18 +153,26 @@ auto batch_apply_qf(lambda qf, const tensor<double, 3, n>& positions, const tens
   return outputs;
 }
 
-template <uint32_t differentiation_index, int Q, mfem::Geometry::Type geom, typename test, typename... trials,
+template<mfem::Geometry::Type geom, typename test, typename... trials>
+auto
+get_trial_elements(FunctionSignature<test(trials...)>) {
+  return tuple<finite_element<geom, trials>...> {};
+}
+
+template<mfem::Geometry::Type geom, typename test, typename... trials>
+auto
+get_test(FunctionSignature<test(trials...)>) {
+  return finite_element<geom, test> {};
+}
+
+ /// @trial_elements the element type for each trial space
+template <uint32_t differentiation_index, int Q, mfem::Geometry::Type geom, typename test_element, typename trial_element_type,
           typename lambda_type, typename derivative_type, int... indices>
-void evaluation_kernel_impl(FunctionSignature<test(trials...)>, const std::vector<const double*>& inputs,
+void evaluation_kernel_impl(trial_element_type trial_elements, test_element, const std::vector<const double*>& inputs,
                             double* outputs, const double* positions, const double* jacobians, lambda_type qf,
                             [[maybe_unused]] derivative_type* qf_derivatives, uint32_t num_elements,
                             std::integer_sequence<int, indices...>)
 {
-  using test_element = finite_element<geom, test>;
-
-  /// @brief the element type for each trial space
-  static constexpr tuple<finite_element<geom, trials>...> trial_elements{};
-
   // mfem provides this information as opaque arrays of doubles,
   // so we reinterpret the pointer with
   constexpr int dim = dimension_of(geom) + 1;
@@ -179,8 +187,17 @@ void evaluation_kernel_impl(FunctionSignature<test(trials...)>, const std::vecto
   [[maybe_unused]] tuple u = {
       reinterpret_cast<const typename decltype(type<indices>(trial_elements))::dof_type*>(inputs[indices])...};
 
+#if defined (USE_CUDA)
+std::cout << "RAJA ENABLE CUDA DEF" << std::endl;
+using policy = RAJA::cuda_exec<512>;
+// #if defined(RAJA_ENABLE_OPENMP)
+//   using policy = RAJA::omp_parallel_for_exec;
+#else
+std::cout << "simd\n";
+  using policy = RAJA::simd_exec;
+#endif
   // for each element in the domain
-  for (uint32_t e = 0; e < num_elements; e++) {
+  RAJA::forall<policy>(RAJA::TypedRangeSegment<uint32_t>(0, num_elements), [&](uint32_t e) {
     // load the jacobians and positions for each quadrature point in this element
     auto J_e = J[e];
     auto x_e = x[e];
@@ -203,7 +220,7 @@ void evaluation_kernel_impl(FunctionSignature<test(trials...)>, const std::vecto
 
     // (batch) integrate the material response against the test-space basis functions
     test_element::integrate(get_value(qf_outputs), rule, &r[e]);
-  }
+  });
 }
 
 //clang-format off
@@ -331,8 +348,10 @@ std::function<void(const std::vector<const double*>&, double*, bool)> evaluation
     signature s, lambda_type qf, const double* positions, const double* jacobians,
     std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
+  auto trial_elements = get_trial_elements<geom>(s);
+  auto test = get_test<geom>(s);
   return [=](const std::vector<const double*>& inputs, double* outputs, bool /* update state */) {
-    evaluation_kernel_impl<wrt, Q, geom>(s, inputs, outputs, positions, jacobians, qf, qf_derivatives.get(),
+    evaluation_kernel_impl<wrt, Q, geom>(trial_elements, test, inputs, outputs, positions, jacobians, qf, qf_derivatives.get(),
                                          num_elements, s.index_seq);
   };
 }

--- a/src/serac/numerics/functional/boundary_integral_kernels.hpp
+++ b/src/serac/numerics/functional/boundary_integral_kernels.hpp
@@ -153,21 +153,21 @@ auto batch_apply_qf(lambda qf, const tensor<double, 3, n>& positions, const tens
   return outputs;
 }
 
-template<mfem::Geometry::Type geom, typename test, typename... trials>
-auto
-get_trial_elements(FunctionSignature<test(trials...)>) {
-  return tuple<finite_element<geom, trials>...> {};
+template <mfem::Geometry::Type geom, typename test, typename... trials>
+auto get_trial_elements(FunctionSignature<test(trials...)>)
+{
+  return tuple<finite_element<geom, trials>...>{};
 }
 
-template<mfem::Geometry::Type geom, typename test, typename... trials>
-auto
-get_test(FunctionSignature<test(trials...)>) {
-  return finite_element<geom, test> {};
+template <mfem::Geometry::Type geom, typename test, typename... trials>
+auto get_test(FunctionSignature<test(trials...)>)
+{
+  return finite_element<geom, test>{};
 }
 
- /// @trial_elements the element type for each trial space
-template <uint32_t differentiation_index, int Q, mfem::Geometry::Type geom, typename test_element, typename trial_element_type,
-          typename lambda_type, typename derivative_type, int... indices>
+/// @trial_elements the element type for each trial space
+template <uint32_t differentiation_index, int Q, mfem::Geometry::Type geom, typename test_element,
+          typename trial_element_type, typename lambda_type, typename derivative_type, int... indices>
 void evaluation_kernel_impl(trial_element_type trial_elements, test_element, const std::vector<const double*>& inputs,
                             double* outputs, const double* positions, const double* jacobians, lambda_type qf,
                             [[maybe_unused]] derivative_type* qf_derivatives, uint32_t num_elements,
@@ -187,13 +187,13 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
   [[maybe_unused]] tuple u = {
       reinterpret_cast<const typename decltype(type<indices>(trial_elements))::dof_type*>(inputs[indices])...};
 
-#if defined (USE_CUDA)
-std::cout << "RAJA ENABLE CUDA DEF" << std::endl;
-using policy = RAJA::cuda_exec<512>;
+#if defined(USE_CUDA)
+  std::cout << "RAJA ENABLE CUDA DEF" << std::endl;
+  using policy = RAJA::cuda_exec<512>;
 // #if defined(RAJA_ENABLE_OPENMP)
 //   using policy = RAJA::omp_parallel_for_exec;
 #else
-std::cout << "simd\n";
+  std::cout << "simd\n";
   using policy = RAJA::simd_exec;
 #endif
   // for each element in the domain
@@ -349,10 +349,10 @@ std::function<void(const std::vector<const double*>&, double*, bool)> evaluation
     std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
   auto trial_elements = get_trial_elements<geom>(s);
-  auto test = get_test<geom>(s);
+  auto test           = get_test<geom>(s);
   return [=](const std::vector<const double*>& inputs, double* outputs, bool /* update state */) {
-    evaluation_kernel_impl<wrt, Q, geom>(trial_elements, test, inputs, outputs, positions, jacobians, qf, qf_derivatives.get(),
-                                         num_elements, s.index_seq);
+    evaluation_kernel_impl<wrt, Q, geom>(trial_elements, test, inputs, outputs, positions, jacobians, qf,
+                                         qf_derivatives.get(), num_elements, s.index_seq);
   };
 }
 

--- a/src/serac/numerics/functional/detail/hexahedron_H1.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_H1.inl
@@ -167,7 +167,8 @@ struct finite_element<mfem::Geometry::CUBE, H1<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
   {
     // we want to compute the following:
     //
@@ -228,7 +229,7 @@ struct finite_element<mfem::Geometry::CUBE, H1<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q * q * q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q * q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/detail/hexahedron_H1.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_H1.inl
@@ -130,7 +130,7 @@ struct finite_element<mfem::Geometry::CUBE, H1<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q * q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q * q * q> input, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/hexahedron_Hcurl.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_Hcurl.inl
@@ -255,7 +255,7 @@ struct finite_element<mfem::Geometry::CUBE, Hcurl<p>> {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q * q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q * q * q> input, const TensorProductQuadratureRule<q>&)
   {
     constexpr bool                     apply_weights = false;
     constexpr tensor<double, q, p>     B1            = calculate_B1<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/hexahedron_Hcurl.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_Hcurl.inl
@@ -334,7 +334,8 @@ struct finite_element<mfem::Geometry::CUBE, Hcurl<p>> {
   }
 
   template <int q>
-  static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
   {
     constexpr bool                     apply_weights = false;
     constexpr tensor<double, q, p>     B1            = calculate_B1<apply_weights, q>();
@@ -395,7 +396,7 @@ struct finite_element<mfem::Geometry::CUBE, Hcurl<p>> {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q * q * q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q * q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual,
                         [[maybe_unused]] int step = 1)
   {

--- a/src/serac/numerics/functional/detail/hexahedron_L2.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_L2.inl
@@ -171,7 +171,8 @@ struct finite_element<mfem::Geometry::CUBE, L2<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
   {
     // we want to compute the following:
     //
@@ -232,7 +233,7 @@ struct finite_element<mfem::Geometry::CUBE, L2<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q * q * q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q * q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/detail/hexahedron_L2.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_L2.inl
@@ -134,7 +134,7 @@ struct finite_element<mfem::Geometry::CUBE, L2<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q * q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q * q * q> input, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/qoi.inl
+++ b/src/serac/numerics/functional/detail/qoi.inl
@@ -24,14 +24,14 @@ struct finite_element<g, QOI> {
   SERAC_HOST_DEVICE static constexpr double shape_functions(double /* xi */) { return 1.0; }
 
   template <int Q, int q>
-  static void integrate(const tensor<zero, Q>&, const TensorProductQuadratureRule<q>&, dof_type*,
+  RAJA_HOST_DEVICE static void integrate(const tensor<zero, Q>&, const TensorProductQuadratureRule<q>&, dof_type*,
                         [[maybe_unused]] int step = 1)
   {
     return;  // integrating zeros is a no-op
   }
 
   template <int Q, int q>
-  static void integrate(const tensor<double, Q>& qf_output, const TensorProductQuadratureRule<q>&,
+  RAJA_HOST_DEVICE static void integrate(const tensor<double, Q>& qf_output, const TensorProductQuadratureRule<q>&,
                         dof_type* element_total, [[maybe_unused]] int step = 1)
   {
     if constexpr (geometry == mfem::Geometry::SEGMENT) {
@@ -77,7 +77,7 @@ struct finite_element<g, QOI> {
   // this overload is used for boundary integrals, since they pad the
   // output to be a tuple with a hardcoded `zero` flux term
   template <typename source_type, int Q, int q>
-  static void integrate(const tensor<serac::tuple<source_type, zero>, Q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<serac::tuple<source_type, zero>, Q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_total, [[maybe_unused]] int step = 1)
   {
     if constexpr (is_zero<source_type>{}) {

--- a/src/serac/numerics/functional/detail/quadrilateral_H1.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_H1.inl
@@ -202,7 +202,8 @@ struct finite_element<mfem::Geometry::SQUARE, H1<p, c> > {
   // A(dy, qx)  := B(qx, dx) * X_e(dy, dx)
   // X_q(qy, qx) := B(qy, dy) * A(dy, qx)
   template <int q>
-  static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();
@@ -245,7 +246,7 @@ struct finite_element<mfem::Geometry::SQUARE, H1<p, c> > {
   // flux can be one of: {zero, tensor<double,dim>, tensor<double,dim,dim>, tensor<double,dim,dim,dim>,
   // tensor<double,dim,dim,dim>}
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/detail/quadrilateral_H1.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_H1.inl
@@ -155,7 +155,7 @@ struct finite_element<mfem::Geometry::SQUARE, H1<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/quadrilateral_Hcurl.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_Hcurl.inl
@@ -285,7 +285,8 @@ struct finite_element<mfem::Geometry::SQUARE, Hcurl<p> > {
   }
 
   template <int q>
-  static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
   {
     constexpr bool                     apply_weights = false;
     constexpr tensor<double, q, p>     B1            = calculate_B1<apply_weights, q>();
@@ -323,7 +324,7 @@ struct finite_element<mfem::Geometry::SQUARE, Hcurl<p> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual,
                         [[maybe_unused]] int step = 1)
   {

--- a/src/serac/numerics/functional/detail/quadrilateral_Hcurl.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_Hcurl.inl
@@ -243,7 +243,7 @@ struct finite_element<mfem::Geometry::SQUARE, Hcurl<p> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
   {
     constexpr bool                     apply_weights = false;
     constexpr tensor<double, q, p>     B1            = calculate_B1<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/quadrilateral_L2.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_L2.inl
@@ -154,7 +154,7 @@ struct finite_element<mfem::Geometry::SQUARE, L2<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/quadrilateral_L2.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_L2.inl
@@ -201,7 +201,8 @@ struct finite_element<mfem::Geometry::SQUARE, L2<p, c> > {
   // A(dy, qx)  := B(qx, dx) * X_e(dy, dx)
   // X_q(qy, qx) := B(qy, dy) * A(dy, qx)
   template <int q>
-  static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();
@@ -244,7 +245,7 @@ struct finite_element<mfem::Geometry::SQUARE, L2<p, c> > {
   // flux can be one of: {zero, tensor<double,dim>, tensor<double,dim,dim>, tensor<double,dim,dim,dim>,
   // tensor<double,dim,dim,dim>}
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/detail/segment_H1.inl
+++ b/src/serac/numerics/functional/detail/segment_H1.inl
@@ -95,7 +95,7 @@ struct finite_element<mfem::Geometry::SEGMENT, H1<p, c> > {
 
   template <typename T, int q>
   RAJA_HOST_DEVICE
-  static auto batch_apply_shape_fn(int jx, tensor<T, q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int jx, tensor<T, q> input, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/segment_H1.inl
+++ b/src/serac/numerics/functional/detail/segment_H1.inl
@@ -94,6 +94,7 @@ struct finite_element<mfem::Geometry::SEGMENT, H1<p, c> > {
   }
 
   template <typename T, int q>
+  RAJA_HOST_DEVICE
   static auto batch_apply_shape_fn(int jx, tensor<T, q> input, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
@@ -121,7 +122,8 @@ struct finite_element<mfem::Geometry::SEGMENT, H1<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();
@@ -155,7 +157,7 @@ struct finite_element<mfem::Geometry::SEGMENT, H1<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual,
                         [[maybe_unused]] int step = 1)
   {

--- a/src/serac/numerics/functional/detail/segment_L2.inl
+++ b/src/serac/numerics/functional/detail/segment_L2.inl
@@ -94,7 +94,7 @@ struct finite_element<mfem::Geometry::SEGMENT, L2<p, c> > {
   }
 
   template <typename T, int q>
-  static auto batch_apply_shape_fn(int jx, tensor<T, q> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int jx, tensor<T, q> input, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();

--- a/src/serac/numerics/functional/detail/segment_L2.inl
+++ b/src/serac/numerics/functional/detail/segment_L2.inl
@@ -121,7 +121,8 @@ struct finite_element<mfem::Geometry::SEGMENT, L2<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
   {
     static constexpr bool apply_weights = false;
     static constexpr auto B             = calculate_B<apply_weights, q>();
@@ -155,7 +156,7 @@ struct finite_element<mfem::Geometry::SEGMENT, L2<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q>& qf_output,
                         const TensorProductQuadratureRule<q>&, dof_type* element_residual,
                         [[maybe_unused]] int step = 1)
   {

--- a/src/serac/numerics/functional/detail/tetrahedron_H1.inl
+++ b/src/serac/numerics/functional/detail/tetrahedron_H1.inl
@@ -336,7 +336,7 @@ struct finite_element<mfem::Geometry::TETRAHEDRON, H1<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, nqpts(q)> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, nqpts(q)> input, const TensorProductQuadratureRule<q>&)
   {
     using source_t = decltype(get<0>(get<0>(in_t{})) + dot(get<1>(get<0>(in_t{})), tensor<double, dim>{}));
     using flux_t   = decltype(get<0>(get<1>(in_t{})) + dot(get<1>(get<1>(in_t{})), tensor<double, dim>{}));

--- a/src/serac/numerics/functional/detail/tetrahedron_H1.inl
+++ b/src/serac/numerics/functional/detail/tetrahedron_H1.inl
@@ -361,7 +361,8 @@ struct finite_element<mfem::Geometry::TETRAHEDRON, H1<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
   {
     constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TETRAHEDRON>();
 
@@ -384,7 +385,7 @@ struct finite_element<mfem::Geometry::TETRAHEDRON, H1<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, nqpts(q)>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, nqpts(q)>& qf_output,
                         const TensorProductQuadratureRule<q>&, tensor<double, c, ndof>* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/detail/tetrahedron_L2.inl
+++ b/src/serac/numerics/functional/detail/tetrahedron_L2.inl
@@ -366,7 +366,8 @@ struct finite_element<mfem::Geometry::TETRAHEDRON, L2<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
   {
     constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TETRAHEDRON>();
 
@@ -389,7 +390,7 @@ struct finite_element<mfem::Geometry::TETRAHEDRON, L2<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, nqpts(q)>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, nqpts(q)>& qf_output,
                         const TensorProductQuadratureRule<q>&, tensor<double, c, ndof>* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/detail/tetrahedron_L2.inl
+++ b/src/serac/numerics/functional/detail/tetrahedron_L2.inl
@@ -341,7 +341,7 @@ struct finite_element<mfem::Geometry::TETRAHEDRON, L2<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, nqpts(q)> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, nqpts(q)> input, const TensorProductQuadratureRule<q>&)
   {
     using source_t = decltype(get<0>(get<0>(in_t{})) + dot(get<1>(get<0>(in_t{})), tensor<double, dim>{}));
     using flux_t   = decltype(get<0>(get<1>(in_t{})) + dot(get<1>(get<1>(in_t{})), tensor<double, dim>{}));

--- a/src/serac/numerics/functional/detail/triangle_H1.inl
+++ b/src/serac/numerics/functional/detail/triangle_H1.inl
@@ -266,7 +266,8 @@ struct finite_element<mfem::Geometry::TRIANGLE, H1<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
   {
     constexpr auto       xi                    = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
     static constexpr int num_quadrature_points = q * (q + 1) / 2;
@@ -290,7 +291,7 @@ struct finite_element<mfem::Geometry::TRIANGLE, H1<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q*(q + 1) / 2>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q*(q + 1) / 2>& qf_output,
                         const TensorProductQuadratureRule<q>&, tensor<double, c, ndof>* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/detail/triangle_H1.inl
+++ b/src/serac/numerics/functional/detail/triangle_H1.inl
@@ -240,7 +240,7 @@ struct finite_element<mfem::Geometry::TRIANGLE, H1<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q*(q + 1) / 2> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q*(q + 1) / 2> input, const TensorProductQuadratureRule<q>&)
   {
     using source_t = decltype(get<0>(get<0>(in_t{})) + dot(get<1>(get<0>(in_t{})), tensor<double, 2>{}));
     using flux_t   = decltype(get<0>(get<1>(in_t{})) + dot(get<1>(get<1>(in_t{})), tensor<double, 2>{}));

--- a/src/serac/numerics/functional/detail/triangle_L2.inl
+++ b/src/serac/numerics/functional/detail/triangle_L2.inl
@@ -249,7 +249,7 @@ struct finite_element<mfem::Geometry::TRIANGLE, L2<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q*(q + 1) / 2> input, const TensorProductQuadratureRule<q>&)
+  static auto RAJA_HOST_DEVICE batch_apply_shape_fn(int j, tensor<in_t, q*(q + 1) / 2> input, const TensorProductQuadratureRule<q>&)
   {
     using source_t = decltype(get<0>(get<0>(in_t{})) + dot(get<1>(get<0>(in_t{})), tensor<double, 2>{}));
     using flux_t   = decltype(get<0>(get<1>(in_t{})) + dot(get<1>(get<1>(in_t{})), tensor<double, 2>{}));

--- a/src/serac/numerics/functional/detail/triangle_L2.inl
+++ b/src/serac/numerics/functional/detail/triangle_L2.inl
@@ -275,7 +275,8 @@ struct finite_element<mfem::Geometry::TRIANGLE, L2<p, c> > {
   }
 
   template <int q>
-  static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
+  RAJA_HOST_DEVICE
+static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
   {
     constexpr auto       xi                    = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
     static constexpr int num_quadrature_points = q * (q + 1) / 2;
@@ -299,7 +300,7 @@ struct finite_element<mfem::Geometry::TRIANGLE, L2<p, c> > {
   }
 
   template <typename source_type, typename flux_type, int q>
-  static void integrate(const tensor<tuple<source_type, flux_type>, q*(q + 1) / 2>& qf_output,
+  RAJA_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q*(q + 1) / 2>& qf_output,
                         const TensorProductQuadratureRule<q>&, tensor<double, c, ndof>* element_residual, int step = 1)
   {
     if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {

--- a/src/serac/numerics/functional/differentiate_wrt.hpp
+++ b/src/serac/numerics/functional/differentiate_wrt.hpp
@@ -23,7 +23,7 @@ struct differentiate_wrt_this {
   const mfem::Vector& ref;  ///< the actual data wrapped by this type
 
   /// @brief implicitly convert back to `mfem::Vector` to extract the actual data
-  operator const mfem::Vector &() const { return ref; }
+  operator const mfem::Vector&() const { return ref; }
 };
 
 /**

--- a/src/serac/numerics/functional/domain_integral_kernels.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels.hpp
@@ -171,10 +171,8 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
       reinterpret_cast<const typename decltype(type<indices>(trial_elements))::dof_type*>(inputs[indices])...};
 
 #if defined(USE_CUDA)
-  std::cout << "USING CUDA :)\n";
   using policy = RAJA::cuda_exec<512>;
 #else
-  std::cout << "USING SIMD :)\n";
   using policy = RAJA::simd_exec;
 #endif
 
@@ -183,19 +181,18 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
       RAJA::TypedRangeSegment<uint32_t>(0, num_elements),
       [J, x, qf, u, qpts_per_elem, rule, r, qf_state, qf_derivatives, update_state] RAJA_HOST_DEVICE(uint32_t e) {
         // load the jacobians and positions for each quadrature point in this element
-        // printf("HERE1\n");
         auto J_e = J[e];
         auto x_e = x[e];
-        // printf("HERE2\n");
+
         static constexpr trial_element_type empty_trial_element{};
         // batch-calculate values / derivatives of each trial space, at each quadrature point
         [[maybe_unused]] tuple qf_inputs = {promote_each_to_dual_when<indices == differentiation_index>(
             get<indices>(empty_trial_element).interpolate(get<indices>(u)[e], rule))...};
-        // printf("HERE3\n");
+
         // use J_e to transform values / derivatives on the parent element
         // to the to the corresponding values / derivatives on the physical element
         (parent_to_physical<get<indices>(empty_trial_element).family>(get<indices>(qf_inputs), J_e), ...);
-        // printf("HERE4\n");
+
         // (batch) evalute the q-function at each quadrature point
         //
         // note: the weird immediately-invoked lambda expression is
@@ -208,11 +205,11 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
             return batch_apply_qf(qf, x_e, &qf_state(e, 0), update_state, get<indices>(qf_inputs)...);
           }
         }();
-        // printf("HERE5\n");
+
         // use J to transform sources / fluxes on the physical element
         // back to the corresponding sources / fluxes on the parent element
         physical_to_parent<test_element::family>(qf_outputs, J_e);
-        // printf("HERE6\n");
+
         // write out the q-function derivatives after applying the
         // physical_to_parent transformation, so that those transformations
         // won't need to be applied in the action_of_gradient and element_gradient kernels
@@ -221,10 +218,9 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
             qf_derivatives[e * uint32_t(qpts_per_elem) + uint32_t(q)] = get_gradient(qf_outputs[q]);
           }
         }
-        // printf("HERE7\n");
+
         // (batch) integrate the material response against the test-space basis functions
         test_element::integrate(get_value(qf_outputs), rule, &r[e]);
-        // printf("HERE8\n");
       });
 
   return;
@@ -383,9 +379,9 @@ void element_gradient_kernel(ExecArrayView<double, 3, ExecutionSpace::CPU> dK,
 template <uint32_t wrt, int Q, mfem::Geometry::Type geom, typename signature, typename lambda_type, typename state_type,
           typename derivative_type>
 std::function<void(const std::vector<const double*>&, double*, bool)> evaluation_kernel(
-    signature s, [[maybe_unused]] lambda_type qf, const double* positions, const double* jacobians,
-    [[maybe_unused]] std::shared_ptr<QuadratureData<state_type> > qf_state,
-    [[maybe_unused]] std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
+    signature s, lambda_type qf, const double* positions, const double* jacobians,
+    std::shared_ptr<QuadratureData<state_type> > qf_state, std::shared_ptr<derivative_type> qf_derivatives,
+    uint32_t num_elements)
 {
   auto trial_elements = get_trial_elements<geom>(s);
   auto test           = get_test<geom>(s);

--- a/src/serac/numerics/functional/domain_integral_kernels.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels.hpp
@@ -165,17 +165,18 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
   auto                           J = reinterpret_cast<const typename batched_jacobian<geom, Q>::type*>(jacobians);
   TensorProductQuadratureRule<Q> rule{};
 
-  [[maybe_unused]] auto qpts_per_elem = num_quadrature_points(geom, Q);
+  auto qpts_per_elem = num_quadrature_points(geom, Q);
 
   [[maybe_unused]] tuple u = {
       reinterpret_cast<const typename decltype(type<indices>(trial_elements))::dof_type*>(inputs[indices])...};
 
 #if defined(USE_CUDA)
+  std::cout << "USING CUDA :)\n";
   using policy = RAJA::cuda_exec<512>;
 #else
   using policy = RAJA::simd_exec;
 #endif
-
+    printf("HERE 42\n");
   // for each element in the domain
   RAJA::forall<policy>(
       RAJA::TypedRangeSegment<uint32_t>(0, num_elements),
@@ -184,6 +185,12 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
         auto J_e = J[e];
         auto x_e = x[e];
 
+        // Avoid unused warning/error ([[maybe_unused]] is not possible in the capture list)
+        (void)qf_derivatives;
+        (void)qpts_per_elem;
+        (void)update_state;
+        (void)qf_state;
+    printf("HERE 43\n");
         static constexpr trial_element_type empty_trial_element{};
         // batch-calculate values / derivatives of each trial space, at each quadrature point
         [[maybe_unused]] tuple qf_inputs = {promote_each_to_dual_when<indices == differentiation_index>(
@@ -222,7 +229,7 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
         // (batch) integrate the material response against the test-space basis functions
         test_element::integrate(get_value(qf_outputs), rule, &r[e]);
       });
-
+  std::cout << "HERE1\n";
   return;
 }
 
@@ -282,7 +289,7 @@ RAJA_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, co
  */
 
 template <int Q, mfem::Geometry::Type g, typename test, typename trial, typename derivatives_type>
-void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* qf_derivatives, std::size_t num_elements)
+void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* qf_derivatives, uint32_t num_elements)
 {
   using test_element  = finite_element<g, test>;
   using trial_element = finite_element<g, trial>;
@@ -302,16 +309,18 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
   using policy = RAJA::simd_exec;
 #endif
 
+
   // for each element in the domain
   RAJA::forall<policy>(RAJA::TypedRangeSegment<uint32_t>(0, num_elements), [=] RAJA_HOST_DEVICE(uint32_t e) {
     // (batch) interpolate each quadrature point's value
     auto qf_inputs = trial_element::interpolate(du[e], rule);
-
+printf("HERE2\n");
     // (batch) evalute the q-function at each quadrature point
     auto qf_outputs = batch_apply_chain_rule<is_QOI>(qf_derivatives + e * num_qpts, qf_inputs);
-
+printf("HERE3\n");
     // (batch) integrate the material response against the test-space basis functions
     test_element::integrate(qf_outputs, rule, &dr[e]);
+printf("HERE4\n");
   });
 }
 
@@ -353,27 +362,38 @@ void element_gradient_kernel(ExecArrayView<double, 3, ExecutionSpace::CPU> dK,
   using trial_element = finite_element<g, trial>;
 
   constexpr int nquad = num_quadrature_points(g, Q);
-
-  static constexpr TensorProductQuadratureRule<Q> rule{};
+  constexpr TensorProductQuadratureRule<Q> rule{};
+#if defined(USE_CUDA)
+  std::cout << "USING CUDA :)\n";
+  using policy = RAJA::cuda_exec<512>;
+#else
+  using policy = RAJA::simd_exec;
+#endif
 
   // for each element in the domain
-  for (uint32_t e = 0; e < num_elements; e++) {
+  RAJA::forall<policy>(
+      RAJA::TypedRangeSegment<uint32_t>(0, num_elements),
+        [=] RAJA_HOST_DEVICE(uint32_t e) {
+    printf("HERE6\n");
+    static constexpr bool is_QOI_2        = test::family == Family::QOI;
     auto* output_ptr = reinterpret_cast<typename test_element::dof_type*>(&dK(e, 0, 0));
-
+printf("HERE7\n");
     tensor<padded_derivative_type, nquad> derivatives{};
     for (int q = 0; q < nquad; q++) {
-      if constexpr (is_QOI) {
+      if constexpr (is_QOI_2) {
         get<0>(derivatives(q)) = qf_derivatives[e * nquad + uint32_t(q)];
       } else {
         derivatives(q) = qf_derivatives[e * nquad + uint32_t(q)];
       }
     }
-
+printf("HERE8\n");
     for (int J = 0; J < trial_element::ndof; J++) {
       auto source_and_flux = trial_element::batch_apply_shape_fn(J, derivatives, rule);
+      printf("HERE8\n");
       test_element::integrate(source_and_flux, rule, output_ptr + J, trial_element::ndof);
+      printf("HERE10\n");
     }
-  }
+  });
 }
 
 template <uint32_t wrt, int Q, mfem::Geometry::Type geom, typename signature, typename lambda_type, typename state_type,

--- a/src/serac/numerics/functional/domain_integral_kernels.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels.hpp
@@ -27,47 +27,40 @@ using std::integer_sequence;
  * trial space
  */
 template <typename space, typename dimension>
-RAJA_HOST_DEVICE
-struct QFunctionArgument;
+RAJA_HOST_DEVICE struct QFunctionArgument;
 
 /// @overload
 template <int p, int dim>
-RAJA_HOST_DEVICE
-struct QFunctionArgument<H1<p, 1>, Dimension<dim> > {
+RAJA_HOST_DEVICE struct QFunctionArgument<H1<p, 1>, Dimension<dim> > {
   using type = tuple<double, tensor<double, dim> >;  ///< what will be passed to the q-function
 };
 
 /// @overload
 template <int p, int c, int dim>
-RAJA_HOST_DEVICE
-struct QFunctionArgument<H1<p, c>, Dimension<dim> > {
+RAJA_HOST_DEVICE struct QFunctionArgument<H1<p, c>, Dimension<dim> > {
   using type = tuple<tensor<double, c>, tensor<double, c, dim> >;  ///< what will be passed to the q-function
 };
 
 /// @overload
 template <int p, int dim>
-RAJA_HOST_DEVICE
-struct QFunctionArgument<L2<p, 1>, Dimension<dim> > {
+RAJA_HOST_DEVICE struct QFunctionArgument<L2<p, 1>, Dimension<dim> > {
   using type = tuple<double, tensor<double, dim> >;  ///< what will be passed to the q-function
 };
 /// @overload
 template <int p, int c, int dim>
-RAJA_HOST_DEVICE
-struct QFunctionArgument<L2<p, c>, Dimension<dim> > {
+RAJA_HOST_DEVICE struct QFunctionArgument<L2<p, c>, Dimension<dim> > {
   using type = tuple<tensor<double, c>, tensor<double, c, dim> >;  ///< what will be passed to the q-function
 };
 
 /// @overload
 template <int p>
-RAJA_HOST_DEVICE
-struct QFunctionArgument<Hcurl<p>, Dimension<2> > {
+RAJA_HOST_DEVICE struct QFunctionArgument<Hcurl<p>, Dimension<2> > {
   using type = tuple<tensor<double, 2>, double>;  ///< what will be passed to the q-function
 };
 
 /// @overload
 template <int p>
-RAJA_HOST_DEVICE
-struct QFunctionArgument<Hcurl<p>, Dimension<3> > {
+RAJA_HOST_DEVICE struct QFunctionArgument<Hcurl<p>, Dimension<3> > {
   using type = tuple<tensor<double, 3>, tensor<double, 3> >;  ///< what will be passed to the q-function
 };
 
@@ -75,7 +68,7 @@ struct QFunctionArgument<Hcurl<p>, Dimension<3> > {
 SERAC_SUPPRESS_NVCC_HOSTDEVICE_WARNING
 template <typename lambda, typename coords_type, typename T, typename qpt_data_type, int... i>
 RAJA_HOST_DEVICE auto apply_qf_helper(lambda&& qf, coords_type&& x_q, qpt_data_type&& qpt_data, const T& arg_tuple,
-                                       std::integer_sequence<int, i...>)
+                                      std::integer_sequence<int, i...>)
 {
   if constexpr (std::is_same<typename std::decay<qpt_data_type>::type, Nothing>::value) {
     return qf(x_q, serac::get<i>(arg_tuple)...);
@@ -95,7 +88,7 @@ RAJA_HOST_DEVICE auto apply_qf_helper(lambda&& qf, coords_type&& x_q, qpt_data_t
  */
 template <typename lambda, typename coords_type, typename... T, typename qpt_data_type>
 RAJA_HOST_DEVICE auto apply_qf(lambda&& qf, coords_type&& x_q, qpt_data_type&& qpt_data,
-                                const serac::tuple<T...>& arg_tuple)
+                               const serac::tuple<T...>& arg_tuple)
 {
   return apply_qf_helper(qf, x_q, qpt_data, arg_tuple,
                          std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>{});
@@ -109,8 +102,7 @@ auto get_derivative_type(lambda qf, qpt_data_type&& qpt_data)
 };
 
 template <typename lambda, int dim, int n, typename... T>
-RAJA_HOST_DEVICE
-auto batch_apply_qf_no_qdata(lambda qf, const tensor<double, dim, n> x, const T&... inputs)
+RAJA_HOST_DEVICE auto batch_apply_qf_no_qdata(lambda qf, const tensor<double, dim, n> x, const T&... inputs)
 {
   using return_type = decltype(qf(tensor<double, dim>{}, T{}[0]...));
   tensor<return_type, n> outputs{};
@@ -125,9 +117,8 @@ auto batch_apply_qf_no_qdata(lambda qf, const tensor<double, dim, n> x, const T&
 }
 
 template <typename lambda, int dim, int n, typename qpt_data_type, typename... T>
-RAJA_HOST_DEVICE
-auto batch_apply_qf(lambda qf, const tensor<double, dim, n> x, qpt_data_type* qpt_data, bool update_state,
-                    const T&... inputs)
+RAJA_HOST_DEVICE auto batch_apply_qf(lambda qf, const tensor<double, dim, n> x, qpt_data_type* qpt_data,
+                                     bool update_state, const T&... inputs)
 {
   using return_type = decltype(qf(tensor<double, dim>{}, qpt_data[0], T{}[0]...));
   tensor<return_type, n> outputs{};
@@ -146,31 +137,32 @@ auto batch_apply_qf(lambda qf, const tensor<double, dim, n> x, qpt_data_type* qp
   return outputs;
 }
 
-template<mfem::Geometry::Type geom, typename test, typename... trials>
-auto
-get_trial_elements(FunctionSignature<test(trials...)>) {
-  return tuple<finite_element<geom, trials>...> {};
+template <mfem::Geometry::Type geom, typename test, typename... trials>
+auto get_trial_elements(FunctionSignature<test(trials...)>)
+{
+  return tuple<finite_element<geom, trials>...>{};
 }
 
-template<mfem::Geometry::Type geom, typename test, typename... trials>
-auto
-get_test(FunctionSignature<test(trials...)>) {
-  return finite_element<geom, test> {};
+template <mfem::Geometry::Type geom, typename test, typename... trials>
+auto get_test(FunctionSignature<test(trials...)>)
+{
+  return finite_element<geom, test>{};
 }
 
-template <uint32_t differentiation_index, int Q, mfem::Geometry::Type geom, typename test_element, typename trial_element_type,
-          typename lambda_type, typename state_type, typename derivative_type, int... indices>
+template <uint32_t differentiation_index, int Q, mfem::Geometry::Type geom, typename test_element,
+          typename trial_element_type, typename lambda_type, typename state_type, typename derivative_type,
+          int... indices>
 void evaluation_kernel_impl(trial_element_type trial_elements, test_element, const std::vector<const double*>& inputs,
-                            double* outputs, const double* positions, const double* jacobians, 
-                             lambda_type qf, [[maybe_unused]] axom::ArrayView<state_type, 2> qf_state, [[maybe_unused]] derivative_type* qf_derivatives, 
-                            uint32_t num_elements, bool update_state, camp::int_seq<int, indices...> 
-                            )
+                            double* outputs, const double* positions, const double* jacobians, lambda_type qf,
+                            [[maybe_unused]] axom::ArrayView<state_type, 2> qf_state,
+                            [[maybe_unused]] derivative_type* qf_derivatives, uint32_t num_elements, bool update_state,
+                            camp::int_seq<int, indices...>)
 {
   // mfem provides this information as opaque arrays of doubles,
   // so we reinterpret the pointer with
-  auto r = reinterpret_cast<typename test_element::dof_type*>(outputs);
-  auto x = reinterpret_cast<const typename batched_position<geom, Q>::type*>(positions);
-  auto J = reinterpret_cast<const typename batched_jacobian<geom, Q>::type*>(jacobians);
+  auto                           r = reinterpret_cast<typename test_element::dof_type*>(outputs);
+  auto                           x = reinterpret_cast<const typename batched_position<geom, Q>::type*>(positions);
+  auto                           J = reinterpret_cast<const typename batched_jacobian<geom, Q>::type*>(jacobians);
   TensorProductQuadratureRule<Q> rule{};
 
   [[maybe_unused]] auto qpts_per_elem = num_quadrature_points(geom, Q);
@@ -178,69 +170,69 @@ void evaluation_kernel_impl(trial_element_type trial_elements, test_element, con
   [[maybe_unused]] tuple u = {
       reinterpret_cast<const typename decltype(type<indices>(trial_elements))::dof_type*>(inputs[indices])...};
 
- #if defined (USE_CUDA)
- std::cout << "USING CUDA :)\n";
- using policy = RAJA::cuda_exec<512>;
- #else
+#if defined(USE_CUDA)
+  std::cout << "USING CUDA :)\n";
+  using policy = RAJA::cuda_exec<512>;
+#else
   std::cout << "USING SIMD :)\n";
-using policy = RAJA::simd_exec;
+  using policy = RAJA::simd_exec;
 #endif
 
   // for each element in the domain
-  RAJA::forall<policy>(RAJA::TypedRangeSegment<uint32_t>(0, num_elements),
-  [J, x, qf, u, qpts_per_elem, rule, r, qf_state, qf_derivatives, update_state] RAJA_HOST_DEVICE (uint32_t e) {
-    // load the jacobians and positions for each quadrature point in this element
-    //printf("HERE1\n");
-    auto J_e = J[e];
-    auto x_e = x[e];
-   //printf("HERE2\n");
-    static constexpr trial_element_type empty_trial_element {};
-    // batch-calculate values / derivatives of each trial space, at each quadrature point
-    [[maybe_unused]] tuple qf_inputs = {promote_each_to_dual_when<indices == differentiation_index>(
-        get<indices>(empty_trial_element).interpolate(get<indices>(u)[e], rule))...};
-   //printf("HERE3\n");
-    // use J_e to transform values / derivatives on the parent element
-    // to the to the corresponding values / derivatives on the physical element
-    (parent_to_physical<get<indices>(empty_trial_element).family>(get<indices>(qf_inputs), J_e), ...);
-   //printf("HERE4\n");
-    // (batch) evalute the q-function at each quadrature point
-    //
-    // note: the weird immediately-invoked lambda expression is
-    // a workaround for a bug in GCC(<12.0) where it fails to
-    // decide which function overload to use, and crashes
-    auto qf_outputs = [&]() {
-      if constexpr (std::is_same_v<state_type, Nothing>) {
-        return batch_apply_qf_no_qdata(qf, x_e, get<indices>(qf_inputs)...);
-      } else {
-        return batch_apply_qf(qf, x_e, &qf_state(e, 0), update_state, get<indices>(qf_inputs)...);
-      }
-    }();
-   //printf("HERE5\n");
-    // use J to transform sources / fluxes on the physical element
-    // back to the corresponding sources / fluxes on the parent element
-    physical_to_parent<test_element::family>(qf_outputs, J_e);
-   //printf("HERE6\n");
-    // write out the q-function derivatives after applying the
-    // physical_to_parent transformation, so that those transformations
-    // won't need to be applied in the action_of_gradient and element_gradient kernels
-    if constexpr (differentiation_index != serac::NO_DIFFERENTIATION) {
-      for (int q = 0; q < leading_dimension(qf_outputs); q++) {
-        qf_derivatives[e * uint32_t(qpts_per_elem) + uint32_t(q)] = get_gradient(qf_outputs[q]);
-      }
-    }
-   //printf("HERE7\n");
-    // (batch) integrate the material response against the test-space basis functions
-    test_element::integrate(get_value(qf_outputs), rule, &r[e]);
-   //printf("HERE8\n");
-  });
+  RAJA::forall<policy>(
+      RAJA::TypedRangeSegment<uint32_t>(0, num_elements),
+      [J, x, qf, u, qpts_per_elem, rule, r, qf_state, qf_derivatives, update_state] RAJA_HOST_DEVICE(uint32_t e) {
+        // load the jacobians and positions for each quadrature point in this element
+        // printf("HERE1\n");
+        auto J_e = J[e];
+        auto x_e = x[e];
+        // printf("HERE2\n");
+        static constexpr trial_element_type empty_trial_element{};
+        // batch-calculate values / derivatives of each trial space, at each quadrature point
+        [[maybe_unused]] tuple qf_inputs = {promote_each_to_dual_when<indices == differentiation_index>(
+            get<indices>(empty_trial_element).interpolate(get<indices>(u)[e], rule))...};
+        // printf("HERE3\n");
+        // use J_e to transform values / derivatives on the parent element
+        // to the to the corresponding values / derivatives on the physical element
+        (parent_to_physical<get<indices>(empty_trial_element).family>(get<indices>(qf_inputs), J_e), ...);
+        // printf("HERE4\n");
+        // (batch) evalute the q-function at each quadrature point
+        //
+        // note: the weird immediately-invoked lambda expression is
+        // a workaround for a bug in GCC(<12.0) where it fails to
+        // decide which function overload to use, and crashes
+        auto qf_outputs = [&]() {
+          if constexpr (std::is_same_v<state_type, Nothing>) {
+            return batch_apply_qf_no_qdata(qf, x_e, get<indices>(qf_inputs)...);
+          } else {
+            return batch_apply_qf(qf, x_e, &qf_state(e, 0), update_state, get<indices>(qf_inputs)...);
+          }
+        }();
+        // printf("HERE5\n");
+        // use J to transform sources / fluxes on the physical element
+        // back to the corresponding sources / fluxes on the parent element
+        physical_to_parent<test_element::family>(qf_outputs, J_e);
+        // printf("HERE6\n");
+        // write out the q-function derivatives after applying the
+        // physical_to_parent transformation, so that those transformations
+        // won't need to be applied in the action_of_gradient and element_gradient kernels
+        if constexpr (differentiation_index != serac::NO_DIFFERENTIATION) {
+          for (int q = 0; q < leading_dimension(qf_outputs); q++) {
+            qf_derivatives[e * uint32_t(qpts_per_elem) + uint32_t(q)] = get_gradient(qf_outputs[q]);
+          }
+        }
+        // printf("HERE7\n");
+        // (batch) integrate the material response against the test-space basis functions
+        test_element::integrate(get_value(qf_outputs), rule, &r[e]);
+        // printf("HERE8\n");
+      });
 
   return;
 }
 
 //clang-format off
 template <bool is_QOI, typename S, typename T>
-RAJA_HOST_DEVICE
-auto chain_rule(const S& dfdx, const T& dx)
+RAJA_HOST_DEVICE auto chain_rule(const S& dfdx, const T& dx)
 {
   if constexpr (is_QOI) {
     return serac::chain_rule(serac::get<0>(dfdx), serac::get<0>(dx)) +
@@ -257,8 +249,7 @@ auto chain_rule(const S& dfdx, const T& dx)
 //clang-format on
 
 template <bool is_QOI, typename derivative_type, int n, typename T>
-RAJA_HOST_DEVICE
-auto batch_apply_chain_rule(derivative_type* qf_derivatives, const tensor<T, n>& inputs)
+RAJA_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, const tensor<T, n>& inputs)
 {
   using return_type = decltype(chain_rule<is_QOI>(derivative_type{}, T{}));
   tensor<return_type, n> outputs{};
@@ -305,19 +296,18 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
 
   // mfem provides this information in 1D arrays, so we reshape it
   // into strided multidimensional arrays before using
-  auto                                            du = reinterpret_cast<const typename trial_element::dof_type*>(dU);
-  auto                                            dr = reinterpret_cast<typename test_element::dof_type*>(dR);
+  auto                                 du = reinterpret_cast<const typename trial_element::dof_type*>(dU);
+  auto                                 dr = reinterpret_cast<typename test_element::dof_type*>(dR);
   const TensorProductQuadratureRule<Q> rule{};
 
- #if defined (USE_CUDA)
- using policy = RAJA::cuda_exec<512>;
- #else
-using policy = RAJA::simd_exec;
+#if defined(USE_CUDA)
+  using policy = RAJA::cuda_exec<512>;
+#else
+  using policy = RAJA::simd_exec;
 #endif
 
   // for each element in the domain
- RAJA::forall<policy>(RAJA::TypedRangeSegment<uint32_t>(0, num_elements),
- [=] RAJA_HOST_DEVICE (uint32_t e) {
+  RAJA::forall<policy>(RAJA::TypedRangeSegment<uint32_t>(0, num_elements), [=] RAJA_HOST_DEVICE(uint32_t e) {
     // (batch) interpolate each quadrature point's value
     auto qf_inputs = trial_element::interpolate(du[e], rule);
 
@@ -351,13 +341,12 @@ using policy = RAJA::simd_exec;
  * @param[in] num_elements The number of elements in the mesh
  */
 template <mfem::Geometry::Type g, typename test, typename trial, int Q, typename derivatives_type>
-#if defined (USE_CUDA)
+#if defined(USE_CUDA)
 void element_gradient_kernel(ExecArrayView<double, 3, ExecutionSpace::GPU> dK,
 #else
 void element_gradient_kernel(ExecArrayView<double, 3, ExecutionSpace::CPU> dK,
 #endif
-                             derivatives_type* qf_derivatives,
-                             std::size_t num_elements)
+                             derivatives_type* qf_derivatives, std::size_t num_elements)
 {
   // quantities of interest have no flux term, so we pad the derivative
   // tuple with a "zero" type in the second position to treat it like the standard case
@@ -395,14 +384,15 @@ template <uint32_t wrt, int Q, mfem::Geometry::Type geom, typename signature, ty
           typename derivative_type>
 std::function<void(const std::vector<const double*>&, double*, bool)> evaluation_kernel(
     signature s, [[maybe_unused]] lambda_type qf, const double* positions, const double* jacobians,
-    [[maybe_unused]]std::shared_ptr<QuadratureData<state_type> > qf_state, 
+    [[maybe_unused]] std::shared_ptr<QuadratureData<state_type> > qf_state,
     [[maybe_unused]] std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
   auto trial_elements = get_trial_elements<geom>(s);
-  auto test = get_test<geom>(s);
-  return [=] (const std::vector<const double*>& inputs, double* outputs, bool update_state) {
-    domain_integral::evaluation_kernel_impl<wrt, Q, geom>(trial_elements, test, inputs, outputs, positions, jacobians, 
-        qf, (*qf_state)[geom], qf_derivatives.get(), num_elements, update_state, s.index_seq);
+  auto test           = get_test<geom>(s);
+  return [=](const std::vector<const double*>& inputs, double* outputs, bool update_state) {
+    domain_integral::evaluation_kernel_impl<wrt, Q, geom>(trial_elements, test, inputs, outputs, positions, jacobians,
+                                                          qf, (*qf_state)[geom], qf_derivatives.get(), num_elements,
+                                                          update_state, s.index_seq);
   };
 }
 
@@ -418,19 +408,18 @@ std::function<void(const double*, double*)> jacobian_vector_product_kernel(
 }
 
 template <int wrt, int Q, mfem::Geometry::Type geom, typename signature, typename derivative_type>
-#if defined (USE_CUDA)
+#if defined(USE_CUDA)
 std::function<void(ExecArrayView<double, 3, ExecutionSpace::GPU>)>
-#else 
-std::function<void(ExecArrayView<double, 3, ExecutionSpace::CPU>)> 
+#else
+std::function<void(ExecArrayView<double, 3, ExecutionSpace::CPU>)>
 #endif
-element_gradient_kernel(
-    signature, std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
+element_gradient_kernel(signature, std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
-  #if defined (USE_CUDA)
+#if defined(USE_CUDA)
   return [=](ExecArrayView<double, 3, ExecutionSpace::GPU> K_elem) {
-  #else 
+#else
   return [=](ExecArrayView<double, 3, ExecutionSpace::CPU> K_elem) {
-  #endif
+#endif
     using test_space  = typename signature::return_type;
     using trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
     element_gradient_kernel<geom, test_space, trial_space, Q>(K_elem, qf_derivatives.get(), num_elements);

--- a/src/serac/numerics/functional/element_restriction.cpp
+++ b/src/serac/numerics/functional/element_restriction.cpp
@@ -440,6 +440,15 @@ void ElementRestriction::GetElementVDofs(int i, std::vector<DoF>& vdofs) const
   }
 }
 
+void ElementRestriction::GetElementVDofs(int i, DoF* vdofs) const
+{
+  for (uint64_t c = 0; c < components; c++) {
+    for (uint64_t j = 0; j < nodes_per_elem; j++) {
+      vdofs[c * nodes_per_elem + j] = GetVDof(dof_info(i, j), c);
+    }
+  }
+}
+
 void ElementRestriction::Gather(const mfem::Vector& L_vector, mfem::Vector& E_vector) const
 {
   for (uint64_t i = 0; i < num_elements; i++) {

--- a/src/serac/numerics/functional/element_restriction.hpp
+++ b/src/serac/numerics/functional/element_restriction.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <RAJA/util/macros.hpp>
 #include <vector>
 
 #include "mfem.hpp"
@@ -55,27 +56,34 @@ struct DoF {
   uint64_t bits;
 
   /// default ctor
+  RAJA_HOST_DEVICE
   DoF() : bits{} {}
 
   /// copy ctor
+  RAJA_HOST_DEVICE
   DoF(const DoF& other) : bits{other.bits} {}
 
   /// create a `DoF` from the given index, sign and orientation values
+  RAJA_HOST_DEVICE
   DoF(uint64_t index, uint64_t sign = 0, uint64_t orientation = 0)
       : bits((sign & 0x1ULL << sign_shift) + ((orientation & 0x7ULL) << orientation_shift) + index)
   {
   }
 
   /// copy assignment operator
+  RAJA_HOST_DEVICE
   void operator=(const DoF& other) { bits = other.bits; }
 
   /// get the sign field of this `DoF`
+  RAJA_HOST_DEVICE
   int sign() const { return (bits & sign_mask) ? -1 : 1; }
 
   /// get the orientation field of this `DoF`
+  RAJA_HOST_DEVICE
   uint64_t orientation() const { return ((bits & orientation_mask) >> orientation_shift); }
 
   /// get the index field of this `DoF`
+  RAJA_HOST_DEVICE
   uint64_t index() const { return (bits & index_mask); }
 };
 
@@ -167,7 +175,17 @@ struct ElementRestriction {
    */
   void GetElementVDofs(int i, std::vector<DoF>& dofs) const;
 
+  /**
+   * @brief Overload for device code.
+   *
+   * @param i the index of the element
+   * @param dofs (output) the DoFs associated with element `i`
+   */
+  RAJA_HOST_DEVICE
+  void GetElementVDofs(int i, DoF* vdofs) const;
+
   /// get the dof information for a given node / component
+  RAJA_HOST_DEVICE
   DoF GetVDof(DoF node, uint64_t component) const;
 
   /// "L->E" in mfem parlance, each element gathers the values that belong to it, and stores them in the "E-vector"

--- a/src/serac/numerics/functional/finite_element.hpp
+++ b/src/serac/numerics/functional/finite_element.hpp
@@ -244,6 +244,7 @@ struct QOI {
  * @param jacobians the jacobians of the isoparametric map from parent to physical space of each quadrature point
  */
 template <Family f, typename T, int q, int dim>
+RAJA_HOST_DEVICE
 void parent_to_physical(tensor<T, q>& qf_input, const tensor<double, dim, dim, q>& jacobians)
 {
   [[maybe_unused]] constexpr int VALUE      = 0;
@@ -285,6 +286,7 @@ void parent_to_physical(tensor<T, q>& qf_input, const tensor<double, dim, dim, q
  * @param jacobians the jacobians of the isoparametric map from parent to physical space of each quadrature point
  */
 template <Family f, typename T, int q, int dim>
+RAJA_HOST_DEVICE
 void physical_to_parent(tensor<T, q>& qf_output, const tensor<double, dim, dim, q>& jacobians)
 {
   [[maybe_unused]] constexpr int SOURCE = 0;
@@ -347,6 +349,7 @@ void physical_to_parent(tensor<T, q>& qf_output, const tensor<double, dim, dim, 
  *
  */
 template <mfem::Geometry::Type g, typename family>
+RAJA_HOST_DEVICE
 struct finite_element;
 
 #include "detail/segment_H1.inl"

--- a/src/serac/numerics/functional/finite_element.hpp
+++ b/src/serac/numerics/functional/finite_element.hpp
@@ -244,8 +244,7 @@ struct QOI {
  * @param jacobians the jacobians of the isoparametric map from parent to physical space of each quadrature point
  */
 template <Family f, typename T, int q, int dim>
-RAJA_HOST_DEVICE
-void parent_to_physical(tensor<T, q>& qf_input, const tensor<double, dim, dim, q>& jacobians)
+RAJA_HOST_DEVICE void parent_to_physical(tensor<T, q>& qf_input, const tensor<double, dim, dim, q>& jacobians)
 {
   [[maybe_unused]] constexpr int VALUE      = 0;
   [[maybe_unused]] constexpr int DERIVATIVE = 1;
@@ -286,8 +285,7 @@ void parent_to_physical(tensor<T, q>& qf_input, const tensor<double, dim, dim, q
  * @param jacobians the jacobians of the isoparametric map from parent to physical space of each quadrature point
  */
 template <Family f, typename T, int q, int dim>
-RAJA_HOST_DEVICE
-void physical_to_parent(tensor<T, q>& qf_output, const tensor<double, dim, dim, q>& jacobians)
+RAJA_HOST_DEVICE void physical_to_parent(tensor<T, q>& qf_output, const tensor<double, dim, dim, q>& jacobians)
 {
   [[maybe_unused]] constexpr int SOURCE = 0;
   [[maybe_unused]] constexpr int FLUX   = 1;
@@ -349,8 +347,7 @@ void physical_to_parent(tensor<T, q>& qf_output, const tensor<double, dim, dim, 
  *
  */
 template <mfem::Geometry::Type g, typename family>
-RAJA_HOST_DEVICE
-struct finite_element;
+RAJA_HOST_DEVICE struct finite_element;
 
 #include "detail/segment_H1.inl"
 #include "detail/segment_Hcurl.inl"

--- a/src/serac/numerics/functional/function_signature.hpp
+++ b/src/serac/numerics/functional/function_signature.hpp
@@ -1,3 +1,4 @@
+#include <camp/camp.hpp>
 #pragma once
 
 template <typename T>
@@ -17,5 +18,5 @@ struct FunctionSignature<output_type(input_types...)> {
   static constexpr int num_args = sizeof...(input_types);
 
   /// integer sequence used to make iterating over arguments easier
-  static constexpr auto index_seq = std::make_integer_sequence<int, num_args>{};
+  static constexpr auto index_seq = camp::make_int_seq<int, num_args>{};
 };

--- a/src/serac/numerics/functional/integral.hpp
+++ b/src/serac/numerics/functional/integral.hpp
@@ -123,8 +123,13 @@ struct Integral {
    * test_dofs_per_elem)
    * @param differentiation_index the index of the trial space being differentiated
    */
+  #if defined (USE_CUDA)
+  void ComputeElementGradients(std::map<mfem::Geometry::Type, ExecArray<double, 3, ExecutionSpace::GPU> >& K_e,
+                                                                          uint32_t differentiation_index) const
+  #else
   void ComputeElementGradients(std::map<mfem::Geometry::Type, ExecArray<double, 3, ExecutionSpace::CPU> >& K_e,
-                               uint32_t differentiation_index) const
+                                                                          uint32_t differentiation_index) const
+  #endif
   {
     // if this integral actually depends on the specified variable
     if (functional_to_integral_index_.count(differentiation_index) > 0) {
@@ -153,7 +158,11 @@ struct Integral {
   std::vector<std::map<mfem::Geometry::Type, jacobian_vector_product_func> > jvp_;
 
   /// @brief signature of element gradient kernel
+  #if defined (USE_CUDA)
+  using grad_func = std::function<void(ExecArrayView<double, 3, ExecutionSpace::GPU>)>;
+  #else
   using grad_func = std::function<void(ExecArrayView<double, 3, ExecutionSpace::CPU>)>;
+  #endif
 
   /// @brief kernels for calculation of element jacobians
   std::vector<std::map<mfem::Geometry::Type, grad_func> > element_gradient_;
@@ -223,8 +232,11 @@ void generate_kernels(FunctionSignature<test(trials...)> s, Integral& integral, 
     // action_of_gradient functor below to augment the reference count, and extend its lifetime to match
     // that of the DomainIntegral that allocated it.
     using derivative_type = decltype(domain_integral::get_derivative_type<index, dim, trials...>(qf, qpt_data_type{}));
+    #if defined (USE_CUDA)
+    auto ptr = accelerator::make_shared_array<ExecutionSpace::GPU, derivative_type>(num_elements * qpts_per_element);
+    #else
     auto ptr = accelerator::make_shared_array<ExecutionSpace::CPU, derivative_type>(num_elements * qpts_per_element);
-
+    #endif
     integral.evaluation_with_AD_[index][geom] =
         domain_integral::evaluation_kernel<index, Q, geom>(s, qf, positions, jacobians, qdata, ptr, num_elements);
 
@@ -310,7 +322,11 @@ void generate_bdr_kernels(FunctionSignature<test(trials...)> s, Integral& integr
     // action_of_gradient functor below to augment the reference count, and extend its lifetime to match
     // that of the boundaryIntegral that allocated it.
     using derivative_type = decltype(boundary_integral::get_derivative_type<index, dim, trials...>(qf));
+    #if defined (USE_CUDA)
+    auto ptr = accelerator::make_shared_array<ExecutionSpace::GPU, derivative_type>(num_elements * qpts_per_element);
+    #else
     auto ptr = accelerator::make_shared_array<ExecutionSpace::CPU, derivative_type>(num_elements * qpts_per_element);
+    #endif
 
     integral.evaluation_with_AD_[index][geom] =
         boundary_integral::evaluation_kernel<index, Q, geom>(s, qf, positions, jacobians, ptr, num_elements);

--- a/src/serac/numerics/functional/integral.hpp
+++ b/src/serac/numerics/functional/integral.hpp
@@ -116,20 +116,20 @@ struct Integral {
     }
   }
 
-  /**
-   * @brief evaluate the jacobian (with respect to some trial space) of this integral
-   *
-   * @param K_e a collection (one for each element type) of element jacobians (num_elements x trial_dofs_per_elem x
-   * test_dofs_per_elem)
-   * @param differentiation_index the index of the trial space being differentiated
-   */
-  #if defined (USE_CUDA)
+/**
+ * @brief evaluate the jacobian (with respect to some trial space) of this integral
+ *
+ * @param K_e a collection (one for each element type) of element jacobians (num_elements x trial_dofs_per_elem x
+ * test_dofs_per_elem)
+ * @param differentiation_index the index of the trial space being differentiated
+ */
+#if defined(USE_CUDA)
   void ComputeElementGradients(std::map<mfem::Geometry::Type, ExecArray<double, 3, ExecutionSpace::GPU> >& K_e,
-                                                                          uint32_t differentiation_index) const
-  #else
+                               uint32_t differentiation_index) const
+#else
   void ComputeElementGradients(std::map<mfem::Geometry::Type, ExecArray<double, 3, ExecutionSpace::CPU> >& K_e,
-                                                                          uint32_t differentiation_index) const
-  #endif
+                               uint32_t differentiation_index) const
+#endif
   {
     // if this integral actually depends on the specified variable
     if (functional_to_integral_index_.count(differentiation_index) > 0) {
@@ -157,12 +157,12 @@ struct Integral {
   /// @brief kernels for jacobian-vector product of integral calculation
   std::vector<std::map<mfem::Geometry::Type, jacobian_vector_product_func> > jvp_;
 
-  /// @brief signature of element gradient kernel
-  #if defined (USE_CUDA)
+/// @brief signature of element gradient kernel
+#if defined(USE_CUDA)
   using grad_func = std::function<void(ExecArrayView<double, 3, ExecutionSpace::GPU>)>;
-  #else
+#else
   using grad_func = std::function<void(ExecArrayView<double, 3, ExecutionSpace::CPU>)>;
-  #endif
+#endif
 
   /// @brief kernels for calculation of element jacobians
   std::vector<std::map<mfem::Geometry::Type, grad_func> > element_gradient_;
@@ -232,11 +232,11 @@ void generate_kernels(FunctionSignature<test(trials...)> s, Integral& integral, 
     // action_of_gradient functor below to augment the reference count, and extend its lifetime to match
     // that of the DomainIntegral that allocated it.
     using derivative_type = decltype(domain_integral::get_derivative_type<index, dim, trials...>(qf, qpt_data_type{}));
-    #if defined (USE_CUDA)
+#if defined(USE_CUDA)
     auto ptr = accelerator::make_shared_array<ExecutionSpace::GPU, derivative_type>(num_elements * qpts_per_element);
-    #else
+#else
     auto ptr = accelerator::make_shared_array<ExecutionSpace::CPU, derivative_type>(num_elements * qpts_per_element);
-    #endif
+#endif
     integral.evaluation_with_AD_[index][geom] =
         domain_integral::evaluation_kernel<index, Q, geom>(s, qf, positions, jacobians, qdata, ptr, num_elements);
 
@@ -322,11 +322,11 @@ void generate_bdr_kernels(FunctionSignature<test(trials...)> s, Integral& integr
     // action_of_gradient functor below to augment the reference count, and extend its lifetime to match
     // that of the boundaryIntegral that allocated it.
     using derivative_type = decltype(boundary_integral::get_derivative_type<index, dim, trials...>(qf));
-    #if defined (USE_CUDA)
+#if defined(USE_CUDA)
     auto ptr = accelerator::make_shared_array<ExecutionSpace::GPU, derivative_type>(num_elements * qpts_per_element);
-    #else
+#else
     auto ptr = accelerator::make_shared_array<ExecutionSpace::CPU, derivative_type>(num_elements * qpts_per_element);
-    #endif
+#endif
 
     integral.evaluation_with_AD_[index][geom] =
         boundary_integral::evaluation_kernel<index, Q, geom>(s, qf, positions, jacobians, ptr, num_elements);

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1266,8 +1266,7 @@ auto matrix_sqrt(const tensor<T, dim, dim>& A)
  * @param B the right operand
  */
 template <int i1, int i2, typename S, int m, int... n, typename T, int p, int q>
-RAJA_HOST_DEVICE
-auto contract(const tensor<S, m, n...>& A, const tensor<T, p, q>& B)
+RAJA_HOST_DEVICE auto contract(const tensor<S, m, n...>& A, const tensor<T, p, q>& B)
 {
   constexpr int Adims[] = {m, n...};
   constexpr int Bdims[] = {p, q};
@@ -1325,8 +1324,7 @@ auto contract(const tensor<S, m, n...>& A, const tensor<T, p, q>& B)
 
 /// @overload
 template <int i1, int i2, typename T>
-RAJA_HOST_DEVICE
-auto contract(const zero&, const T&)
+RAJA_HOST_DEVICE auto contract(const zero&, const T&)
 {
   return zero{};
 }

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1266,6 +1266,7 @@ auto matrix_sqrt(const tensor<T, dim, dim>& A)
  * @param B the right operand
  */
 template <int i1, int i2, typename S, int m, int... n, typename T, int p, int q>
+RAJA_HOST_DEVICE
 auto contract(const tensor<S, m, n...>& A, const tensor<T, p, q>& B)
 {
   constexpr int Adims[] = {m, n...};
@@ -1324,6 +1325,7 @@ auto contract(const tensor<S, m, n...>& A, const tensor<T, p, q>& B)
 
 /// @overload
 template <int i1, int i2, typename T>
+RAJA_HOST_DEVICE
 auto contract(const zero&, const T&)
 {
   return zero{};

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -58,4 +58,8 @@ if(ENABLE_CUDA)
     serac_add_tests( SOURCES ${functional_tests_cuda}
                      DEPENDS_ON gtest serac_functional serac_state ${functional_depends} cuda)
 
+            
+    blt_add_executable(NAME functional_cuda
+                       SOURCES functional_cuda.cpp
+                       DEPENDS_ON gtest serac_functional serac_state ${functional_depends} cuda)
 endif()

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ foreach(filename ${functional_tests_mpi})
     set_source_files_properties(${filename} PROPERTIES LANGUAGE CXX)
 endforeach()
 
+
 if(ENABLE_CUDA)
 
     set(functional_tests_cuda 
@@ -62,4 +63,10 @@ if(ENABLE_CUDA)
     blt_add_executable(NAME functional_cuda
                        SOURCES functional_cuda.cpp
                        DEPENDS_ON gtest serac_functional serac_state ${functional_depends} cuda)
+
+    blt_add_executable(NAME functional_basic_h1_scalar_cuda
+                       SOURCES functional_basic_h1_scalar.cpp
+                       DEPENDS_ON gtest serac_functional serac_state ${functional_depends} cuda)
+    
+    target_compile_definitions(functional_basic_h1_scalar_cuda PUBLIC ENABLE_CUDA)
 endif()

--- a/src/serac/numerics/functional/tests/check_gradient.hpp
+++ b/src/serac/numerics/functional/tests/check_gradient.hpp
@@ -9,11 +9,12 @@
 
 #include "mfem.hpp"
 
+#include "serac/infrastructure/accelerator.hpp"
 #include "serac/serac_config.hpp"
 #include "serac/numerics/functional/functional.hpp"
 
-template <typename T>
-void check_gradient(serac::Functional<T>& f, mfem::Vector& U, double epsilon = 1.0e-4)
+template <typename T, serac::ExecutionSpace exec>
+void check_gradient(serac::Functional<T, exec>& f, mfem::Vector& U, double epsilon = 1.0e-4)
 {
   int seed = 42;
 
@@ -213,8 +214,8 @@ void check_gradient(serac::Functional<T>& f, mfem::Vector& U, mfem::Vector& dU_d
 // qoi overloads //
 ///////////////////
 
-template <typename T>
-void check_gradient(serac::Functional<double(T)>& f, mfem::HypreParVector& U)
+template <typename T, serac::ExecutionSpace execution_space>
+void check_gradient(serac::Functional<double(T), execution_space>& f, mfem::HypreParVector& U)
 {
   int seed = 42;
 

--- a/src/serac/numerics/functional/tests/functional_boundary_test.cpp
+++ b/src/serac/numerics/functional/tests/functional_boundary_test.cpp
@@ -11,6 +11,8 @@
 #include <gtest/gtest.h>
 #include "mfem.hpp"
 
+#define ENABLE_CUDA
+
 #include "serac/serac_config.hpp"
 #include "serac/numerics/stdfunction_operator.hpp"
 #include "serac/numerics/functional/functional.hpp"

--- a/src/serac/numerics/functional/tests/functional_cuda.cpp
+++ b/src/serac/numerics/functional/tests/functional_cuda.cpp
@@ -1,0 +1,214 @@
+#include <functional>
+#define USE_CUDA
+// Copyright (c) 2019-2023, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include <fstream>
+#include <iostream>
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include <gtest/gtest.h>
+#include "mfem.hpp"
+
+#include "serac/serac_config.hpp"
+#include "serac/mesh/mesh_utils_base.hpp"
+#include "serac/numerics/stdfunction_operator.hpp"
+#include "serac/numerics/functional/functional.hpp"
+#include "serac/numerics/functional/tensor.hpp"
+
+using namespace serac;
+
+int num_procs, myid;
+
+constexpr bool                 verbose = true;
+std::unique_ptr<mfem::ParMesh> mesh2D;
+std::unique_ptr<mfem::ParMesh> mesh3D;
+
+struct TestThermalModelOne {
+  [[maybe_unused]] static constexpr double a = 1.7;
+  [[maybe_unused]] static constexpr double b = 0.0;
+  template<typename X, typename Temp>
+  RAJA_HOST_DEVICE
+  auto operator()([[maybe_unused]] X x, [[maybe_unused]] Temp temperature) {
+    // get the value and the gradient from the input tuple
+    auto [u, du_dx] = temperature;
+    auto source     = a * u - (100 * x[0] * x[1]);
+    auto flux       = b * du_dx;
+    return serac::tuple{source, flux};
+  }
+};
+
+//struct TestThermalModelTwo {
+//  template<typename A, typename X>
+//  auto operator()(A, [[maybe_unused]] X x) {
+//      auto dp_dX = serac::get<1>(X);
+//      auto I     = serac::Identity<dim>();
+//      return serac::tuple{serac::det(dp_dX + I), serac::zero{}};
+//  }
+//};
+
+// this test sets up a toy "thermal" problem where the residual includes contributions
+// from a temperature-dependent source term and a temperature-gradient-dependent flux
+//
+// the same problem is expressed with mfem and functional, and their residuals and gradient action
+// are compared to ensure the implementations are in agreement.
+template <int p, int dim>
+void functional_test(mfem::ParMesh& mesh, L2<p> test, L2<p> trial, Dimension<dim>)
+{
+
+  [[maybe_unused]] static constexpr double a = 1.7;
+  [[maybe_unused]] static constexpr double b = 0.0;
+  // Create standard MFEM bilinear and linear forms on H1
+  auto                        fec = mfem::L2_FECollection(p, dim, mfem::BasisType::GaussLobatto);
+  mfem::ParFiniteElementSpace fespace(&mesh, &fec);
+
+  mfem::ParBilinearForm A(&fespace);
+
+  // Add the mass term using the standard MFEM method
+  mfem::ConstantCoefficient a_coef(a);
+  A.AddDomainIntegrator(new mfem::MassIntegrator(a_coef));
+
+  // Assemble the bilinear form into a matrix
+  A.Assemble(0);
+  A.Finalize();
+  std::unique_ptr<mfem::HypreParMatrix> J(A.ParallelAssemble());
+
+  // Create a linear form for the load term using the standard MFEM method
+  mfem::ParLinearForm       f(&fespace);
+  mfem::FunctionCoefficient load_func([&](const mfem::Vector& coords) { return 100 * coords(0) * coords(1); });
+  // FunctionCoefficient load_func([&]([[maybe_unused]] const Vector& coords) { return 1.0; });
+
+  // Create and assemble the linear load term into a vector
+  f.AddDomainIntegrator(new mfem::DomainLFIntegrator(load_func));
+  f.Assemble();
+  std::unique_ptr<mfem::HypreParVector> F(f.ParallelAssemble());
+
+  // Set a random state to evaluate the residual
+  mfem::ParGridFunction u_global(&fespace);
+  u_global.Randomize();
+
+  mfem::Vector U(fespace.TrueVSize());
+  u_global.GetTrueDofs(U);
+
+  // Set up the same problem using weak form
+
+  // Define the types for the test and trial spaces using the function arguments
+  using test_space  = decltype(test);
+  using trial_space = decltype(trial);
+
+  // Construct the new weak form object using the known test and trial spaces
+  Functional<test_space(trial_space), ExecutionSpace::GPU> residual(&fespace, {&fespace});
+
+  cudaDeviceSynchronize();
+  // Add the total domain residual term to the weak form
+  residual.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0>{},
+      TestThermalModelOne {},
+      mesh);
+  cudaDeviceSynchronize();
+  // uncomment lines below to verify that compile-time error messages
+  // explain L2 spaces are not currently supported in boundary integrals.
+  //
+  // residual.AddBoundaryIntegral(
+  //    Dimension<dim-1>{},
+  //    DependsOn<0>{},
+  //    [&]([[maybe_unused]] auto x, [[maybe_unused]] auto temperature) { return 1.0; },
+  //    mesh);
+
+  // Compute the residual using standard MFEM methods
+  // mfem::Vector r1 = A * U - (*F);
+  mfem::Vector r1(U.Size());
+  A.Mult(U, r1);
+  r1 -= (*F);
+
+  // Compute the residual using weak form
+  auto [r2, drdU] = residual(differentiate_wrt(U));
+
+  mfem::Vector diff(r1.Size());
+  subtract(r1, r2, diff);
+
+  if (verbose) {
+    std::cout << "||r1||: " << r1.Norml2() << std::endl;
+    std::cout << "||r2||: " << r2.Norml2() << std::endl;
+    std::cout << "||r1-r2||/||r1||: " << diff.Norml2() / r1.Norml2() << std::endl;
+  }
+
+  // Test that the two residuals are equivalent
+  EXPECT_NEAR(0., diff.Norml2() / r1.Norml2(), 1.e-14);
+
+  // Compute the gradient action using standard MFEM and Functional
+  // mfem::Vector g1 = (*J) * U;
+  mfem::Vector g1(U.Size());
+  J->Mult(U, g1);
+
+  mfem::Vector g2 = drdU(U);
+
+  subtract(g1, g2, diff);
+
+  if (verbose) {
+    std::cout << "||g1||: " << g1.Norml2() << std::endl;
+    std::cout << "||g2||: " << g2.Norml2() << std::endl;
+    std::cout << "||g1-g2||/||g1||: " << diff.Norml2() / g1.Norml2() << std::endl;
+  }
+
+  // Ensure the two methods generate the same result
+  EXPECT_NEAR(0., diff.Norml2() / g1.Norml2(), 1.e-14);
+}
+
+TEST(L2, 2DConstant) { functional_test(*mesh2D, L2<0>{}, L2<0>{}, Dimension<2>{}); }
+TEST(L2, 2DLinear) { functional_test(*mesh2D, L2<1>{}, L2<1>{}, Dimension<2>{}); }
+TEST(L2, 2DQuadratic) { functional_test(*mesh2D, L2<2>{}, L2<2>{}, Dimension<2>{}); }
+TEST(L2, 2DCubic) { functional_test(*mesh2D, L2<3>{}, L2<3>{}, Dimension<2>{}); }
+
+TEST(L2, 3DLinear) { functional_test(*mesh3D, L2<1>{}, L2<1>{}, Dimension<3>{}); }
+TEST(L2, 3DQuadratic) { functional_test(*mesh3D, L2<2>{}, L2<2>{}, Dimension<3>{}); }
+TEST(L2, 3DCubic) { functional_test(*mesh3D, L2<3>{}, L2<3>{}, Dimension<3>{}); }
+
+//TEST(L2, 2DMixed)
+//{
+//  constexpr int dim = 2;
+//  using test_space  = L2<0>;
+//  using trial_space = H1<1, dim>;
+//
+//  auto                        L2fec = mfem::L2_FECollection(0, dim, mfem::BasisType::GaussLobatto);
+//  mfem::ParFiniteElementSpace L2fespace(mesh2D.get(), &L2fec);
+//
+//  auto                        H1fec = mfem::H1_FECollection(1, dim);
+//  mfem::ParFiniteElementSpace H1fespace(mesh2D.get(), &H1fec, dim);
+//
+//  serac::Functional<test_space(trial_space)> f(&L2fespace, {&H1fespace});
+//
+//  TestThermalModelTwo test;
+//  f.AddDomainIntegral(
+//      serac::Dimension<dim>{}, serac::DependsOn<0>{},
+//      test,
+//      *mesh2D);
+//}
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  MPI_Init(&argc, &argv);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
+  MPI_Comm_rank(MPI_COMM_WORLD, &myid);
+  cudaDeviceSynchronize();
+  axom::slic::SimpleLogger logger;
+
+  int serial_refinement   = 0;
+  int parallel_refinement = 0;
+
+  std::string meshfile2D = SERAC_REPO_DIR "/data/meshes/star.mesh";
+  mesh2D = mesh::refineAndDistribute(buildMeshFromFile(meshfile2D), serial_refinement, parallel_refinement);
+
+  std::string meshfile3D = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
+  mesh3D = mesh::refineAndDistribute(buildMeshFromFile(meshfile3D), serial_refinement, parallel_refinement);
+
+  int result = RUN_ALL_TESTS();
+
+  MPI_Finalize();
+
+  return result;
+}

--- a/src/serac/numerics/functional/tests/functional_cuda.cpp
+++ b/src/serac/numerics/functional/tests/functional_cuda.cpp
@@ -30,9 +30,9 @@ std::unique_ptr<mfem::ParMesh> mesh3D;
 struct TestThermalModelOne {
   [[maybe_unused]] static constexpr double a = 1.7;
   [[maybe_unused]] static constexpr double b = 0.0;
-  template<typename X, typename Temp>
-  RAJA_HOST_DEVICE
-  auto operator()([[maybe_unused]] X x, [[maybe_unused]] Temp temperature) {
+  template <typename X, typename Temp>
+  RAJA_HOST_DEVICE auto operator()([[maybe_unused]] X x, [[maybe_unused]] Temp temperature)
+  {
     // get the value and the gradient from the input tuple
     auto [u, du_dx] = temperature;
     auto source     = a * u - (100 * x[0] * x[1]);
@@ -41,7 +41,7 @@ struct TestThermalModelOne {
   }
 };
 
-//struct TestThermalModelTwo {
+// struct TestThermalModelTwo {
 //  template<typename A, typename X>
 //  auto operator()(A, [[maybe_unused]] X x) {
 //      auto dp_dX = serac::get<1>(X);
@@ -58,7 +58,6 @@ struct TestThermalModelOne {
 template <int p, int dim>
 void functional_test(mfem::ParMesh& mesh, L2<p> test, L2<p> trial, Dimension<dim>)
 {
-
   [[maybe_unused]] static constexpr double a = 1.7;
   [[maybe_unused]] static constexpr double b = 0.0;
   // Create standard MFEM bilinear and linear forms on H1
@@ -104,10 +103,7 @@ void functional_test(mfem::ParMesh& mesh, L2<p> test, L2<p> trial, Dimension<dim
 
   cudaDeviceSynchronize();
   // Add the total domain residual term to the weak form
-  residual.AddDomainIntegral(
-      Dimension<dim>{}, DependsOn<0>{},
-      TestThermalModelOne {},
-      mesh);
+  residual.AddDomainIntegral(Dimension<dim>{}, DependsOn<0>{}, TestThermalModelOne{}, mesh);
   cudaDeviceSynchronize();
   // uncomment lines below to verify that compile-time error messages
   // explain L2 spaces are not currently supported in boundary integrals.
@@ -167,7 +163,7 @@ TEST(L2, 3DLinear) { functional_test(*mesh3D, L2<1>{}, L2<1>{}, Dimension<3>{});
 TEST(L2, 3DQuadratic) { functional_test(*mesh3D, L2<2>{}, L2<2>{}, Dimension<3>{}); }
 TEST(L2, 3DCubic) { functional_test(*mesh3D, L2<3>{}, L2<3>{}, Dimension<3>{}); }
 
-//TEST(L2, 2DMixed)
+// TEST(L2, 2DMixed)
 //{
 //  constexpr int dim = 2;
 //  using test_space  = L2<0>;

--- a/src/serac/numerics/functional/tests/functional_cuda.cpp
+++ b/src/serac/numerics/functional/tests/functional_cuda.cpp
@@ -105,14 +105,6 @@ void functional_test(mfem::ParMesh& mesh, L2<p> test, L2<p> trial, Dimension<dim
   // Add the total domain residual term to the weak form
   residual.AddDomainIntegral(Dimension<dim>{}, DependsOn<0>{}, TestThermalModelOne{}, mesh);
   cudaDeviceSynchronize();
-  // uncomment lines below to verify that compile-time error messages
-  // explain L2 spaces are not currently supported in boundary integrals.
-  //
-  // residual.AddBoundaryIntegral(
-  //    Dimension<dim-1>{},
-  //    DependsOn<0>{},
-  //    [&]([[maybe_unused]] auto x, [[maybe_unused]] auto temperature) { return 1.0; },
-  //    mesh);
 
   // Compute the residual using standard MFEM methods
   // mfem::Vector r1 = A * U - (*F);

--- a/src/serac/numerics/functional/tuple_tensor_dual_functions.hpp
+++ b/src/serac/numerics/functional/tuple_tensor_dual_functions.hpp
@@ -220,7 +220,7 @@ SERAC_HOST_DEVICE auto promote_to_dual_when(const T& x)
  * @param x the values to be promoted
  */
 template <bool dualify, typename T, int n>
-SERAC_HOST_DEVICE auto promote_each_to_dual_when(const tensor<T, n>& x)
+RAJA_HOST_DEVICE auto promote_each_to_dual_when(const tensor<T, n>& x)
 {
   if constexpr (dualify) {
     using return_type = decltype(make_dual(T{}));

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -280,6 +280,16 @@ public:
   struct ThermalMaterialIntegrand {
     ThermalMaterialIntegrand(MaterialType material) : material_(material) {}
 
+    // The template parameter MaterialType is meant to be a callable functor.  Due
+    // to nvcc's lack of support for generic lambdas (i.e. functions of the form
+    // auto lambda = [](auto) {}; ), this cannot be allowed.  In order for this code
+    // to be portable to CUDA platforms, the asserts below prevent serac from compiling
+    // if such a lambda is supplied.
+    class DummyArgumentType {};
+    static_assert(!std::is_invocable<MaterialType, DummyArgumentType&>::value);
+    static_assert(!std::is_invocable<MaterialType, DummyArgumentType*>::value);
+    static_assert(!std::is_invocable<MaterialType, DummyArgumentType>::value);
+
     template <typename X, typename T, typename dT_dt, typename Shape, typename... Params>
     auto operator()(X x, T temperature, dT_dt dtemp_dt, Shape shape, Params... params)
     {

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -294,7 +294,8 @@ public:
     // to be portable to CUDA platforms, the asserts below prevent serac from compiling
     // if such a lambda is supplied.
   private:
-    class DummyArgumentType {};
+    class DummyArgumentType {
+    };
     static_assert(!std::is_invocable<MaterialType, DummyArgumentType&>::value);
     static_assert(!std::is_invocable<MaterialType, DummyArgumentType*>::value);
     static_assert(!std::is_invocable<MaterialType, DummyArgumentType>::value);

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -276,21 +276,34 @@ public:
     cycle_ += 1;
   }
 
+  /**
+   * @brief Functor representing the integrand of a thermal material.  Material type must be
+   * a functor as well.
+   */
   template <typename MaterialType>
   struct ThermalMaterialIntegrand {
+    /**
+     * @brief Construct a ThermalMaterialIntegrand functor with material model of type `MaterialType`.
+     * @param[in] material A functor representing the material model.  Should be a functor, or a class/struct with
+     * public operator() method.  Must NOT be a generic lambda, or serac will not compile due to static asserts below.
+     */
     ThermalMaterialIntegrand(MaterialType material) : material_(material) {}
 
-    // The template parameter MaterialType is meant to be a callable functor.  Due
-    // to nvcc's lack of support for generic lambdas (i.e. functions of the form
+    // Due to nvcc's lack of support for generic lambdas (i.e. functions of the form
     // auto lambda = [](auto) {}; ), this cannot be allowed.  In order for this code
     // to be portable to CUDA platforms, the asserts below prevent serac from compiling
     // if such a lambda is supplied.
+  private:
     class DummyArgumentType {};
     static_assert(!std::is_invocable<MaterialType, DummyArgumentType&>::value);
     static_assert(!std::is_invocable<MaterialType, DummyArgumentType*>::value);
     static_assert(!std::is_invocable<MaterialType, DummyArgumentType>::value);
 
+  public:
     template <typename X, typename T, typename dT_dt, typename Shape, typename... Params>
+    /**
+     * @brief Evaluate integrand
+     */
     auto operator()(X x, T temperature, dT_dt dtemp_dt, Shape shape, Params... params)
     {
       // Get the value and the gradient from the input tuple

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -300,10 +300,10 @@ public:
     static_assert(!std::is_invocable<MaterialType, DummyArgumentType>::value);
 
   public:
-    template <typename X, typename T, typename dT_dt, typename Shape, typename... Params>
     /**
      * @brief Evaluate integrand
      */
+    template <typename X, typename T, typename dT_dt, typename Shape, typename... Params>
     auto operator()(X x, T temperature, dT_dt dtemp_dt, Shape shape, Params... params)
     {
       // Get the value and the gradient from the input tuple

--- a/src/serac/serac_config.hpp.in
+++ b/src/serac/serac_config.hpp.in
@@ -21,6 +21,7 @@
 // Serac Locations
 #define SERAC_REPO_DIR "@SERAC_REPO_DIR@"
 #define SERAC_BIN_DIR "@SERAC_BIN_DIR@"
+//#define RAJA_ENABLE_CUDA On
 
 // General defines
 #cmakedefine SERAC_DEBUG

--- a/src/serac/serac_config.hpp.in
+++ b/src/serac/serac_config.hpp.in
@@ -21,7 +21,6 @@
 // Serac Locations
 #define SERAC_REPO_DIR "@SERAC_REPO_DIR@"
 #define SERAC_BIN_DIR "@SERAC_BIN_DIR@"
-//#define RAJA_ENABLE_CUDA On
 
 // General defines
 #cmakedefine SERAC_DEBUG


### PR DESCRIPTION
This PR enables CUDA execution via RAJA, as well as compilation of GPU kernels with NVCC.  Several important restrictions imposed by nvcc that this PR works around are
(1) Multiple variadic template parameters in the enclosing function of a generic lambda
(2) Using [=] to capture local variables in a lambda declaration doesn't work with if the enclosing function has a variadic template parameter
(3) Fully generic lambdas (where both arguments and return type are deduced with `auto`)

Some template programming workarounds were required to expand the multiple template parameter restriction of nvcc, but this is currently passing some very basic unit tests ported from CPU.