### PR TITLE
(WIP) enzyme integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ if(ENABLE_CUDA AND ${CMAKE_VERSION} VERSION_LESS 3.18.0)
     message(FATAL_ERROR "Serac requires CMake version 3.18.0+ when CUDA is enabled.")
 endif()
 
+# N.B. leave compilers unspecified when configuring CMake to ensure that            
+#      the clang/clang++ binaries appropriate for enzyme are chosen              
+set(CMAKE_C_COMPILER "${LLVM_BIN_DIR}/clang")
+set(CMAKE_CXX_COMPILER "${LLVM_BIN_DIR}/clang++")
+
 project(serac LANGUAGES CXX C)
 
 # MPI is required in Serac.

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -564,6 +564,7 @@ endif()
 #------------------------------------------------------------------------------
 # Enzyme
 #------------------------------------------------------------------------------
+if (FALSE) 
 include(FetchContent)                                                            
                                                                                  
 FetchContent_Declare(                                                            
@@ -572,3 +573,6 @@ FetchContent_Declare(
   SOURCE_SUBDIR enzyme                                                           
 )                                                                                
 FetchContent_MakeAvailable(enzyme)   
+else()
+add_subdirectory("/home/sam/code/Enzyme/official/enzyme" ${PROJECT_BINARY_DIR}/tmp/enzyme)
+endif ()

--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -559,3 +559,16 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
         endforeach()
     endif()
 endif()
+
+
+#------------------------------------------------------------------------------
+# Enzyme
+#------------------------------------------------------------------------------
+include(FetchContent)                                                            
+                                                                                 
+FetchContent_Declare(                                                            
+  enzyme                                                                         
+  URL https://github.com/EnzymeAD/Enzyme/archive/refs/tags/v0.0.110.tar.gz          
+  SOURCE_SUBDIR enzyme                                                           
+)                                                                                
+FetchContent_MakeAvailable(enzyme)   

--- a/src/serac/numerics/functional/CMakeLists.txt
+++ b/src/serac/numerics/functional/CMakeLists.txt
@@ -71,6 +71,7 @@ blt_add_library(
       DEPENDS_ON  ${functional_depends}
       )
 
+target_link_libraries(serac_functional PUBLIC ClangEnzymeFlags)
 
 install(FILES ${functional_headers} DESTINATION include/serac/numerics/functional )
 install(FILES ${functional_detail_headers} DESTINATION include/serac/numerics/functional/detail )

--- a/src/serac/numerics/functional/CMakeLists.txt
+++ b/src/serac/numerics/functional/CMakeLists.txt
@@ -69,8 +69,14 @@ blt_add_library(
       HEADERS     ${functional_headers} ${functional_detail_headers} 
       SOURCES     ${functional_sources}
       DEPENDS_ON  ${functional_depends}
-      )
+)
 
+# without this, I get 
+# "error while loading shared libraries: libomp.so: cannot open 
+#    shared object file: No such file or directory"
+#
+# are we not using the native OpenMP cmake targets already?
+target_link_libraries(serac_functional PUBLIC OpenMP::OpenMP_CXX)
 target_link_libraries(serac_functional PUBLIC ClangEnzymeFlags)
 
 install(FILES ${functional_headers} DESTINATION include/serac/numerics/functional )

--- a/src/serac/numerics/functional/CMakeLists.txt
+++ b/src/serac/numerics/functional/CMakeLists.txt
@@ -74,8 +74,6 @@ blt_add_library(
 # without this, I get 
 # "error while loading shared libraries: libomp.so: cannot open 
 #    shared object file: No such file or directory"
-#
-# are we not using the native OpenMP cmake targets already?
 target_link_libraries(serac_functional PUBLIC OpenMP::OpenMP_CXX)
 target_link_libraries(serac_functional PUBLIC ClangEnzymeFlags)
 

--- a/src/serac/numerics/functional/CMakeLists.txt
+++ b/src/serac/numerics/functional/CMakeLists.txt
@@ -77,6 +77,8 @@ blt_add_library(
 target_link_libraries(serac_functional PUBLIC OpenMP::OpenMP_CXX)
 target_link_libraries(serac_functional PUBLIC ClangEnzymeFlags)
 
+target_compile_options(serac_functional PUBLIC -mllvm -enzyme-loose-types)
+
 install(FILES ${functional_headers} DESTINATION include/serac/numerics/functional )
 install(FILES ${functional_detail_headers} DESTINATION include/serac/numerics/functional/detail )
 

--- a/src/serac/numerics/functional/detail/triangle_H1.inl
+++ b/src/serac/numerics/functional/detail/triangle_H1.inl
@@ -240,7 +240,7 @@ struct finite_element<mfem::Geometry::TRIANGLE, H1<p, c> > {
   }
 
   template <typename in_t, int q>
-  static auto batch_apply_shape_fn(int j, tensor<in_t, q*(q + 1) / 2> input, const TensorProductQuadratureRule<q>&)
+  static auto batch_apply_shape_fn(int j, tensor<in_t, q*(q+1) / 2> input, const TensorProductQuadratureRule<q>&)
   {
     using source_t = decltype(get<0>(get<0>(in_t{})) + dot(get<1>(get<0>(in_t{})), tensor<double, 2>{}));
     using flux_t   = decltype(get<0>(get<1>(in_t{})) + dot(get<1>(get<1>(in_t{})), tensor<double, 2>{}));

--- a/src/serac/numerics/functional/domain_integral_kernels.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels.hpp
@@ -159,12 +159,6 @@ SERAC_HOST_DEVICE auto batch_apply_qf_derivative(derivative_type * doutputs, lam
     };
 
     doutputs[i] = jacfwd<differentiation_index>(func, inputs[i]...);
-
-    std::cout << doutputs[i] << std::endl;
-    //std::cout << get_gradient(func(make_dual(inputs[i]...))) << std::endl;
-
-    //doutputs[i] = get_gradient(func(make_dual(inputs[i]...)));
-
   }
 
   return doutputs;

--- a/src/serac/numerics/functional/domain_integral_kernels.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels.hpp
@@ -134,8 +134,7 @@ SERAC_HOST_DEVICE auto batch_apply_qf_no_qdata(lambda qf, double t, const tensor
     double detJ_q = det(J_q);
     tensor<double, dim, dim > invJ_q = inv(J_q);
     auto qf_output = qf(t, serac::tuple{x_q, J_q}, parent_to_physical(inputs[i], invJ_q) ...);
-    physical_to_parent(qf_output, invJ_q, detJ_q);
-    outputs[i] = qf_output;
+    outputs[i] = physical_to_parent(qf_output, invJ_q, detJ_q);
   }
   return outputs;
 }
@@ -162,7 +161,7 @@ SERAC_HOST_DEVICE auto batch_apply_qf_derivative(derivative_type * doutputs, lam
     doutputs[i] = jacfwd<differentiation_index>(func, inputs[i]...);
 
     std::cout << doutputs[i] << std::endl;
-    std::cout << get_gradient(func(make_dual(inputs[i]...))) << std::endl;
+    //std::cout << get_gradient(func(make_dual(inputs[i]...))) << std::endl;
 
     //doutputs[i] = get_gradient(func(make_dual(inputs[i]...)));
 

--- a/src/serac/numerics/functional/domain_integral_kernels.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels.hpp
@@ -9,6 +9,7 @@
 #include "serac/numerics/functional/quadrature_data.hpp"
 #include "serac/numerics/functional/function_signature.hpp"
 #include "serac/numerics/functional/differentiate_wrt.hpp"
+#include "serac/numerics/functional/enzyme_wrapper.hpp"
 
 #include <RAJA/index/RangeSegment.hpp>
 #include <RAJA/RAJA.hpp>
@@ -90,24 +91,36 @@ template <typename lambda, typename coords_type, typename... T, typename qpt_dat
 SERAC_HOST_DEVICE auto apply_qf(lambda&& qf, double t, coords_type&& x_q, qpt_data_type&& qpt_data,
                                 const serac::tuple<T...>& arg_tuple)
 {
-  return apply_qf_helper(qf, t, x_q, qpt_data, arg_tuple,
-                         std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>{});
+  return apply_qf_helper(qf, t, x_q, qpt_data, arg_tuple, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>{});
 }
 
 template <int i, int dim, typename... trials, typename lambda, typename qpt_data_type>
 auto get_derivative_type(lambda qf, qpt_data_type&& qpt_data)
 {
   using qf_arguments = serac::tuple<typename QFunctionArgument<trials, serac::Dimension<dim> >::type...>;
-  return get_gradient(apply_qf(qf, double{}, serac::tuple<tensor<double, dim>, tensor<double, dim, dim> >{}, qpt_data,
-                               make_dual_wrt<i>(qf_arguments{})));
+  using output_type = decltype(apply_qf(qf, double{}, serac::tuple<tensor<double, dim>, tensor<double, dim, dim> >{}, qpt_data, qf_arguments{}));
+  return typename impl::nested< output_type, decltype(type<i>(qf_arguments{})) >::type{};
 };
 
-template <typename lambda, int dim, int n, typename... T>
+
+template <typename T1, typename T2, int dim>
+SERAC_HOST_DEVICE auto parent_to_physical(const tuple<T1, T2>& qf_input, const tensor<double, dim, dim> & invJ) {
+  return tuple{get<0>(qf_input), dot(get<1>(qf_input), invJ)};
+}
+
+template <typename T1, typename T2, int dim>
+SERAC_HOST_DEVICE auto physical_to_parent(const tuple<T1, T2>& qf_output, const tensor<double, dim, dim> & invJ, double detJ) {
+  // assumes family == Family::H1 for now
+  return tuple{get<0>(qf_output) * detJ, dot(get<1>(qf_output), transpose(invJ)) * detJ};
+}
+
+template < typename lambda, int dim, int n, typename... T>
 SERAC_HOST_DEVICE auto batch_apply_qf_no_qdata(lambda qf, double t, const tensor<double, dim, n>& x,
                                                const tensor<double, dim, dim, n>& J, const T&... inputs)
 {
   using position_t  = serac::tuple<tensor<double, dim>, tensor<double, dim, dim> >;
   using return_type = decltype(qf(double{}, position_t{}, T{}[0]...));
+
   tensor<return_type, n> outputs{};
   for (int i = 0; i < n; i++) {
     tensor<double, dim>      x_q;
@@ -118,9 +131,53 @@ SERAC_HOST_DEVICE auto batch_apply_qf_no_qdata(lambda qf, double t, const tensor
       }
       x_q[j] = x(j, i);
     }
-    outputs[i] = qf(t, serac::tuple{x_q, J_q}, inputs[i]...);
+    double detJ_q = det(J_q);
+    tensor<double, dim, dim > invJ_q = inv(J_q);
+    auto qf_output = qf(t, serac::tuple{x_q, J_q}, parent_to_physical(inputs[i], invJ_q) ...);
+    physical_to_parent(qf_output, invJ_q, detJ_q);
+    outputs[i] = qf_output;
   }
   return outputs;
+}
+
+template < uint32_t differentiation_index, typename derivative_type, typename lambda, int dim, int n, typename... T>
+SERAC_HOST_DEVICE auto batch_apply_qf_derivative(derivative_type * doutputs, lambda qf, double t, const tensor<double, dim, n>& x,
+                                               const tensor<double, dim, dim, n>& J, const tensor<T, n> &... inputs)
+{
+  for (int i = 0; i < n; i++) {
+    tensor<double, dim>      x_q;
+    tensor<double, dim, dim> J_q;
+    for (int j = 0; j < dim; j++) {
+      for (int k = 0; k < dim; k++) {
+        J_q[j][k] = J(k, j, i);
+      }
+      x_q[j] = x(j, i);
+    }
+    double detJ_q = det(J_q);
+    tensor<double, dim, dim > invJ_q = inv(J_q);
+    auto func = [&](const auto & ... input){
+      return physical_to_parent(qf(t, serac::tuple{x_q, J_q}, parent_to_physical(input, invJ_q) ...), invJ_q, detJ_q);
+    };
+
+    doutputs[i] = jacfwd<differentiation_index>(func, inputs[i]...);
+
+    std::cout << doutputs[i] << std::endl;
+    std::cout << get_gradient(func(make_dual(inputs[i]...))) << std::endl;
+
+    #if 0
+    tuple{
+      tuple{0.1309, {-0.0013125, 0.265717, 0.484116}}, 
+      tuple{{-0.004375, 0.510588, 1.58955}, {{3.4324, 0.536657, 1.05022}, {2.15217, 4.00694, 1.96279}, {1.47173, 2.55073, 4.34394}}}
+    }
+    tuple{
+      tuple{0.1309, {-0.0013125, 0.265717, 0.484116}}, 
+      tuple{{-0.004375, 0.536657, 1.96279}, {{0.510588, 1.58955, 3.4324}, {1.05022, 2.15217, 4.00694}, {1.47173, 2.55073, 4.34394}}}}
+    }
+    #endif
+
+  }
+
+  return doutputs;
 }
 
 template <typename lambda, int dim, int n, typename qpt_data_type, typename... T>
@@ -179,37 +236,21 @@ void evaluation_kernel_impl(trial_element_tuple trial_elements, test_element, do
 
     //[[maybe_unused]] static constexpr trial_element_tuple trial_element_tuple{};
     // batch-calculate values / derivatives of each trial space, at each quadrature point
-    [[maybe_unused]] tuple qf_inputs = {promote_each_to_dual_when<indices == differentiation_index>(
-        get<indices>(trial_elements).interpolate(get<indices>(u)[elements[e]], rule))...};
-
-    // use J_e to transform values / derivatives on the parent element
-    // to the to the corresponding values / derivatives on the physical element
-    (parent_to_physical<get<indices>(trial_elements).family>(get<indices>(qf_inputs), J_e), ...);
+    tuple qf_inputs = {get<indices>(trial_elements).interpolate(get<indices>(u)[elements[e]], rule)...};
 
     // (batch) evalute the q-function at each quadrature point
     //
     // note: the weird immediately-invoked lambda expression is
     // a workaround for a bug in GCC(<12.0) where it fails to
     // decide which function overload to use, and crashes
-    auto qf_outputs = [&]() {
-      if constexpr (std::is_same_v<state_type, Nothing>) {
-        return batch_apply_qf_no_qdata(qf, t, x_e, J_e, get<indices>(qf_inputs)...);
-      } else {
-        return batch_apply_qf(qf, t, x_e, J_e, &qf_state(e, 0), update_state, get<indices>(qf_inputs)...);
-      }
-    }();
-
-    // use J to transform sources / fluxes on the physical element
-    // back to the corresponding sources / fluxes on the parent element
-    physical_to_parent<test_element::family>(qf_outputs, J_e);
+    // TODO: reenable internal_variables
+    auto qf_outputs = batch_apply_qf_no_qdata(qf, t, x_e, J_e, get<indices>(qf_inputs)...);
 
     // write out the q-function derivatives after applying the
     // physical_to_parent transformation, so that those transformations
     // won't need to be applied in the action_of_gradient and element_gradient kernels
     if constexpr (differentiation_index != serac::NO_DIFFERENTIATION) {
-      for (int q = 0; q < leading_dimension(qf_outputs); q++) {
-        qf_derivatives[e * uint32_t(qpts_per_elem) + uint32_t(q)] = get_gradient(qf_outputs[q]);
-      }
+      batch_apply_qf_derivative<differentiation_index>(qf_derivatives + e * uint32_t(qpts_per_elem), qf, t, x_e, J_e, get<indices>(qf_inputs)...);
     }
 
     // (batch) integrate the material response against the test-space basis functions
@@ -229,6 +270,14 @@ SERAC_HOST_DEVICE auto chain_rule(const S& dfdx, const T& dx)
   }
 
   if constexpr (!is_QOI) {
+#if 0
+    serac::tuple<
+      serac::tuple< double, serac::tensor<double, 2> >, 
+      serac::tensor< serac::tuple<double, serac::tensor<double, 2> >, 2> >, 3, serac::tuple<double, serac::tensor<double, 2>
+
+#endif
+
+
     return serac::tuple{serac::chain_rule(serac::get<0>(serac::get<0>(dfdx)), serac::get<0>(dx)) +
                             serac::chain_rule(serac::get<1>(serac::get<0>(dfdx)), serac::get<1>(dx)),
                         serac::chain_rule(serac::get<0>(serac::get<1>(dfdx)), serac::get<0>(dx)) +

--- a/src/serac/numerics/functional/domain_integral_kernels_old.hpp
+++ b/src/serac/numerics/functional/domain_integral_kernels_old.hpp
@@ -102,76 +102,25 @@ auto get_derivative_type(lambda qf, qpt_data_type&& qpt_data)
                                make_dual_wrt<i>(qf_arguments{})));
 };
 
-
-template <typename T1, typename T2, int dim>
-SERAC_HOST_DEVICE auto parent_to_physical(const tuple<T1, T2>& qf_input, const tensor<double, dim, dim> & invJ) {
-  return tuple{get<0>(qf_input), dot(get<1>(qf_input), invJ)};
-}
-
-template <typename T1, typename T2, int dim>
-SERAC_HOST_DEVICE auto physical_to_parent(const tuple<T1, T2>& qf_output, const tensor<double, dim, dim> & invJ, double detJ) {
-  // assumes family == Family::H1 for now
-  return tuple{get<0>(qf_output) * detJ, dot(get<1>(qf_output), transpose(invJ)) * detJ};
-}
-
-double scalar_type(double) { return 0.0; }
-
-template < typename T >
-dual<T> scalar_type(dual<T>) { return dual<T>{}; }
-
-template < typename T, int ... n >
-T scalar_type(tensor<T, n ... >) { return {}; }
-
-template < typename T1, typename T2 >
-auto scalar_type(tuple< T1, T2 >) { return tuple{ scalar_type(T1{}), scalar_type(T2{}) }; }
-
-template < uint32_t differentiation_index, typename lambda, int dim, int n, typename... T>
+template <typename lambda, int dim, int n, typename... T>
 SERAC_HOST_DEVICE auto batch_apply_qf_no_qdata(lambda qf, double t, const tensor<double, dim, n>& x,
                                                const tensor<double, dim, dim, n>& J, const T&... inputs)
 {
-  if constexpr (differentiation_index == NO_DIFFERENTIATION) {
-    using position_t  = serac::tuple<tensor<double, dim>, tensor<double, dim, dim> >;
-    using return_type = decltype(qf(double{}, position_t{}, T{}[0]...));
-
-    tensor<return_type, n> outputs{};
-    for (int i = 0; i < n; i++) {
-      tensor<double, dim>      x_q;
-      tensor<double, dim, dim> J_q;
-      for (int j = 0; j < dim; j++) {
-        for (int k = 0; k < dim; k++) {
-          J_q[j][k] = J(k, j, i);
-        }
-        x_q[j] = x(j, i);
+  using position_t  = serac::tuple<tensor<double, dim>, tensor<double, dim, dim> >;
+  using return_type = decltype(qf(double{}, position_t{}, T{}[0]...));
+  tensor<return_type, n> outputs{};
+  for (int i = 0; i < n; i++) {
+    tensor<double, dim>      x_q;
+    tensor<double, dim, dim> J_q;
+    for (int j = 0; j < dim; j++) {
+      for (int k = 0; k < dim; k++) {
+        J_q[j][k] = J(k, j, i);
       }
-      double detJ_q = det(J_q);
-      tensor<double, dim, dim > invJ_q = inv(J_q);
-      auto qf_output = qf(t, serac::tuple{x_q, J_q}, parent_to_physical(inputs[i], invJ_q) ...);
-      physical_to_parent(qf_output, invJ_q, detJ_q);
-      outputs[i] = qf_output;
+      x_q[j] = x(j, i);
     }
-    return outputs;
-
-  } else {
-    using position_t  = serac::tuple<tensor<double, dim>, tensor<double, dim, dim> >;
-    using return_value_type = decltype(qf(double{}, position_t{}, get_value(T{}[0])...));
-    using gradient_type = decltype(get_gradient((scalar_type(inputs[0]) + ...)));
-
-    tensor<return_value_type, n> outputs{};
-    for (int i = 0; i < n; i++) {
-      tensor<double, dim>      x_q;
-      tensor<double, dim, dim> J_q;
-      for (int j = 0; j < dim; j++) {
-        for (int k = 0; k < dim; k++) {
-          J_q[j][k] = J(k, j, i);
-        }
-        x_q[j] = x(j, i);
-      }
-      double detJ_q = det(J_q);
-      tensor<double, dim, dim > invJ_q = inv(J_q);
-      outputs[i] = physical_to_parent(qf(t, serac::tuple{x_q, J_q}, parent_to_physical(inputs[i], invJ_q) ...), invJ_q, detJ_q);
-    }
-    return outputs;
+    outputs[i] = qf(t, serac::tuple{x_q, J_q}, inputs[i]...);
   }
+  return outputs;
 }
 
 template <typename lambda, int dim, int n, typename qpt_data_type, typename... T>
@@ -230,21 +179,36 @@ void evaluation_kernel_impl(trial_element_tuple trial_elements, test_element, do
 
     //[[maybe_unused]] static constexpr trial_element_tuple trial_element_tuple{};
     // batch-calculate values / derivatives of each trial space, at each quadrature point
-    tuple qf_inputs = {get<indices>(trial_elements).interpolate(get<indices>(u)[elements[e]], rule)...};
+    [[maybe_unused]] tuple qf_inputs = {promote_each_to_dual_when<indices == differentiation_index>(
+        get<indices>(trial_elements).interpolate(get<indices>(u)[elements[e]], rule))...};
+
+    // use J_e to transform values / derivatives on the parent element
+    // to the to the corresponding values / derivatives on the physical element
+    (parent_to_physical<get<indices>(trial_elements).family>(get<indices>(qf_inputs), J_e), ...);
 
     // (batch) evalute the q-function at each quadrature point
     //
     // note: the weird immediately-invoked lambda expression is
     // a workaround for a bug in GCC(<12.0) where it fails to
     // decide which function overload to use, and crashes
-    auto qf_outputs = batch_apply_qf_no_qdata<differentiation_index>(qf, t, x_e, J_e, get<indices>(qf_inputs)...);
+    auto qf_outputs = [&]() {
+      if constexpr (std::is_same_v<state_type, Nothing>) {
+        return batch_apply_qf_no_qdata(qf, t, x_e, J_e, get<indices>(qf_inputs)...);
+      } else {
+        return batch_apply_qf(qf, t, x_e, J_e, &qf_state(e, 0), update_state, get<indices>(qf_inputs)...);
+      }
+    }();
+
+    // use J to transform sources / fluxes on the physical element
+    // back to the corresponding sources / fluxes on the parent element
+    physical_to_parent<test_element::family>(qf_outputs, J_e);
 
     // write out the q-function derivatives after applying the
     // physical_to_parent transformation, so that those transformations
     // won't need to be applied in the action_of_gradient and element_gradient kernels
     if constexpr (differentiation_index != serac::NO_DIFFERENTIATION) {
       for (int q = 0; q < leading_dimension(qf_outputs); q++) {
-        //qf_derivatives[e * uint32_t(qpts_per_elem) + uint32_t(q)] = get_gradient(qf_outputs[q]);
+        qf_derivatives[e * uint32_t(qpts_per_elem) + uint32_t(q)] = get_gradient(qf_outputs[q]);
       }
     }
 

--- a/src/serac/numerics/functional/enzyme_declarations.hpp
+++ b/src/serac/numerics/functional/enzyme_declarations.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+int enzyme_dup;
+int enzyme_dupnoneed;
+int enzyme_out;
+int enzyme_const;
+
+template < typename return_type, typename ... T >
+return_type __enzyme_fwddiff(void*, T ... );
+
+template < typename return_type, typename ... T >
+return_type __enzyme_autodiff(void*, T ... );

--- a/src/serac/numerics/functional/enzyme_wrapper.hpp
+++ b/src/serac/numerics/functional/enzyme_wrapper.hpp
@@ -1,0 +1,241 @@
+#pragma once
+
+#include <enzyme/enzyme>
+
+#include "serac/numerics/functional/tuple.hpp"
+#include "serac/numerics/functional/tensor.hpp"
+
+namespace serac {
+
+namespace impl {
+
+  constexpr int vsize(const double &) { return 1; }
+
+  template < int n >
+  constexpr int vsize(const tensor< double, n > &) { return n; }
+
+  template < int m, int n >
+  constexpr int vsize(const tensor< double, m, n > &) { return m * n; }
+
+  template < typename T0, typename T1 >
+  constexpr int vsize(const tuple< T0, T1 > &) { return vsize(T0{}) + vsize(T1{}); }
+
+  template < typename T0, typename T1 >
+  struct nested;
+
+  template <> 
+  struct nested< double, double >{ using type = double; };
+
+  template < int ... n > 
+  struct nested< double, tensor<double,n...> >{ using type = tensor<double,n...>; };
+
+  template < typename T0, typename T1 > 
+  struct nested< double, tuple<T0, T1> >{ using type = tuple<T0, T1>; };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  template < int ... n, typename T > 
+  struct nested< tensor<double, n...>, T >{ using type = tensor<T, n ...>; };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  //template < int ... n, typename T > 
+  //struct nested< tensor<double, n...>, T >{ using type = tensor<T, n ...>; };
+
+//  sam: with tuples-of-tuples, figuring out which indices correspond to the directional
+//       derivatives gets pretty nasty, so I'm commenting these out to prevent jacfwd from
+//       compiling in that case
+// 
+//  template < typename S0, typename S1, typename T > 
+//  struct nested< tuple< S0, S1 >, T >{ 
+//    using type = tuple< typename nested<S0, T>::type, typename nested<S1, T>::type >; 
+//  };
+//
+//  template < typename S0, typename S1, typename T0, typename T1 > 
+//  struct nested< tuple< S0, S1 >, tuple< T0, T1 > >{ 
+//    using type = tuple< 
+//        tuple< typename nested<S0, T0>::type, typename nested<S0, T1>::type >,
+//        tuple< typename nested<S1, T0>::type, typename nested<S1, T1>::type >
+//    >; 
+//  };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  template< typename output_type, typename function, typename ... arg_types >
+  void wrapper(output_type & output, const function & f, const arg_types & ... args) {
+      output = f(args...);
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+
+  template < typename function, typename input_type > 
+  __attribute__((always_inline))
+  auto jvp(const function & f, const input_type & x) {
+    using output_type = decltype(f(x));
+    void * func_ptr = reinterpret_cast<void*>(wrapper< output_type, function, input_type >);
+    return [=](const input_type & dx) {
+      output_type unused{};
+      output_type df{};
+      __enzyme_fwddiff<void>(func_ptr,
+        enzyme_dupnoneed, &unused, &df,
+        enzyme_const, reinterpret_cast<const void*>(&f), 
+        enzyme_dup, &x, &dx
+      );
+      return df;
+    };
+  }
+
+////////////////////////////////////////////////////////////////////////////////
+
+  template < typename function, typename input_type > 
+  __attribute__((always_inline))
+  auto jacfwd(const function & f, const input_type & x) {
+    using output_type = decltype(f(x));
+    using jac_type = typename impl::nested<output_type, input_type>::type;
+    void * func_ptr = reinterpret_cast<void*>(wrapper< output_type, function, input_type >);
+  
+    constexpr int m = impl::vsize(output_type{});
+    jac_type J{};
+    double * J_ptr = reinterpret_cast<double *>(&J);
+  
+    constexpr int n = impl::vsize(input_type{});
+    input_type dx{};
+    double * dx_ptr = reinterpret_cast<double *>(&dx);
+  
+    for (int j = 0; j < n; j++) {
+      dx_ptr[j] = 1.0;
+
+      std::cout << dx << std::endl;
+  
+      output_type unused{};
+      output_type df_dxj{};
+      __enzyme_fwddiff<void>(func_ptr,
+        enzyme_dupnoneed, &unused, &df_dxj,
+        enzyme_const, reinterpret_cast<const void*>(&f), 
+        enzyme_dup, &x, &dx
+      );
+
+      std::cout << df_dxj << std::endl;
+  
+      double * df_dxj_ptr = reinterpret_cast<double *>(&df_dxj);
+      for (int i = 0; i < m; i++) {
+        J_ptr[i * n + j] = df_dxj_ptr[i];
+      }
+  
+      std::cout << J << std::endl;
+
+      dx_ptr[j] = 0.0;
+    }
+  
+    return J;
+  }
+  
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template < int i, typename function, typename T0 > 
+__attribute__((always_inline))
+auto jvp(const function & f, const T0 & arg0) {
+  if constexpr (i == 0) { return impl::jvp(f, arg0); }
+}
+
+template < int i, typename function, typename T0, typename T1 > 
+__attribute__((always_inline))
+auto jvp(const function & f, const T0 & arg0, const T1 & arg1) {
+  if constexpr (i == 0) { return impl::jvp([&](T0 x){ return f(x, arg1); }, arg0); }
+  if constexpr (i == 1) { return impl::jvp([&](T1 x){ return f(arg0, x); }, arg1); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2 > 
+__attribute__((always_inline))
+auto jvp(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2) {
+  if constexpr (i == 0) { return impl::jvp([&](const T0 & x){ return f(x, arg1, arg2); }, arg0); }
+  if constexpr (i == 1) { return impl::jvp([&](const T1 & x){ return f(arg0, x, arg2); }, arg1); }
+  if constexpr (i == 2) { return impl::jvp([&](const T2 & x){ return f(arg0, arg1, x); }, arg2); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3 > 
+__attribute__((always_inline))
+auto jvp(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3) {
+  if constexpr (i == 0) { return impl::jvp([&](const T0 & x){ return f(x, arg1, arg2, arg3); }, arg0); }
+  if constexpr (i == 1) { return impl::jvp([&](const T1 & x){ return f(arg0, x, arg2, arg3); }, arg1); }
+  if constexpr (i == 2) { return impl::jvp([&](const T2 & x){ return f(arg0, arg1, x, arg3); }, arg2); }
+  if constexpr (i == 3) { return impl::jvp([&](const T3 & x){ return f(arg0, arg1, arg2, x); }, arg3); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4 > 
+__attribute__((always_inline))
+auto jvp(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4) {
+  if constexpr (i == 0) { return impl::jvp([&](const T0 & x){ return f(x, arg1, arg2, arg3, arg4); }, arg0); }
+  if constexpr (i == 1) { return impl::jvp([&](const T1 & x){ return f(arg0, x, arg2, arg3, arg4); }, arg1); }
+  if constexpr (i == 2) { return impl::jvp([&](const T2 & x){ return f(arg0, arg1, x, arg3, arg4); }, arg2); }
+  if constexpr (i == 3) { return impl::jvp([&](const T3 & x){ return f(arg0, arg1, arg2, x, arg4); }, arg3); }
+  if constexpr (i == 4) { return impl::jvp([&](const T4 & x){ return f(arg0, arg1, arg2, arg3, x); }, arg4); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5 > 
+__attribute__((always_inline))
+auto jvp(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4, const T5 & arg5) {
+  if constexpr (i == 0) { return impl::jvp([&](const T0 & x){ return f(x, arg1, arg2, arg3, arg4, arg5); }, arg0); }
+  if constexpr (i == 1) { return impl::jvp([&](const T1 & x){ return f(arg0, x, arg2, arg3, arg4, arg5); }, arg1); }
+  if constexpr (i == 2) { return impl::jvp([&](const T2 & x){ return f(arg0, arg1, x, arg3, arg4, arg5); }, arg2); }
+  if constexpr (i == 3) { return impl::jvp([&](const T3 & x){ return f(arg0, arg1, arg2, x, arg4, arg5); }, arg3); }
+  if constexpr (i == 4) { return impl::jvp([&](const T4 & x){ return f(arg0, arg1, arg2, arg3, x, arg5); }, arg4); }
+  if constexpr (i == 5) { return impl::jvp([&](const T5 & x){ return f(arg0, arg1, arg2, arg3, arg4, x); }, arg5); }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template < int i, typename function, typename T0 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0) {
+  if constexpr (i == 0) { return impl::jacfwd(f, arg0); }
+}
+
+template < int i, typename function, typename T0, typename T1 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1) {
+  if constexpr (i == 0) { return impl::jacfwd([&](T0 x){ return f(x, arg1); }, arg0); }
+  if constexpr (i == 1) { return impl::jacfwd([&](T1 x){ return f(arg0, x); }, arg1); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2) {
+  if constexpr (i == 0) { return impl::jacfwd([&](T0 x){ return f(x, arg1, arg2); }, arg0); }
+  if constexpr (i == 1) { return impl::jacfwd([&](T1 x){ return f(arg0, x, arg2); }, arg1); }
+  if constexpr (i == 2) { return impl::jacfwd([&](T2 x){ return f(arg0, arg1, x); }, arg2); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3) {
+  if constexpr (i == 0) { return impl::jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3); }, arg0); }
+  if constexpr (i == 1) { return impl::jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3); }, arg1); }
+  if constexpr (i == 2) { return impl::jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3); }, arg2); }
+  if constexpr (i == 3) { return impl::jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x); }, arg3); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4) {
+  if constexpr (i == 0) { return impl::jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3, arg4); }, arg0); }
+  if constexpr (i == 1) { return impl::jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3, arg4); }, arg1); }
+  if constexpr (i == 2) { return impl::jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3, arg4); }, arg2); }
+  if constexpr (i == 3) { return impl::jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x, arg4); }, arg3); }
+  if constexpr (i == 4) { return impl::jacfwd([&](T4 x){ return f(arg0, arg1, arg2, arg3, x); }, arg4); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4, const T5 & arg5) {
+  if constexpr (i == 0) { return impl::jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3, arg4, arg5); }, arg0); }
+  if constexpr (i == 1) { return impl::jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3, arg4, arg5); }, arg1); }
+  if constexpr (i == 2) { return impl::jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3, arg4, arg5); }, arg2); }
+  if constexpr (i == 3) { return impl::jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x, arg4, arg5); }, arg3); }
+  if constexpr (i == 4) { return impl::jacfwd([&](T4 x){ return f(arg0, arg1, arg2, arg3, x, arg5); }, arg4); }
+  if constexpr (i == 5) { return impl::jacfwd([&](T5 x){ return f(arg0, arg1, arg2, arg3, arg4, x); }, arg5); }
+}
+
+}

--- a/src/serac/numerics/functional/enzyme_wrapper.hpp
+++ b/src/serac/numerics/functional/enzyme_wrapper.hpp
@@ -9,6 +9,8 @@ namespace serac {
 
 namespace impl {
 
+  constexpr int vsize(const zero &) { return 0; }
+
   constexpr int vsize(const double &) { return 1; }
 
   template < int n >
@@ -25,6 +27,9 @@ namespace impl {
 
   template <> 
   struct nested< double, double >{ using type = double; };
+
+  template < typename T > 
+  struct nested< zero, T >{ using type = zero; };
 
   template < int ... n > 
   struct nested< double, tensor<double,n...> >{ using type = tensor<double,n...>; };
@@ -112,7 +117,7 @@ namespace impl {
       for (int j = 0; j < (n0 + n1); j++) {
         dx_ptr[j] = 1.0;
 
-        std::cout << dx << std::endl;
+        //std::cout << dx << std::endl;
   
         output_type unused{};
         output_type df_dxj{};
@@ -122,7 +127,7 @@ namespace impl {
           enzyme_dup, &x, &dx
         );
 
-        std::cout << df_dxj << std::endl;
+        //std::cout << df_dxj << std::endl;
 
         double * df0_dxj_ptr = reinterpret_cast<double *>(&get<0>(df_dxj));
         double * df1_dxj_ptr = reinterpret_cast<double *>(&get<1>(df_dxj));
@@ -151,7 +156,7 @@ namespace impl {
           }
         }
  
-        std::cout << J << std::endl;
+        //std::cout << J << std::endl;
 
         dx_ptr[j] = 0.0;
       }
@@ -168,7 +173,7 @@ namespace impl {
       for (int j = 0; j < n; j++) {
         dx_ptr[j] = 1.0;
 
-        std::cout << dx << std::endl;
+        //std::cout << dx << std::endl;
   
         output_type unused{};
         output_type df_dxj{};
@@ -178,14 +183,14 @@ namespace impl {
           enzyme_dup, &x, &dx
         );
 
-        std::cout << df_dxj << std::endl;
+        //std::cout << df_dxj << std::endl;
   
         double * df_dxj_ptr = reinterpret_cast<double *>(&df_dxj);
         for (int i = 0; i < m; i++) {
           J_ptr[i * n + j] = df_dxj_ptr[i];
         }
   
-        std::cout << J << std::endl;
+        //std::cout << J << std::endl;
 
         dx_ptr[j] = 0.0;
       }

--- a/src/serac/numerics/functional/enzyme_wrapper.hpp
+++ b/src/serac/numerics/functional/enzyme_wrapper.hpp
@@ -34,8 +34,11 @@ namespace impl {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-  template < int ... n, typename T > 
-  struct nested< tensor<double, n...>, T >{ using type = tensor<T, n ...>; };
+  template < int ... n > 
+  struct nested< tensor<double, n...>, double >{ using type = tensor<double, n ...>; };
+
+  template < int ... m, int ... n > 
+  struct nested< tensor<double, m...>, tensor<double, n...> >{ using type = tensor<double, m..., n...>; };
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1815,6 +1815,20 @@ SERAC_HOST_DEVICE constexpr auto chain_rule(const tensor<double, n...>& df_dx, c
  * @note for a vector-valued function of a tensor, the chain rule contracts over all indices of dx
  */
 template <int m, int... n>
+SERAC_HOST_DEVICE constexpr auto chain_rule(const tensor< tensor< double, n ... >, m >& df_dx, const tensor<double, n...>& dx)
+{
+  tensor<double, m> total{};
+  for (int i = 0; i < m; i++) {
+    total[i] = chain_rule(df_dx[i], dx);
+  }
+  return total;
+}
+
+/**
+ * @overload
+ * @note for a vector-valued function of a tensor, the chain rule contracts over all indices of dx
+ */
+template <int m, int... n>
 SERAC_HOST_DEVICE constexpr auto chain_rule(const tensor<double, m, n...>& df_dx, const tensor<double, n...>& dx)
 {
   tensor<double, m> total{};

--- a/src/serac/numerics/functional/tensor.hpp
+++ b/src/serac/numerics/functional/tensor.hpp
@@ -1824,6 +1824,18 @@ SERAC_HOST_DEVICE constexpr auto chain_rule(const tensor< tensor< double, n ... 
   return total;
 }
 
+template <int m1, int m2, int... n>
+SERAC_HOST_DEVICE constexpr auto chain_rule(const tensor< tensor< double, n ... >, m1, m2 >& df_dx, const tensor<double, n...>& dx)
+{
+  tensor<double, m1, m2> total{};
+  for (int i1 = 0; i1 < m1; i1++) {
+    for (int i2 = 0; i2 < m2; i2++) {
+      total[i1][i2] = chain_rule(df_dx[i1][i2], dx);
+    }
+  }
+  return total;
+}
+
 /**
  * @overload
  * @note for a vector-valued function of a tensor, the chain rule contracts over all indices of dx

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -68,3 +68,7 @@ if(ENABLE_CUDA)
                      DEPENDS_ON gtest serac_functional serac_state ${functional_depends})
 
 endif()
+
+add_executable(enzyme_test enzyme_test.cpp)
+
+target_link_libraries(enzyme_test PUBLIC serac_functional)

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -69,8 +69,13 @@ if(ENABLE_CUDA)
 
 endif()
 
+target_compile_options(functional_basic_h1_scalar PUBLIC -mllvm -enzyme-loose-types)
+
 add_executable(enzyme_test enzyme_test.cpp)
 target_link_libraries(enzyme_test PUBLIC serac_functional)
+
+add_executable(enzyme_jvp_test enzyme_jvp_test.cpp)
+target_link_libraries(enzyme_jvp_test PUBLIC serac_functional)
 
 add_executable(enzyme_reproducer enzyme_reproducer.cpp)
 target_link_libraries(enzyme_reproducer PUBLIC serac_functional)

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -70,5 +70,10 @@ if(ENABLE_CUDA)
 endif()
 
 add_executable(enzyme_test enzyme_test.cpp)
-
 target_link_libraries(enzyme_test PUBLIC serac_functional)
+
+add_executable(enzyme_reproducer enzyme_reproducer.cpp)
+target_link_libraries(enzyme_reproducer PUBLIC serac_functional)
+
+add_executable(enzyme_reproducer_rbr enzyme_reproducer_rbr.cpp)
+target_link_libraries(enzyme_reproducer_rbr PUBLIC serac_functional)

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -77,6 +77,12 @@ target_link_libraries(enzyme_test PUBLIC serac_functional)
 add_executable(enzyme_jvp_test enzyme_jvp_test.cpp)
 target_link_libraries(enzyme_jvp_test PUBLIC serac_functional)
 
+add_executable(enzyme_test_tuples enzyme_test_tuples.cpp)
+target_link_libraries(enzyme_test_tuples PUBLIC serac_functional)
+
+add_executable(enzyme_test_tuples_of_tuples enzyme_test_tuples_of_tuples.cpp)
+target_link_libraries(enzyme_test_tuples_of_tuples PUBLIC serac_functional)
+
 add_executable(enzyme_reproducer enzyme_reproducer.cpp)
 target_link_libraries(enzyme_reproducer PUBLIC serac_functional)
 

--- a/src/serac/numerics/functional/tests/enzyme_jvp_perf_test.cxx
+++ b/src/serac/numerics/functional/tests/enzyme_jvp_perf_test.cxx
@@ -1,11 +1,23 @@
 #include <iostream>
 
-#include "serac/numerics/functional/dual.hpp"
 #include "serac/numerics/functional/tuple.hpp"
 #include "serac/numerics/functional/tensor.hpp"
+#include "serac/physics/materials/solid_material.hpp"
 #include "serac/numerics/functional/enzyme_wrapper.hpp"
 
 using namespace serac;
+
+template < int i, typename material_model, typename ... arg_types >
+auto precompute_gradient(material_model mat, const std::vector< arg_types > & ... args) {
+  using output_type = decltype(mat(args[0] ...));
+  uint32_t n = 
+
+}
+
+template < int i, typename material_model, typename ... arg_types, typename darg_type >
+double jvp_precomputed_gradient( std::vector< arg_types > & ) {
+
+}
 
 int main() {
 

--- a/src/serac/numerics/functional/tests/enzyme_jvp_test.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_jvp_test.cpp
@@ -1,0 +1,84 @@
+#include <iostream>
+
+#include "serac/numerics/functional/dual.hpp"
+#include "serac/numerics/functional/tuple.hpp"
+#include "serac/numerics/functional/tensor.hpp"
+#include "serac/numerics/functional/enzyme_wrapper.hpp"
+
+namespace serac {
+
+namespace impl {
+
+template < typename function, typename input_type > 
+__attribute__((always_inline))
+auto jvp(const function & f, const input_type & x) {
+  using output_type = decltype(f(x));
+  void * func_ptr = reinterpret_cast<void*>(wrapper< output_type, function, input_type >);
+  return [=](const input_type & dx) {
+    output_type unused{};
+    output_type df{};
+    __enzyme_fwddiff<void>(func_ptr,
+      enzyme_dupnoneed, &unused, &df,
+      enzyme_const, reinterpret_cast<const void*>(&f), 
+      enzyme_dup, &x, &dx
+    );
+    return df;
+  };
+}
+
+}
+
+
+
+}
+
+using namespace serac;
+
+int main() {
+
+  auto f = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return tuple{dot(du_dx, z * u), z * (du_dx + transpose(du_dx)) - outer(u, u)};
+  };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  auto f_jvp0 = [](double z, 
+                   double dz,
+                   const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return tuple{dot(du_dx, u) * dz, (du_dx + transpose(du_dx)) * dz};
+  };
+
+  auto f_jvp1 = [](double z, 
+                   const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement,
+                   const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & ddisplacement) { 
+    auto [u, du_dx] = displacement;
+    auto [du, ddu_dx] = ddisplacement;
+    vec3 df1 = dot(du_dx, du) * z + dot(ddu_dx, u) * z;
+    mat3 df2 = outer(du, u) - outer(u, du) + (ddu_dx + transpose(ddu_dx)) * z;
+    return tuple{df1, df2};
+  };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  double eps = 1.0e-6;
+
+  double z = 3.0;
+  double dz = 1.4;
+
+  auto displacement = tuple { 
+    tensor<double,3>{{1.0, 1.0, 1.0}},
+    tensor<double,3,3>{{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}}
+  };
+
+  auto ddisplacement = tuple { 
+    tensor<double,3>{{0.1, 0.8, -0.3}},
+    tensor<double,3,3>{{{0.2, -0.4, 0.2}, {0.1, 0.8, 0.5}, {0.3, 0.7, 1.8}}}
+  };
+
+  std::cout << "expected: " << f_jvp0(z, dz, displacement) << std::endl;
+  std::cout << "enzyme: " << jvp<0>(f, z, displacement)(dz) << std::endl;
+  std::cout << "finite_difference: " << ((f(z + eps * dz, displacement) - f(z, displacement)) / eps) << std::endl;
+
+}

--- a/src/serac/numerics/functional/tests/enzyme_reproducer.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_reproducer.cpp
@@ -1,0 +1,142 @@
+#include <iostream>
+#include <enzyme/enzyme>
+
+////////////////////////////////////////////////////////////////////////////////
+
+template < typename T, int m, int n >
+struct tensor {
+    T & operator()(int i, int j) { return values[i][j]; }
+    const T & operator()(int i, int j) const { return values[i][j]; }
+    T values[m][n];
+};
+
+template < int m, int n >
+tensor<double, m, n> operator*(double scale, const tensor<double, m, n> & A) {
+    tensor<double, m, n> scaled{};
+    for (int i = 0; i < m; i++) {
+        for (int j = 0; j < n; j++) {
+            scaled(i,j) = scale * A(i,j);
+        }
+    }
+    return scaled;
+}
+
+template < typename T, int m, int n >
+std::ostream& operator<<(std::ostream & out, const tensor<T, m, n> & A) {
+    out << "{";
+    for (int i = 0; i < m; i++) {
+        out << "{";
+        for (int j = 0; j < n; j++) {
+            out << A(i,j);
+            if (j != n - 1) { out << ", "; }
+        }
+        out << "}";
+        if (i != m - 1) { out << ", "; }
+    }
+    out << "}";
+    return out;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace impl {
+
+  constexpr int vsize(const double &) { return 1; }
+
+  template < int m, int n >
+  constexpr int vsize(const tensor< double, m, n > &) { return m * n; }
+
+  template < int m, int n, int p, int q >
+  constexpr int vsize(const tensor< tensor< double, p, q >, m, n > &) { return m * n * p * q; }
+
+  template < typename T1, typename T2 >
+  struct outer_prod;
+
+  template < int m, int n >
+  struct outer_prod< double, tensor< double, m, n > >{
+    using type = tensor<double, m, n>;
+  };
+
+  template < int m, int n >
+  struct outer_prod< tensor< double, m, n >, double >{
+    using type = tensor<double, m, n>;
+  };
+
+  template < int m, int n, int p, int q >
+  struct outer_prod< tensor< double, m, n >, tensor< double, p, q > >{
+    using type = tensor<tensor<double, p, q>, m, n>;
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template< typename output_type, typename function, typename ... arg_types >
+void wrapper(output_type & output, const function & f, const arg_types & ... args) {
+    output = f(args...);
+}
+
+template < typename function, typename input_type > 
+auto jacfwd(const function & f, const input_type & x) {
+  using output_type = decltype(f(x));
+  using jac_type = typename impl::outer_prod<output_type, input_type>::type;
+  void * func_ptr = reinterpret_cast<void*>(wrapper< output_type, function, input_type >);
+
+  constexpr int m = impl::vsize(output_type{});
+  jac_type J{};
+  double * J_ptr = reinterpret_cast<double *>(&J);
+
+  constexpr int n = impl::vsize(input_type{});
+  input_type dx{};
+  double * dx_ptr = reinterpret_cast<double *>(&dx);
+
+  for (int j = 0; j < n; j++) {
+    dx_ptr[j] = 1.0;
+
+    output_type unused{};
+    output_type df_dxj{};
+    __enzyme_fwddiff<void>(func_ptr,
+      enzyme_dupnoneed, &unused, &df_dxj,
+      enzyme_const, reinterpret_cast<const void*>(&f), 
+      enzyme_dup, &x, &dx
+    );
+
+    double * df_dxj_ptr = reinterpret_cast<double *>(&df_dxj);
+    for (int i = 0; i < m; i++) {
+      J_ptr[i * n + j] = df_dxj_ptr[i];
+    }
+
+    dx_ptr[j] = 0.0;
+  }
+
+  return J;
+}
+
+template < int i, typename function, typename T0, typename T1 > 
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1) {
+  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1); }, arg0); }
+  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x); }, arg1); }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int main() {
+
+  auto f = [=](double z, const tensor< double, 3, 3 > & du_dx) { return z * du_dx; };
+
+  double z = 3.0;
+  tensor<double,3,3> du_dx = {{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}};
+
+  std::cout << "f(x, du_dx): " << f(z, du_dx) << std::endl;
+  std::cout << "expected: {{3., 6., 9.}, {6., 9., 3.}, {3., 1.5, 0.6}}" << std::endl;
+  std::cout << std::endl;
+
+  auto df_darg0 = jacfwd<0>(f, z, du_dx);
+  std::cout << "df_dz: " << df_darg0 << std::endl;
+  std::cout << "expected: {{1., 2., 3.}, {2., 3., 1.}, {1., 0.5, 0.2}}" << std::endl;
+  std::cout << std::endl;
+
+  auto df_darg1 = jacfwd<1>(f, z, du_dx);
+  std::cout << "df_d(du_dx): " << df_darg1 << std::endl;
+  std::cout << "expected: {{{{3., 0, 0}, {0, 0, 0}, {0, 0, 0}}, {{0, 3., 0}, {0, 0, 0}, {0, 0, 0}}, {{0, 0, 3.}, {0, 0, 0}, {0, 0, 0}}}, {{{0, 0, 0}, {3., 0, 0}, {0, 0, 0}}, {{0, 0, 0}, {0, 3., 0}, {0, 0, 0}}, {{0, 0, 0}, {0, 0, 3.}, {0, 0, 0}}}, {{{0, 0, 0}, {0, 0, 0}, {3., 0, 0}}, {{0, 0, 0}, {0, 0, 0}, {0, 3., 0}}, {{0, 0, 0}, {0, 0, 0}, {0, 0, 3.}}}}" << std::endl;
+
+}

--- a/src/serac/numerics/functional/tests/enzyme_reproducer_rbr.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_reproducer_rbr.cpp
@@ -1,0 +1,141 @@
+#include <iostream>
+#include <enzyme/enzyme>
+
+extern int enzyme_active_return;
+
+////////////////////////////////////////////////////////////////////////////////
+
+template < typename T, int m, int n >
+struct tensor {
+    T & operator()(int i, int j) { return values[i][j]; }
+    const T & operator()(int i, int j) const { return values[i][j]; }
+    T values[m][n];
+};
+
+template < int m, int n >
+tensor<double, m, n> operator*(double scale, const tensor<double, m, n> & A) {
+    tensor<double, m, n> scaled{};
+    for (int i = 0; i < m; i++) {
+        for (int j = 0; j < n; j++) {
+            scaled(i,j) = scale * A(i,j);
+        }
+    }
+    return scaled;
+}
+
+template < typename T, int m, int n >
+std::ostream& operator<<(std::ostream & out, const tensor<T, m, n> & A) {
+    out << "{";
+    for (int i = 0; i < m; i++) {
+        out << "{";
+        for (int j = 0; j < n; j++) {
+            out << A(i,j);
+            if (j != n - 1) { out << ", "; }
+        }
+        out << "}";
+        if (i != m - 1) { out << ", "; }
+    }
+    out << "}";
+    return out;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+namespace impl {
+
+  constexpr int vsize(const double &) { return 1; }
+
+  template < int m, int n >
+  constexpr int vsize(const tensor< double, m, n > &) { return m * n; }
+
+  template < int m, int n, int p, int q >
+  constexpr int vsize(const tensor< tensor< double, p, q >, m, n > &) { return m * n * p * q; }
+
+  template < typename T1, typename T2 >
+  struct outer_prod;
+
+  template < int m, int n >
+  struct outer_prod< double, tensor< double, m, n > >{
+    using type = tensor<double, m, n>;
+  };
+
+  template < int m, int n >
+  struct outer_prod< tensor< double, m, n >, double >{
+    using type = tensor<double, m, n>;
+  };
+
+  template < int m, int n, int p, int q >
+  struct outer_prod< tensor< double, m, n >, tensor< double, p, q > >{
+    using type = tensor<tensor<double, p, q>, m, n>;
+  };
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+template< typename T, typename ... arg_types >
+auto wrapper(const T & f, const arg_types & ... args) {
+    return f(args...);
+}
+
+template < typename function, typename input_type > 
+auto jacfwd(const function & f, const input_type & x) {
+  using output_type = decltype(f(x));
+  using jac_type = typename impl::outer_prod<output_type, input_type>::type;
+  void * func_ptr = reinterpret_cast<void*>(wrapper< function, input_type >);
+
+  constexpr int m = impl::vsize(output_type{});
+  jac_type J{};
+  double * J_ptr = reinterpret_cast<double *>(&J);
+
+  constexpr int n = impl::vsize(input_type{});
+  input_type dx{};
+  double * dx_ptr = reinterpret_cast<double *>(&dx);
+
+  for (int j = 0; j < n; j++) {
+    dx_ptr[j] = 1.0;
+
+    output_type df_dxj = __enzyme_fwddiff<output_type>(func_ptr, 
+      enzyme_const, reinterpret_cast<const void*>(&f), 
+      enzyme_dup, &x, &dx
+    );
+
+    double * df_dxj_ptr = reinterpret_cast<double *>(&df_dxj);
+    for (int i = 0; i < m; i++) {
+      J_ptr[i * n + j] = df_dxj_ptr[i];
+    }
+
+    dx_ptr[j] = 0.0;
+  }
+
+  return J;
+}
+
+template < int i, typename function, typename T0, typename T1 > 
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1) {
+  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1); }, arg0); }
+  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x); }, arg1); }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+int main() {
+
+  auto f = [=](double z, const tensor< double, 3, 3 > & du_dx) { return z * du_dx; };
+
+  double z = 3.0;
+  tensor<double,3,3> du_dx = {{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}};
+
+  std::cout << "f(x, du_dx): " << f(z, du_dx) << std::endl;
+  std::cout << "expected: {{3., 6., 9.}, {6., 9., 3.}, {3., 1.5, 0.6}}" << std::endl;
+  std::cout << std::endl;
+
+  auto df_darg0 = jacfwd<0>(f, z, du_dx);
+  std::cout << "df_dz: " << df_darg0 << std::endl;
+  std::cout << "expected: {{1., 2., 3.}, {2., 3., 1.}, {1., 0.5, 0.2}}" << std::endl;
+  std::cout << std::endl;
+
+  auto df_darg1 = jacfwd<1>(f, z, du_dx);
+  std::cout << "df_d(du_dx): " << df_darg1 << std::endl;
+  std::cout << "expected: {{{{3., 0, 0}, {0, 0, 0}, {0, 0, 0}}, {{0, 3., 0}, {0, 0, 0}, {0, 0, 0}}, {{0, 0, 3.}, {0, 0, 0}, {0, 0, 0}}}, {{{0, 0, 0}, {3., 0, 0}, {0, 0, 0}}, {{0, 0, 0}, {0, 3., 0}, {0, 0, 0}}, {{0, 0, 0}, {0, 0, 3.}, {0, 0, 0}}}, {{{0, 0, 0}, {0, 0, 0}, {3., 0, 0}}, {{0, 0, 0}, {0, 0, 0}, {0, 3., 0}}, {{0, 0, 0}, {0, 0, 0}, {0, 0, 3.}}}}" << std::endl;
+
+}

--- a/src/serac/numerics/functional/tests/enzyme_test.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_test.cpp
@@ -1,182 +1,32 @@
 #include <iostream>
 
-#include <enzyme/enzyme>
-
+#include "serac/numerics/functional/dual.hpp"
 #include "serac/numerics/functional/tuple.hpp"
 #include "serac/numerics/functional/tensor.hpp"
+#include "serac/numerics/functional/enzyme_wrapper.hpp"
 
-#if 0
-double square(double x) {
-  return x * x;
-}
-
-double dsquare(double x) {
-  return __enzyme_autodiff<double>(reinterpret_cast<void*>(square), x);
-}
-#endif
+template < typename T >
+struct undefined;
 
 using namespace serac;
 
-namespace impl {
-
-  constexpr int vsize(const double &) { return 1; }
-
-  template < int n >
-  constexpr int vsize(const serac::tensor< double, n > &) { return n; }
-
-  template < int m, int n >
-  constexpr int vsize(const serac::tensor< double, m, n > &) { return m * n; }
-
-  template < typename T0, typename T1 >
-  constexpr int vsize(const serac::tuple< T0, T1 > &) { return vsize(T0{}) + vsize(T1{}); }
-
-  template < typename T0, typename T1 >
-  struct nested;
-
-  template <> 
-  struct nested< double, double >{ using type = double; };
-
-  template < int ... n > 
-  struct nested< double, tensor<double,n...> >{ using type = tensor<double,n...>; };
-
-  template < typename T0, typename T1 > 
-  struct nested< double, tuple<T0, T1> >{ using type = tuple<T0, T1>; };
-
-////////////////////////////////////////////////////////////////////////////////
-
-  template < int ... n, typename T > 
-  struct nested< tensor<double, n...>, T >{ using type = tensor<T, n ...>; };
-
-////////////////////////////////////////////////////////////////////////////////
-
-  template < typename S0, typename S1, typename T > 
-  struct nested< tuple< S0, S1 >, T >{ 
-    using type = tuple< typename nested<S0, T>::type, typename nested<S1, T>::type >; 
-  };
-
-}
-
-template < typename S, typename T0, typename T1 >
-struct serac::detail::outer_prod< S, serac::tuple<T0, T1> >{
-  using type = serac::tuple <
-    typename outer_prod< S, T0 >::type,
-    typename outer_prod< S, T1 >::type
-  >;
-};
-
-template< typename output_type, typename function, typename ... arg_types >
-void wrapper(output_type & output, const function & f, const arg_types & ... args) {
-    output = f(args...);
-}
-
-template < typename function, typename input_type > 
-__attribute__((always_inline))
-auto jacfwd(const function & f, const input_type & x) {
-  using output_type = decltype(f(x));
-  using jac_type = typename impl::nested<output_type, input_type>::type;
-  void * func_ptr = reinterpret_cast<void*>(wrapper< output_type, function, input_type >);
-
-  constexpr int m = impl::vsize(output_type{});
-  jac_type J{};
-  double * J_ptr = reinterpret_cast<double *>(&J);
-
-  constexpr int n = impl::vsize(input_type{});
-  input_type dx{};
-  double * dx_ptr = reinterpret_cast<double *>(&dx);
-
-  for (int j = 0; j < n; j++) {
-    dx_ptr[j] = 1.0;
-
-    output_type unused{};
-    output_type df_dxj{};
-    __enzyme_fwddiff<void>(func_ptr,
-      enzyme_dupnoneed, &unused, &df_dxj,
-      enzyme_const, reinterpret_cast<const void*>(&f), 
-      enzyme_dup, &x, &dx
-    );
-
-    double * df_dxj_ptr = reinterpret_cast<double *>(&df_dxj);
-    for (int i = 0; i < m; i++) {
-      J_ptr[i * n + j] = df_dxj_ptr[i];
-    }
-
-    dx_ptr[j] = 0.0;
-  }
-
-  return J;
-}
-
-template < int i, typename function, typename T0, typename T1 > 
-__attribute__((always_inline))
-auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1) {
-  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1); }, arg0); }
-  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x); }, arg1); }
-}
-
-template < int i, typename function, typename T0, typename T1, typename T2 > 
-__attribute__((always_inline))
-auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2) {
-  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2); }, arg0); }
-  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2); }, arg1); }
-  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x); }, arg2); }
-}
-
-template < int i, typename function, typename T0, typename T1, typename T2, typename T3 > 
-__attribute__((always_inline))
-auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3) {
-  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3); }, arg0); }
-  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3); }, arg1); }
-  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3); }, arg2); }
-  if constexpr (i == 3) { return jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x); }, arg3); }
-}
-
-template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4 > 
-__attribute__((always_inline))
-auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4) {
-  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3, arg4); }, arg0); }
-  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3, arg4); }, arg1); }
-  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3, arg4); }, arg2); }
-  if constexpr (i == 3) { return jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x, arg4); }, arg3); }
-  if constexpr (i == 4) { return jacfwd([&](T4 x){ return f(arg0, arg1, arg2, arg3, x); }, arg4); }
-}
-
-template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5 > 
-__attribute__((always_inline))
-auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4, const T5 & arg5) {
-  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3, arg4, arg5); }, arg0); }
-  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3, arg4, arg5); }, arg1); }
-  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3, arg4, arg5); }, arg2); }
-  if constexpr (i == 3) { return jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x, arg4, arg5); }, arg3); }
-  if constexpr (i == 4) { return jacfwd([&](T4 x){ return f(arg0, arg1, arg2, arg3, x, arg5); }, arg4); }
-  if constexpr (i == 5) { return jacfwd([&](T5 x){ return f(arg0, arg1, arg2, arg3, arg4, x); }, arg5); }
-}
-
 int main() {
 
-  auto fg = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+  auto f = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
     auto [u, du_dx] = displacement;
-    return tuple{dot(du_dx, z * u), z * (du_dx + transpose(du_dx)) - outer(u, u)};
+    return z * (du_dx + transpose(du_dx)) - outer(u, u);
   };
 
 ////////////////////////////////////////////////////////////////////////////////
 
   auto dfdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
     auto [u, du_dx] = displacement;
-    return dot(du_dx, u);
-  };
-
-  auto dgdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
-    auto [u, du_dx] = displacement;
     return (du_dx + transpose(du_dx)); 
   };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-  auto dfdu = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
-    return get<1>(displacement) * z;
-  };
-
-  auto dgdu = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+  auto dfdu = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
     auto u = get<0>(displacement);
     tensor<double,3,3,3> output{};
     for (int k = 0; k < 3; k++) {
@@ -191,20 +41,7 @@ int main() {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-  auto dfddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
-    auto u = get<0>(displacement);
-    tensor<double,3,3,3> output{};
-    for (int k = 0; k < 3; k++) {
-      for (int j = 0; j < 3; j++) {
-        for (int i = 0; i < 3; i++) {
-          output(i,j,k) = z * u[k] * (i == j);
-        }
-      }
-    }
-    return output;
-  };
-
-  auto dgddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > &) { 
+  auto dfddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > &) { 
     tensor<double,3,3,3,3> output{};
     for (int l = 0; l < 3; l++) {
       for (int k = 0; k < 3; k++) {
@@ -226,20 +63,19 @@ int main() {
     tensor<double,3,3>{{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}}
   };
 
-  auto [df_dz, dg_dz] = jacfwd<0>(fg, z, displacement);
+  auto df_dz = jacfwd<0>(f, z, displacement);
   std::cout << "df_dz: " << df_dz << std::endl;
   std::cout << "expected: " << dfdz(z, displacement) << std::endl;
   std::cout << std::endl;
 
-  std::cout << "df_dz: " << dg_dz << std::endl;
-  std::cout << "expected: " << dgdz(z, displacement) << std::endl;
-  std::cout << std::endl;
-
-  auto [df_ddisp, dg_ddisp] = jacfwd<1>(fg, z, displacement);
+  auto df_ddisp = jacfwd<1>(f, z, displacement);
   std::cout << "df_du: ";
   std::cout << "{";
   for (int i = 0; i < 3; i++) {
-    std::cout << get<0>(df_ddisp(i));
+    for (int j = 0; j < 3; j++) {
+      std::cout << get<0>(df_ddisp(i,j));
+      if (j != 2) { std::cout << ","; }
+    }
     if (i != 2) { std::cout << ","; }
   }
   std::cout << "}" << std::endl;
@@ -249,42 +85,29 @@ int main() {
   std::cout << "df_d(du_dx): ";
   std::cout << "{";
   for (int i = 0; i < 3; i++) {
-    std::cout << get<1>(df_ddisp(i));
+    for (int j = 0; j < 3; j++) {
+      std::cout << get<1>(df_ddisp(i,j));
+      if (j != 2) { std::cout << ","; }
+    }
     if (i != 2) { std::cout << ","; }
   }
   std::cout << "}" << std::endl;
   std::cout << "expected: " << dfddudx(z, displacement) << std::endl;
   std::cout << std::endl;
 
-  std::cout << "dg_du: ";
-  std::cout << "{";
-  for (int i = 0; i < 3; i++) {
-    std::cout << "{";
-    for (int j = 0; j < 3; j++) {
-      std::cout << get<0>(dg_ddisp(i,j));
-      if (j != 2) { std::cout << ","; }
-    }
-    std::cout << "}";
-    if (i != 2) { std::cout << ","; }
-  }
-  std::cout << "}" << std::endl;
-  std::cout << "expected: " << dgdu(z, displacement) << std::endl;
-  std::cout << std::endl;
+  //tuple< double, vec3 > x;
+  //serac::tuple<
+  //  serac::tuple<double, serac::zero>, 
+  //  serac::tuple<serac::zero, serac::tensor<double, 3, 3>
+  //>
+  //auto x_dx = make_dual(x);
+  //undefined< decltype(get_gradient(x_dx)) > foo;
 
-
-  std::cout << "dg_d(du_dx): ";
-  std::cout << "{";
-  for (int i = 0; i < 3; i++) {
-    std::cout << "{";
-    for (int j = 0; j < 3; j++) {
-      std::cout << get<1>(dg_ddisp(i,j));
-      if (j != 2) { std::cout << ","; }
-    }
-    std::cout << "}";
-    if (i != 2) { std::cout << ","; }
-  }
-  std::cout << "}" << std::endl;
-  std::cout << "expected: " << dgddudx(z, displacement) << std::endl;
-  std::cout << std::endl;
+  //serac::tuple<
+  //  serac::tuple<double, serac::tensor<double, 3>>, 
+  //  serac::tuple<serac::tensor<double, 3>, serac::tensor<serac::tensor<double, 3>, 3>
+  //>
+  //using derivative_type = impl::nested< tuple< double, vec3 >, tuple< double, vec3 > >::type;
+  //undefined< derivative_type > foo;
 
 }

--- a/src/serac/numerics/functional/tests/enzyme_test.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_test.cpp
@@ -153,17 +153,30 @@ auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg
 
 int main() {
 
-  auto f = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+  auto fg = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
     auto [u, du_dx] = displacement;
-    return z * (du_dx + transpose(du_dx)) - outer(u, u); 
+    return tuple{dot(du_dx, z * u), z * (du_dx + transpose(du_dx)) - outer(u, u)};
   };
 
+////////////////////////////////////////////////////////////////////////////////
+
   auto dfdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return dot(du_dx, u);
+  };
+
+  auto dgdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
     auto [u, du_dx] = displacement;
     return (du_dx + transpose(du_dx)); 
   };
 
-  auto dfdu = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+////////////////////////////////////////////////////////////////////////////////
+
+  auto dfdu = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    return get<1>(displacement) * z;
+  };
+
+  auto dgdu = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
     auto u = get<0>(displacement);
     tensor<double,3,3,3> output{};
     for (int k = 0; k < 3; k++) {
@@ -176,7 +189,22 @@ int main() {
     return output;
   };
 
-  auto dfddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > &) { 
+////////////////////////////////////////////////////////////////////////////////
+
+  auto dfddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto u = get<0>(displacement);
+    tensor<double,3,3,3> output{};
+    for (int k = 0; k < 3; k++) {
+      for (int j = 0; j < 3; j++) {
+        for (int i = 0; i < 3; i++) {
+          output(i,j,k) = z * u[k] * (i == j);
+        }
+      }
+    }
+    return output;
+  };
+
+  auto dgddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > &) { 
     tensor<double,3,3,3,3> output{};
     for (int l = 0; l < 3; l++) {
       for (int k = 0; k < 3; k++) {
@@ -190,27 +218,28 @@ int main() {
     return output;
   };
 
+////////////////////////////////////////////////////////////////////////////////
+
   double z = 3.0;
   auto displacement = tuple { 
     tensor<double,3>{{1.0, 1.0, 1.0}},
     tensor<double,3,3>{{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}}
   };
 
-  auto df_dz = jacfwd<0>(f, z, displacement);
+  auto [df_dz, dg_dz] = jacfwd<0>(fg, z, displacement);
   std::cout << "df_dz: " << df_dz << std::endl;
   std::cout << "expected: " << dfdz(z, displacement) << std::endl;
   std::cout << std::endl;
 
-  auto df_ddisp = jacfwd<1>(f, z, displacement);
+  std::cout << "df_dz: " << dg_dz << std::endl;
+  std::cout << "expected: " << dgdz(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  auto [df_ddisp, dg_ddisp] = jacfwd<1>(fg, z, displacement);
   std::cout << "df_du: ";
   std::cout << "{";
   for (int i = 0; i < 3; i++) {
-    std::cout << "{";
-    for (int j = 0; j < 3; j++) {
-      std::cout << get<0>(df_ddisp(i,j));
-      if (j != 2) { std::cout << ","; }
-    }
-    std::cout << "}";
+    std::cout << get<0>(df_ddisp(i));
     if (i != 2) { std::cout << ","; }
   }
   std::cout << "}" << std::endl;
@@ -220,16 +249,42 @@ int main() {
   std::cout << "df_d(du_dx): ";
   std::cout << "{";
   for (int i = 0; i < 3; i++) {
+    std::cout << get<1>(df_ddisp(i));
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dfddudx(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "dg_du: ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
     std::cout << "{";
     for (int j = 0; j < 3; j++) {
-      std::cout << get<1>(df_ddisp(i,j));
+      std::cout << get<0>(dg_ddisp(i,j));
       if (j != 2) { std::cout << ","; }
     }
     std::cout << "}";
     if (i != 2) { std::cout << ","; }
   }
   std::cout << "}" << std::endl;
-  std::cout << "expected: " << dfddudx(z, displacement) << std::endl;
+  std::cout << "expected: " << dgdu(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+
+  std::cout << "dg_d(du_dx): ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
+    std::cout << "{";
+    for (int j = 0; j < 3; j++) {
+      std::cout << get<1>(dg_ddisp(i,j));
+      if (j != 2) { std::cout << ","; }
+    }
+    std::cout << "}";
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dgddudx(z, displacement) << std::endl;
   std::cout << std::endl;
 
 }

--- a/src/serac/numerics/functional/tests/enzyme_test.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_test.cpp
@@ -1,0 +1,17 @@
+#include <iostream>
+
+#include "serac/numerics/functional/enzyme_declarations.hpp"
+
+double square(double x) {
+  return x * x;
+}
+
+double dsquare(double x) {
+  return __enzyme_autodiff<double>(reinterpret_cast<void*>(square), x);
+}
+
+int main() {
+  for(double i=1; i<5; i++) {
+    std::cout << square(i) << " " << dsquare(i) << std::endl;
+  }
+}

--- a/src/serac/numerics/functional/tests/enzyme_test.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_test.cpp
@@ -1,8 +1,9 @@
 #include <iostream>
 
-#include "../enzyme_declarations.hpp"
-#include "../tuple.hpp"
-#include "../tensor.hpp"
+#include <enzyme/enzyme>
+
+#include "serac/numerics/functional/tuple.hpp"
+#include "serac/numerics/functional/tensor.hpp"
 
 #if 0
 double square(double x) {
@@ -14,21 +15,180 @@ double dsquare(double x) {
 }
 #endif
 
-template< typename T, typename ... arg_types >
-auto wrapper(const T & f, arg_types ... args) {
-    return f(args...);
+using namespace serac;
+
+namespace impl {
+
+  constexpr int vsize(const double &) { return 1; }
+
+  template < int n >
+  constexpr int vsize(const serac::tensor< double, n > &) { return n; }
+
+  template < int m, int n >
+  constexpr int vsize(const serac::tensor< double, m, n > &) { return m * n; }
+
+  template < typename T0, typename T1 >
+  constexpr int vsize(const serac::tuple< T0, T1 > &) { return vsize(T0{}) + vsize(T1{}); }
+
+}
+
+template < typename S, typename T0, typename T1 >
+struct serac::detail::outer_prod< S, serac::tuple<T0, T1> >{
+  using type = serac::tuple <
+    typename outer_prod< S, T0 >::type,
+    typename outer_prod< S, T1 >::type
+  >;
+};
+
+template< typename output_type, typename function, typename ... arg_types >
+void wrapper(output_type & output, const function & f, const arg_types & ... args) {
+    output = f(args...);
+}
+
+template < typename function, typename input_type > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const input_type & x) {
+  using output_type = decltype(f(x));
+  using jac_type = typename serac::detail::outer_prod<output_type, input_type>::type;
+  void * func_ptr = reinterpret_cast<void*>(wrapper< output_type, function, input_type >);
+
+  constexpr int m = impl::vsize(output_type{});
+  jac_type J{};
+  double * J_ptr = reinterpret_cast<double *>(&J);
+
+  constexpr int n = impl::vsize(input_type{});
+  input_type dx{};
+  double * dx_ptr = reinterpret_cast<double *>(&dx);
+
+  for (int j = 0; j < n; j++) {
+    dx_ptr[j] = 1.0;
+
+    std::cout << dx << std::endl;
+
+    output_type unused{};
+    output_type df_dxj{};
+    __enzyme_fwddiff<void>(func_ptr,
+      enzyme_dupnoneed, &unused, &df_dxj,
+      enzyme_const, reinterpret_cast<const void*>(&f), 
+      enzyme_dup, &x, &dx
+    );
+    std::cout << df_dxj << std::endl;
+
+    double * df_dxj_ptr = reinterpret_cast<double *>(&df_dxj);
+    for (int i = 0; i < m; i++) {
+      J_ptr[i * n + j] = df_dxj_ptr[i];
+    }
+
+    std::cout << J << std::endl;
+
+    dx_ptr[j] = 0.0;
+  }
+
+  return J;
+}
+
+template < int i, typename function, typename T0, typename T1 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1) {
+  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1); }, arg0); }
+  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x); }, arg1); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2) {
+  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2); }, arg0); }
+  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2); }, arg1); }
+  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x); }, arg2); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3) {
+  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3); }, arg0); }
+  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3); }, arg1); }
+  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3); }, arg2); }
+  if constexpr (i == 3) { return jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x); }, arg3); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4) {
+  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3, arg4); }, arg0); }
+  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3, arg4); }, arg1); }
+  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3, arg4); }, arg2); }
+  if constexpr (i == 3) { return jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x, arg4); }, arg3); }
+  if constexpr (i == 4) { return jacfwd([&](T4 x){ return f(arg0, arg1, arg2, arg3, x); }, arg4); }
+}
+
+template < int i, typename function, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5 > 
+__attribute__((always_inline))
+auto jacfwd(const function & f, const T0 & arg0, const T1 & arg1, const T2 & arg2, const T3 & arg3, const T4 & arg4, const T5 & arg5) {
+  if constexpr (i == 0) { return jacfwd([&](T0 x){ return f(x, arg1, arg2, arg3, arg4, arg5); }, arg0); }
+  if constexpr (i == 1) { return jacfwd([&](T1 x){ return f(arg0, x, arg2, arg3, arg4, arg5); }, arg1); }
+  if constexpr (i == 2) { return jacfwd([&](T2 x){ return f(arg0, arg1, x, arg3, arg4, arg5); }, arg2); }
+  if constexpr (i == 3) { return jacfwd([&](T3 x){ return f(arg0, arg1, arg2, x, arg4, arg5); }, arg3); }
+  if constexpr (i == 4) { return jacfwd([&](T4 x){ return f(arg0, arg1, arg2, arg3, x, arg5); }, arg4); }
+  if constexpr (i == 5) { return jacfwd([&](T5 x){ return f(arg0, arg1, arg2, arg3, arg4, x); }, arg5); }
 }
 
 int main() {
 
-    auto f = [](double x) { return x * x; };
+  auto f = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return z * (du_dx + transpose(du_dx)) - outer(u, u); 
+  };
 
-    auto df = [&](double x) {
-      return __enzyme_fwddiff<double>((void*)(wrapper<decltype(f), double>), 
-          enzyme_const, (void*)&f,
-          enzyme_dup, x, 1.0);
-    };
+  auto dfdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return (du_dx + transpose(du_dx)); 
+  };
 
-    std::cout << df(3) << std::endl;
+  auto dfdu = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto u = get<0>(displacement);
+    tensor<double,3,3,3> output{};
+    for (int k = 0; k < 3; k++) {
+      for (int j = 0; j < 3; j++) {
+        for (int i = 0; i < 3; i++) {
+          output(i,j,k) = - (u(i) * (j == k) + u(j) * (i == k));
+        }
+      }
+    }
+    return output;
+  };
+
+  auto dfddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > &) { 
+    tensor<double,3,3,3,3> output{};
+    for (int l = 0; l < 3; l++) {
+      for (int k = 0; k < 3; k++) {
+        for (int j = 0; j < 3; j++) {
+          for (int i = 0; i < 3; i++) {
+            output(i,j,k,l) = z * ((i==k) * (j==l) + (j==k) * (i==l));
+          }
+        }
+      }
+    }
+    return output;
+  };
+
+  double z = 3.0;
+  auto displacement = tuple { 
+    tensor<double,3>{{1.0, 1.0, 1.0}},
+    tensor<double,3,3>{{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}}
+  };
+
+  auto df_dz = jacfwd<0>(f, z, displacement);
+  std::cout << "df_dz: " << df_dz << std::endl;
+  std::cout << "expected: " << dfdz(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  auto df_ddisp = jacfwd<1>(f, z, displacement);
+  std::cout << "df_du: " << get<0>(df_ddisp) << std::endl;
+  std::cout << "expected: " << dfdu(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "df_d(du_dx): " << get<1>(df_ddisp) << std::endl;
+  std::cout << "expected: " << dfddudx(z, displacement) << std::endl;
+  std::cout << std::endl;
 
 }

--- a/src/serac/numerics/functional/tests/enzyme_test.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_test.cpp
@@ -1,7 +1,10 @@
 #include <iostream>
 
-#include "serac/numerics/functional/enzyme_declarations.hpp"
+#include "../enzyme_declarations.hpp"
+#include "../tuple.hpp"
+#include "../tensor.hpp"
 
+#if 0
 double square(double x) {
   return x * x;
 }
@@ -9,9 +12,23 @@ double square(double x) {
 double dsquare(double x) {
   return __enzyme_autodiff<double>(reinterpret_cast<void*>(square), x);
 }
+#endif
+
+template< typename T, typename ... arg_types >
+auto wrapper(const T & f, arg_types ... args) {
+    return f(args...);
+}
 
 int main() {
-  for(double i=1; i<5; i++) {
-    std::cout << square(i) << " " << dsquare(i) << std::endl;
-  }
+
+    auto f = [](double x) { return x * x; };
+
+    auto df = [&](double x) {
+      return __enzyme_fwddiff<double>((void*)(wrapper<decltype(f), double>), 
+          enzyme_const, (void*)&f,
+          enzyme_dup, x, 1.0);
+    };
+
+    std::cout << df(3) << std::endl;
+
 }

--- a/src/serac/numerics/functional/tests/enzyme_test_tuples.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_test_tuples.cpp
@@ -1,0 +1,92 @@
+#include <iostream>
+
+#include <enzyme/enzyme>
+
+#include "serac/numerics/functional/tuple.hpp"
+#include "serac/numerics/functional/tensor.hpp"
+#include "serac/numerics/functional/enzyme_wrapper.hpp"
+
+using namespace serac;
+
+int main() {
+
+  auto f = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return z * (du_dx + transpose(du_dx)) - outer(u, u); 
+  };
+
+  auto dfdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return (du_dx + transpose(du_dx)); 
+  };
+
+  auto dfdu = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto u = get<0>(displacement);
+    tensor<double,3,3,3> output{};
+    for (int k = 0; k < 3; k++) {
+      for (int j = 0; j < 3; j++) {
+        for (int i = 0; i < 3; i++) {
+          output(i,j,k) = - (u(i) * (j == k) + u(j) * (i == k));
+        }
+      }
+    }
+    return output;
+  };
+
+  auto dfddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > &) { 
+    tensor<double,3,3,3,3> output{};
+    for (int l = 0; l < 3; l++) {
+      for (int k = 0; k < 3; k++) {
+        for (int j = 0; j < 3; j++) {
+          for (int i = 0; i < 3; i++) {
+            output(i,j,k,l) = z * ((i==k) * (j==l) + (j==k) * (i==l));
+          }
+        }
+      }
+    }
+    return output;
+  };
+
+  double z = 3.0;
+  auto displacement = tuple { 
+    tensor<double,3>{{1.0, 1.0, 1.0}},
+    tensor<double,3,3>{{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}}
+  };
+
+  auto df_dz = jacfwd<0>(f, z, displacement);
+  std::cout << "df_dz: " << df_dz << std::endl;
+  std::cout << "expected: " << dfdz(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  auto df_ddisp = jacfwd<1>(f, z, displacement);
+  std::cout << "df_du: ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
+    std::cout << "{";
+    for (int j = 0; j < 3; j++) {
+      std::cout << get<0>(df_ddisp(i,j));
+      if (j != 2) { std::cout << ","; }
+    }
+    std::cout << "}";
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dfdu(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "df_d(du_dx): ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
+    std::cout << "{";
+    for (int j = 0; j < 3; j++) {
+      std::cout << get<1>(df_ddisp(i,j));
+      if (j != 2) { std::cout << ","; }
+    }
+    std::cout << "}";
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dfddudx(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+}

--- a/src/serac/numerics/functional/tests/enzyme_test_tuples_of_tuples.cpp
+++ b/src/serac/numerics/functional/tests/enzyme_test_tuples_of_tuples.cpp
@@ -1,0 +1,147 @@
+#include <iostream>
+
+#include <enzyme/enzyme>
+
+#include "serac/numerics/functional/tuple.hpp"
+#include "serac/numerics/functional/tensor.hpp"
+#include "serac/numerics/functional/enzyme_wrapper.hpp"
+
+using namespace serac;
+
+int main() {
+
+  auto fg = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return tuple{dot(du_dx, z * u), z * (du_dx + transpose(du_dx)) - outer(u, u)};
+  };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  auto dfdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return dot(du_dx, u);
+  };
+
+  auto dgdz = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto [u, du_dx] = displacement;
+    return (du_dx + transpose(du_dx)); 
+  };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  auto dfdu = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    return get<1>(displacement) * z;
+  };
+
+  auto dgdu = [](double, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto u = get<0>(displacement);
+    tensor<double,3,3,3> output{};
+    for (int k = 0; k < 3; k++) {
+      for (int j = 0; j < 3; j++) {
+        for (int i = 0; i < 3; i++) {
+          output(i,j,k) = - (u(i) * (j == k) + u(j) * (i == k));
+        }
+      }
+    }
+    return output;
+  };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  auto dfddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > & displacement) { 
+    auto u = get<0>(displacement);
+    tensor<double,3,3,3> output{};
+    for (int k = 0; k < 3; k++) {
+      for (int j = 0; j < 3; j++) {
+        for (int i = 0; i < 3; i++) {
+          output(i,j,k) = z * u[k] * (i == j);
+        }
+      }
+    }
+    return output;
+  };
+
+  auto dgddudx = [](double z, const tuple< tensor< double, 3 >, tensor< double, 3, 3 > > &) { 
+    tensor<double,3,3,3,3> output{};
+    for (int l = 0; l < 3; l++) {
+      for (int k = 0; k < 3; k++) {
+        for (int j = 0; j < 3; j++) {
+          for (int i = 0; i < 3; i++) {
+            output(i,j,k,l) = z * ((i==k) * (j==l) + (j==k) * (i==l));
+          }
+        }
+      }
+    }
+    return output;
+  };
+
+////////////////////////////////////////////////////////////////////////////////
+
+  double z = 3.0;
+  auto displacement = tuple { 
+    tensor<double,3>{{1.0, 1.0, 1.0}},
+    tensor<double,3,3>{{{1.0, 2.0, 3.0}, {2.0, 3.0, 1.0}, {1.0, 0.5, 0.2}}}
+  };
+
+  auto [df_dz, dg_dz] = jacfwd<0>(fg, z, displacement);
+  std::cout << "df_dz: " << df_dz << std::endl;
+  std::cout << "expected: " << dfdz(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "df_dz: " << dg_dz << std::endl;
+  std::cout << "expected: " << dgdz(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  auto [df_ddisp, dg_ddisp] = jacfwd<1>(fg, z, displacement);
+  std::cout << "df_du: ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
+    std::cout << get<0>(df_ddisp)(i);
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dfdu(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "df_d(du_dx): ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
+    std::cout << get<1>(df_ddisp)(i);
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dfddudx(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "dg_du: ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
+    std::cout << "{";
+    for (int j = 0; j < 3; j++) {
+      std::cout << get<0>(dg_ddisp)(i,j);
+      if (j != 2) { std::cout << ","; }
+    }
+    std::cout << "}";
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dgdu(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+
+  std::cout << "dg_d(du_dx): ";
+  std::cout << "{";
+  for (int i = 0; i < 3; i++) {
+    std::cout << "{";
+    for (int j = 0; j < 3; j++) {
+      std::cout << get<1>(dg_ddisp)(i,j);
+      if (j != 2) { std::cout << ","; }
+    }
+    std::cout << "}";
+    if (i != 2) { std::cout << ","; }
+  }
+  std::cout << "}" << std::endl;
+  std::cout << "expected: " << dgddudx(z, displacement) << std::endl;
+  std::cout << std::endl;
+
+}

--- a/src/serac/numerics/functional/tests/functional_basic_h1_scalar.cpp
+++ b/src/serac/numerics/functional/tests/functional_basic_h1_scalar.cpp
@@ -55,11 +55,12 @@ void thermal_test_impl(std::unique_ptr<mfem::ParMesh>& mesh)
 
   residual.AddDomainIntegral(
       Dimension<dim>{}, DependsOn<0>{},
-      [=](double /*t*/, auto position, auto temperature) {
+      [=](double /*t*/, tuple< tensor<double,dim>, tensor<double,dim,dim> > position, tuple< double, tensor<double,dim> > temperature) {
         auto [X, dX_dxi] = position;
         auto [u, du_dx]  = temperature;
-        auto source      = d00 * u + dot(d01, du_dx) - 0.0 * (100 * X[0] * X[1]);
-        auto flux        = d10 * u + dot(d11, du_dx);
+        double source           = d00 * u + dot(d01, du_dx) - 0.0 * (100 * X[0] * X[1]);
+        tensor<double,dim> flux = d10 * u + dot(d11, du_dx);
+        flux[0] += X[1];
         return serac::tuple{source, flux};
       },
       *mesh);

--- a/src/serac/physics/state/finite_element_vector.hpp
+++ b/src/serac/physics/state/finite_element_vector.hpp
@@ -18,7 +18,7 @@
 #include "mfem.hpp"
 
 #include "serac/infrastructure/variant.hpp"
-#include "serac/numerics/functional/functional.hpp"
+#include "serac/numerics/functional/finite_element.hpp"
 
 namespace serac {
 


### PR DESCRIPTION
a preliminary example of integrating enzyme into serac as the primary mechanism of material model differentiation

Some notable benefits of enzyme over `serac::dual`:
- excessive use of `auto` in material models is not required
- qfunction arguments can also be regular C++ types, rather than `auto`
- bodies of qfunctions do not need to use the C++ type system for AD, so some programming constructs (conditionals, operator+=, etc) are much easier to write
- support for reverse mode differentiation


some notable downsides/changes include:
- enzyme is relatively new and has some sharp edges (e.g. currently, some qfunctions that use `serac::zero` are crashing enzyme).
- requires finite element kernels to be compiled with `clang` compiler. `clang` and `enzyme` do claim to support AMD/NVIDIA GPU backends, but I have not verified that yet.
- must compile with optimization or enzyme doesn't work (this is fixed if we adopt C++20)