### PR TITLE
Tupek/newton profiling

### DIFF
--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -66,10 +66,10 @@ public:
   }
 
   /// solve the linear system
-  void solveLinearSystem(const mfem::Vector& r, mfem::Vector& c) const
+  void solveLinearSystem(const mfem::Vector& r_, mfem::Vector& c_) const
   {
     CALI_CXX_MARK_FUNCTION;
-    prec->Mult(r, c);  // c = [DF(x_i)]^{-1} [F(x_i)-b]
+    prec->Mult(r_, c_);  // c = [DF(x_i)]^{-1} [F(x_i)-b]
   }
 
   /// @overload

--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 #include "serac/numerics/equation_solver.hpp"
+
 #include <iomanip>
 #include <sstream>
 #include <ios>

--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -51,15 +51,19 @@ public:
     return normEval;
   }
 
-
   void assembleJacobian(const mfem::Vector& x) const
   {
     CALI_CXX_MARK_FUNCTION;
     grad = &oper->GetGradient(x);
+  }
+
+  void setPreconditioner() const
+  {
+    CALI_CXX_MARK_FUNCTION;
     prec->SetOperator(*grad);
   }
 
-  void applyPreconditioner(const mfem::Vector& r, mfem::Vector& c) const
+  void solveLinearSystem(const mfem::Vector& r, mfem::Vector& c) const
   {
     CALI_CXX_MARK_FUNCTION;
     prec->Mult(r, c);  // c = [DF(x_i)]^{-1} [F(x_i)-b]
@@ -107,7 +111,8 @@ public:
       real_t norm_nm1 = norm;
 
       assembleJacobian(x);
-      applyPreconditioner(r, c);
+      setPreconditioner();
+      solveLinearSystem(r, c);
 
       // there must be a better way to do this?
       x0.SetSize(x.Size());

--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -76,8 +76,6 @@ public:
   /// @overload
   void Mult(const mfem::Vector&, mfem::Vector& x) const
   {
-    serac::profiling::initialize();
-
     MFEM_ASSERT(oper != NULL, "the Operator is not set (use SetOperator).");
     MFEM_ASSERT(prec != NULL, "the Solver is not set (use SetSolver).");
 
@@ -190,7 +188,6 @@ public:
     if (!converged && (print_options.summary || print_options.warnings)) {
       mfem::out << "Newton: No convergence!\n";
     }
-    serac::profiling::finalize();
   }
 };
 
@@ -458,8 +455,6 @@ public:
   /// @overload
   void Mult(const mfem::Vector&, mfem::Vector& X) const
   {
-    serac::profiling::initialize();
-
     MFEM_ASSERT(oper != NULL, "the Operator is not set (use SetOperator).");
     MFEM_ASSERT(prec != NULL, "the Solver is not set (use SetSolver).");
 
@@ -638,7 +633,6 @@ public:
     if (!converged && (print_options.summary || print_options.warnings)) {
       mfem::out << "Newton: No convergence!\n";
     }
-    serac::profiling::finalize();
   }
 };
 

--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -425,25 +425,31 @@ public:
     }
   }
 
-    /// assemble the jacobian
+  /// assemble the jacobian
   void assemble_jacobian(const mfem::Vector& x) const
   {
     CALI_CXX_MARK_FUNCTION;
     grad = &oper->GetGradient(x);
   }
 
-  mfem::real_t computeResidual(const mfem::Vector& x_, mfem::Vector& r_) const {
+  /// evaluate the nonlinear residual
+  mfem::real_t computeResidual(const mfem::Vector& x_, mfem::Vector& r_) const
+  {
     CALI_CXX_MARK_FUNCTION;
     oper->Mult(x_, r_);
     return Norm(r_);
   }
 
-  void hess_vec(const mfem::Vector& x_, mfem::Vector& v_) const {
+  /// apply the action of the assembled Jacobian matrix to a vector
+  void hess_vec(const mfem::Vector& x_, mfem::Vector& v_) const
+  {
     CALI_CXX_MARK_FUNCTION;
     grad->Mult(x_, v_);
   }
 
-  void precond(const mfem::Vector& x_, mfem::Vector& v_) const {
+  /// apply trust region specific preconditioner
+  void precond(const mfem::Vector& x_, mfem::Vector& v_) const
+  {
     CALI_CXX_MARK_FUNCTION;
     trPrecond.Mult(x_, v_);
   };
@@ -500,9 +506,9 @@ public:
         converged = false;
         break;
       }
-      
+
       assemble_jacobian(X);
-  
+
       if (it == 0 || (trResults.cgIterationsCount >= settings.maxCgIterations ||
                       cumulativeCgIters >= settings.maxCumulativeIteration)) {
         trPrecond.SetOperator(*grad);


### PR DESCRIPTION
Break out lambdas into functions so they can be caliper'd with CALI_CXX_MARK_FUNCTION;  profiling must be turned on in the configuration, and a call somewhere to profiling::initialize and profling::finalize must be added above in the call stack in order for the caliper data to be output.