### PR TITLE
Contact API updates (If no Tribol)

### DIFF
--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -53,6 +53,15 @@ quartz-gcc_10_3_1-src:
     ALLOC_TIME: "20"
   extends: .src_build_on_quartz
 
+quartz-gcc_10_3_1-src-no-tribol:
+  variables:
+    COMPILER: "gcc@10.3.1"
+    HOST_CONFIG: "quartz-toss_4_x86_64_ib-${COMPILER}.cmake"
+    EXTRA_BUILD_OPTIONS: "--extra-cmake-options='-DTRIBOL_DIR=' "
+    ALLOC_NODES: "1"
+    ALLOC_TIME: "20"
+  extends: .src_build_on_quartz
+
 quartz-clang_14_0_6-full:
   variables:
     COMPILER: "clang@14.0.6"

--- a/src/serac/physics/contact/contact_data.cpp
+++ b/src/serac/physics/contact/contact_data.cpp
@@ -12,8 +12,11 @@
 #ifdef SERAC_USE_TRIBOL
 #include "tribol/interface/tribol.hpp"
 #include "tribol/interface/mfem_tribol.hpp"
+#endif
 
 namespace serac {
+
+#ifdef SERAC_USE_TRIBOL
 
 ContactData::ContactData(const mfem::ParMesh& mesh)
     : mesh_{mesh},
@@ -328,11 +331,7 @@ void ContactData::updateDofOffsets() const
   offsets_up_to_date_ = true;
 }
 
-}  // namespace serac
-
 #else
-
-namespace serac {
 
 ContactData::ContactData([[maybe_unused]] const mfem::ParMesh& mesh)
     : have_lagrange_multipliers_{false}, num_pressure_dofs_{0}
@@ -397,6 +396,6 @@ void ContactData::setPressures([[maybe_unused]] const mfem::Vector& true_pressur
 
 void ContactData::setDisplacements([[maybe_unused]] const mfem::Vector& true_displacement) {}
 
-}  // namespace serac
-
 #endif
+
+}  // namespace serac

--- a/src/serac/physics/contact/contact_data.cpp
+++ b/src/serac/physics/contact/contact_data.cpp
@@ -360,7 +360,10 @@ FiniteElementDual ContactData::forces() const
 
 mfem::HypreParVector ContactData::mergedPressures() const { return mfem::HypreParVector(); }
 
-mfem::HypreParVector ContactData::mergedGaps([[maybe_unused]] bool zero_inactive) const { return mfem::HypreParVector(); }
+mfem::HypreParVector ContactData::mergedGaps([[maybe_unused]] bool zero_inactive) const
+{
+  return mfem::HypreParVector();
+}
 
 std::unique_ptr<mfem::BlockOperator> ContactData::mergedJacobian() const
 {
@@ -369,9 +372,7 @@ std::unique_ptr<mfem::BlockOperator> ContactData::mergedJacobian() const
   return std::make_unique<mfem::BlockOperator>(jacobian_offsets_);
 }
 
-void ContactData::residualFunction([[maybe_unused]] const mfem::Vector& u, [[maybe_unused]] mfem::Vector& r)
-{
-}
+void ContactData::residualFunction([[maybe_unused]] const mfem::Vector& u, [[maybe_unused]] mfem::Vector& r) {}
 
 std::unique_ptr<mfem::BlockOperator> ContactData::jacobianFunction(const mfem::Vector&   u,
                                                                    mfem::HypreParMatrix* orig_J) const

--- a/src/serac/physics/contact/contact_data.hpp
+++ b/src/serac/physics/contact/contact_data.hpp
@@ -156,22 +156,20 @@ public:
    */
   void setDisplacements(const mfem::Vector& u);
 
-#ifdef SERAC_USE_TRIBOL
   /**
    * @brief Have there been contact interactions added?
    *
    * @return true if contact interactions have been added
    * @return false if there are no contact interactions
    */
-  bool haveContactInteractions() const { return !interactions_.empty(); }
+  bool haveContactInteractions() const
+  {
+#ifdef SERAC_USE_TRIBOL
+    return !interactions_.empty();
 #else
-  /**
-   * @brief Have there been contact interactions added?
-   *
-   * @return false
-   */
-  bool haveContactInteractions() const { return false; }
+    return false;
 #endif
+  }
 
   /**
    * @brief Are any contact interactions enforced using Lagrange multipliers?

--- a/src/serac/physics/contact/contact_data.hpp
+++ b/src/serac/physics/contact/contact_data.hpp
@@ -156,6 +156,7 @@ public:
    */
   void setDisplacements(const mfem::Vector& u);
 
+#ifdef SERAC_USE_TRIBOL
   /**
    * @brief Have there been contact interactions added?
    *
@@ -163,6 +164,14 @@ public:
    * @return false if there are no contact interactions
    */
   bool haveContactInteractions() const { return !interactions_.empty(); }
+#else
+  /**
+   * @brief Have there been contact interactions added?
+   *
+   * @return false
+   */
+  bool haveContactInteractions() const { return false; }
+#endif
 
   /**
    * @brief Are any contact interactions enforced using Lagrange multipliers?


### PR DESCRIPTION
In the future we may want to test `TRIBOL_DIR=''` in Serac rather than Smith. Or always include tribol?