### PR TITLE
Limit serac's use of axom's components

### DIFF
--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -419,7 +419,7 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
             endforeach()
 
             if(ENABLE_OPENMP)
-                target_link_libraries(axom INTERFACE openmp)
+                target_link_libraries(axom::core INTERFACE openmp)
             endif()
 
             # Mark the axom includes as "system" and filter unallowed directories

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -387,62 +387,26 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
         endif()
         set(AXOM_FOUND TRUE CACHE BOOL "" FORCE)
 
-        # Alias axom builtin thirdparty targets under axom namespace
-        if(NOT TARGET axom::fmt)
-            add_library(axom::fmt ALIAS fmt)
-        endif()
-        if(NOT TARGET axom::cli11)
-            add_library(axom::cli11 ALIAS cli11)
-        endif()
-
         if (STRUMPACK_DIR)
-            if(TARGET axom::sidre)
-                target_link_libraries(axom::sidre PUBLIC STRUMPACK::strumpack)
-            else()
-                target_link_libraries(sidre PUBLIC STRUMPACK::strumpack)
-            endif()
+            target_link_libraries(sidre PUBLIC STRUMPACK::strumpack)
         endif()
 
-        if(NOT TARGET axom)
-            # New axom target case where all components have individual libraries
+        # Alias Axom's builtin thirdparty targets under axom namespace
+        foreach(_comp ${AXOM_COMPONENTS_ENABLED};cli11;fmt)
+            add_library(axom::${_comp} ALIAS ${_comp})
+        endforeach()
 
-            # Create convenience target that bundles all Axom targets (axom)
-            # This normally happens in axom's installed config file
-            add_library(axom INTERFACE IMPORTED)
+        # Create convenience target that bundles all Axom targets (axom)
+        # This normally happens in axom's installed config file
+        add_library(axom INTERFACE IMPORTED)
+        target_link_libraries(axom INTERFACE ${AXOM_COMPONENTS_ENABLED})
 
-            set(AXOM_COMPONENTS_ENABLED
-              core;lumberjack;slic;slam;primal;sidre;mint;spin;inlet;klee;quest;multimat)
-            target_link_libraries(axom INTERFACE ${AXOM_COMPONENTS_ENABLED})
-
-            foreach(_comp ${AXOM_COMPONENTS_ENABLED})
-                add_library(axom::${_comp} ALIAS ${_comp})
-            endforeach()
-
-            if(ENABLE_OPENMP)
-                target_link_libraries(axom::core INTERFACE openmp)
-            endif()
-
-            # Mark the axom includes as "system" and filter unallowed directories
-            get_target_property(_dirs core INTERFACE_INCLUDE_DIRECTORIES)
-            set_property(TARGET core 
-                         PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                         "${_dirs}")
-            set_property(TARGET core 
-                         APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                         "${_dirs}")
-        else()
-            # Old axom way where there is a singular combined axom library
-
-            # Mark the axom includes as "system" and filter unallowed directories
-            get_target_property(_dirs axom INTERFACE_INCLUDE_DIRECTORIES)
-            list(REMOVE_ITEM _dirs ${PROJECT_SOURCE_DIR})
-            set_property(TARGET axom 
-                         PROPERTY INTERFACE_INCLUDE_DIRECTORIES
-                         "${_dirs}")
-            set_property(TARGET axom 
-                         APPEND PROPERTY INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
-                         "${_dirs}")
+        if(ENABLE_OPENMP)
+            target_link_libraries(core INTERFACE openmp)
         endif()
+
+        blt_convert_to_system_includes(TARGET core)
+
         set(ENABLE_FORTRAN ON CACHE BOOL "" FORCE)
     endif()
 

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -414,6 +414,10 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
               core;lumberjack;slic;slam;primal;sidre;mint;spin;inlet;klee;quest;multimat)
             target_link_libraries(axom INTERFACE ${AXOM_COMPONENTS_ENABLED})
 
+            foreach(_comp ${AXOM_COMPONENTS_ENABLED})
+                add_library(axom::${_comp} ALIAS ${_comp})
+            endforeach()
+
             if(ENABLE_OPENMP)
                 target_link_libraries(axom INTERFACE openmp)
             endif()

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -45,7 +45,7 @@ set(infrastructure_sources
     terminator.cpp
     )
 
-set(infrastructure_depends axom axom::fmt axom::cli11 mfem)
+set(infrastructure_depends axom::inlet axom::fmt axom::cli11 mfem)
 blt_list_append(TO infrastructure_depends ELEMENTS tribol IF TRIBOL_FOUND)
 blt_list_append(TO infrastructure_depends ELEMENTS caliper adiak::adiak IF SERAC_ENABLE_PROFILING)
 blt_list_append(TO infrastructure_depends ELEMENTS cuda IF ENABLE_CUDA)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 #
 
 serac_add_tests( SOURCES       axom_smoketest.cpp
-                 DEPENDS_ON    axom)
+                 DEPENDS_ON    axom::inlet)
 
 if(SERAC_USE_PETSC)
     serac_add_tests( SOURCES       petsc_smoketest.cpp


### PR DESCRIPTION
This won't make a huge change because Tribol requires Quest but it will only make us link in Inlet. I was able to limit the inheritance of Tribol's components in this PR:

https://github.com/LLNL/Tribol/pull/40

This will come into affect when we update Tribol next.

Addresses part of https://github.com/LLNL/axom/issues/1203