### PR TITLE
allowing Functional QoI without trial spaces

### DIFF
--- a/src/serac/numerics/functional/functional_qoi.inl
+++ b/src/serac/numerics/functional/functional_qoi.inl
@@ -379,6 +379,7 @@ public:
   template <typename... T>
   auto operator()(double t, const T&... args)
   {
+    // below we add 0 so the number of differentiated arguments defaults to 0 if trial spaces are not provided
     constexpr int num_differentiated_arguments = (std::is_same_v<T, differentiate_wrt_this> + ... + 0);
     static_assert(num_differentiated_arguments <= 1,
                   "Error: Functional::operator() can only differentiate w.r.t. 1 argument a time");

--- a/src/serac/numerics/functional/functional_qoi.inl
+++ b/src/serac/numerics/functional/functional_qoi.inl
@@ -379,7 +379,7 @@ public:
   template <typename... T>
   auto operator()(double t, const T&... args)
   {
-    constexpr int num_differentiated_arguments = (std::is_same_v<T, differentiate_wrt_this> + ...);
+    constexpr int num_differentiated_arguments = (std::is_same_v<T, differentiate_wrt_this> + ... + 0);
     static_assert(num_differentiated_arguments <= 1,
                   "Error: Functional::operator() can only differentiate w.r.t. 1 argument a time");
     static_assert(sizeof...(T) == num_trial_spaces,


### PR DESCRIPTION
This small change allows creating a functional without trial spaces. I was trying to calculate the volume of a mesh and the surface area of a particular boundary attribute and was getting compilation errors when I tried to construct a functional object without a trial space. @samuelpmish suggested this fix.