### PR TITLE
Update the time for quasi-static time-varying loads

### DIFF
--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -281,7 +281,7 @@ public:
       time_ += dt;
 
       // Set the ODE time point for the time-varying loads in quasi-static problems
-      ode_time_point_ += time_;
+      ode_time_point_ = time_;
 
       // Project the essential boundary coefficients
       for (auto& bc : bcs_.essentials()) {

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -279,6 +279,10 @@ public:
   {
     if (is_quasistatic_) {
       time_ += dt;
+
+      // Set the ODE time point for the time-varying loads in quasi-static problems
+      ode_time_point_ += time_;
+
       // Project the essential boundary coefficients
       for (auto& bc : bcs_.essentials()) {
         bc.setDofs(temperature_, time_);

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -1068,7 +1068,7 @@ public:
     time_ += dt;
 
     // Set the ODE time point for the time-varying loads in quasi-static problems
-    ode_time_point_ += time_;
+    ode_time_point_ = time_;
 
     // this method is essentially equivalent to the 1-liner
     // u += dot(inv(J), dot(J_elim[:, dofs], (U(t + dt) - u)[dofs]));

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -1067,6 +1067,9 @@ public:
   {
     time_ += dt;
 
+    // Set the ODE time point for the time-varying loads in quasi-static problems
+    ode_time_point_ += time_;
+
     // this method is essentially equivalent to the 1-liner
     // u += dot(inv(J), dot(J_elim[:, dofs], (U(t + dt) - u)[dofs]));
     warmStartDisplacement();

--- a/src/serac/physics/solid_mechanics_contact.hpp
+++ b/src/serac/physics/solid_mechanics_contact.hpp
@@ -221,6 +221,9 @@ public:
 
     time_ += dt;
 
+    // Set the ODE time point for the time-varying loads in quasi-static problems
+    ode_time_point_ = time_;
+
     // this method is essentially equivalent to the 1-liner
     // u += dot(inv(J), dot(J_elim[:, dofs], (U(t + dt) - u)[dofs]));
     warmStartDisplacement();
@@ -256,6 +259,7 @@ protected:
   using SolidMechanicsBase::J_;
   using SolidMechanicsBase::J_e_;
   using SolidMechanicsBase::nonlin_solver_;
+  using SolidMechanicsBase::ode_time_point_;
   using SolidMechanicsBase::residual_;
   using SolidMechanicsBase::residual_with_bcs_;
   using SolidMechanicsBase::warmStartDisplacement;


### PR DESCRIPTION
As quasi-static and dynamic problems use the same integrators, the ODE time point also needs to be updated in the quasi-static case as the ODE solver does not get called for that code path.