### PR TITLE
Enabling dimension to be deduced for parameterized solid materials

### DIFF
--- a/examples/contact/beam_bending.cpp
+++ b/examples/contact/beam_bending.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
   G_field.project(G_coeff);
   solid_solver.setParameter(1, G_field);
 
-  serac::solid_mechanics::ParameterizedNeoHookeanSolid<dim> mat{1.0, 0.0, 0.0};
+  serac::solid_mechanics::ParameterizedNeoHookeanSolid mat{1.0, 0.0, 0.0};
   solid_solver.setMaterial(serac::DependsOn<0, 1>{}, mat);
 
   // Pass the BC information to the solver object

--- a/examples/contact/ironing.cpp
+++ b/examples/contact/ironing.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
   G_field.project(G_coeff);
   solid_solver.setParameter(1, G_field);
 
-  serac::solid_mechanics::ParameterizedNeoHookeanSolid<dim> mat{1.0, 0.0, 0.0};
+  serac::solid_mechanics::ParameterizedNeoHookeanSolid mat{1.0, 0.0, 0.0};
   solid_solver.setMaterial(serac::DependsOn<0, 1>{}, mat);
 
   // Pass the BC information to the solver object

--- a/src/serac/physics/materials/parameterized_solid_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_material.hpp
@@ -80,7 +80,7 @@ struct ParameterizedNeoHookeanSolid {
    * @param DeltaG The shear modulus offset
    * @return The calculated material response (Cauchy stress) for the material
    */
-  template <typename dim, typename DispGradType, typename BulkType, typename ShearType>
+  template <int dim, typename DispGradType, typename BulkType, typename ShearType>
   SERAC_HOST_DEVICE auto operator()(State& /*state*/, const serac::tensor<DispGradType, dim, dim> & du_dX, const BulkType& DeltaK,
                                     const ShearType& DeltaG) const
   {

--- a/src/serac/physics/materials/parameterized_solid_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_material.hpp
@@ -21,15 +21,14 @@ namespace serac::solid_mechanics {
 /**
  * @brief Linear isotropic elasticity material model
  *
- * @tparam dim Spatial dimension of the mesh
  */
-template <int dim>
 struct ParameterizedLinearIsotropicSolid {
   using State = Empty;  ///< this material has no internal variables
 
   /**
    * @brief stress calculation for a linear isotropic material model
    *
+   * @tparam dim Spatial dimension of the mesh
    * @tparam DispGradType Displacement gradient type
    * @tparam BulkType Bulk modulus type
    * @tparam ShearType Shear modulus type
@@ -38,8 +37,8 @@ struct ParameterizedLinearIsotropicSolid {
    * @param DeltaG The shear modulus offset
    * @return The calculated material response (Cauchy stress) for the material
    */
-  template <typename DispGradType, typename BulkType, typename ShearType>
-  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const DispGradType& du_dX, const BulkType& DeltaK,
+  template <int dim, typename DispGradType, typename BulkType, typename ShearType>
+  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const serac::tensor<DispGradType, dim, dim> & du_dX, const BulkType& DeltaK,
                                     const ShearType& DeltaG) const
   {
     constexpr auto I       = Identity<dim>();
@@ -65,15 +64,14 @@ struct ParameterizedLinearIsotropicSolid {
 /**
  * @brief Neo-Hookean material model
  *
- * @tparam dim The spatial dimension of the mesh
  */
-template <int dim>
 struct ParameterizedNeoHookeanSolid {
   using State = Empty;  ///< this material has no internal variables
 
   /**
    * @brief stress calculation for a NeoHookean material model
    *
+   * @tparam dim The spatial dimension of the mesh
    * @tparam DispGradType Displacement gradient type
    * @tparam BulkType Bulk modulus type
    * @tparam ShearType Shear modulus type
@@ -82,8 +80,8 @@ struct ParameterizedNeoHookeanSolid {
    * @param DeltaG The shear modulus offset
    * @return The calculated material response (Cauchy stress) for the material
    */
-  template <typename DispGradType, typename BulkType, typename ShearType>
-  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const DispGradType& du_dX, const BulkType& DeltaK,
+  template <typename dim, typename DispGradType, typename BulkType, typename ShearType>
+  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const serac::tensor<DispGradType, dim, dim> & du_dX, const BulkType& DeltaK,
                                     const ShearType& DeltaG) const
   {
     using std::log1p;

--- a/src/serac/physics/materials/parameterized_solid_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_material.hpp
@@ -38,8 +38,8 @@ struct ParameterizedLinearIsotropicSolid {
    * @return The calculated material response (Cauchy stress) for the material
    */
   template <int dim, typename DispGradType, typename BulkType, typename ShearType>
-  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const serac::tensor<DispGradType, dim, dim> & du_dX, const BulkType& DeltaK,
-                                    const ShearType& DeltaG) const
+  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const serac::tensor<DispGradType, dim, dim>& du_dX,
+                                    const BulkType& DeltaK, const ShearType& DeltaG) const
   {
     constexpr auto I       = Identity<dim>();
     auto           K       = K0 + get<0>(DeltaK);
@@ -81,8 +81,8 @@ struct ParameterizedNeoHookeanSolid {
    * @return The calculated material response (Cauchy stress) for the material
    */
   template <int dim, typename DispGradType, typename BulkType, typename ShearType>
-  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const serac::tensor<DispGradType, dim, dim> & du_dX, const BulkType& DeltaK,
-                                    const ShearType& DeltaG) const
+  SERAC_HOST_DEVICE auto operator()(State& /*state*/, const serac::tensor<DispGradType, dim, dim>& du_dX,
+                                    const BulkType& DeltaK, const ShearType& DeltaG) const
   {
     using std::log1p;
     constexpr auto I         = Identity<dim>();

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -328,7 +328,7 @@ void functional_parameterized_solid_test(double expected_disp_norm)
   solid_solver.setParameter(0, user_defined_bulk_modulus);
   solid_solver.setParameter(1, user_defined_shear_modulus);
 
-  solid_mechanics::ParameterizedLinearIsotropicSolid<dim> mat{1.0, 0.0, 0.0};
+  solid_mechanics::ParameterizedLinearIsotropicSolid mat{1.0, 0.0, 0.0};
   solid_solver.setMaterial(DependsOn<0, 1>{}, mat);
 
   // Define the function for the initial displacement and boundary condition

--- a/src/serac/physics/tests/solid_finite_diff.cpp
+++ b/src/serac/physics/tests/solid_finite_diff.cpp
@@ -72,7 +72,7 @@ TEST(SolidMechanics, FiniteDifferenceParameter)
   // As we only have one parameter in this example, the index is zero.
   constexpr int bulk_parameter_index = 0;
 
-  solid_mechanics::ParameterizedNeoHookeanSolid<dim> mat{1.0, 0.0, 0.0};
+  solid_mechanics::ParameterizedNeoHookeanSolid mat{1.0, 0.0, 0.0};
   solid_solver.setMaterial(DependsOn<0, 1>{}, mat);
 
   // Define the function for the initial displacement and boundary condition

--- a/src/serac/physics/tests/solid_periodic.cpp
+++ b/src/serac/physics/tests/solid_periodic.cpp
@@ -76,7 +76,7 @@ void periodic_test(mfem::Element::Type element_type)
   solid_solver.setParameter(0, user_defined_bulk_modulus);
   solid_solver.setParameter(1, user_defined_shear_modulus);
 
-  solid_mechanics::ParameterizedNeoHookeanSolid<dim> mat{1.0, 0.0, 0.0};
+  solid_mechanics::ParameterizedNeoHookeanSolid mat{1.0, 0.0, 0.0};
   solid_solver.setMaterial(DependsOn<0, 1>{}, mat);
 
   // Boundary conditions:

--- a/src/serac/physics/tests/solid_reaction_adjoint.cpp
+++ b/src/serac/physics/tests/solid_reaction_adjoint.cpp
@@ -29,7 +29,7 @@ using SolidMechanicsType = SolidMechanics<p, dim, Parameters<H1<1>, H1<1>>>;
 const std::string mesh_tag       = "mesh";
 const std::string physics_prefix = "solid";
 
-using SolidMaterial = solid_mechanics::ParameterizedNeoHookeanSolid<dim>;
+using SolidMaterial = solid_mechanics::ParameterizedNeoHookeanSolid;
 auto geoNonlinear   = GeometricNonlinearities::On;
 
 constexpr double boundary_disp       = 0.013;


### PR DESCRIPTION
While helping Irvin get his code to compile I realized the parameterized materials require a template `dim` parameter in the struct type. I moved this template argument to the operator overload so that the compiler can deduce it from the displacement gradient. This is how the non-parameterized material are set up