### PR TITLE
Revert usage of `tee`

### DIFF
--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -191,8 +191,13 @@ def test_examples(host_config, build_dir, install_dir, report_to_stdout = False)
     # Install
     log_file =  pjoin(build_dir,"output.log.make.install.txt")
     print("[log file: %s]" % log_file)
-    cmd = "cd {0} && make VERBOSE=1 install | tee {1}".format(build_dir, log_file)
-    res = sexe(cmd, echo=True)
+    res = sexe("cd %s && make VERBOSE=1 install " % build_dir,
+                output_file = log_file,
+                echo=True)
+
+    if report_to_stdout:
+        with open(log_file, 'r') as ex_out:
+            print(ex_out.read())
 
     if res != 0:
         print("[ERROR: error code={0}: Install for host-config: {1} failed]\n".format(res, host_config))
@@ -202,8 +207,13 @@ def test_examples(host_config, build_dir, install_dir, report_to_stdout = False)
     log_file =  pjoin(build_dir,"output.log.configure.examples.txt")
     print("[log file: %s]" % log_file)
     example_dir = pjoin(install_dir, "examples", get_project_name(), "using-with-cmake")
-    cmd = "cd {0} && mkdir build && cd build && cmake -C {0}/host-config.cmake {0} | tee {1}".format(example_dir, log_file)
-    res = sexe(cmd, echo=True)
+    res = sexe("cd {0} && mkdir build && cd build && cmake -C {0}/host-config.cmake {0}".format(example_dir),
+                output_file = log_file,
+                echo=True)
+
+    if report_to_stdout:
+        with open(log_file, 'r') as ex_out:
+            print(ex_out.read())
 
     if res != 0:
         print("[ERROR: error code={0}: Configure examples for host-config: {1} failed]\n".format(res, host_config))
@@ -213,8 +223,13 @@ def test_examples(host_config, build_dir, install_dir, report_to_stdout = False)
     log_file =  pjoin(build_dir,"output.log.make.examples.txt")
     print("[log file: %s]" % log_file)
     install_build_dir = pjoin(example_dir, "build")
-    cmd = "cd {0} && make && ls -al && make test | tee {1}".format(install_build_dir, log_file)
-    res = sexe(cmd, echo=True)
+    res = sexe("cd {0} && make && ls -al && make test ".format(install_build_dir),
+                output_file = log_file,
+                echo=True)
+
+    if report_to_stdout:
+        with open(log_file, 'r') as ex_out:
+            print(ex_out.read())
 
     if res != 0:
         print("[ERROR: error code={0}: Make and test examples for host-config: {1} failed]\n".format(res, host_config))
@@ -232,17 +247,17 @@ def build_and_test_host_config(test_root, host_config, report_to_stdout=False, e
     print("[ install dir: %s]"   % install_dir)
 
     # configure
-    log_file = pjoin(test_root,"output.log.%s.configure.txt" % host_config_root)
+    cfg_output_file = pjoin(test_root,"output.log.%s.configure.txt" % host_config_root)
     print("[starting configure of %s]" % host_config)
-    print("[log file: %s]" % log_file)
+    print("[log file: %s]" % cfg_output_file)
     # Disable docs until we build our own doxygen/sphinx to stop the random failures on LC
-    cmd = "{0} config-build.py -DENABLE_DOCS=OFF -bp {1} -hc {2} -ip {3} {4} | tee {5}".format(sys.executable, 
-                                                                                               build_dir,
-                                                                                               host_config,
-                                                                                               install_dir,
-                                                                                               extra_cmake_options,
-                                                                                               log_file)
-    res = sexe(cmd, echo=True)
+    res = sexe("%s config-build.py -DENABLE_DOCS=OFF -bp %s -hc %s -ip %s %s" % (sys.executable, build_dir, host_config, install_dir, extra_cmake_options),
+               output_file = cfg_output_file,
+               echo=True)
+
+    if report_to_stdout:
+        with open(cfg_output_file, 'r') as build_out:
+            print(build_out.read())
 
     if res != 0:
         print("[ERROR: Configure for host-config: %s failed]\n" % host_config)
@@ -253,23 +268,35 @@ def build_and_test_host_config(test_root, host_config, report_to_stdout=False, e
     ####
 
     # build the code
-    log_file =  pjoin(build_dir,"output.log.make.txt")
+    bld_output_file =  pjoin(build_dir,"output.log.make.txt")
     print("[starting build]")
-    print("[log file: %s]" % log_file)
-    cmd = "cd {0} && make -j 8 VERBOSE=1 | tee {1}".format(build_dir, log_file)
-    res = sexe(cmd, echo=True)
+    print("[log file: %s]" % bld_output_file)
+    res = sexe("cd %s && make -j 8 VERBOSE=1 " % build_dir,
+                output_file = bld_output_file,
+                echo=True)
+
+    if report_to_stdout:
+        with open(bld_output_file, 'r') as build_out:
+            print(build_out.read())
 
     if res != 0:
         print("[ERROR: Build for host-config: %s failed]\n" % host_config)
         return res
 
     # test the code
-    log_file = pjoin(build_dir,"output.log.make.test.txt")
+    tst_output_file = pjoin(build_dir,"output.log.make.test.txt")
     print("[starting unit tests]")
-    print("[log file: %s]" % log_file)
+    print("[log file: %s]" % tst_output_file)
 
-    cmd = "cd {0} && make CTEST_OUTPUT_ON_FAILURE=1 test ARGS=\"--no-compress-output -T Test -VV -j8\" | tee {1}".format(build_dir, log_file)
-    res = sexe(cmd, echo=True)
+    tst_cmd = "cd %s && make CTEST_OUTPUT_ON_FAILURE=1 test ARGS=\"--no-compress-output -T Test -VV -j8\"" % build_dir
+
+    res = sexe(tst_cmd,
+               output_file = tst_output_file,
+               echo=True)
+
+    if report_to_stdout:
+        with open(tst_output_file, 'r') as test_out:
+            print(test_out.read())
 
     # Convert CTest output to JUnit, do not overwrite previous res
     print("[Checking to see if xsltproc exists...]")
@@ -293,11 +320,17 @@ def build_and_test_host_config(test_root, host_config, report_to_stdout=False, e
 
     # Disable docs until we build our own doxygen/sphinx to stop the random failures on LC
     # build the docs
-    # log_file = pjoin(build_dir,"output.log.make.docs.txt")
+    # docs_output_file = pjoin(build_dir,"output.log.make.docs.txt")
     # print("[starting docs generation]")
-    # print("[log file: %s]" % log_file)
-    # cmd = "cd {0} && make docs | tee {1}".format(build_dir, log_file)
-    # res = sexe(cmd, echo=True)
+    # print("[log file: %s]" % docs_output_file)
+
+    # res = sexe("cd %s && make docs " % build_dir,
+    #            output_file = docs_output_file,
+    #            echo=True)
+
+    # if report_to_stdout:
+    #     with open(docs_output_file, 'r') as docs_out:
+    #         print(docs_out.read())
 
     # if res != 0:
     #     print("[ERROR: Docs generation for host-config: %s failed]\n\n" % host_config)


### PR DESCRIPTION
I'd say this was an elaborate April Fool's Joke but it's just sad.

`tee` does not forward the error code of the previous command like I assumed and clearly didn't check. My bad.

```
$ ./error.sh; echo $?
~~~~~~~~ test about to error
1
$ ./error.sh | tee output; echo $?
~~~~~~~~ test about to error
0
```

There are some very specific to bash ways of handling this, which we can't rely on, or I can jump through some pipe'ing hoops in Python. I'll do the later later.