### PR TITLE
Feature/tupek/transient adj states

### DIFF
--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -153,8 +153,20 @@ public:
         !nonlin_solver_,
         "EquationSolver argument is nullptr in HeatTransfer constructor. It is possible that it was previously moved.");
 
+    // Check for dynamic mode
+    if (timestepping_opts.timestepper != TimestepMethod::QuasiStatic) {
+      ode_.SetTimestepper(timestepping_opts.timestepper);
+      ode_.SetEnforcementMethod(timestepping_opts.enforcement_method);
+      is_quasistatic_ = false;
+    } else {
+      is_quasistatic_ = true;
+    }
+
     states_.push_back(&temperature_);
-    // states_.push_back(&temperature_rate_);
+    if (!is_quasistatic_) {
+      //states_.push_back(&temperature_rate_);
+    }
+
     adjoints_.push_back(&adjoint_temperature_);
 
     // Create a pack of the primal field and parameter finite element spaces
@@ -183,15 +195,6 @@ public:
         test_space, trial_spaces);
 
     nonlin_solver_->setOperator(residual_with_bcs_);
-
-    // Check for dynamic mode
-    if (timestepping_opts.timestepper != TimestepMethod::QuasiStatic) {
-      ode_.SetTimestepper(timestepping_opts.timestepper);
-      ode_.SetEnforcementMethod(timestepping_opts.enforcement_method);
-      is_quasistatic_ = false;
-    } else {
-      is_quasistatic_ = true;
-    }
 
     dt_          = 0.0;
     previous_dt_ = -1.0;
@@ -597,7 +600,13 @@ public:
    *
    * @return The primal solution names
    */
-  virtual std::vector<std::string> stateNames() const override { return std::vector<std::string>{{"temperature"}}; }
+  virtual std::vector<std::string> stateNames() const override {
+    if (is_quasistatic_) {
+      return std::vector<std::string>{{"temperature"}};
+    } else {
+      return std::vector<std::string>{{"temperature", "temperature_rate"}};
+    }
+  }
 
   /**
    * @brief Accessor for getting named finite element state adjoint solution from the physics modules
@@ -846,6 +855,10 @@ public:
   {
     if (state_name == "temperature") {
       FiniteElementState previous_state = temperature_;
+      StateManager::loadCheckpointedStates(cycle, {previous_state});
+      return previous_state;
+    } else if (state_name == "temperature_rate") {
+      FiniteElementState previous_state = temperature_rate_;
       StateManager::loadCheckpointedStates(cycle, {previous_state});
       return previous_state;
     }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -181,9 +181,21 @@ public:
                        "EquationSolver argument is nullptr in SolidMechanics constructor. It is possible that it was "
                        "previously moved.");
 
+    // Check for dynamic mode
+    if (timestepping_opts.timestepper != TimestepMethod::QuasiStatic) {
+      ode2_.SetTimestepper(timestepping_opts.timestepper);
+      ode2_.SetEnforcementMethod(timestepping_opts.enforcement_method);
+      is_quasistatic_ = false;
+    } else {
+      is_quasistatic_ = true;
+    }
+
     states_.push_back(&displacement_);
-    states_.push_back(&velocity_);
-    states_.push_back(&acceleration_);
+    if (!is_quasistatic_) {
+      states_.push_back(&velocity_);
+      states_.push_back(&acceleration_);
+    }
+
     adjoints_.push_back(&adjoint_displacement_);
 
     duals_.push_back(&reactions_);
@@ -235,15 +247,6 @@ public:
       // method as of Hypre version v2.26.0. Instead, we just set the system size for Hypre. This is a temporary work
       // around as it will decrease the effectiveness of the preconditioner.
       amg_prec->SetSystemsOptions(dim, true);
-    }
-
-    // Check for dynamic mode
-    if (timestepping_opts.timestepper != TimestepMethod::QuasiStatic) {
-      ode2_.SetTimestepper(timestepping_opts.timestepper);
-      ode2_.SetEnforcementMethod(timestepping_opts.enforcement_method);
-      is_quasistatic_ = false;
-    } else {
-      is_quasistatic_ = true;
     }
 
     int true_size = velocity_.space().TrueVSize();
@@ -622,7 +625,11 @@ public:
    */
   std::vector<std::string> stateNames() const override
   {
-    return std::vector<std::string>{{"displacement"}, {"velocity"}, {"acceleration"}};
+    if (is_quasistatic_) {
+      return std::vector<std::string>{{"displacement"}};
+    } else {
+      return std::vector<std::string>{{"displacement"}, {"velocity"}, {"acceleration"}};
+    }
   }
 
   /**


### PR DESCRIPTION
After discussing with Kenny.  The number of states for quasi-statics in solids went from 1 to 3 recently.  This slightly breaks the lido interface (though there is a work around).  Seems sensible for there to only be 1 (displacement) state on the stateNames list for quasiStatics.  It is expected by Lido that every stateName() will require an adjoint load to be passed in.  

Also, refactored so temperature_rate is a state and checkpointed for more consistency between the physics.