### PR TITLE
fix off-by-one error when looking up boundary element attributes

### DIFF
--- a/src/serac/numerics/functional/domain.cpp
+++ b/src/serac/numerics/functional/domain.cpp
@@ -187,7 +187,7 @@ static Domain domain_of_faces(const mfem::Mesh&                                 
       attr = mesh.GetAttribute(i);
     } else {
       int bdr_id = face_id_to_bdr_id[i];
-      attr       = (bdr_id > 0) ? mesh.GetBdrAttribute(bdr_id) : -1;
+      attr       = (bdr_id >= 0) ? mesh.GetBdrAttribute(bdr_id) : -1;
     }
 
     if (predicate(x, attr)) {
@@ -332,7 +332,7 @@ static Domain domain_of_boundary_elems(const mfem::Mesh&                        
     auto x = gather<d>(vertices, vertex_ids);
 
     int bdr_id = face_id_to_bdr_id[f];
-    int attr   = (bdr_id > 0) ? mesh.GetBdrAttribute(bdr_id) : -1;
+    int attr   = (bdr_id >= 0) ? mesh.GetBdrAttribute(bdr_id) : -1;
 
     bool add = predicate(x, attr);
 

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -80,7 +80,7 @@ inline void check_for_missing_nodal_gridfunc(const mfem::Mesh& mesh)
       following member functions are invoked before use
 
       > mfem::Mesh::EnsureNodes();
-      > mfem::Mesh::ExchangeFaceNbrData();
+      > mfem::ParMesh::ExchangeFaceNbrData();
 
       or else the mfem::Mesh won't be fully initialized
       )errmsg";);

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ blt_add_executable(NAME        tensor_unit_tests
 set(functional_tests_serial
     functional_shape_derivatives.cpp
     simplex_basis_function_unit_tests.cpp
+    bug_boundary_qoi.cpp
     domain_tests.cpp
     geometric_factors_tests.cpp
     hcurl_unit_tests.cpp
@@ -47,6 +48,8 @@ serac_add_tests( SOURCES ${functional_tests_mpi}
 foreach(filename ${functional_tests_mpi})
     set_source_files_properties(${filename} PROPERTIES LANGUAGE CXX)
 endforeach()
+
+target_link_libraries(bug_boundary_qoi PUBLIC serac_physics)
 
 if(ENABLE_CUDA)
 

--- a/src/serac/numerics/functional/tests/bug_boundary_qoi.cpp
+++ b/src/serac/numerics/functional/tests/bug_boundary_qoi.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2019-2023, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include <fstream>
+#include <iostream>
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include <gtest/gtest.h>
+#include "mfem.hpp"
+
+#include "serac/serac_config.hpp"
+#include "serac/mesh/mesh_utils_base.hpp"
+#include "serac/numerics/functional/functional.hpp"
+#include "serac/numerics/functional/shape_aware_functional.hpp"
+#include "serac/numerics/functional/tensor.hpp"
+#include "serac/infrastructure/profiling.hpp"
+#include "serac/physics/state/finite_element_state.hpp"
+
+using namespace serac;
+using namespace serac::profiling;
+
+double t = 0.0;
+
+int num_procs, my_rank;
+
+TEST(BoundaryIntegralQOI, AttrBug) {
+
+  constexpr int ORDER = 1;
+
+  mfem::Mesh mesh = mfem::Mesh::MakeCartesian2D(10, 10, mfem::Element::QUADRILATERAL, false, 1.0, 1.0);
+
+  auto pmesh = std::make_unique<mfem::ParMesh>(MPI_COMM_WORLD, mesh);
+
+  pmesh->EnsureNodes();
+  pmesh->ExchangeFaceNbrData();
+
+  using shapeFES = serac::H1<ORDER, 2>;
+  auto [shape_fes, shape_fec] = serac::generateParFiniteElementSpace<shapeFES>(pmesh.get());
+
+  serac::ShapeAwareFunctional<shapeFES, double()> totalSurfArea(shape_fes.get(), {});
+  totalSurfArea.AddBoundaryIntegral(serac::Dimension<2-1>{}, serac::DependsOn<>{}, [](auto, auto) {return 1.0;}, *pmesh);
+  serac::FiniteElementState shape(*shape_fes);
+  double totalSurfaceArea = totalSurfArea(0.0, shape);
+
+  EXPECT_NEAR(totalSurfaceArea, 4.0, 1.0e-14);
+  
+  serac::Domain attr1 = serac::Domain::ofBoundaryElements(*pmesh, serac::by_attr<2>(1));
+  serac::ShapeAwareFunctional<shapeFES, double()> attr1SurfArea(shape_fes.get(), {});
+  attr1SurfArea.AddBoundaryIntegral(serac::Dimension<2-1>{}, serac::DependsOn<>{}, [](auto, auto) {return 1.0;}, attr1);
+  double attr1SurfaceArea = attr1SurfArea(0.0, shape);
+  
+  EXPECT_NEAR(attr1SurfaceArea, 1.0, 1.0e-14);
+
+}
+
+int main(int argc, char* argv[])
+{
+
+  ::testing::InitGoogleTest(&argc, argv);
+
+  MPI_Init(&argc, &argv);
+  MPI_Comm_size(MPI_COMM_WORLD, &num_procs);
+  MPI_Comm_rank(MPI_COMM_WORLD, &my_rank);
+
+  axom::slic::SimpleLogger logger;
+
+  int result = RUN_ALL_TESTS();
+
+  MPI_Finalize();
+
+  return result;
+
+}

--- a/src/serac/numerics/functional/tests/bug_boundary_qoi.cpp
+++ b/src/serac/numerics/functional/tests/bug_boundary_qoi.cpp
@@ -26,8 +26,8 @@ double t = 0.0;
 
 int num_procs, my_rank;
 
-TEST(BoundaryIntegralQOI, AttrBug) {
-
+TEST(BoundaryIntegralQOI, AttrBug)
+{
   constexpr int ORDER = 1;
 
   mfem::Mesh mesh = mfem::Mesh::MakeCartesian2D(10, 10, mfem::Element::QUADRILATERAL, false, 1.0, 1.0);
@@ -37,28 +37,28 @@ TEST(BoundaryIntegralQOI, AttrBug) {
   pmesh->EnsureNodes();
   pmesh->ExchangeFaceNbrData();
 
-  using shapeFES = serac::H1<ORDER, 2>;
+  using shapeFES              = serac::H1<ORDER, 2>;
   auto [shape_fes, shape_fec] = serac::generateParFiniteElementSpace<shapeFES>(pmesh.get());
 
   serac::ShapeAwareFunctional<shapeFES, double()> totalSurfArea(shape_fes.get(), {});
-  totalSurfArea.AddBoundaryIntegral(serac::Dimension<2-1>{}, serac::DependsOn<>{}, [](auto, auto) {return 1.0;}, *pmesh);
+  totalSurfArea.AddBoundaryIntegral(
+      serac::Dimension<2 - 1>{}, serac::DependsOn<>{}, [](auto, auto) { return 1.0; }, *pmesh);
   serac::FiniteElementState shape(*shape_fes);
-  double totalSurfaceArea = totalSurfArea(0.0, shape);
+  double                    totalSurfaceArea = totalSurfArea(0.0, shape);
 
   EXPECT_NEAR(totalSurfaceArea, 4.0, 1.0e-14);
-  
+
   serac::Domain attr1 = serac::Domain::ofBoundaryElements(*pmesh, serac::by_attr<2>(1));
   serac::ShapeAwareFunctional<shapeFES, double()> attr1SurfArea(shape_fes.get(), {});
-  attr1SurfArea.AddBoundaryIntegral(serac::Dimension<2-1>{}, serac::DependsOn<>{}, [](auto, auto) {return 1.0;}, attr1);
+  attr1SurfArea.AddBoundaryIntegral(
+      serac::Dimension<2 - 1>{}, serac::DependsOn<>{}, [](auto, auto) { return 1.0; }, attr1);
   double attr1SurfaceArea = attr1SurfArea(0.0, shape);
-  
-  EXPECT_NEAR(attr1SurfaceArea, 1.0, 1.0e-14);
 
+  EXPECT_NEAR(attr1SurfaceArea, 1.0, 1.0e-14);
 }
 
 int main(int argc, char* argv[])
 {
-
   ::testing::InitGoogleTest(&argc, argv);
 
   MPI_Init(&argc, &argv);
@@ -72,5 +72,4 @@ int main(int argc, char* argv[])
   MPI_Finalize();
 
   return result;
-
 }


### PR DESCRIPTION
thanks to @kswartz92 for noticing an error in a surface area calculation and providing a minimal reproducer