### PR TITLE
Fix bug and correct parameter getter routine

### DIFF
--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -310,6 +310,22 @@ std::string addPrefix(const std::string& prefix, const std::string& target)
   }
   return prefix + "_" + target;
 }
+
+std::string removePrefix(const std::string& prefix, const std::string& target)
+{
+  std::string modified_target{target};
+  // Ensure the prefix isn't an empty string
+  if (!prefix.empty()) {
+    // Ensure the prefix is at the beginning of the string
+    auto index = modified_target.find(prefix + "_");
+    if (index == 0) {
+      // Remove the prefix
+      modified_target.erase(0, prefix.size() + 1);
+    }
+  }
+  return modified_target;
+}
+
 }  // namespace detail
 
 }  // namespace serac

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -162,6 +162,9 @@ public:
    *
    * @param parameter_name The name of the Finite Element State parameter to retrieve
    * @return The named parameter Finite Element State
+   *
+   * @note The input parameter name should not contain the base physics name. It should be identical to what
+   * is in the physics module constructor argument list.
    */
   const FiniteElementState& parameter(const std::string& parameter_name) const
   {

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -165,8 +165,10 @@ public:
    */
   const FiniteElementState& parameter(const std::string& parameter_name) const
   {
+    std::string appended_name = detail::addPrefix(name_, parameter_name);
+
     for (auto& parameter : parameters_) {
-      if (parameter_name == parameter.state->name()) {
+      if (appended_name == parameter.state->name()) {
         return *parameter.state;
       }
     }

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -35,6 +35,14 @@ namespace detail {
  * @param[in] target The string to prepend to
  */
 std::string addPrefix(const std::string& prefix, const std::string& target);
+
+/**
+ * @brief Removes a prefix and the underscore delimiter from a target string
+ * @param[in] prefix The prefix string to remove
+ * @param[in] target The larger string to remove the prefix from
+ */
+std::string removePrefix(const std::string& prefix, const std::string& target);
+
 }  // namespace detail
 
 /**
@@ -208,7 +216,7 @@ public:
     std::vector<std::string> parameter_names;
 
     for (auto& parameter : parameters_) {
-      parameter_names.emplace_back(parameter.state->name());
+      parameter_names.emplace_back(detail::removePrefix(name_, parameter.state->name()));
     }
 
     return parameter_names;

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -618,9 +618,9 @@ public:
   virtual std::vector<std::string> stateNames() const override
   {
     if (is_quasistatic_) {
-      return std::vector<std::string>{{"temperature"}};
+      return std::vector<std::string>{"temperature"};
     } else {
-      return std::vector<std::string>{{"temperature", "temperature_rate"}};
+      return std::vector<std::string>{"temperature", "temperature_rate"};
     }
   }
 

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -650,9 +650,9 @@ public:
   std::vector<std::string> stateNames() const override
   {
     if (is_quasistatic_) {
-      return std::vector<std::string>{{"displacement"}};
+      return std::vector<std::string>{"displacement"};
     } else {
-      return std::vector<std::string>{{"displacement"}, {"velocity"}, {"acceleration"}};
+      return std::vector<std::string>{"displacement", "velocity", "acceleration"};
     }
   }
 

--- a/src/serac/physics/thermomechanics.hpp
+++ b/src/serac/physics/thermomechanics.hpp
@@ -198,7 +198,7 @@ public:
    */
   virtual std::vector<std::string> stateNames() const override
   {
-    return std::vector<std::string>{{"displacement"}, {"velocity"}, {"temperature"}};
+    return std::vector<std::string>{"displacement", "velocity", "temperature"};
   }
 
   /**


### PR DESCRIPTION
1. Fixes a bug in the state name getter function for dynamic adjoint problems. While the previous code would compile, it would hit a runtime exception when called.
2. No longer requires the string-based parameter get function to also contain the base physics module name. This means that the strings input in the physics module constructor should be the same for the getter request.