### PR TITLE
limit lifetime of artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,7 @@ variables:
     - ${ALLOC_COMMAND} scripts/gitlab/build_and_test.sh
     - echo -e "section_end:$(date +%s):src_build_and_unit_test\r\e[0K"
   artifacts:
+    expire_in: 2 weeks
     when: always
     paths:
       - _serac_build_and_test_*/output.log*.txt
@@ -53,6 +54,7 @@ variables:
     - ${ALLOC_COMMAND} python3 scripts/llnl/build_tpls.py -v ${SPEC} --directory=${FULL_BUILD_ROOT} --short-path
     - echo -e "section_end:$(date +%s):full_build_and_unit_test\r\e[0K"
   artifacts:
+    expire_in: 2 weeks
     when: always
     paths:
       - ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/output.log*.txt


### PR DESCRIPTION
The default for job artifacts is 30 days. Other projects were running into space issues. I don't see why we would want to look back farther than this without just rerunning the job.