### PR TITLE
Add nvToolsExt after all cuda libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,11 @@ endif()
 
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 
+# white238 - On some machines, the linker needs nvToolsExt after all the cuda libraries
+if(ENABLE_CUDA AND AMGX_DIR)
+    target_link_libraries(cuda INTERFACE nvToolsExt)
+endif()
+
 #------------------------------------------------------------------------------
 # Setup Macros and dependencies
 #------------------------------------------------------------------------------

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -191,6 +191,14 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
         serac_assert_find_succeeded(PROJECT_NAME MFEM
                                     TARGET       mfem
                                     DIR_VARIABLE MFEM_DIR)
+        if(AMGX_DIR AND ENABLE_CUDA)
+            get_target_property(_mfem_libs mfem INTERFACE_LINK_LIBRARIES)
+            # white238: Add an extra one at the end because its in the wrong order
+            # but if I touch it the link fails for other reasons
+            if("${_mfem_libs}" MATCHES "-lnvToolsExt")
+                target_link_libraries(mfem INTERFACE "-lnvToolsExt")
+            endif()
+       endif()
     else()
         message(STATUS "Using MFEM submodule")
 


### PR DESCRIPTION
@samuelpmishLLNL 

For reasons, I don't understand but `nvToolsExt` needs to be after a lot of libraries otherwise you get missing symbols from the AMGX libraries.