### PR TITLE
Fix a lot of issues with the ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,11 +13,15 @@ sphinx:
 # TODO this was turned off due to build failures in the pdf generation. See https://github.com/LLNL/serac/issues/901
 # formats: all
 
-# Optionally set the version of Python and requirements required to build your docs
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
 python:
-  version: 3.11
   install:
-    - requirements: src/docs/requirements.txt
+    - requirements: docs/requirements.txt
 
 submodules:
   exclude:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,7 +15,7 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.11
   install:
     - requirements: src/docs/requirements.txt
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,6 +18,8 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  apt_packages:
+    - graphviz
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,6 +21,7 @@ build:
   apt_packages:
     - ghostscript
     - graphviz
+    - texlive-latex-recommended
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,10 +19,9 @@ build:
   tools:
     python: "3.11"
   apt_packages:
-    - dvips
     - ghostscript
     - graphviz
-    - texlive-latex-recommended
+    - texlive-full
 
 python:
   install:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,7 +21,7 @@ build:
 
 python:
   install:
-    - requirements: docs/requirements.txt
+    - requirements: src/docs/requirements.txt
 
 submodules:
   exclude:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,6 +19,7 @@ build:
   tools:
     python: "3.11"
   apt_packages:
+    - ghostscript
     - graphviz
 
 python:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,6 +19,7 @@ build:
   tools:
     python: "3.11"
   apt_packages:
+    - dvips
     - ghostscript
     - graphviz
     - texlive-latex-recommended

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -1530,7 +1530,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = NO
+GENERATE_LATEX         = YES
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of

--- a/src/docs/doxygen/Doxyfile.in
+++ b/src/docs/doxygen/Doxyfile.in
@@ -1420,7 +1420,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example

--- a/src/docs/requirements.txt
+++ b/src/docs/requirements.txt
@@ -1,1 +1,3 @@
 docutils<0.18
+sphinx==6.2.1
+sphinx-rtd-theme==1.2.2

--- a/src/docs/requirements.txt
+++ b/src/docs/requirements.txt
@@ -1,3 +1,3 @@
-docutils<0.18
+docutils
 sphinx==6.2.1
 sphinx-rtd-theme==1.2.2


### PR DESCRIPTION
ReadTheDocs decided to not install a lot of packages:

https://blog.readthedocs.com/defaulting-latest-build-tools/

Also MathJax seems to have turned off their service. I am not sure how this ever worked considering it was turned off in 2017 as far as I can tell:

https://www.mathjax.org/cdn-shutting-down/