### PR TITLE
Improve precision of determinant of matrices near the identity matrix

### DIFF
--- a/src/serac/numerics/functional/dual.hpp
+++ b/src/serac/numerics/functional/dual.hpp
@@ -363,6 +363,14 @@ SERAC_HOST_DEVICE auto log(dual<gradient_type> a)
   return dual<gradient_type>{log(a.value), a.gradient / a.value};
 }
 
+/** @brief implementation of the natural logarithm of one plus the argument function for dual numbers */
+template <typename gradient_type>
+SERAC_HOST_DEVICE auto log1p(dual<gradient_type> a)
+{
+  using std::log1p;
+  return dual<gradient_type>{log1p(a.value), a.gradient / (1.0 + a.value)};
+}
+
 /** @brief implementation of `a` (dual) raised to the `b` (dual) power */
 template <typename gradient_type>
 SERAC_HOST_DEVICE auto pow(dual<gradient_type> a, dual<gradient_type> b)

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1219,11 +1219,11 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
 }
 
 /**
- * @brief Take determinant of a matrix near the identity without losing precision
+ * @brief computes det(A + I) - 1, where precision is not lost when the entries A_{ij} << 1
  *
  * detApIm1(A) = det(A + I) - 1
- * When the entries of A are small compared to unity, the straightforward way of
- * computing this will suffer from catasrophic cancellation.
+ * When the entries of A are small compared to unity, computing
+ * det(A + I) - 1 directly will suffer from catastrophic cancellation.
  *
  * @param A Input matrix
  * @return det(A + I) - 1, where I is the identity matrix
@@ -1239,20 +1239,18 @@ SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 2, 2>& A)
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
 {
+  // clang-format off
   // equivalent to tr(A) + I2(A) + det(A)
-  return A(0, 0) 
-       + A(1, 1) 
-       + A(2, 2) 
-
+  return A(0, 0) + A(1, 1) + A(2, 2) 
        - A(0, 1) * A(1, 0) * (1 + A(2, 2))
        + A(0, 0) * A(1, 1) * (1 + A(2, 2))
        - A(0, 2) * A(2, 0) * (1 + A(1, 1))
        - A(1, 2) * A(2, 1) * (1 + A(0, 0))
        + A(0, 0) * A(2, 2) 
        + A(1, 1) * A(2, 2) 
-
        + A(0, 1) * A(1, 2) * A(2, 0) 
        + A(0, 2) * A(1, 0) * A(2, 1);
+  // clang-format on
 }
 
 /**

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1219,11 +1219,11 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
 }
 /**
  * @brief Take determinant of a matrix near the identity without losing precision
- * 
+ *
  * detApIm1(A) = det(A + I) - 1
- * When the entries of A are small compared to unity, the straightforward way of 
+ * When the entries of A are small compared to unity, the straightforward way of
  * computing this will suffer from catasrophic cancellation.
- * 
+ *
  * @param A Input matrix
  * @return det(A + I) - 1, where I is the identity matrix
  */
@@ -1240,7 +1240,7 @@ template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
 {
   auto I1 = tr(A);
-  auto I2 = 0.5*(I1*I1 - inner(A, transpose(A)));
+  auto I2 = 0.5 * (I1 * I1 - inner(A, transpose(A)));
   auto I3 = det(A);
   return I1 + I2 + I3;
 }

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1218,6 +1218,15 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
          A[0][0] * A[1][2] * A[2][1] - A[0][1] * A[1][0] * A[2][2] - A[0][2] * A[1][1] * A[2][0];
 }
 
+template <typename T>
+SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
+{
+  double I1 = tr(A);
+  double I2 = 0.5*(I1*I1 - inner(A, transpose(A)));
+  double I3 = det(A);
+  return I1 + I2 + I3;
+}
+
 /**
  * @brief compute the matrix square root of a square, real-valued, symmetric matrix
  *        i.e. given A, find B such that A = dot(B, B)

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1231,6 +1231,11 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 2, 2>& A)
 {
+  // From the Cayley-Hamilton theorem, we get that for any N by N matrix A,
+  // det(A - I) - 1 = I1(A) + I2(A) + ... + IN(A),
+  // where the In are the principal invariants of A.
+  // We inline the definitions of the principal invariants to increase computational speed.
+
   // equivalent to tr(A) + det(A)
   return A(0, 0) - A(0, 1) * A(1, 0) + A(1, 1) + A(0, 0) * A(1, 1);
 }
@@ -1239,6 +1244,8 @@ SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 2, 2>& A)
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
 {
+  // For notes on the implementation, see the 2x2 version.
+
   // clang-format off
   // equivalent to tr(A) + I2(A) + det(A)
   return A(0, 0) + A(1, 1) + A(2, 2) 
@@ -1246,9 +1253,9 @@ SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
        + A(0, 0) * A(1, 1) * (1 + A(2, 2))
        - A(0, 2) * A(2, 0) * (1 + A(1, 1))
        - A(1, 2) * A(2, 1) * (1 + A(0, 0))
-       + A(0, 0) * A(2, 2) 
-       + A(1, 1) * A(2, 2) 
-       + A(0, 1) * A(1, 2) * A(2, 0) 
+       + A(0, 0) * A(2, 2)
+       + A(1, 1) * A(2, 2)
+       + A(0, 1) * A(1, 2) * A(2, 0)
        + A(0, 2) * A(1, 0) * A(2, 1);
   // clang-format on
 }

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1217,7 +1217,25 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
   return A[0][0] * A[1][1] * A[2][2] + A[0][1] * A[1][2] * A[2][0] + A[0][2] * A[1][0] * A[2][1] -
          A[0][0] * A[1][2] * A[2][1] - A[0][1] * A[1][0] * A[2][2] - A[0][2] * A[1][1] * A[2][0];
 }
+/**
+ * @brief Take determinant of a matrix near the identity without losing precision
+ * 
+ * detApIm1(A) = det(A + I) - 1
+ * When the entries of A are small compared to unity, the straightforward way of 
+ * computing this will suffer from catasrophic cancellation.
+ * 
+ * @param A Input matrix
+ * @return det(A + I) - 1, where I is the identity matrix
+ */
+template <typename T>
+SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 2, 2>& A)
+{
+  double I1 = tr(A);
+  double I2 = det(A);
+  return I1 + I2;
+}
 
+/// @overload
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
 {

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1230,8 +1230,8 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 2, 2>& A)
 {
-  double I1 = tr(A);
-  double I2 = det(A);
+  auto I1 = tr(A);
+  auto I2 = det(A);
   return I1 + I2;
 }
 
@@ -1239,9 +1239,9 @@ SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 2, 2>& A)
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
 {
-  double I1 = tr(A);
-  double I2 = 0.5*(I1*I1 - inner(A, transpose(A)));
-  double I3 = det(A);
+  auto I1 = tr(A);
+  auto I2 = 0.5*(I1*I1 - inner(A, transpose(A)));
+  auto I3 = det(A);
   return I1 + I2 + I3;
 }
 

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1217,6 +1217,7 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
   return A[0][0] * A[1][1] * A[2][2] + A[0][1] * A[1][2] * A[2][0] + A[0][2] * A[1][0] * A[2][1] -
          A[0][0] * A[1][2] * A[2][1] - A[0][1] * A[1][0] * A[2][2] - A[0][2] * A[1][1] * A[2][0];
 }
+
 /**
  * @brief Take determinant of a matrix near the identity without losing precision
  *

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1231,19 +1231,28 @@ SERAC_HOST_DEVICE constexpr auto det(const tensor<T, 3, 3>& A)
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 2, 2>& A)
 {
-  auto I1 = tr(A);
-  auto I2 = det(A);
-  return I1 + I2;
+  // equivalent to tr(A) + det(A)
+  return A(0, 0) - A(0, 1) * A(1, 0) + A(1, 1) + A(0, 0) * A(1, 1);
 }
 
 /// @overload
 template <typename T>
 SERAC_HOST_DEVICE constexpr auto detApIm1(const tensor<T, 3, 3>& A)
 {
-  auto I1 = tr(A);
-  auto I2 = 0.5 * (I1 * I1 - inner(A, transpose(A)));
-  auto I3 = det(A);
-  return I1 + I2 + I3;
+  // equivalent to tr(A) + I2(A) + det(A)
+  return A(0, 0) 
+       + A(1, 1) 
+       + A(2, 2) 
+
+       - A(0, 1) * A(1, 0) * (1 + A(2, 2))
+       + A(0, 0) * A(1, 1) * (1 + A(2, 2))
+       - A(0, 2) * A(2, 0) * (1 + A(1, 1))
+       - A(1, 2) * A(2, 1) * (1 + A(0, 0))
+       + A(0, 0) * A(2, 2) 
+       + A(1, 1) * A(2, 2) 
+
+       + A(0, 1) * A(1, 2) * A(2, 0) 
+       + A(0, 2) * A(1, 0) * A(2, 1);
 }
 
 /**

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -65,37 +65,37 @@ TEST(Tensor, BasicOperations)
 
 TEST(Tensor, DeterminantPrecision2x2)
 {
-  double eps = 1e-8;
-  tensor<double, 2, 2> A = diag(tensor<double, 2>{eps, eps});
+  double               eps = 1e-8;
+  tensor<double, 2, 2> A   = diag(tensor<double, 2>{eps, eps});
 
   // compute det(A + I) - 1
-  double exact = eps*eps + 2*eps;
+  double exact = eps * eps + 2 * eps;
   // naive approach
   double Jm1_naive = det(A + Identity<2>()) - 1;
-  double error = (Jm1_naive - exact)/exact;
+  double error     = (Jm1_naive - exact) / exact;
   // the naive approach loses 7 or 8 significant figures in this case
   EXPECT_GT(abs(error), 1e-8);
 
   // the detApIm1 function maintains high precision
   double good = detApIm1(A);
-  error = (good - exact)/exact;
+  error       = (good - exact) / exact;
   EXPECT_LT(abs(error), 1e-15);
 }
 
 TEST(Tensor, DeterminantPrecision3x3)
 {
-  double eps = 1e-8;
-  tensor<double, 3, 3> A = diag(tensor<double, 3>{eps, eps, eps});
+  double               eps = 1e-8;
+  tensor<double, 3, 3> A   = diag(tensor<double, 3>{eps, eps, eps});
 
   // compute det(A + I) - 1
-  double exact = eps*eps*eps + 3*eps*eps + 3*eps;
+  double exact = eps * eps * eps + 3 * eps * eps + 3 * eps;
   // naive approach
   double Jm1_naive = det(A + Identity<3>()) - 1;
-  double error = (Jm1_naive - exact)/exact;
+  double error     = (Jm1_naive - exact) / exact;
   EXPECT_GT(abs(error), 1e-9);
 
   double good = detApIm1(A);
-  error = (good - exact)/exact;
+  error       = (good - exact) / exact;
   EXPECT_LT(abs(error), 1e-14);
 }
 

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -63,6 +63,23 @@ TEST(Tensor, BasicOperations)
   EXPECT_LT(abs(dot(u, B, v) - uBv), tolerance);
 }
 
+TEST(Tensor, DeterminantPrecision)
+{
+  double eps = 1e-8;
+  tensor<double, 3, 3> A = diag(tensor<double, 3>{eps, eps, eps});
+
+  // compute det(A + I) - 1
+  double exact = eps*eps*eps + 3*eps*eps + 3*eps;
+  // naive approach
+  double Jm1_naive = det(A + Identity<3>()) - 1;
+  double error = (Jm1_naive - exact)/exact;
+  EXPECT_GT(abs(error), 1e-9);
+
+  double good = detApIm1(A);
+  error = (good - exact)/exact;
+  EXPECT_LT(abs(error), 1e-14);
+}
+
 TEST(Tensor, Elasticity)
 {
   static auto abs = [](auto x) { return (x < 0) ? -x : x; };

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -63,25 +63,48 @@ TEST(Tensor, BasicOperations)
   EXPECT_LT(abs(dot(u, B, v) - uBv), tolerance);
 }
 
-template < int dim >
-void DeterminantPrecisionTest(tensor<double, dim,dim> A, double exact) {
-  // naive approach
-  double Jm1_naive = det(A + Identity<dim>()) - 1;
-  double error     = (Jm1_naive - exact) / exact;
-  // the naive approach loses 7 or 8 significant figures in this case
-  EXPECT_GT(abs(error), 1e-8);
+TEST(Tensor, DeterminantPrecision2x2Diagonal)
+{
+  double               eps = 1e-8;
+  tensor<double, 2, 2> A   = diag(tensor<double, 2>{eps, eps});
 
-  // the detApIm1 function maintains high precision
+  // compute det(A + I) - 1
+  double exact = eps * eps + 2 * eps;
+
+  // naive approach reduces precision
+  double Jm1_naive = det(A + Identity<2>()) - 1;
+  double error     = (Jm1_naive - exact) / exact;
+  EXPECT_GT(abs(error), 1e-9);
+
+  // detApIm1 retains more significant digits
   double good = detApIm1(A);
   error       = (good - exact) / exact;
-  EXPECT_LT(abs(error), 1e-15);
+  EXPECT_LT(abs(error), 1e-14);
 }
 
-//TEST(Tensor, DeterminantPrecision2x2Diagonal)
-//{
-//  DeterminantPrecision
+TEST(Tensor, DeterminantPrecision3x3Diagonal)
+{
+  double               eps = 1e-8;
+  tensor<double, 3, 3> A   = diag(tensor<double, 3>{eps, eps, eps});
 
-//}
+  // compute det(A + I) - 1
+  double exact = eps * eps * eps + 3 * eps * eps + 3 * eps;
+
+  // naive approach reduces precision
+  double Jm1_naive = det(A + Identity<3>()) - 1;
+  double error     = (Jm1_naive - exact) / exact;
+  EXPECT_GT(abs(error), 1e-9);
+
+  // detApIm1 retains more significant digits
+  double good = detApIm1(A);
+  error       = (good - exact) / exact;
+  EXPECT_LT(abs(error), 1e-14);
+}
+
+template < int dim >
+void DeterminantPrecisionTest(tensor<double, dim,dim> A, double exact) {
+  EXPECT_LT((detApIm1(A) - exact) / exact, 1e-15);
+}
 
 TEST(Tensor, DeterminantPrecision3x3Traceless) {
   DeterminantPrecisionTest(
@@ -105,60 +128,25 @@ TEST(Tensor, DeterminantPrecision3x3BigValues) {
   );
 }
 
-TEST(Tensor, DeterminantPrecision3x3Diagonal)
-{
-  double               eps = 1e-8;
-  tensor<double, 3, 3> A   = diag(tensor<double, 3>{eps, eps, eps});
-
-  // compute det(A + I) - 1
-  double exact = eps * eps * eps + 3 * eps * eps + 3 * eps;
-  // naive approach
-  double Jm1_naive = det(A + Identity<3>()) - 1;
-  double error     = (Jm1_naive - exact) / exact;
-  EXPECT_GT(abs(error), 1e-9);
-
-  double good = detApIm1(A);
-  error       = (good - exact) / exact;
-  EXPECT_LT(abs(error), 1e-14);
+TEST(Tensor, DeterminantPrecision2x2Full) {
+  DeterminantPrecisionTest(
+    tensor<double, 3, 3>{{
+      {6.0519045489321714136e-9,4.2204473372429726693e-9},
+      {6.7553256448010560473e-9,9.8331979502279764439e-9}
+    }},
+    1.5885102530159227133e-8
+  );
 }
 
-TEST(Tensor, DeterminantPrecision2x2Full)
-{
-  tensor<double, 3, 3> A   = {{
-    {6.0519045489321714136e-9,4.2204473372429726693e-9},
-    {6.7553256448010560473e-9,9.8331979502279764439e-9}
-  }};
-
-  // compute det(A + I) - 1
-  double exact = 1.5885102530159227133e-8;
-  // naive approach
-  double Jm1_naive = det(A + Identity<3>()) - 1;
-  double error     = (Jm1_naive - exact) / exact;
-  EXPECT_GT(abs(error), 1e-9);
-
-  double good = detApIm1(A);
-  error       = (good - exact) / exact;
-  EXPECT_LT(abs(error), 1e-14);
-}
-
-TEST(Tensor, DeterminantPrecision3x3Full)
-{
-  tensor<double, 3, 3> A   = {{
-    {1.310296154038524804e-9,7.7019210397700792489e-10,-3.88105063413916636e-9},
-    {-9.6885551085033972374e-9,2.3209904948585927485e-9,-2.6115913838723596183e-9},
-    {-5.3080861000106470727e-9,-9.661806979681210324e-9,-2.6934399320872054577e-9}
-  }};
-
-  // compute det(A + I) - 1
-  double exact = 9.3784667169884994515e-10;
-  // naive approach
-  double Jm1_naive = det(A + Identity<3>()) - 1;
-  double error     = (Jm1_naive - exact) / exact;
-  EXPECT_GT(abs(error), 1e-9);
-
-  double good = detApIm1(A);
-  error       = (good - exact) / exact;
-  EXPECT_LT(abs(error), 1e-14);
+TEST(Tensor, DeterminantPrecision3x3Full) {
+  DeterminantPrecisionTest(
+    tensor<double,3,3>{{
+      {1.310296154038524804e-9,7.7019210397700792489e-10,-3.88105063413916636e-9},
+      {-9.6885551085033972374e-9,2.3209904948585927485e-9,-2.6115913838723596183e-9},
+      {-5.3080861000106470727e-9,-9.661806979681210324e-9,-2.6934399320872054577e-9}
+    }},
+    9.3784667169884994515e-10
+  );
 }
 
 TEST(Tensor, Elasticity)

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -63,15 +63,10 @@ TEST(Tensor, BasicOperations)
   EXPECT_LT(abs(dot(u, B, v) - uBv), tolerance);
 }
 
-TEST(Tensor, DeterminantPrecision2x2)
-{
-  double               eps = 1e-8;
-  tensor<double, 2, 2> A   = diag(tensor<double, 2>{eps, eps});
-
-  // compute det(A + I) - 1
-  double exact = eps * eps + 2 * eps;
+template < int dim >
+void DeterminantPrecisionTest(tensor<double, dim,dim> A, double exact) {
   // naive approach
-  double Jm1_naive = det(A + Identity<2>()) - 1;
+  double Jm1_naive = det(A + Identity<dim>()) - 1;
   double error     = (Jm1_naive - exact) / exact;
   // the naive approach loses 7 or 8 significant figures in this case
   EXPECT_GT(abs(error), 1e-8);
@@ -82,13 +77,80 @@ TEST(Tensor, DeterminantPrecision2x2)
   EXPECT_LT(abs(error), 1e-15);
 }
 
-TEST(Tensor, DeterminantPrecision3x3)
+//TEST(Tensor, DeterminantPrecision2x2Diagonal)
+//{
+//  DeterminantPrecision
+
+//}
+
+TEST(Tensor, DeterminantPrecision3x3Traceless) {
+  DeterminantPrecisionTest(
+    tensor<double,3,3>{{
+      {0,8.1410612065726112756e-9,1.2465784741225520151e-10},
+      {4.1199563125954303502e-9,0,7.8639877144532155295e-9},
+      {6.5857188451272948298e-9,-4.3009442283120782604e-9,0}
+    }},
+    -5.3920505272908503097e-19
+  );
+}
+
+TEST(Tensor, DeterminantPrecision3x3BigValues) {
+  DeterminantPrecisionTest(
+    tensor<double,3,3>{{
+      {-8.7644781692191447986e-7,-0.00060943437636452272438,0.0006160110345770283824},
+      {0.00059197095431573693372,-0.00032421698142571543644,-0.00075031460538177354586},
+      {-0.00057095032376313107833,0.00042675236045286923589,-0.00029239794707394684004}
+    }},
+    -0.00061636368316760725654
+  );
+}
+
+TEST(Tensor, DeterminantPrecision3x3Diagonal)
 {
   double               eps = 1e-8;
   tensor<double, 3, 3> A   = diag(tensor<double, 3>{eps, eps, eps});
 
   // compute det(A + I) - 1
   double exact = eps * eps * eps + 3 * eps * eps + 3 * eps;
+  // naive approach
+  double Jm1_naive = det(A + Identity<3>()) - 1;
+  double error     = (Jm1_naive - exact) / exact;
+  EXPECT_GT(abs(error), 1e-9);
+
+  double good = detApIm1(A);
+  error       = (good - exact) / exact;
+  EXPECT_LT(abs(error), 1e-14);
+}
+
+TEST(Tensor, DeterminantPrecision2x2Full)
+{
+  tensor<double, 3, 3> A   = {{
+    {6.0519045489321714136e-9,4.2204473372429726693e-9},
+    {6.7553256448010560473e-9,9.8331979502279764439e-9}
+  }};
+
+  // compute det(A + I) - 1
+  double exact = 1.5885102530159227133e-8;
+  // naive approach
+  double Jm1_naive = det(A + Identity<3>()) - 1;
+  double error     = (Jm1_naive - exact) / exact;
+  EXPECT_GT(abs(error), 1e-9);
+
+  double good = detApIm1(A);
+  error       = (good - exact) / exact;
+  EXPECT_LT(abs(error), 1e-14);
+}
+
+TEST(Tensor, DeterminantPrecision3x3Full)
+{
+  tensor<double, 3, 3> A   = {{
+    {1.310296154038524804e-9,7.7019210397700792489e-10,-3.88105063413916636e-9},
+    {-9.6885551085033972374e-9,2.3209904948585927485e-9,-2.6115913838723596183e-9},
+    {-5.3080861000106470727e-9,-9.661806979681210324e-9,-2.6934399320872054577e-9}
+  }};
+
+  // compute det(A + I) - 1
+  double exact = 9.3784667169884994515e-10;
   // naive approach
   double Jm1_naive = det(A + Identity<3>()) - 1;
   double error     = (Jm1_naive - exact) / exact;

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -101,52 +101,43 @@ TEST(Tensor, DeterminantPrecision3x3Diagonal)
   EXPECT_LT(abs(error), 1e-14);
 }
 
-template < int dim >
-void DeterminantPrecisionTest(tensor<double, dim,dim> A, double exact) {
+template <int dim>
+void DeterminantPrecisionTest(tensor<double, dim, dim> A, double exact)
+{
   EXPECT_LT((detApIm1(A) - exact) / exact, 1e-15);
 }
 
-TEST(Tensor, DeterminantPrecision3x3Traceless) {
-  DeterminantPrecisionTest(
-    tensor<double,3,3>{{
-      {0,8.1410612065726112756e-9,1.2465784741225520151e-10},
-      {4.1199563125954303502e-9,0,7.8639877144532155295e-9},
-      {6.5857188451272948298e-9,-4.3009442283120782604e-9,0}
-    }},
-    -5.3920505272908503097e-19
-  );
+TEST(Tensor, DeterminantPrecision3x3Traceless)
+{
+  DeterminantPrecisionTest(tensor<double, 3, 3>{{{0, 8.1410612065726112756e-9, 1.2465784741225520151e-10},
+                                                 {4.1199563125954303502e-9, 0, 7.8639877144532155295e-9},
+                                                 {6.5857188451272948298e-9, -4.3009442283120782604e-9, 0}}},
+                           -5.3920505272908503097e-19);
 }
 
-TEST(Tensor, DeterminantPrecision3x3BigValues) {
+TEST(Tensor, DeterminantPrecision3x3BigValues)
+{
   DeterminantPrecisionTest(
-    tensor<double,3,3>{{
-      {-8.7644781692191447986e-7,-0.00060943437636452272438,0.0006160110345770283824},
-      {0.00059197095431573693372,-0.00032421698142571543644,-0.00075031460538177354586},
-      {-0.00057095032376313107833,0.00042675236045286923589,-0.00029239794707394684004}
-    }},
-    -0.00061636368316760725654
-  );
+      tensor<double, 3, 3>{{{-8.7644781692191447986e-7, -0.00060943437636452272438, 0.0006160110345770283824},
+                            {0.00059197095431573693372, -0.00032421698142571543644, -0.00075031460538177354586},
+                            {-0.00057095032376313107833, 0.00042675236045286923589, -0.00029239794707394684004}}},
+      -0.00061636368316760725654);
 }
 
-TEST(Tensor, DeterminantPrecision2x2Full) {
-  DeterminantPrecisionTest(
-    tensor<double, 3, 3>{{
-      {6.0519045489321714136e-9,4.2204473372429726693e-9},
-      {6.7553256448010560473e-9,9.8331979502279764439e-9}
-    }},
-    1.5885102530159227133e-8
-  );
+TEST(Tensor, DeterminantPrecision2x2Full)
+{
+  DeterminantPrecisionTest(tensor<double, 3, 3>{{{6.0519045489321714136e-9, 4.2204473372429726693e-9},
+                                                 {6.7553256448010560473e-9, 9.8331979502279764439e-9}}},
+                           1.5885102530159227133e-8);
 }
 
-TEST(Tensor, DeterminantPrecision3x3Full) {
+TEST(Tensor, DeterminantPrecision3x3Full)
+{
   DeterminantPrecisionTest(
-    tensor<double,3,3>{{
-      {1.310296154038524804e-9,7.7019210397700792489e-10,-3.88105063413916636e-9},
-      {-9.6885551085033972374e-9,2.3209904948585927485e-9,-2.6115913838723596183e-9},
-      {-5.3080861000106470727e-9,-9.661806979681210324e-9,-2.6934399320872054577e-9}
-    }},
-    9.3784667169884994515e-10
-  );
+      tensor<double, 3, 3>{{{1.310296154038524804e-9, 7.7019210397700792489e-10, -3.88105063413916636e-9},
+                            {-9.6885551085033972374e-9, 2.3209904948585927485e-9, -2.6115913838723596183e-9},
+                            {-5.3080861000106470727e-9, -9.661806979681210324e-9, -2.6934399320872054577e-9}}},
+      9.3784667169884994515e-10);
 }
 
 TEST(Tensor, Elasticity)

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -63,7 +63,26 @@ TEST(Tensor, BasicOperations)
   EXPECT_LT(abs(dot(u, B, v) - uBv), tolerance);
 }
 
-TEST(Tensor, DeterminantPrecision)
+TEST(Tensor, DeterminantPrecision2x2)
+{
+  double eps = 1e-8;
+  tensor<double, 2, 2> A = diag(tensor<double, 2>{eps, eps});
+
+  // compute det(A + I) - 1
+  double exact = eps*eps + 2*eps;
+  // naive approach
+  double Jm1_naive = det(A + Identity<2>()) - 1;
+  double error = (Jm1_naive - exact)/exact;
+  // the naive approach loses 7 or 8 significant figures in this case
+  EXPECT_GT(abs(error), 1e-8);
+
+  // the detApIm1 function maintains high precision
+  double good = detApIm1(A);
+  error = (good - exact)/exact;
+  EXPECT_LT(abs(error), 1e-15);
+}
+
+TEST(Tensor, DeterminantPrecision3x3)
 {
   double eps = 1e-8;
   tensor<double, 3, 3> A = diag(tensor<double, 3>{eps, eps, eps});

--- a/src/serac/physics/materials/parameterized_solid_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_material.hpp
@@ -93,7 +93,7 @@ struct ParameterizedNeoHookeanSolid {
     auto           lambda    = K - (2.0 / dim) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
     auto           J_minus_1 = detApIm1(du_dX);
-    auto J = J_minus_1 + 1;
+    auto           J         = J_minus_1 + 1;
     return (lambda * log1p(J_minus_1) * I + G * B_minus_I) / J;
   }
 

--- a/src/serac/physics/materials/parameterized_solid_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_material.hpp
@@ -86,14 +86,15 @@ struct ParameterizedNeoHookeanSolid {
   SERAC_HOST_DEVICE auto operator()(State& /*state*/, const DispGradType& du_dX, const BulkType& DeltaK,
                                     const ShearType& DeltaG) const
   {
-    using std::log;
+    using std::log1p;
     constexpr auto I         = Identity<dim>();
     auto           K         = K0 + get<0>(DeltaK);
     auto           G         = G0 + get<0>(DeltaG);
     auto           lambda    = K - (2.0 / dim) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    auto           J         = det(I + du_dX);
-    return (lambda * log(J) * I + G * B_minus_I) / J;
+    auto           J_minus_1 = detApIm1(du_dX);
+    auto J = J_minus_1 + 1;
+    return (lambda * log1p(J_minus_1) * I + G * B_minus_I) / J;
   }
 
   /**

--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -112,12 +112,13 @@ struct NeoHookean {
   template <typename T, int dim>
   SERAC_HOST_DEVICE auto operator()(State& /* state */, const tensor<T, dim, dim>& du_dX) const
   {
-    using std::log;
+    using std::log1p;
     constexpr auto I         = Identity<dim>();
     auto           lambda    = K - (2.0 / 3.0) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    auto           J         = det(I + du_dX);
-    return (lambda * log(J) * I + G * B_minus_I) / J;
+    auto J_minus_1 = detApIm1(du_dX);
+    auto J = J_minus_1 + 1;
+    return (lambda * log1p(J_minus_1) * I + G * B_minus_I) / J;
   }
 
   double density;  ///< mass density

--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -116,8 +116,8 @@ struct NeoHookean {
     constexpr auto I         = Identity<dim>();
     auto           lambda    = K - (2.0 / 3.0) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    auto J_minus_1 = detApIm1(du_dX);
-    auto J = J_minus_1 + 1;
+    auto           J_minus_1 = detApIm1(du_dX);
+    auto           J         = J_minus_1 + 1;
     return (lambda * log1p(J_minus_1) * I + G * B_minus_I) / J;
   }
 


### PR DESCRIPTION
Implements a new function `detApIm1` that computes `det(A + I) - 1` while avoiding catastrophic cancellation for matrices that are close to the identity matrix. The formulas follow from the Cayley-Hamilton theorem applied to $A + I$.

Closes #634 