### PR TITLE
Default to 1 OpenMP thread for our unit tests

### DIFF
--- a/cmake/SeracMacros.cmake
+++ b/cmake/SeracMacros.cmake
@@ -120,9 +120,10 @@ endmacro(serac_convert_to_native_escaped_file_path)
 
 
 ##------------------------------------------------------------------------------
-## serac_add_tests( SOURCES       [source1 [source2 ...]]
-##                  DEPENDS_ON    [dep1 [dep2 ...]]
-##                  NUM_MPI_TASKS [num tasks])
+## serac_add_tests( SOURCES         [source1 [source2 ...]]
+##                  DEPENDS_ON      [dep1 [dep2 ...]]
+##                  NUM_MPI_TASKS   [num tasks]
+##                  NUM_OMP_THREADS [num threads])
 ##
 ## Creates an executable per given source and then adds the test to CTest
 ##------------------------------------------------------------------------------
@@ -130,7 +131,7 @@ endmacro(serac_convert_to_native_escaped_file_path)
 macro(serac_add_tests)
 
     set(options )
-    set(singleValueArgs NUM_MPI_TASKS)
+    set(singleValueArgs NUM_MPI_TASKS NUM_OMP_THREADS)
     set(multiValueArgs SOURCES DEPENDS_ON)
 
     # Parse the arguments to the macro
@@ -139,6 +140,10 @@ macro(serac_add_tests)
 
     if ( NOT DEFINED arg_NUM_MPI_TASKS )
         set( arg_NUM_MPI_TASKS 1 )
+    endif()
+
+    if ( NOT DEFINED arg_NUM_OMP_THREADS )
+        set( arg_NUM_OMP_THREADS 1 )
     endif()
 
     foreach(filename ${arg_SOURCES})
@@ -150,9 +155,10 @@ macro(serac_add_tests)
                            DEPENDS_ON  ${arg_DEPENDS_ON}
                            FOLDER      serac/tests )
 
-        blt_add_test(NAME          ${test_name}
-                     COMMAND       ${test_name}
-                     NUM_MPI_TASKS ${arg_NUM_MPI_TASKS} )
+        blt_add_test(NAME            ${test_name}
+                     COMMAND         ${test_name}
+                     NUM_MPI_TASKS   ${arg_NUM_MPI_TASKS}
+                     NUM_OMP_THREADS ${arg_NUM_OMP_THREADS} )
     endforeach()
 
 endmacro(serac_add_tests)


### PR DESCRIPTION
I compared these changes with develop and personally saw basically no change in time on toss4 (135 seconds vs 132 seconds). This may be to how LC is setup, possibly better defaults.

@tepperly, can you see if this fixes the problem you were running into?