### PR TITLE
Fix FindPETSc.cmake path to use cmake current list dir

### DIFF
--- a/cmake/serac-config.cmake.in
+++ b/cmake/serac-config.cmake.in
@@ -22,8 +22,6 @@ if(NOT SERAC_FOUND)
   set(SERAC_INSTALL_PREFIX "@SERAC_INSTALL_PREFIX@")
   set(SERAC_INCLUDE_DIRS "${SERAC_INSTALL_PREFIX}/include")
 
-  list(APPEND CMAKE_MODULE_PATH "${SERAC_INSTALL_PREFIX}/@SERAC_INSTALL_CMAKE_MODULE_DIR@")
-
   #----------------------------------------------------------------------------
   # Set user configuration options and features
   #----------------------------------------------------------------------------
@@ -141,7 +139,7 @@ if(NOT SERAC_FOUND)
 
   # Petsc
   if(SERAC_USE_PETSC)
-    include("${CMAKE_MODULE_PATH}/FindPETSc.cmake")
+    include("${CMAKE_CURRENT_LIST_DIR}/FindPETSc.cmake")
   endif()
 
   # Umpire


### PR DESCRIPTION
I was using `CMAKE_MODULE_PATH`, which could contain multiple paths, instead of something like `CMAKE_CURRENT_LIST_DIR`.

Related to: https://github.com/LLNL/serac/pull/1087