### PR TITLE
Give jobs a deadline on Quartz

### DIFF
--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -2,7 +2,7 @@
 # This is the shared configuration of jobs for quartz
 .on_quartz:
   variables:
-    ALLOC_OPTIONS: "--res=ci --exclusive=user -A ${ALLOC_BANK}"
+    ALLOC_OPTIONS: "--res=ci --exclusive=user -A ${ALLOC_BANK} --deadline=now+1hour"
     ALLOC_COMMAND: "salloc ${ALLOC_OPTIONS} -N ${ALLOC_NODES} -t ${ALLOC_TIME}"
   tags:
     - shell

--- a/src/docs/sphinx/dev_guide/codevelop.rst
+++ b/src/docs/sphinx/dev_guide/codevelop.rst
@@ -1,4 +1,4 @@
-.. ## Copyright (c) 2019-2021, Lawrence Livermore National Security, LLC and
+.. ## Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
 .. ## other Serac Project Developers. See the top-level COPYRIGHT file for details.
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)

--- a/src/docs/sphinx/dev_guide/testing.rst
+++ b/src/docs/sphinx/dev_guide/testing.rst
@@ -1,4 +1,4 @@
-.. ## Copyright (c) 2019-2021, Lawrence Livermore National Security, LLC and
+.. ## Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
 .. ## other Serac Project Developers. See the top-level COPYRIGHT file for details.
 .. ##
 .. ## SPDX-License-Identifier: (BSD-3-Clause)

--- a/src/serac/numerics/functional/CMakeLists.txt
+++ b/src/serac/numerics/functional/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+# Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
 # other Serac Project Developers. See the top-level LICENSE file for
 # details.
 #

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020, Lawrence Livermore National Security, LLC and
+# Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
 # other Serac Project Developers. See the top-level LICENSE file for
 # details.
 #

--- a/src/serac/numerics/functional/tests/bug_boundary_qoi.cpp
+++ b/src/serac/numerics/functional/tests/bug_boundary_qoi.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2023, Lawrence Livermore National Security, LLC and
+// Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
 // other Serac Project Developers. See the top-level LICENSE file for
 // details.
 //


### PR DESCRIPTION
With this PR, CI jobs now have a deadline on Quartz. This way, if jobs get stuck on the queue after gitlab fails, it won't clog up the system. I choose an hour because that's the same deadline as Gitlab.

If `--deadline=now+1hour` and `-t25`, the job will dequeue after 35 minutes (60-25).

I couldn't find a similar argument on `lalloc`/ `bsub` commands (Lassen).

Also, I snuck in some more copyright updates.