### PR TITLE
Additional base physics capability

### DIFF
--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -95,10 +95,10 @@ public:
    */
   virtual const FiniteElementState& state(const std::string& state_name) const = 0;
 
-  virtual void setState(const std::string&, const FiniteElementState&)
-  {
-    SLIC_ERROR_ROOT(axom::fmt::format("setState not implemented for physics {}.", name_));
-  }
+  /**
+   * @brief Set the primal solution field values of the underlying physics solver
+   */
+  virtual void setState(const std::string&, const FiniteElementState&) = 0;
 
   /**
    * @brief Get a vector of the finite element state primal solution names
@@ -155,10 +155,7 @@ public:
    * @param parameter_index The index of the Finite Element State parameter to retrieve
    * @return The indexed parameter Finite Element State
    */
-  const FiniteElementState& parameter(std::size_t parameter_index) const
-  {
-    return *parameters_[parameter_index].state;
-  }
+  const FiniteElementState& parameter(std::size_t parameter_index) const { return *parameters_[parameter_index].state; }
 
   /**
    * @brief Get a vector of the finite element state parameter names

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -95,6 +95,11 @@ public:
    */
   virtual const FiniteElementState& state(const std::string& state_name) const = 0;
 
+  virtual void setState(const std::string&, const FiniteElementState&)
+  {
+    SLIC_ERROR_ROOT(axom::fmt::format("setState not implemented for physics {}.", name_));
+  }
+
   /**
    * @brief Get a vector of the finite element state primal solution names
    *

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -150,6 +150,17 @@ public:
   }
 
   /**
+   * @brief Accessor for getting indexed finite element state parameter fields from the physics modules
+   *
+   * @param parameter_index The index of the Finite Element State parameter to retrieve
+   * @return The indexed parameter Finite Element State
+   */
+  const FiniteElementState& parameter(std::size_t parameter_index) const
+  {
+    return *parameters_[parameter_index].state;
+  }
+
+  /**
    * @brief Get a vector of the finite element state parameter names
    *
    * @return The parameter names

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -522,6 +522,27 @@ public:
   }
 
   /**
+   * @brief Set the primal solution field (temperature) for the underlying heat transfer solver
+   *
+   * @param state_name The name of the field to initialize (must be "temperature")
+   * @param state The finite element state vector containing the values for either the temperature field
+   *
+   * It is expected that @a state has the same underlying finite element space and mesh as the selected primal solution
+   * field.
+   */
+  void setState(const std::string& state_name, const FiniteElementState& state) override
+  {
+    if (state_name == "temperature") {
+      temperature_ = state;
+      return;
+    }
+
+    SLIC_ERROR_ROOT(axom::fmt::format(
+        "setState for state named '{}' requested from heat transfer module '{}', but it doesn't exist", state_name,
+        name_));
+  }
+
+  /**
    * @brief Get a vector of the finite element state primal solution names
    *
    * @return The primal solution names

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -579,6 +579,20 @@ public:
     return displacement_;
   }
 
+  void setState(const std::string& state_name, const FiniteElementState& state) override
+  {
+    if (state_name == "displacement") {
+      displacement_ = state;
+      return;
+    } else if (state_name == "velocity") {
+      velocity_ = state;
+      return;
+    }
+
+    SLIC_ERROR_ROOT(axom::fmt::format("setState for state named '{}' requested from solid mechanics module '{}', but it doesn't exist",
+                                      state_name, name_));
+  }
+
   /**
    * @brief Get a vector of the finite element state solution variable names
    *

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -579,6 +579,15 @@ public:
     return displacement_;
   }
 
+  /**
+   * @brief Set the primal solution field (displacement, velocity) for the underlying solid mechanics solver
+   *
+   * @param state_name The name of the field to initialize ("displacement", or "velocity")
+   * @param state The finite element state vector containing the values for either the displacement or velocity fields
+   *
+   * It is expected that @a state has the same underlying finite element space and mesh as the selected primal solution
+   * field.
+   */
   void setState(const std::string& state_name, const FiniteElementState& state) override
   {
     if (state_name == "displacement") {
@@ -589,8 +598,9 @@ public:
       return;
     }
 
-    SLIC_ERROR_ROOT(axom::fmt::format("setState for state named '{}' requested from solid mechanics module '{}', but it doesn't exist",
-                                      state_name, name_));
+    SLIC_ERROR_ROOT(axom::fmt::format(
+        "setState for state named '{}' requested from solid mechanics module '{}', but it doesn't exist", state_name,
+        name_));
   }
 
   /**

--- a/src/serac/physics/thermomechanics.hpp
+++ b/src/serac/physics/thermomechanics.hpp
@@ -155,6 +155,34 @@ public:
   }
 
   /**
+   * @brief Set the primal solution field (displacement, velocity, temperature) for the underlying thermomechanics
+   * solver
+   *
+   * @param state_name The name of the field to initialize ("displacement", or "velocity")
+   * @param state The finite element state vector containing the values for either the displacement or velocity fields
+   *
+   * It is expected that @a state has the same underlying finite element space and mesh as the selected primal solution
+   * field.
+   */
+  void setState(const std::string& state_name, const FiniteElementState& state) override
+  {
+    if (state_name == "displacement") {
+      const_cast<FiniteElementState&>(solid_.displacement()) = state;
+      return;
+    } else if (state_name == "velocity") {
+      const_cast<FiniteElementState&>(solid_.velocity()) = state;
+      return;
+    } else if (state_name == "temperature") {
+      const_cast<FiniteElementState&>(thermal_.temperature()) = state;
+      return;
+    }
+
+    SLIC_ERROR_ROOT(axom::fmt::format(
+        "setState for state named '{}' requested from thermomechanics module '{}', but it doesn't exist", state_name,
+        name_));
+  }
+
+  /**
    * @brief Get a vector of the finite element state solution variable names
    *
    * @return The solution variable names


### PR DESCRIPTION
This adds two `BasePhysics` capabilities as needed by downstream users:

- Adds a way to set a generic primal solution field to an initial value
- Adds an index-based accessor for the parameter fields