### PR TITLE
Add homebrew-based build instructions for apple silicon

### DIFF
--- a/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
+++ b/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
@@ -1,0 +1,128 @@
+
+spack:
+  # add package specs to the `specs` list
+  view: true
+  concretizer:
+    unify: true
+  packages:
+    all:
+      compiler: [clang, gcc]
+      providers:
+        blas: [netlib-lapack]
+        lapack: [netlib-lapack]
+        mpi: [openmpi]
+    mpi:
+      buildable: false
+    openmpi:
+      buildable: false
+      externals:
+      - spec: openmpi@5.0.3_1
+        prefix: /opt/homebrew
+    netlib-lapack:
+      buildable: false
+      externals:
+      - spec: netlib-lapack@3.12.0
+        prefix: /opt/homebrew/opt/lapack
+    autoconf:
+      buildable: false
+      externals:
+      - spec: autoconf@2.72
+        prefix: /opt/homebrew
+    automake:
+      buildable: false
+      externals:
+      - spec: automake@1.16.5
+        prefix: /opt/homebrew
+    bzip2:
+      buildable: false
+      externals:
+      - spec: bzip2@1.0.8
+        prefix: /opt/homebrew/opt/bzip2
+    cmake:
+      version: [3.29.6]
+      buildable: false
+      externals:
+      - spec: cmake@3.29.5
+        prefix: /opt/homebrew
+    gettext:
+      buildable: false
+      externals:
+      - spec: gettext@0.22.5
+        prefix: /opt/homebrew
+    graphviz:
+      buildable: false
+      externals:
+      - spec: graphviz@11.0.0
+        prefix: /opt/homebrew
+    libtool:
+      buildable: false
+      externals:
+      - spec: libtool@2.4.7
+        prefix: /opt/homebrew
+    libx11:
+      buildable: false
+      externals:
+      - spec: libx11@1.8.9
+        prefix: /opt/homebrew
+    llvm:
+      version: [18.1.8]
+      buildable: false
+      externals:
+      - spec: llvm+clang@18.1.8
+        prefix: /opt/homebrew/opt/llvm
+    m4:
+      buildable: false
+      externals:
+      - spec: m4@1.4.19
+        prefix: /opt/homebrew/opt/m4
+    perl:
+      buildable: false
+      externals:
+      - spec: perl@5.34.1~cpanm+opcode+open+shared+threads
+        prefix: /usr
+    pkg-config:
+      buildable: false
+      externals:
+      - spec: pkg-config@0.29.2_3
+        prefix: /opt/homebrew
+    python:
+      buildable: false
+      externals:
+      - spec: python@3.12.4+bz2+crypt+ctypes+dbm+lzma+nis+pyexpat~pythoncmd+readline+sqlite3+ssl~tkinter+uuid+zlib
+        prefix: /opt/homebrew/opt/python
+    tar:
+      buildable: false
+      externals:
+      - spec: tar@3.5.3
+        prefix: /usr
+    readline:
+      buildable: false
+      externals:
+      - spec: readline@8.2.10
+        prefix: /opt/homebrew
+    unzip:
+      buildable: false
+      externals:
+      - spec: unzip@6.0
+        prefix: /usr
+    zlib:
+      buildable: false
+      externals:
+      - spec: zlib@1.3.1
+        prefix: /opt/homebrew
+
+  compilers:
+  - compiler:
+      spec: clang@=18.1.8
+      paths:
+        cc: /opt/homebrew/opt/llvm/bin/clang
+        cxx: /opt/homebrew/opt/llvm/bin/clang++
+        f77: /opt/homebrew/bin/gfortran-14
+        fc: /opt/homebrew/bin/gfortran-14
+      flags: {}
+      operating_system: sonoma
+      target: aarch64
+      modules: []
+      environment: {}
+      extra_rpaths:
+      - /opt/homebrew/lib/gcc/14

--- a/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
+++ b/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
@@ -111,7 +111,8 @@ spack:
       - spec: zlib@1.3.1
         prefix: /opt/homebrew
 
-  compilers:
+ # The "::" removes all found/known compilers from Spack except for these.
+  compilers::
   - compiler:
       spec: clang@=18.1.8
       paths:

--- a/src/docs/sphinx/quickstart.rst
+++ b/src/docs/sphinx/quickstart.rst
@@ -278,11 +278,15 @@ Installing base dependencies using Homebrew
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Install the following packages using Homebrew.
+
 .. code-block:: bash
+
    $ brew install autoconf automake bzip2 clingo cmake gcc gettext gnu-sed graphviz hwloc lapack libx11 llvm m4 make ninja open-mpi openblas pkg-config python readline spack zlib
 
 If you plan to install the developer tools, you should also run
+
 .. code-block:: bash
+
    $ brew install cppcheck doxygen llvm@14
    $ ln -s /opt/homebrew/opt/llvm@14/bin/clang-format /opt/homebrew/bin/clang-format
 
@@ -293,7 +297,9 @@ Homebrew will warn about such packages after installing them.
 
 In order for the correct compilers to be used for the installation, you should also add the bin directory for LLVM clang to your path in your ``.bash_profile``, ``.bashrc``, or ``.zshrc``, etc.
 This is also useful for a few additional packages:
+
 .. code-block:: bash
+
    $ export PATH="/opt/homebrew/opt/llvm/bin:/opt/homebrew/opt/m4/bin:/opt/homebrew/opt/gnu-sed/libexec/gnubin:$PATH"
 
 Configuring Spack
@@ -301,23 +307,27 @@ Configuring Spack
 In order to build Serac, we must define a ``spack.yaml`` file which tells Spack what packages we have installed.
 You will likely need to update the versions of packages in the provided example script ``scripts/spack/configs/macos_sonoma_aarch64/spack.yaml`` to match the versions installed by Homebrew.
 The versions for all installed packages can be listed via:
+
 .. code-block:: bash
+
    $ brew list --versions
+
 Note that the version format output by the above command is not the same as that expected by Spack, so be sure to add an ``@`` symbol between the package name and version string.
 
 If you are not using an M2 or M3 Mac, you will need to change the ``target`` for the compiler to ``x86_64`` or ``m1`` for Intel and M1-based Macs, respectively.
 Similarly, you need to set the ``operating_system`` to the proper value if you are not using ``sonoma`` (MacOS 14.X).
 
 If you want to install the devtools, you should also add the following under ``packages`` in the ``spack.yaml`` files.
+
 .. code-block:: yaml
+
   # optional, for dev tools
   cppcheck:
     version: [2.14.2]
     buildable: false
     externals:
-    - spec: cppcheck@2.14.1
+    - spec: cppcheck@2.14.2
       prefix: /opt/homebrew
-  # optional, for dev tools
   doxygen:
     version: [1.11.0]
     buildable: false
@@ -331,9 +341,11 @@ Building dependencies
 The invocation of ``uberenv.py`` is slightly modified from the standard instructions above in order to force the use of the Homebrew-installed MPI and compilers:
 
 .. code-block:: bash
+
    $ ./scripts/uberenv/uberenv.py --spack-env-file=scripts/spack/configs/macos_sonoma_aarch64/spack.yaml --prefix=../path/to/install --spec="%clang@18.1.8 ^openmpi@5.0.3_1"
 
 Note: If you want to build with PETSc, you should instead use the command
 
 .. code-block:: bash
+
    $ ./scripts/uberenv/uberenv.py --spack-env-file=scripts/spack/configs/macos_sonoma_aarch64/spack.yaml --prefix=../path/to/install --spec="++petsc %clang@18.1.8 ^openmpi@5.0.3_1 ^petsc+tetgen+scalapack+strumpack"

--- a/src/docs/sphinx/quickstart.rst
+++ b/src/docs/sphinx/quickstart.rst
@@ -348,4 +348,4 @@ Note: If you want to build with PETSc, you should instead use the command
 
 .. code-block:: bash
 
-   $ ./scripts/uberenv/uberenv.py --spack-env-file=scripts/spack/configs/macos_sonoma_aarch64/spack.yaml --prefix=../path/to/install --spec="++petsc %clang@18.1.8 ^openmpi@5.0.3_1 ^petsc+tetgen+scalapack+strumpack"
+   $ ./scripts/uberenv/uberenv.py --spack-env-file=scripts/spack/configs/macos_sonoma_aarch64/spack.yaml --prefix=../path/to/install --spec="+petsc %clang@18.1.8 ^openmpi@5.0.3_1 ^petsc+tetgen+scalapack+strumpack"


### PR DESCRIPTION
Updates the build documentation to work for M2 macbooks. This will likely need to be revised to support x86_64 and other apple silicon.