### PR TITLE
Finite deformation J2 plasticity

### DIFF
--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -524,6 +524,36 @@ TEST(Tensor, Log)
   EXPECT_LT(norm(e), 1e-12);
 }
 
+TEST(Tensor, LogWithDualNumbers)
+{
+  const tensor lambda{{1.1, 2.6, 2.2}};
+  const tensor<double, 3, 3> Q{{{-0.928152308749236, -0.091036503308254, -0.360895617636}  ,
+                                { 0.238177386319198,  0.599832274220295, -0.763853896664712},
+                                { 0.28601542687348 , -0.794929932679048, -0.535052873762272}}};
+  auto A = dot(Q, dot(diag(lambda), transpose(Q)));
+  auto logA = log_symm(make_dual(A));
+  tensor<double, 3, 3, 3, 3> dlogA_h{};
+  double h = 1e-4;
+  for (int k = 0; k < 3; k++) {
+    for (int l = 0; l < 3; l++) {
+      A[k][l] += 0.5*h;
+      A[l][k] += 0.5*h;
+      tensor<double, 3, 3> logA_p = log_symm(A);
+      for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+          dlogA_h[i][j][k][l] = (logA_p[i][j] - logA[i][j].value)/h;
+          std::cout << i << j << k << l << std::endl;
+          std::cout << "dlogA   = " << logA[i][j].gradient[k][l] << std::endl;
+          std::cout << "dlogA_h = " << dlogA_h[i][j][k][l] << std::endl;
+        }
+      }
+      A[k][l] -= 0.5*h;
+      A[l][k] -= 0.5*h;
+    }
+  }
+  
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -562,6 +562,50 @@ TEST(Tensor, LogDerivative)
   EXPECT_LT(norm(dlogA[0] - dlogA[2]), 1.0e-14);
 }
 
+TEST(Tensor, ExponentialTraceIdentity)
+{
+  const tensor lambda{{1.1, 2.6, 2.2}};
+  const tensor<double, 3, 3> Q{{{-0.928152308749236, -0.091036503308254, -0.360895617636}  ,
+                                { 0.238177386319198,  0.599832274220295, -0.763853896664712},
+                                { 0.28601542687348 , -0.794929932679048, -0.535052873762272}}};
+  auto A = dot(Q, dot(diag(lambda), transpose(Q)));
+
+  auto expA = exp_symm(A);
+  EXPECT_NEAR(det(expA), std::exp(tr(A)), 1e-12);
+}
+
+TEST(Tensor, ExpDerivative)
+{
+  const tensor lambda{{1.1, 2.6, 2.2}};
+  const tensor<double, 3, 3> Q{{{-0.928152308749236, -0.091036503308254, -0.360895617636}  ,
+                                { 0.238177386319198,  0.599832274220295, -0.763853896664712},
+                                { 0.28601542687348 , -0.794929932679048, -0.535052873762272}}};
+  auto A = dot(Q, dot(diag(lambda), transpose(Q)));
+
+  auto expA = exp_symm(make_dual(A));
+  auto dexpA_dA = get_gradient(expA);
+
+  // perturbation should be symmetric, or else violates requirement of log_symm 
+  const tensor<double, 3, 3> dA{{{ 0.2, -0.4, -1.6},
+                                 {-0.4,  0.1, -1.7},
+                                 {-1.6, -1.7,  2.0}}};
+
+  tensor< dual<double>, 3, 3 > Adual = make_tensor< 3, 3 >([&](int i, int j) {
+    return dual<double>{A[i][j], dA[i][j]};
+  });
+
+  const double epsilon = 1.0e-6;
+
+  tensor<double, 3, 3> dexpA[3] = {
+    double_dot(dexpA_dA, dA),
+    (exp_symm(A + epsilon * dA) - exp_symm(A - epsilon * dA)) / (2 * epsilon),
+    get_gradient(exp_symm(Adual))
+  };
+
+  EXPECT_LT(norm(dexpA[0] - dexpA[1]), 1.0e-8);
+  EXPECT_LT(norm(dexpA[0] - dexpA[2]), 1.0e-13);
+}
+
 
 int main(int argc, char* argv[])
 {

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -525,7 +525,7 @@ TEST(Tensor, LogOfGeneralSymmetric)
   // use same eigenvalue matrix for A and B to ensure they commute
   const auto A = dot(Q, dot(diag(lambda_A), transpose(Q)));
   const auto B = dot(Q, dot(diag(lambda_B), transpose(Q)));
-  
+
   auto e = log_symm(dot(A, B)) - (log_symm(A) + log_symm(B));
   EXPECT_LT(norm(e), 1e-12);
 }
@@ -550,7 +550,7 @@ TEST(Tensor, LogDerivative)
     return dual<double>{A[i][j], dA[i][j]};
   });
 
-  const double epsilon = 1.0e-8;
+  const double epsilon = 1.0e-5;
 
   tensor<double, 3, 3> dlogA[3] = {
     double_dot(dlogA_dA, dA),
@@ -558,9 +558,10 @@ TEST(Tensor, LogDerivative)
     get_gradient(log_symm(Adual))
   };
 
-  EXPECT_LT(norm(dlogA[0] - dlogA[1]), 1.0e-7);
+  EXPECT_LT(norm(dlogA[0] - dlogA[1]), 1.0e-9);
   EXPECT_LT(norm(dlogA[0] - dlogA[2]), 1.0e-14);
 }
+
 
 int main(int argc, char* argv[])
 {

--- a/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
+++ b/src/serac/numerics/functional/tests/tensor_unit_tests.cpp
@@ -504,6 +504,26 @@ TEST(Tensor, EigendecompWith2NearlyDegenerateEigenvalues)
   EXPECT_LT(norm(A - should_be_A), 1e-12);
 }
 
+TEST(Tensor, LogOfSpherical)
+{
+  auto A = M_E*DenseIdentity<3>();
+  auto logA = log_symm(A);
+  ASSERT_LT(norm(logA - DenseIdentity<3>()), 1e-12);
+}
+
+TEST(Tensor, Log)
+{
+  const tensor lambda_A{{1.1, 2.6, 2.2}};
+  const tensor lambda_B{{0.8, 1.3, 1.3}};
+  const tensor<double, 3, 3> Q{{{-0.928152308749236, -0.091036503308254, -0.360895617636}  ,
+                                { 0.238177386319198,  0.599832274220295, -0.763853896664712},
+                                { 0.28601542687348 , -0.794929932679048, -0.535052873762272}}};
+  const auto A = dot(Q, dot(diag(lambda_A), transpose(Q)));
+  const auto B = dot(Q, dot(diag(lambda_B), transpose(Q)));
+  auto e = log_symm(dot(A, B)) - (log_symm(A) + log_symm(B));
+  EXPECT_LT(norm(e), 1e-12);
+}
+
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/serac/numerics/functional/tuple_tensor_dual_functions.hpp
+++ b/src/serac/numerics/functional/tuple_tensor_dual_functions.hpp
@@ -911,4 +911,22 @@ inline SERAC_HOST_DEVICE tuple<vec3, mat3> eig_symm(const mat3& A)
   return {eigvals, eigvecs};
 }
 
+template <typename Function>
+auto isotropic_tensor_function(mat3 A, const Function& f)
+{
+  auto [lambda, Q] = eig_symm(A);
+  vec3 y;
+  for (int i = 0; i < 3; i++) {
+    y[i] = f(lambda[i]);
+  }
+  return dot(Q, dot(diag(y), transpose(Q)));
+}
+
+auto log_symm(mat3 A)
+{
+  using std::log;
+  mat3 logA = isotropic_tensor_function(A, [](double x) { return log(x); });
+  return logA;
+}
+
 }  // namespace serac

--- a/src/serac/numerics/functional/tuple_tensor_dual_functions.hpp
+++ b/src/serac/numerics/functional/tuple_tensor_dual_functions.hpp
@@ -911,10 +911,10 @@ inline SERAC_HOST_DEVICE tuple<vec3, mat3> eig_symm(const mat3& A)
   return {eigvals, eigvecs};
 }
 
-template <typename Function>
-auto isotropic_tensor_function(mat3 A, const Function& f)
+template <typename T, typename Function>
+auto isotropic_tensor_function(tensor<T, 3, 3> A, const Function& f)
 {
-  auto [lambda, Q] = eig_symm(A);
+  auto [lambda, Q] = eig_symm(get_value(A));
   vec3 y;
   for (int i = 0; i < 3; i++) {
     y[i] = f(lambda[i]);
@@ -922,10 +922,11 @@ auto isotropic_tensor_function(mat3 A, const Function& f)
   return dot(Q, dot(diag(y), transpose(Q)));
 }
 
-auto log_symm(mat3 A)
+template <typename T>
+auto log_symm(tensor<T, 3, 3> A)
 {
   using std::log;
-  mat3 logA = isotropic_tensor_function(A, [](double x) { return log(x); });
+  auto logA = isotropic_tensor_function(A, [](double x) { return log(x); });
   return logA;
 }
 


### PR DESCRIPTION
Implements a J2 plasticity model for finite deformation. The model is based on the multiplicative decomposition $F = F^e F^p$, and the elastic response is hyperelastic and isotropic using the logarithmic elastic strain. 

Implementation details: The update of the plastic distortion tensor $F^p$ is through the first order exponential integrator, $F^p_{n+1} = \exp(\Delta \bar{\epsilon}^p N^p) F^p_{n} $. This technique, from [Weber and Anand](https://doi.org/10.1016/0045-7825(90)90131-5), has the nice (amazing) property that the plastic flow is exactly volume preserving $\det F^p = 1$. Another nice feature is that the most of the algorithm coincides with the small strain one, except for a small amount of pre- and post-processing to account for the finite deformation kinematics. We could easily implement this model and the linear version in the same struct, with just a few helper functions. For now, I'm leaving it separate.