### PR TITLE
Update compiler versions specified in docker documentation

### DIFF
--- a/src/docs/sphinx/dev_guide/docker_env.rst
+++ b/src/docs/sphinx/dev_guide/docker_env.rst
@@ -1,4 +1,4 @@
-.. ## Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+.. ## Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
 .. ## other Serac Project Developers. See the top-level COPYRIGHT file for details.
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)
@@ -15,8 +15,8 @@ If you haven't used Docker before, it is recommended that you check out the
 1. Clone a copy of the Serac repo to your computer: ``git clone --recursive https://github.com/LLNL/serac.git``
 
 #. Once you've installed ``docker``, navigate to our `Dockerhub page <https://hub.docker.com/r/seracllnl/tpls/tags?page=1&ordering=last_updated>`_
-   and select the most recent image corresponding to the compiler you'd like to use.  Clang 15 and GCC 13 images are currently offered.
-#. Copy the pull command corresponding to the image you've selected (in this case, it's ``docker pull seracllnl/tpls:clang-15_latest``):
+   and select the most recent image corresponding to the compiler you'd like to use.  Clang 14 and GCC 13 images are currently offered.
+#. Copy the pull command corresponding to the image you've selected (in this case, it's ``docker pull seracllnl/tpls:clang-14_latest``):
 
 .. image:: copy_pull_cmd.png
    :scale: 50 %
@@ -26,7 +26,7 @@ If you haven't used Docker before, it is recommended that you check out the
 
 .. image:: pull_complete.png
 
-5. You can now run the image.  Run ``docker run -it -u serac -v /your/serac/repo:/home/serac/serac seracllnl/tpls:clang-15_latest /bin/bash``,
+5. You can now run the image.  Run ``docker run -it -u serac -v /your/serac/repo:/home/serac/serac seracllnl/tpls:clang-14_latest /bin/bash``,
    replacing the tag (the compiler name following the ``tpls:``) with the tag you used in the ``docker pull`` command and
    replacing ``/your/serac/repo`` with the path to the Serac repo you cloned in the first step.  This will open a terminal into the image.
 

--- a/src/docs/sphinx/dev_guide/new_docker_image.rst
+++ b/src/docs/sphinx/dev_guide/new_docker_image.rst
@@ -1,4 +1,4 @@
-.. ## Copyright (c) 2019-2023, Lawrence Livermore National Security, LLC and
+.. ## Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
 .. ## other Serac Project Developers. See the top-level COPYRIGHT file for details.
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)
@@ -20,14 +20,14 @@ Create New Docker File
    If no corresponding compiler image exists, it should be 
    created before proceeding. Here is the `RADIUSS Docker repository images <https://github.com/LLNL/radiuss-docker/pkgs/container/radiuss>`_.
 #. Go to the ``scripts/docker`` directory and run ``build_new_dockerfile.sh``, passing the compiler
-   name and full version, e.g. for Clang 15, run ``./build_new_dockerfile.sh clang 15.0.7``.
-   This will create a Dockerfile whose name corresponds to a specific compiler and major version, e.g., ``dockerfile_clang-15``.
+   name and full version, e.g. for Clang 14, run ``./build_new_dockerfile.sh clang 14.0.0``.
+   This will create a Dockerfile whose name corresponds to a specific compiler and major version, e.g., ``dockerfile_clang-14``.
    This may require modifications depending on the compiler and base image - for example, an extra system package might
    be installed so Spack doesn't need to build it from source.
 #. Edit ``./github/workflows/docker_build_tpls.yml`` to add new job for the new compiler image.  This can be copy-pasted 
    from one of the existing jobs - the only things that must be changed are the job name and ``TAG``, which should match the
-   name of the compiler/generated ``Dockerfile``.  For example, a build for ``dockerfile_clang-15`` must set ``TAG``
-   to ``clang-15``.  For clarity, the ``name`` field for the job should also be updated.
+   name of the compiler/generated ``Dockerfile``.  For example, a build for ``dockerfile_clang-14`` must set ``TAG``
+   to ``clang-14``.  For clarity, the ``name`` field for the job should also be updated.
 #. Commit and push the added YAML file and new Dockerfile.
 
 
@@ -39,11 +39,11 @@ Update/Add Docker Image
 #. Go to the Actions tab on GitHub, select the "Docker TPL Build" action, and run the workflow on the branch to
    which the above changes were pushed.
 #. Once the "Docker TPL Build" action completes, it will produce artifacts for each of the generated host-configs.
-   Download these artifacts and rename them to just the compiler spec.  For example, ``buildkitsandbox-linux-clang@15.0.7.cmake``
-   to ``clang@15.0.7.cmake`` and commit them to your branch under ``host-configs/docker``.  You will also have to update
+   Download these artifacts and rename them to just the compiler spec.  For example, ``buildkitsandbox-linux-clang@14.0.0.cmake``
+   to ``clang@14.0.0.cmake`` and commit them to your branch under ``host-configs/docker``.  You will also have to update
    ``azure-pipelines.yml`` if you added or change the existing compiler specs. These are all in variables called ``HOST_CONFIG``.
 #. Copy the new docker image names from each job under the ``Get dockerhub repo name`` step.  For example,
-   ``seracllnl/tpls:clang-15_06-02-22_04h-11m``. This will replace the previous image name at the top of ``azure-pipelines.yml``
+   ``seracllnl/tpls:clang-14_06-02-22_04h-11m``. This will replace the previous image name at the top of ``azure-pipelines.yml``
    under the ``matrix`` section or add a new entry if you are adding a new docker image.
 #. To include the new image in CI jobs, add/update the ``matrix`` entry to ``azure-pipelines.yml``, modifying its 
    attributes with the appropriate new image name (which is timestamped) and new host-config file.


### PR DESCRIPTION
Very small PR updating the docker compiler versions of clang from 15 to 14.