### PR TITLE
Add method to check if physics is quasi-static or not.

### DIFF
--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -109,6 +109,13 @@ public:
   virtual int minCycle() const;
 
   /**
+   * @brief Check if the physics is setup as quasi-static
+   *
+   * @return true if quasi-static, false if transient
+   */
+  int isQuasiStatic() const { return is_quasistatic_; }
+
+  /**
    * @brief Get a vector of the timestep sizes (i.e. \f$\Delta t\f$s) taken by the forward solver
    *
    * @return The vector of timestep sizes taken by the foward solver

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -109,11 +109,11 @@ public:
   virtual int minCycle() const;
 
   /**
-   * @brief Check if the physics is setup as quasi-static
+   * @brief Check if the physics is setup as quasistatic
    *
-   * @return true if quasi-static, false if transient
+   * @return true if quasistatic, false if transient
    */
-  bool isQuasiStatic() const { return is_quasistatic_; }
+  bool isQuasistatic() const { return is_quasistatic_; }
 
   /**
    * @brief Get a vector of the timestep sizes (i.e. \f$\Delta t\f$s) taken by the forward solver

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -113,7 +113,7 @@ public:
    *
    * @return true if quasi-static, false if transient
    */
-  int isQuasiStatic() const { return is_quasistatic_; }
+  bool isQuasiStatic() const { return is_quasistatic_; }
 
   /**
    * @brief Get a vector of the timestep sizes (i.e. \f$\Delta t\f$s) taken by the forward solver


### PR DESCRIPTION
The lido wrapper handles quasi-static and dynamic a bit differently (mostly due to checkpointing, but other things).  As such, it is necessary to query which one a given base_physics is.