### PR TITLE
Guard tests against PETSC/SLEPC not being enabled

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -38,10 +38,14 @@ endif()
 serac_add_tests( SOURCES       axom_smoketest.cpp
                  DEPENDS_ON    axom::inlet)
 
-serac_add_tests(SOURCES       petsc_smoketest.cpp
-                DEPENDS_ON    PkgConfig::PETSC gtest axom::slic
-                NUM_MPI_TASKS 4)
+if(PETSC_FOUND)
+    serac_add_tests(SOURCES       petsc_smoketest.cpp
+                    DEPENDS_ON    PkgConfig::PETSC gtest axom::slic
+                    NUM_MPI_TASKS 4)
 
-serac_add_tests(SOURCES       slepc_smoketest.cpp
-                DEPENDS_ON    PkgConfig::SLEPC gtest axom::slic
-                NUM_MPI_TASKS 4)
+    if(SLEPC_FOUND)
+        serac_add_tests(SOURCES       slepc_smoketest.cpp
+                        DEPENDS_ON    PkgConfig::SLEPC gtest axom::slic
+                        NUM_MPI_TASKS 4)
+    endif()
+endif()


### PR DESCRIPTION
Title says it all.