### PR TITLE
fix memory error in element integration

### DIFF
--- a/src/serac/numerics/functional/detail/hexahedron_H1.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_H1.inl
@@ -254,10 +254,14 @@ struct finite_element<mfem::Geometry::CUBE, H1<p, c> > {
           for (int qy = 0; qy < q; qy++) {
             for (int qx = 0; qx < q; qx++) {
               int Q              = (qz * q + qy) * q + qx;
-              source(qz, qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
-              for (int k = 0; k < dim; k++) {
-                flux(k, qz, qy, qx) =
-                    reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+              if constexpr (!is_zero<source_type>{}) {
+                source(qz, qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
+              }
+              if constexpr (!is_zero<flux_type>{}) {
+                for (int k = 0; k < dim; k++) {
+                  flux(k, qz, qy, qx) =
+                      reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+                }
               }
             }
           }

--- a/src/serac/numerics/functional/detail/hexahedron_H1.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_H1.inl
@@ -253,7 +253,7 @@ struct finite_element<mfem::Geometry::CUBE, H1<p, c> > {
         for (int qz = 0; qz < q; qz++) {
           for (int qy = 0; qy < q; qy++) {
             for (int qx = 0; qx < q; qx++) {
-              int Q              = (qz * q + qy) * q + qx;
+              int Q = (qz * q + qy) * q + qx;
               if constexpr (!is_zero<source_type>{}) {
                 source(qz, qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
               }

--- a/src/serac/numerics/functional/detail/hexahedron_L2.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_L2.inl
@@ -258,10 +258,14 @@ struct finite_element<mfem::Geometry::CUBE, L2<p, c> > {
           for (int qy = 0; qy < q; qy++) {
             for (int qx = 0; qx < q; qx++) {
               int Q              = (qz * q + qy) * q + qx;
-              source(qz, qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
-              for (int k = 0; k < dim; k++) {
-                flux(k, qz, qy, qx) =
-                    reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+              if constexpr (!is_zero<source_type>{}) {
+                source(qz, qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
+              }
+              if constexpr (!is_zero<flux_type>{}) {
+                for (int k = 0; k < dim; k++) {
+                  flux(k, qz, qy, qx) =
+                      reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+                }
               }
             }
           }

--- a/src/serac/numerics/functional/detail/hexahedron_L2.inl
+++ b/src/serac/numerics/functional/detail/hexahedron_L2.inl
@@ -257,7 +257,7 @@ struct finite_element<mfem::Geometry::CUBE, L2<p, c> > {
         for (int qz = 0; qz < q; qz++) {
           for (int qy = 0; qy < q; qy++) {
             for (int qx = 0; qx < q; qx++) {
-              int Q              = (qz * q + qy) * q + qx;
+              int Q = (qz * q + qy) * q + qx;
               if constexpr (!is_zero<source_type>{}) {
                 source(qz, qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
               }

--- a/src/serac/numerics/functional/detail/quadrilateral_L2.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_L2.inl
@@ -274,8 +274,7 @@ struct finite_element<mfem::Geometry::SQUARE, L2<p, c> > {
             }
             if constexpr (!is_zero<flux_type>{}) {
               for (int k = 0; k < dim; k++) {
-                flux(k, qy, qx) =
-                    reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+                flux(k, qy, qx) = reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
               }
             }
           }

--- a/src/serac/numerics/functional/detail/quadrilateral_L2.inl
+++ b/src/serac/numerics/functional/detail/quadrilateral_L2.inl
@@ -268,10 +268,15 @@ struct finite_element<mfem::Geometry::SQUARE, L2<p, c> > {
 
         for (int qy = 0; qy < q; qy++) {
           for (int qx = 0; qx < q; qx++) {
-            int Q          = qy * q + qx;
-            source(qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
-            for (int k = 0; k < dim; k++) {
-              flux(k, qy, qx) = reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+            int Q = qy * q + qx;
+            if constexpr (!is_zero<source_type>{}) {
+              source(qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
+            }
+            if constexpr (!is_zero<flux_type>{}) {
+              for (int k = 0; k < dim; k++) {
+                flux(k, qy, qx) =
+                    reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+              }
             }
           }
         }

--- a/src/serac/numerics/functional/detail/segment_H1.inl
+++ b/src/serac/numerics/functional/detail/segment_H1.inl
@@ -182,7 +182,7 @@ struct finite_element<mfem::Geometry::SEGMENT, H1<p, c> > {
             source(qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[qx]))[i * ntrial + j];
           }
           if constexpr (!is_zero<flux_type>{}) {
-            flux(qx)   = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
+            flux(qx) = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
           }
         }
 

--- a/src/serac/numerics/functional/detail/segment_H1.inl
+++ b/src/serac/numerics/functional/detail/segment_H1.inl
@@ -178,8 +178,12 @@ struct finite_element<mfem::Geometry::SEGMENT, H1<p, c> > {
         f_buffer_type flux;
 
         for (int qx = 0; qx < q; qx++) {
-          source(qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[qx]))[i * ntrial + j];
-          flux(qx)   = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
+          if constexpr (!is_zero<source_type>{}) {
+            source(qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[qx]))[i * ntrial + j];
+          }
+          if constexpr (!is_zero<flux_type>{}) {
+            flux(qx)   = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
+          }
         }
 
         element_residual[j * step](i) += dot(source, B) + dot(flux, G);

--- a/src/serac/numerics/functional/detail/segment_L2.inl
+++ b/src/serac/numerics/functional/detail/segment_L2.inl
@@ -182,7 +182,7 @@ struct finite_element<mfem::Geometry::SEGMENT, L2<p, c> > {
             source(qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[qx]))[i * ntrial + j];
           }
           if constexpr (!is_zero<flux_type>{}) {
-            flux(qx)   = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
+            flux(qx) = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
           }
         }
 

--- a/src/serac/numerics/functional/detail/segment_L2.inl
+++ b/src/serac/numerics/functional/detail/segment_L2.inl
@@ -178,8 +178,12 @@ struct finite_element<mfem::Geometry::SEGMENT, L2<p, c> > {
         f_buffer_type flux;
 
         for (int qx = 0; qx < q; qx++) {
-          source(qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[qx]))[i * ntrial + j];
-          flux(qx)   = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
+          if constexpr (!is_zero<source_type>{}) {
+            source(qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[qx]))[i * ntrial + j];
+          }
+          if constexpr (!is_zero<flux_type>{}) {
+            flux(qx)   = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
+          }
         }
 
         element_residual[j * step](i) += dot(source, B) + dot(flux, G);


### PR DESCRIPTION
This PR fixes a bug found by @kswartz92 where some element geometries were trying to read floating point values from the {source/flux} outputs from the q-function, even when one of them was a `serac::zero` type.

Unfortunately, I already fixed this bug a year ago for the simplex elements https://github.com/LLNL/serac/pull/873 (https://github.com/LLNL/serac/pull/873/commits/03281a80e95e30a50ca43504177459026340f8c2) but neglected to apply the fix to the remaining element geometries. I'm sorry for any LIDO headaches caused by this.

