### PR TITLE
Put back in addNatural, which is untested and unused in serac, along …

### DIFF
--- a/src/serac/physics/boundary_conditions/boundary_condition_manager.cpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition_manager.cpp
@@ -13,6 +13,13 @@
 
 namespace serac {
 
+void BoundaryConditionManager::addNatural(const std::set<int>& nat_bdr, serac::GeneralCoefficient nat_bdr_coef,
+                                          mfem::ParFiniteElementSpace& space, const std::optional<int> component)
+{
+  nat_bdr_.emplace_back(nat_bdr_coef, component, space, nat_bdr);
+  all_dofs_valid_ = false;
+}
+
 void BoundaryConditionManager::addEssential(const std::set<int>& ess_bdr, serac::GeneralCoefficient ess_bdr_coef,
                                             mfem::ParFiniteElementSpace& space, const std::optional<int> component)
 {

--- a/src/serac/physics/boundary_conditions/boundary_condition_manager.hpp
+++ b/src/serac/physics/boundary_conditions/boundary_condition_manager.hpp
@@ -163,6 +163,17 @@ public:
   explicit BoundaryConditionManager(const mfem::ParMesh& mesh) : num_attrs_(mesh.bdr_attributes.Max()) {}
 
   /**
+   * @brief Set the natural boundary conditions from a list of boundary markers and a coefficient
+   *
+   * @param[in] nat_bdr The set of mesh attributes denoting a natural boundary
+   * @param[in] nat_bdr_coef The coefficient defining the natural boundary function
+   * @param[in] space The finite element space to which the BC should be applied
+   * @param[in] component The component to set (null implies all components are set)
+   */
+  void addNatural(const std::set<int>& nat_bdr, serac::GeneralCoefficient nat_bdr_coef,
+                  mfem::ParFiniteElementSpace& space, const std::optional<int> component = {});
+
+  /**
    * @brief Set the essential boundary conditions from a list of boundary markers and a coefficient
    *
    * @param[in] ess_bdr The set of essential BC attributes


### PR DESCRIPTION
…with several other functions and members.  Hard to see how to abstract it to only live in Smith, in the 1 stagnant physics model which still uses this approach.