### PR TITLE
Remove old Serac Caliper macros

### DIFF
--- a/src/docs/sphinx/dev_guide/profiling.rst
+++ b/src/docs/sphinx/dev_guide/profiling.rst
@@ -65,51 +65,42 @@ integrals, floating points, and strings. Note that this macro is a no-op if the
 To add profile regions and ensure that Caliper is only used when it has been enabled
 through Spack, only use the macros described below to instrument your code:
 
-Use ``SERAC_MARK_FUNCTION`` at the very top of a function to mark it for profiling.
+Use ``CALI_CXX_MARK_FUNCTION`` at the very top of a function to mark it for profiling.
 
-Use ``SERAC_MARK_BEGIN(name)`` at the beginning of a region and ``SERAC_MARK_END(name)`` at the end of the region.
+Use ``CALI_MARK_BEGIN(name)`` at the beginning of a region and ``CALI_MARK_END(name)`` at the end of the region.
 
-Use ``SERAC_MARK_LOOP_BEGIN(id, name)`` before a loop to mark it for profiling, ``SERAC_MARK_LOOP_ITER(id, i)`` at the beginning
-of the  ``i`` th iteration of a loop, and ``SERAC_MARK_LOOP_END(id)`` immediately after the loop ends:
+Use ``CALI_CXX_MARK_LOOP_BEGIN(id, name)`` before a loop to mark it for profiling, ``CALI_CXX_MARK_LOOP_ITERATION(id, i)`` at the beginning
+of the  ``i`` th iteration of a loop, and ``CALI_CXX_MARK_LOOP_END(id)`` immediately after the loop ends:
 
 .. code-block:: c++
 
-  SERAC_MARK_BEGIN("region_name");
+  CALI_MARK_BEGIN("region_name");
    
-  SERAC_MARK_LOOP_BEGIN(doubling_loop, "doubling_loop");
+  CALI_CXX_MARK_LOOP_BEGIN(doubling_loop, "doubling_loop");
   for (int i = 0; i < input.size(); i++)
   {
-    SERAC_MARK_LOOP_ITER(doubling_loop, i);
+    CALI_CXX_MARK_LOOP_ITERATION(doubling_loop, i);
     output[i] = input[i] * 2;
   }
-  SERAC_MARK_LOOP_END(doubling_loop);
+  CALI_CXX_MARK_LOOP_END(doubling_loop);
 
-  SERAC_MARK_END("region_name");
+  CALI_MARK_END("region_name");
 
 
-Note that the ``id`` argument to the ``SERAC_MARK_LOOP_*`` macros can be any identifier as long as it is consistent
-between all uses of ``SERAC_MARK_LOOP_*`` for a given loop.  
+Note that the ``id`` argument to the ``CALI_CXX_MARK_LOOP_*`` macros can be any identifier as long as it is consistent
+between all uses of ``CALI_CXX_MARK_LOOP_*`` for a given loop.  
 
-To reduce the amount of annotation for regions bounded by a particular scope, use ``SERAC_PROFILE_SCOPE(name)``. This will follow RAII and works with graceful exception handling. When ``SERAC_PROFILE_SCOPE`` is instantiated, profiling of this region starts, and when the scope exits, profiling of this region will end.
+To reduce the amount of annotation for regions bounded by a particular scope, use ``CALI_CXX_MARK_SCOPE(name)``. This will follow RAII and works with graceful exception handling. When ``CALI_CXX_MARK_SCOPE`` is instantiated, profiling of this region starts, and when the scope exits, profiling of this region will end.
 
 .. code-block:: c++
 
-   // Refine once more and utilize SERAC_PROFILE_SCOPE
+   // Refine once more and utilize CALI_CXX_MARK_SCOPE
   {
-    SERAC_PROFILE_SCOPE("RefineOnceMore");
+    CALI_CXX_MARK_SCOPE("RefineOnceMore");
     pmesh->UniformRefinement();
   }
 
-Alternatively, for single line expressions, use ``SERAC_PROFILE_EXPR(name, expr)``. In the following example, only the call to ``buildMeshFromFile`` will be profiled (tag = "LOAD_MESH").
 
-.. code-block:: c++
-
-     auto pmesh = mesh::refineAndDistribute(SERAC_PROFILE_EXPR("LOAD_MESH", buildMeshFromFile(mesh_file)), 0, 0);
-
-.. note::
-   ``SERAC_PROFILE_EXPR`` creates a lambda and the expression is evaluated within that scope, and then the result is returned.
-
-     
 Performance Data
 ----------------
 

--- a/src/serac/infrastructure/profiling.cpp
+++ b/src/serac/infrastructure/profiling.cpp
@@ -71,23 +71,4 @@ void finalize()
 #endif
 }
 
-/// @cond
-namespace detail {
-
-void startCaliperRegion([[maybe_unused]] const char* name)
-{
-#ifdef SERAC_USE_CALIPER
-  CALI_MARK_BEGIN(name);
-#endif
-}
-
-void endCaliperRegion([[maybe_unused]] const char* name)
-{
-#ifdef SERAC_USE_CALIPER
-  CALI_MARK_END(name);
-#endif
-}
-
-}  // namespace detail
-   /// @endcond
 }  // namespace serac::profiling

--- a/src/serac/infrastructure/profiling.hpp
+++ b/src/serac/infrastructure/profiling.hpp
@@ -33,121 +33,20 @@
  * Sets metadata in adiak/caliper. Calls adiak::value
  */
 
-/**
- * @def SERAC_MARK_FUNCTION
- * Marks a function for Caliper profiling
- */
-
-/**
- * @def SERAC_MARK_LOOP_BEGIN(id, name)
- * Marks the beginning of a loop block for Caliper profiling
- */
-
-/**
- * @def SERAC_MARK_LOOP_ITER(id, i)
- * Marks the beginning of a loop iteration for Caliper profiling
- */
-
-/**
- * @def SERAC_MARK_LOOP_END(id)
- * Marks the end of a loop block for Caliper profiling
- */
-
-/**
- * @def SERAC_MARK_BEGIN(id)
- * Marks the start of a region Caliper profiling
- */
-
-/**
- * @def SERAC_MARK_END(id)
- * Marks the end of a region Caliper profiling
- */
-
-/**
- * @def SERAC_PROFILE_SCOPE(name)
- * Uses cali::ScopeAnnotation to profile a particular scope
- */
-
-/**
- * @def SERAC_PROFILE_EXPR(name, expr)
- * Profiles a single expression using a cali::ScopeAnnotation internally. Returns evaluation.
- */
-
-/**
- * @def SERAC_PROFILE_EXPR_LOOP(name, expr, ntest)
- * Profiles an expression several times. Returns the last evaluation
- */
-
 #ifdef SERAC_USE_ADIAK
 #define SERAC_SET_METADATA(name, data) adiak::value(name, data)
 #else
 #define SERAC_SET_METADATA(name, data)
 #endif
 
-#ifdef SERAC_USE_CALIPER
-
-#define SERAC_MARK_FUNCTION CALI_CXX_MARK_FUNCTION
-#define SERAC_MARK_LOOP_BEGIN(id, name) CALI_CXX_MARK_LOOP_BEGIN(id, name)
-#define SERAC_MARK_LOOP_ITER(id, i) CALI_CXX_MARK_LOOP_ITERATION(id, i)
-#define SERAC_MARK_LOOP_END(id) CALI_CXX_MARK_LOOP_END(id)
-#define SERAC_MARK_BEGIN(name) serac::profiling::detail::startCaliperRegion(name)
-#define SERAC_MARK_END(name) serac::profiling::detail::endCaliperRegion(name)
-
-#define SERAC_CONCAT_(a, b) a##b
-#define SERAC_CONCAT(a, b) SERAC_CONCAT_(a, b)
-
-namespace serac::profiling::detail {
-
-/**
- * @brief Guarantees str is a c string
- */
-inline const char* make_cstr(const char* str) { return str; }
-
-/**
- * @brief Converts a std::string into a c string
- */
-inline const char* make_cstr(const std::string& str) { return str.c_str(); }
-
-}  // namespace serac::profiling::detail
-
-#define SERAC_PROFILE_SCOPE(name) \
-  cali::ScopeAnnotation SERAC_CONCAT(region, __LINE__)(serac::profiling::detail::make_cstr(name))
-
-// We use decltype(auto) here instead of the default auto for a different set of type deduction rules -
-// the latter uses template type deduction rules but the former uses those for decltype, which we need
-// in order for the return type to take into account the value category (rvalue, lvalue) of the expression
-// We have to return (expr) instead of expr to ensure that reference-ness is propagated through correctly
-// in Clang - GCC handles this correctly without the parentheses as expected
-#define SERAC_PROFILE_EXPR(name, expr)                                                                     \
-  [&]() -> decltype(auto) {                                                                                \
-    const cali::ScopeAnnotation SERAC_CONCAT(region, __LINE__)(serac::profiling::detail::make_cstr(name)); \
-    return (expr);                                                                                         \
-  }()
-
-/**
- * @brief Profiles an expression several times; Return the last evaluation
- */
-#define SERAC_PROFILE_EXPR_LOOP(name, expr, ntest)                                                                  \
-  (                                                                                                                 \
-      [&]() {                                                                                                       \
-        for (int SERAC_CONCAT(i, __LINE__) = 0; SERAC_CONCAT(i, __LINE__) < ntest - 1; SERAC_CONCAT(i, __LINE__)++) \
-          SERAC_PROFILE_EXPR(serac::profiling::detail::make_cstr(name), expr);                                      \
-      }(),                                                                                                          \
-      SERAC_PROFILE_EXPR(serac::profiling::detail::make_cstr(name), expr))
-
-#else  // SERAC_USE_CALIPER not defined
-
-// Define all these as nothing so annotated code will still compile
-#define SERAC_MARK_FUNCTION
-#define SERAC_MARK_LOOP_BEGIN(id, name)
-#define SERAC_MARK_LOOP_ITER(id, i)
-#define SERAC_MARK_LOOP_END(id)
-#define SERAC_MARK_BEGIN(name)
-#define SERAC_MARK_END(name)
-#define SERAC_PROFILE_SCOPE(name)
-#define SERAC_PROFILE_EXPR(name, expr) expr
-#define SERAC_PROFILE_EXPR_LOOP(name, expr, ntest) expr
-
+#ifndef SERAC_USE_CALIPER
+#define CALI_CXX_MARK_FUNCTION
+#define CALI_CXX_MARK_LOOP_BEGIN(id, name)
+#define CALI_CXX_MARK_LOOP_ITERATION(id, i)
+#define CALI_CXX_MARK_LOOP_END(id)
+#define CALI_MARK_BEGIN(name)
+#define CALI_MARK_END(name)
+#define CALI_CXX_MARK_SCOPE(name)
 #endif
 
 /// profiling namespace
@@ -165,25 +64,6 @@ void initialize([[maybe_unused]] MPI_Comm comm = MPI_COMM_WORLD, [[maybe_unused]
  * @brief Concludes performance monitoring and writes collected data to a file
  */
 void finalize();
-
-/// detail namespace
-namespace detail {
-
-/**
- * @brief Caliper method for marking the start of a profiling region
- *
- * @param[in] name The tag to associate with the region.
- */
-void startCaliperRegion(const char* name);
-
-/**
- * @brief Caliper methods for marking the end of a region
- *
- * @param[in] name The tag to associate with the region.
- */
-void endCaliperRegion(const char* name);
-
-}  // namespace detail
 
 /// Produces a string by applying << to all arguments
 template <typename... T>

--- a/src/serac/infrastructure/profiling.hpp
+++ b/src/serac/infrastructure/profiling.hpp
@@ -39,6 +39,41 @@
 #define SERAC_SET_METADATA(name, data)
 #endif
 
+/**
+ * @def CALI_CXX_MARK_FUNCTION
+ * No-op macro in case Serac is not built with Caliper
+ */
+
+/**
+ * @def CALI_CXX_MARK_LOOP_BEGIN(id, name)
+ * No-op macro in case Serac is not built with Caliper
+ */
+
+/**
+ * @def CALI_CXX_MARK_LOOP_ITERATION(id, i)
+ * No-op macro in case Serac is not built with Caliper
+ */
+
+/**
+ * @def CALI_CXX_MARK_LOOP_END(id)
+ * No-op macro in case Serac is not built with Caliper
+ */
+
+/**
+ * @def CALI_MARK_BEGIN(name)
+ * No-op macro in case Serac is not built with Caliper
+ */
+
+/**
+ * @def CALI_MARK_END(name)
+ * No-op macro in case Serac is not built with Caliper
+ */
+
+/**
+ * @def CALI_CXX_MARK_SCOPE(name)
+ * No-op macro in case Serac is not built with Caliper
+ */
+
 #ifndef SERAC_USE_CALIPER
 #define CALI_CXX_MARK_FUNCTION
 #define CALI_CXX_MARK_LOOP_BEGIN(id, name)

--- a/src/serac/infrastructure/tests/profiling.cpp
+++ b/src/serac/infrastructure/tests/profiling.cpp
@@ -29,16 +29,16 @@ TEST(Profiling, MeshRefinement)
   // the following string is a proxy for templated test names
   std::string test_name = "_profiling";
 
-  SERAC_MARK_BEGIN(profiling::concat("RefineAndLoadMesh", test_name).c_str());
+  CALI_MARK_BEGIN(profiling::concat("RefineAndLoadMesh", test_name).c_str());
   auto pmesh = mesh::refineAndDistribute(SERAC_PROFILE_EXPR("LOAD_MESH", buildMeshFromFile(mesh_file)), 0, 0);
-  SERAC_MARK_END(profiling::concat("RefineAndLoadMesh", test_name).c_str());
+  CALI_MARK_END(profiling::concat("RefineAndLoadMesh", test_name).c_str());
 
-  SERAC_MARK_LOOP_BEGIN(refinement_loop, "refinement_loop");
+  CALI_CXX_MARK_LOOP_BEGIN(refinement_loop, "refinement_loop");
   for (int i = 0; i < 2; i++) {
-    SERAC_MARK_LOOP_ITER(refinement_loop, i);
+    CALI_CXX_MARK_LOOP_ITERATION(refinement_loop, i);
     pmesh->UniformRefinement();
   }
-  SERAC_MARK_LOOP_END(refinement_loop);
+  CALI_CXX_MARK_LOOP_END(refinement_loop);
 
   // Refine once more and utilize SERAC_PROFILE_SCOPE
   {

--- a/src/serac/infrastructure/tests/profiling.cpp
+++ b/src/serac/infrastructure/tests/profiling.cpp
@@ -16,6 +16,8 @@
 #include "serac/infrastructure/profiling.hpp"
 #include "serac/mesh/mesh_utils.hpp"
 
+#if defined(SERAC_USE_CALIPER) && defined(SERAC_USE_ADIAK)
+
 namespace serac {
 
 TEST(Profiling, MeshRefinement)
@@ -153,6 +155,8 @@ TEST(Profiling, TempRvalueReferenceExpr)
 }
 
 }  // namespace serac
+
+#endif
 
 int main(int argc, char* argv[])
 {

--- a/src/serac/infrastructure/tests/profiling.cpp
+++ b/src/serac/infrastructure/tests/profiling.cpp
@@ -16,8 +16,6 @@
 #include "serac/infrastructure/profiling.hpp"
 #include "serac/mesh/mesh_utils.hpp"
 
-#if defined(SERAC_USE_CALIPER) && defined(SERAC_USE_ADIAK)
-
 namespace serac {
 
 TEST(Profiling, MeshRefinement)
@@ -33,7 +31,7 @@ TEST(Profiling, MeshRefinement)
   std::string test_name = "_profiling";
 
   CALI_MARK_BEGIN(profiling::concat("RefineAndLoadMesh", test_name).c_str());
-  auto pmesh = mesh::refineAndDistribute(SERAC_PROFILE_EXPR("LOAD_MESH", buildMeshFromFile(mesh_file)), 0, 0);
+  auto pmesh = mesh::refineAndDistribute(buildMeshFromFile(mesh_file));
   CALI_MARK_END(profiling::concat("RefineAndLoadMesh", test_name).c_str());
 
   CALI_CXX_MARK_LOOP_BEGIN(refinement_loop, "refinement_loop");
@@ -49,12 +47,12 @@ TEST(Profiling, MeshRefinement)
     pmesh->UniformRefinement();
   }
 
-  adiak::value("mesh_file", mesh_file.c_str());
-  adiak::value("number_mesh_elements", pmesh->GetNE());
+  SERAC_SET_METADATA("mesh_file", mesh_file.c_str());
+  SERAC_SET_METADATA("number_mesh_elements", pmesh->GetNE());
 
   // this number represents "llnl" as an unsigned integer
   unsigned int magic_uint = 1819176044;
-  adiak::value("magic_uint", magic_uint);
+  SERAC_SET_METADATA("magic_uint", magic_uint);
 
   // decode unsigned int back into char[4]
   std::array<char, sizeof(magic_uint) + 1> uint_string;
@@ -65,7 +63,7 @@ TEST(Profiling, MeshRefinement)
   // encode double with "llnl" bytes
   double magic_double;
   std::memcpy(&magic_double, "llnl", 4);
-  adiak::value("magic_double", magic_double);
+  SERAC_SET_METADATA("magic_double", magic_double);
 
   // decode the double and print
   std::array<char, sizeof(magic_double) + 1> double_string;
@@ -99,64 +97,7 @@ TEST(Profiling, Exception)
   MPI_Barrier(MPI_COMM_WORLD);
 }
 
-struct NonCopyableOrMovable {
-  int value                                         = 0;
-  NonCopyableOrMovable()                            = default;
-  NonCopyableOrMovable(const NonCopyableOrMovable&) = delete;
-  NonCopyableOrMovable(NonCopyableOrMovable&&)      = delete;
-};
-
-TEST(Profiling, LvalueReferenceExpr)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
-  serac::profiling::initialize();
-  NonCopyableOrMovable foo;
-  // This statement requires that the RHS be *exactly* a non-const lvalue
-  // reference - of course a const lvalue reference cannot be bound here,
-  // but also an rvalue reference would also cause compilation to fail
-  NonCopyableOrMovable& bar = SERAC_PROFILE_EXPR("lvalue_reference_assign", foo);
-  serac::profiling::finalize();
-  bar.value = 6;
-  EXPECT_EQ(foo.value, 6);
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
-struct MovableOnly {
-  int value                       = 0;
-  MovableOnly()                   = default;
-  MovableOnly(const MovableOnly&) = delete;
-  MovableOnly(MovableOnly&&)      = default;
-};
-
-TEST(Profiling, RvalueReferenceExpr)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
-  serac::profiling::initialize();
-  MovableOnly foo;
-  foo.value = 6;
-  // This statement requires that the RHS be *exactly* an rvalue reference
-  // An lvalue reference cannot be used to construct here (copy ctor deleted)
-  MovableOnly bar = SERAC_PROFILE_EXPR("rvalue_reference_assign", std::move(foo));
-  serac::profiling::finalize();
-  EXPECT_EQ(bar.value, 6);
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
-TEST(Profiling, TempRvalueReferenceExpr)
-{
-  MPI_Barrier(MPI_COMM_WORLD);
-  serac::profiling::initialize();
-  // This statement requires that the RHS be *exactly* an rvalue reference
-  // An lvalue reference cannot be used to construct here (copy ctor deleted)
-  MovableOnly bar = SERAC_PROFILE_EXPR("rvalue_reference_assign", MovableOnly{6});
-  serac::profiling::finalize();
-  EXPECT_EQ(bar.value, 6);
-  MPI_Barrier(MPI_COMM_WORLD);
-}
-
 }  // namespace serac
-
-#endif
 
 int main(int argc, char* argv[])
 {

--- a/src/serac/infrastructure/tests/profiling.cpp
+++ b/src/serac/infrastructure/tests/profiling.cpp
@@ -21,6 +21,7 @@ namespace serac {
 TEST(Profiling, MeshRefinement)
 {
   // profile mesh refinement
+  CALI_CXX_MARK_FUNCTION;
   MPI_Barrier(MPI_COMM_WORLD);
   serac::profiling::initialize();
 
@@ -40,18 +41,18 @@ TEST(Profiling, MeshRefinement)
   }
   CALI_CXX_MARK_LOOP_END(refinement_loop);
 
-  // Refine once more and utilize SERAC_PROFILE_SCOPE
+  // Refine once more and utilize CALI_CXX_MARK_SCOPE
   {
-    SERAC_PROFILE_SCOPE("RefineOnceMore");
+    CALI_CXX_MARK_SCOPE("RefineOnceMore");
     pmesh->UniformRefinement();
   }
 
-  SERAC_SET_METADATA("mesh_file", mesh_file.c_str());
-  SERAC_SET_METADATA("number_mesh_elements", pmesh->GetNE());
+  adiak::value("mesh_file", mesh_file.c_str());
+  adiak::value("number_mesh_elements", pmesh->GetNE());
 
   // this number represents "llnl" as an unsigned integer
   unsigned int magic_uint = 1819176044;
-  SERAC_SET_METADATA("magic_uint", magic_uint);
+  adiak::value("magic_uint", magic_uint);
 
   // decode unsigned int back into char[4]
   std::array<char, sizeof(magic_uint) + 1> uint_string;
@@ -62,7 +63,7 @@ TEST(Profiling, MeshRefinement)
   // encode double with "llnl" bytes
   double magic_double;
   std::memcpy(&magic_double, "llnl", 4);
-  SERAC_SET_METADATA("magic_double", magic_double);
+  adiak::value("magic_double", magic_double);
 
   // decode the double and print
   std::array<char, sizeof(magic_double) + 1> double_string;
@@ -82,9 +83,9 @@ TEST(Profiling, Exception)
   serac::profiling::initialize();
 
   {
-    SERAC_PROFILE_SCOPE("Non-exceptionScope");
+    CALI_CXX_MARK_SCOPE("Non-exceptionScope");
     try {
-      SERAC_PROFILE_SCOPE("Exception scope");
+      CALI_CXX_MARK_SCOPE("Exception scope");
       throw std::runtime_error("Caliper to verify RAII");
     } catch (std::exception& e) {
       std::cout << e.what() << "\n";

--- a/src/serac/numerics/functional/tests/functional_comparisons_cuda.cu
+++ b/src/serac/numerics/functional/tests/functional_comparisons_cuda.cu
@@ -113,7 +113,7 @@ void functional_test(H1<p> test, H1<p> trial, Dimension<dim>)
 
   // Assemble the bilinear form into a matrix
   {
-    SERAC_PROFILE_SCOPE(concat("mfem_localAssemble", postfix));
+    CALI_CXX_MARK_SCOPE(concat("mfem_localAssemble", postfix));
     A.Assemble(0);
   }
 
@@ -229,7 +229,7 @@ void functional_test(H1<p, dim> test, H1<p, dim> trial, Dimension<dim>)
   mfem::ConstantCoefficient mu_coef(b);
   A.AddDomainIntegrator(new mfem::ElasticityIntegrator(lambda_coef, mu_coef));
   {
-    SERAC_PROFILE_SCOPE(concat("mfem_localAssemble", postfix));
+    CALI_CXX_MARK_SCOPE(concat("mfem_localAssemble", postfix));
     A.Assemble(0);
   }
   A.Finalize();
@@ -245,7 +245,7 @@ void functional_test(H1<p, dim> test, H1<p, dim> trial, Dimension<dim>)
 
   f.AddDomainIntegrator(new mfem::VectorDomainLFIntegrator(load_func));
   {
-    SERAC_PROFILE_SCOPE(concat("mfem_fAssemble", postfix));
+    CALI_CXX_MARK_SCOPE(concat("mfem_fAssemble", postfix));
     f.Assemble();
   }
 
@@ -321,7 +321,7 @@ void functional_test(Hcurl<p> test, Hcurl<p> trial, Dimension<dim>)
   mfem::ConstantCoefficient b_coef(b);
   B.AddDomainIntegrator(new mfem::CurlCurlIntegrator(b_coef));
   {
-    SERAC_PROFILE_SCOPE(concat("mfem_localAssemble", postfix));
+    CALI_CXX_MARK_SCOPE(concat("mfem_localAssemble", postfix));
     B.Assemble(0);
   }
   B.Finalize();
@@ -339,7 +339,7 @@ void functional_test(Hcurl<p> test, Hcurl<p> trial, Dimension<dim>)
 
   f.AddDomainIntegrator(new mfem::VectorFEDomainLFIntegrator(load_func));
   {
-    SERAC_PROFILE_SCOPE(concat("mfem_fAssemble", postfix));
+    CALI_CXX_MARK_SCOPE(concat("mfem_fAssemble", postfix));
     f.Assemble();
   }
   std::unique_ptr<mfem::HypreParVector> F(
@@ -363,7 +363,7 @@ void functional_test(Hcurl<p> test, Hcurl<p> trial, Dimension<dim>)
   // Compute the residual using standard MFEM methods
   mfem::Vector r1(U.Size());
   {
-    SERAC_PROFILE_SCOPE(concat("mfem_Apply", postfix));
+    CALI_CXX_MARK_SCOPE(concat("mfem_Apply", postfix));
     J->Mult(U, r1);
     r1 -= *F;
   }

--- a/src/serac/physics/benchmarks/benchmark_functional.cpp
+++ b/src/serac/physics/benchmarks/benchmark_functional.cpp
@@ -60,21 +60,21 @@ void functional_test(int parallel_refinement)
   // Compute the residual using functional
   double t = 0.0;
 
-  SERAC_MARK_BEGIN("residual evaluation");
+  CALI_MARK_BEGIN("residual evaluation");
   mfem::Vector r1 = residual(t, U);
-  SERAC_MARK_END("residual evaluation");
+  CALI_MARK_END("residual evaluation");
 
-  SERAC_MARK_BEGIN("compute gradient");
+  CALI_MARK_BEGIN("compute gradient");
   auto [r2, drdU] = residual(t, serac::differentiate_wrt(U));
-  SERAC_MARK_END("compute gradient");
+  CALI_MARK_END("compute gradient");
 
-  SERAC_MARK_BEGIN("apply gradient");
+  CALI_MARK_BEGIN("apply gradient");
   mfem::Vector g = drdU(U);
-  SERAC_MARK_END("apply gradient");
+  CALI_MARK_END("apply gradient");
 
-  SERAC_MARK_BEGIN("assemble gradient");
+  CALI_MARK_BEGIN("assemble gradient");
   auto g_mat = assemble(drdU);
-  SERAC_MARK_END("assemble gradient");
+  CALI_MARK_END("assemble gradient");
 }
 
 int main(int argc, char* argv[])
@@ -88,45 +88,45 @@ int main(int argc, char* argv[])
   // Initialize profiling
   serac::profiling::initialize();
 
-  SERAC_MARK_BEGIN("scalar H1");
+  CALI_MARK_BEGIN("scalar H1");
 
-  SERAC_MARK_BEGIN("dimension 2, order 1");
+  CALI_MARK_BEGIN("dimension 2, order 1");
   functional_test<1, 2, 1>(parallel_refinement);
-  SERAC_MARK_END("dimension 2, order 1");
+  CALI_MARK_END("dimension 2, order 1");
 
-  SERAC_MARK_BEGIN("dimension 2, order 2");
+  CALI_MARK_BEGIN("dimension 2, order 2");
   functional_test<2, 2, 1>(parallel_refinement);
-  SERAC_MARK_END("dimension 2, order 2");
+  CALI_MARK_END("dimension 2, order 2");
 
-  SERAC_MARK_BEGIN("dimension 3, order 1");
+  CALI_MARK_BEGIN("dimension 3, order 1");
   functional_test<1, 3, 1>(parallel_refinement);
-  SERAC_MARK_END("dimension 3, order 1");
+  CALI_MARK_END("dimension 3, order 1");
 
-  SERAC_MARK_BEGIN("dimension 3, order 2");
+  CALI_MARK_BEGIN("dimension 3, order 2");
   functional_test<2, 3, 1>(parallel_refinement);
-  SERAC_MARK_END("dimension 3, order 2");
+  CALI_MARK_END("dimension 3, order 2");
 
-  SERAC_MARK_END("scalar H1");
+  CALI_MARK_END("scalar H1");
 
-  SERAC_MARK_BEGIN("vector H1");
+  CALI_MARK_BEGIN("vector H1");
 
-  SERAC_MARK_BEGIN("dimension 2, order 1");
+  CALI_MARK_BEGIN("dimension 2, order 1");
   functional_test<1, 2, 2>(parallel_refinement);
-  SERAC_MARK_END("dimension 2, order 1");
+  CALI_MARK_END("dimension 2, order 1");
 
-  SERAC_MARK_BEGIN("dimension 2, order 2");
+  CALI_MARK_BEGIN("dimension 2, order 2");
   functional_test<2, 2, 2>(parallel_refinement);
-  SERAC_MARK_END("dimension 2, order 2");
+  CALI_MARK_END("dimension 2, order 2");
 
-  SERAC_MARK_BEGIN("dimension 3, order 1");
+  CALI_MARK_BEGIN("dimension 3, order 1");
   functional_test<1, 3, 3>(parallel_refinement);
-  SERAC_MARK_END("dimension 3, order 1");
+  CALI_MARK_END("dimension 3, order 1");
 
-  SERAC_MARK_BEGIN("dimension 3, order 2");
+  CALI_MARK_BEGIN("dimension 3, order 2");
   functional_test<2, 3, 3>(parallel_refinement);
-  SERAC_MARK_END("dimension 3, order 2");
+  CALI_MARK_END("dimension 3, order 2");
 
-  SERAC_MARK_END("vector H1");
+  CALI_MARK_END("vector H1");
 
   // Finalize profiling
   serac::profiling::finalize();

--- a/src/serac/physics/benchmarks/benchmark_thermal.cpp
+++ b/src/serac/physics/benchmarks/benchmark_thermal.cpp
@@ -166,37 +166,37 @@ int main(int argc, char* argv[])
   // Add metadata
   SERAC_SET_METADATA("test", "thermal_functional");
 
-  SERAC_MARK_BEGIN("2D Linear Static");
+  CALI_MARK_BEGIN("2D Linear Static");
   functional_test_static<1, 2>();
-  SERAC_MARK_END("2D Linear Static");
+  CALI_MARK_END("2D Linear Static");
 
-  SERAC_MARK_BEGIN("2D Quadratic Static");
+  CALI_MARK_BEGIN("2D Quadratic Static");
   functional_test_static<2, 2>();
-  SERAC_MARK_END("2D Quadratic Static");
+  CALI_MARK_END("2D Quadratic Static");
 
-  SERAC_MARK_BEGIN("3D Linear Static");
+  CALI_MARK_BEGIN("3D Linear Static");
   functional_test_static<1, 3>();
-  SERAC_MARK_END("3D Linear Static");
+  CALI_MARK_END("3D Linear Static");
 
-  SERAC_MARK_BEGIN("3D Quadratic Static");
+  CALI_MARK_BEGIN("3D Quadratic Static");
   functional_test_static<2, 3>();
-  SERAC_MARK_END("3D Quadratic Static");
+  CALI_MARK_END("3D Quadratic Static");
 
-  SERAC_MARK_BEGIN("2D Linear Dynamic");
+  CALI_MARK_BEGIN("2D Linear Dynamic");
   functional_test_dynamic<1, 2>();
-  SERAC_MARK_END("2D Linear Dynamic");
+  CALI_MARK_END("2D Linear Dynamic");
 
-  SERAC_MARK_BEGIN("2D Quadratic Dynamic");
+  CALI_MARK_BEGIN("2D Quadratic Dynamic");
   functional_test_dynamic<2, 2>();
-  SERAC_MARK_END("2D Quadratic Dynamic");
+  CALI_MARK_END("2D Quadratic Dynamic");
 
-  SERAC_MARK_BEGIN("3D Linear Dynamic");
+  CALI_MARK_BEGIN("3D Linear Dynamic");
   functional_test_dynamic<1, 3>();
-  SERAC_MARK_END("3D Linear Dynamic");
+  CALI_MARK_END("3D Linear Dynamic");
 
-  SERAC_MARK_BEGIN("3D Quadratic Dynamic");
+  CALI_MARK_BEGIN("3D Quadratic Dynamic");
   functional_test_dynamic<2, 3>();
-  SERAC_MARK_END("3D Quadratic Dynamic");
+  CALI_MARK_END("3D Quadratic Dynamic");
 
   // Finalize profiling
   serac::profiling::finalize();

--- a/src/serac/physics/benchmarks/benchmark_thermal.cpp
+++ b/src/serac/physics/benchmarks/benchmark_thermal.cpp
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
   serac::profiling::initialize();
 
   // Add metadata
-  SERAC_SET_METADATA("test", "thermal_functional");
+  adiak::value("test", "thermal_functional");
 
   CALI_MARK_BEGIN("2D Linear Static");
   functional_test_static<1, 2>();

--- a/src/serac/physics/benchmarks/benchmark_thermal.cpp
+++ b/src/serac/physics/benchmarks/benchmark_thermal.cpp
@@ -164,7 +164,7 @@ int main(int argc, char* argv[])
   serac::profiling::initialize();
 
   // Add metadata
-  adiak::value("test", "thermal_functional");
+  SERAC_SET_METADATA("test", "thermal_functional");
 
   CALI_MARK_BEGIN("2D Linear Static");
   functional_test_static<1, 2>();


### PR DESCRIPTION
This PR removes the Serac profiling wrapper macros in favor of just using Caliper's.

Note:
* I left `SERAC_SET_METADATA`, since the `adiak::value()` is not a macro.
* I left `concat()` in `profile.hpp`, as it's being used in various places.
* I left `funcional_comparisons_cuda.cu` unchanged, since it's not being compiled anyway.

Fixes #1098 