### PR TITLE
In about.cpp, print TRIBOL_VERSION_FULL

### DIFF
--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -448,6 +448,8 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
         set_property(TARGET tribol
                      APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
                      ${TRIBOL_INCLUDE_DIR})
+
+        set(TRIBOL_FOUND ON)
     else()
         set(TRIBOL_FOUND OFF)
     endif()

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -46,6 +46,7 @@ set(infrastructure_sources
     )
 
 set(infrastructure_depends axom axom::fmt axom::cli11 mfem)
+blt_list_append(TO infrastructure_depends ELEMENTS tribol IF SERAC_USE_TRIBOL)
 blt_list_append(TO infrastructure_depends ELEMENTS caliper adiak::adiak IF SERAC_ENABLE_PROFILING)
 blt_list_append(TO infrastructure_depends ELEMENTS cuda IF ENABLE_CUDA)
 list(APPEND infrastructure_depends mpi)

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -46,7 +46,7 @@ set(infrastructure_sources
     )
 
 set(infrastructure_depends axom axom::fmt axom::cli11 mfem)
-blt_list_append(TO infrastructure_depends ELEMENTS tribol IF SERAC_USE_TRIBOL)
+blt_list_append(TO infrastructure_depends ELEMENTS tribol IF TRIBOL_FOUND)
 blt_list_append(TO infrastructure_depends ELEMENTS caliper adiak::adiak IF SERAC_ENABLE_PROFILING)
 blt_list_append(TO infrastructure_depends ELEMENTS cuda IF ENABLE_CUDA)
 list(APPEND infrastructure_depends mpi)

--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -41,8 +41,7 @@
 #endif
 
 #ifdef SERAC_USE_TRIBOL
-// TODO: This can be uncommented when Tribol MR!59 gets merged and we update to it
-//#include "tribol/config.hpp"
+#include "tribol/config.hpp"
 #endif
 
 #include "serac/infrastructure/git_sha.hpp"
@@ -161,9 +160,7 @@ std::string about()
 
   // Tribol
 #ifdef SERAC_USE_TRIBOL
-  // TODO: This can be un-hardcoded when Tribol MR!59 gets merged and we update to it
-  //  about += format("Tribol Version:    {0}\n", TRIBOL_VERSION_FULL);
-  about += "Tribol Version:    0.1.0\n";
+  about += format("Tribol Version:    {0}\n", TRIBOL_VERSION_FULL);
 #else
   disabled_libs.push_back("Tribol");
 #endif


### PR DESCRIPTION
This PR will use the TRIBOL_VERSION_FULL cmake variable to print the tribol version in about.cpp, as opposed to hard coded values.