### PR TITLE
Fix Tribol is always built if +cuda

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -238,7 +238,7 @@ class Serac(CachedCMakePackage, CudaPackage):
     # Check if these variants are true and +cuda before adding
     cuda_deps_with_variants = ["raja", "sundials", "tribol", "umpire"]
     for dep in cuda_deps_with_variants:
-        depends_on("{0}+cuda".format(dep), when="+{0}+cuda")
+        depends_on("{0}+cuda".format(dep), when="+{0}+cuda".format(dep))
         for sm_ in CudaPackage.cuda_arch_values:
             depends_on("{0} cuda_arch={1}".format(dep, sm_),
                     when="+{0}+cuda cuda_arch={1}".format(dep, sm_))

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -235,10 +235,10 @@ class Serac(CachedCMakePackage, CudaPackage):
             depends_on("{0} cuda_arch={1}".format(dep, sm_),
                     when="cuda_arch={0}".format(sm_))
     
-    # Check if these variants are true first
+    # Check if these variants are true and +cuda before adding
     cuda_deps_with_variants = ["raja", "sundials", "tribol", "umpire"]
     for dep in cuda_deps_with_variants:
-        depends_on("{0}+cuda".format(dep), when="+cuda")
+        depends_on("{0}+cuda".format(dep), when="+{0}+cuda")
         for sm_ in CudaPackage.cuda_arch_values:
             depends_on("{0} cuda_arch={1}".format(dep, sm_),
                     when="+{0}+cuda cuda_arch={1}".format(dep, sm_))


### PR DESCRIPTION
Small PR that ensures optional packages are not built if they are set not to be (only relevant with +cuda)

I noticed this because LiDO does not build serac with +tribol, yet it was being built on our lassen configuration.

Fixes #1017