### PR TITLE
Fix time-varying predicate-based component-wise Dirichlet boundary condition

### DIFF
--- a/src/serac/numerics/functional/tests/functional_shape_derivatives.cpp
+++ b/src/serac/numerics/functional/tests/functional_shape_derivatives.cpp
@@ -329,13 +329,13 @@ void functional_test_3D(mfem::ParMesh& mesh, double tolerance)
   EXPECT_NEAR(mfem::InnerProduct(ones, dr), 0.0, tolerance);
 }
 
-TEST(ShapeDerivative, 2DLinear) { functional_test_2D<1>(*mesh2D, 1.0e-14); }
-TEST(ShapeDerivative, 2DQuadratic) { functional_test_2D<2>(*mesh2D, 1.0e-14); }
+TEST(ShapeDerivative, 2DLinear) { functional_test_2D<1>(*mesh2D, 3.0e-14); }
+TEST(ShapeDerivative, 2DQuadratic) { functional_test_2D<2>(*mesh2D, 3.0e-14); }
 
-TEST(ShapeDerivative, 3DLinear) { functional_test_3D<1>(*mesh3D, 1.0e-13); }
+TEST(ShapeDerivative, 3DLinear) { functional_test_3D<1>(*mesh3D, 2.0e-13); }
 
 // note: see description at top of file
-TEST(ShapeDerivative, 3DQuadratic) { functional_test_3D<2>(*mesh3D, 1.0e-2); }
+TEST(ShapeDerivative, 3DQuadratic) { functional_test_3D<2>(*mesh3D, 1.5e-2); }
 
 int main(int argc, char* argv[])
 {

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -468,21 +468,23 @@ public:
    *
    * @param is_node_constrained A callback function that returns true if displacement nodes at a certain position should
    * be constrained by this boundary condition
-   * @param disp The scalar function containing the prescribed component displacement values
+   * @param disp The vector function containing the prescribed displacement values.
    * @param component The component of the displacement vector that should be set by this boundary condition. The other
    * components of displacement are unconstrained.
+   * 
+   * @note Even though a vector-valued function is given, only the dofs of the appropriate component are set.
    *
    * The displacement function takes a spatial position as the first argument and time as the second argument. It
-   * computes the desired displacement scalar for the given component and returns that value.
+   * computes the desired displacement and fills the third argument with these displacement values.
    *
    * @note This method searches over the entire mesh, not just the boundary nodes.
    */
-  void setDisplacementBCs(std::function<bool(const mfem::Vector& x)>           is_node_constrained,
-                          std::function<double(const mfem::Vector& x, double)> disp, int component)
+  void setDisplacementBCs(std::function<bool(const mfem::Vector&)>           is_node_constrained,
+                          std::function<void(const mfem::Vector&, double, mfem::Vector&)> disp, int component)
   {
     auto constrained_dofs = calculateConstrainedDofs(is_node_constrained, component);
 
-    setDisplacementBCsByDofList(constrained_dofs, disp, component);
+    setDisplacementBCsByDofList(constrained_dofs, disp);
   }
 
   /**

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -472,12 +472,12 @@ public:
    * @param component The component of the displacement vector that should be set by this boundary condition. The other
    * components of displacement are unconstrained.
    *
-   * The displacement function takes a spatial position as the first argument and current time as the second argument. 
+   * The displacement function takes a spatial position as the first argument and current time as the second argument.
    * It computes the desired displacement scalar for the given component and returns that value.
    *
    * @note This method searches over the entire mesh, not just the boundary nodes.
    */
-  void setDisplacementBCs(std::function<bool(const mfem::Vector&)>   is_node_constrained,
+  void setDisplacementBCs(std::function<bool(const mfem::Vector&)>           is_node_constrained,
                           std::function<double(const mfem::Vector&, double)> disp, int component)
   {
     auto constrained_dofs = calculateConstrainedDofs(is_node_constrained, component);

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -136,8 +136,11 @@ void functional_solid_spatial_essential_bc()
   solid_solver.setMaterial(mat);
 
   // Set up
-  auto zero_vector   = [](const mfem::Vector&, mfem::Vector& u) { u = 0.0; };
-  auto zero_scalar   = [](const mfem::Vector&) { return 0.0; };
+  auto zero_vector = [](const mfem::Vector&, mfem::Vector& u) { u = 0.0; };
+
+  // We want to test both the scalar displacement functions including the time argument and the scalar displacement
+  // functions without
+  auto zero_scalar   = [](const mfem::Vector&, double) { return 0.0; };
   auto scalar_offset = [](const mfem::Vector&) { return -0.1; };
 
   auto is_on_bottom = [](const mfem::Vector& x) {

--- a/src/serac/physics/tests/solid_shape.cpp
+++ b/src/serac/physics/tests/solid_shape.cpp
@@ -175,7 +175,7 @@ void shape_test(GeometricNonlinearities geo_nonlin)
 
   double error          = pure_displacement.DistanceTo(shape_displacement.GetData());
   double relative_error = error / pure_displacement.Norml2();
-  EXPECT_LT(relative_error, 3.0e-12);
+  EXPECT_LT(relative_error, 3.5e-12);
 }
 
 TEST(SolidMechanics, MoveShapeLinear) { shape_test(GeometricNonlinearities::Off); }


### PR DESCRIPTION
The function to set a Dirichlet boundary condition in the solid mechanics module did not previously compile. The issue was that the `setDisplacementBCsByDofList` method does not accept a component argument. This is now tested and fixed here, as well as used in one of @barreracruz 's test problems.

This also slightly loosens the tolerances on one of the tests that is now failing on Ubuntu 22 after the MFEM update.

It also loosens the tolerance of the `functional_shape_derivative` test as this was failing occasionally due to roundoff error.

Resolves https://github.com/LLNL/serac/issues/986