### PR TITLE
create github actions that triggers based on comment '/style' in a PR

### DIFF
--- a/.github/actions/apply-style/Dockerfile
+++ b/.github/actions/apply-style/Dockerfile
@@ -2,4 +2,6 @@ FROM ghcr.io/llnl/radiuss:clang-14-ubuntu-22.04
 
 COPY entrypoint.sh /entrypoint.sh
 
+USER root
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/apply-style/Dockerfile
+++ b/.github/actions/apply-style/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/llnl/radiuss:clang-14-ubuntu-22.04
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/apply-style/entrypoint.sh
+++ b/.github/actions/apply-style/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+CMAKE_ARGS=-DCMAKE_CXX_COMPILER=clang++
+CMAKE_ARGS=$CMAKE_ARGS -DENABLE_CLANGFORMAT=ON
+CMAKE_ARGS=$CMAKE_ARGS -DCLANGFORMAT_EXECUTABLE=/usr/bin/clang-format
+
+git submodule update --init --recursive
+
+mkdir build && cd build 
+cmake $CMAKE_ARGS ..
+make style

--- a/.github/actions/apply-style/entrypoint.sh
+++ b/.github/actions/apply-style/entrypoint.sh
@@ -1,11 +1,69 @@
 #!/bin/bash
 
+# This is a bare minimum of options needed to create the `style` build target
+# This does not create a working build.
 CMAKE_ARGS=-DCMAKE_CXX_COMPILER=clang++
-CMAKE_ARGS=$CMAKE_ARGS -DENABLE_CLANGFORMAT=ON
-CMAKE_ARGS=$CMAKE_ARGS -DCLANGFORMAT_EXECUTABLE=/usr/bin/clang-format
+CMAKE_ARGS="$CMAKE_ARGS -DENABLE_CLANGFORMAT=ON"
+CMAKE_ARGS="$CMAKE_ARGS -DCLANGFORMAT_EXECUTABLE=/usr/bin/clang-format"
+CMAKE_ARGS="$CMAKE_ARGS -DSERAC_STYLE_ONLY=ON"
+
+# Avoid error "fatal: detected dubious ownership in repository at '/github/workspace'"
+REPO_PATH=/github/workspace
+git config --global --add safe.directory "$REPO_PATH"
+find "$REPO_PATH" -type d | while read -r dir; do
+  git config --global --add safe.directory "$dir"
+done
+
+git fetch
+
+###
+# Attempt to find the branch of the PR from the detached head state
+##
+
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+echo "Attempting to find branch that matches commit..."
+
+# Get the current commit SHA
+current_commit_sha=$(git rev-parse HEAD)
+# List all branches containing the current commit SHA
+branches=$(git branch -r --contains $current_commit_sha)
+
+# Loop over the string split by whitespace
+branch=""
+num_branches_found=0
+for _possible_branch in $branches; do
+  # Skip items that start with "refs/"
+  if [[ $_possible_branch == refs/* ]]; then
+    continue
+  fi
+  if [[ $_possible_branch == origin/* ]]; then
+    _possible_branch=$(echo "$_possible_branch" | sed 's/origin\///')
+  fi
+  echo "Possible Branch: $_possible_branch"
+  branch=$_possible_branch
+  num_branches_found=$((num_branches_found+1))
+done
+
+if [ "$num_branches_found" -ne 1 ]; then
+  echo "Error: Unable to find a single branch that matched git sha $current_commit_sha"
+  exit 1
+fi
+
+echo "Found branch: $branch"
+echo "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+
+git checkout $branch
 
 git submodule update --init --recursive
 
 mkdir build && cd build 
 cmake $CMAKE_ARGS ..
 make style
+cd ..
+
+git config user.name "Agent Style"
+git config user.email "no-reply@llnl.gov"
+if [ -n "$(git status --porcelain)" ]; then
+  git commit -am 'Apply style updates'
+  git push
+fi

--- a/.github/actions/apply-style/entrypoint.sh
+++ b/.github/actions/apply-style/entrypoint.sh
@@ -5,7 +5,7 @@
 CMAKE_ARGS=-DCMAKE_CXX_COMPILER=clang++
 CMAKE_ARGS="$CMAKE_ARGS -DENABLE_CLANGFORMAT=ON"
 CMAKE_ARGS="$CMAKE_ARGS -DCLANGFORMAT_EXECUTABLE=/usr/bin/clang-format"
-CMAKE_ARGS="$CMAKE_ARGS -DSERAC_STYLE_ONLY=ON"
+CMAKE_ARGS="$CMAKE_ARGS -DSERAC_STYLE_CI_ONLY=ON"
 
 # Avoid error "fatal: detected dubious ownership in repository at '/github/workspace'"
 REPO_PATH=/github/workspace

--- a/.github/workflows/apply-style.yml
+++ b/.github/workflows/apply-style.yml
@@ -11,26 +11,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      # Checkout the GitHub created reference for the PR.
+      # The only way to do this is by using the "issue" number
+      # but that is really the PR number in this context.
+      # This is due to using an `issue_comment` event which
+      # is due to the GitHub Actions API that does not have
+      # a `pull_request_comment` event or something similar.
+      # This leaves us in a detached head state which is corrected
+      # in `apply-style/entrypoint.sh`
+      - name: Checkout pull request
+        uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
-          fetch-depth: 0
+          ref: refs/pull/${{ github.event.issue.number }}/head
 
       - name: Apply style updates
         uses: ./.github/actions/apply-style
-
-      - name: Push changed files
-        run: |
-          printf "GitHub Actor: ${GITHUB_ACTOR}\n"
-          git config user.name "Agent Style"
-          git config user.email "no-reply@llnl.gov"
-          if [ -n "$(git status --porcelain)" ]; then
-            git commit -am 'Apply style updates'
-            git push
-          fi
-
-      - name: Comment on PR
-        run: |
-          COMMENT_URL=$(jq -r .issue.pull_request.url < $GITHUB_EVENT_PATH || jq -r .issue.url < $GITHUB_EVENT_PATH)
-          COMMENT_BODY="Style check completed successfully!"
-          curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"body\":\"$COMMENT_BODY\"}" $COMMENT_URL/comments

--- a/.github/workflows/apply-style.yml
+++ b/.github/workflows/apply-style.yml
@@ -1,8 +1,9 @@
+name: Apply Style
+
 on:
   issue_comment:
     types: [created]
 
-name: Apply Style
 jobs:
   apply-style:
     if: startsWith(github.event.comment.body, '/style')

--- a/.github/workflows/apply-style.yml
+++ b/.github/workflows/apply-style.yml
@@ -1,0 +1,35 @@
+on:
+  issue_comment:
+    types: [created]
+
+name: Apply Style
+jobs:
+  apply-style:
+    if: startsWith(github.event.comment.body, '/style')
+    name: Apply Style to Source
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+
+      - name: Apply style updates
+        uses: ./.github/actions/apply-style
+
+      - name: Push changed files
+        run: |
+          printf "GitHub Actor: ${GITHUB_ACTOR}\n"
+          git config user.name "Agent Style"
+          git config user.email "no-reply@llnl.gov"
+          if [ -n "$(git status --porcelain)" ]; then
+            git commit -am 'Apply style updates'
+            git push
+          fi
+
+      - name: Comment on PR
+          run: |
+            COMMENT_URL=$(jq -r .issue.pull_request.url < $GITHUB_EVENT_PATH || jq -r .issue.url < $GITHUB_EVENT_PATH)
+            COMMENT_BODY="Style check completed successfully!"
+            curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"body\":\"$COMMENT_BODY\"}" $COMMENT_URL/comments

--- a/.github/workflows/apply-style.yml
+++ b/.github/workflows/apply-style.yml
@@ -29,7 +29,7 @@ jobs:
           fi
 
       - name: Comment on PR
-          run: |
-            COMMENT_URL=$(jq -r .issue.pull_request.url < $GITHUB_EVENT_PATH || jq -r .issue.url < $GITHUB_EVENT_PATH)
-            COMMENT_BODY="Style check completed successfully!"
-            curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"body\":\"$COMMENT_BODY\"}" $COMMENT_URL/comments
+        run: |
+          COMMENT_URL=$(jq -r .issue.pull_request.url < $GITHUB_EVENT_PATH || jq -r .issue.url < $GITHUB_EVENT_PATH)
+          COMMENT_BODY="Style check completed successfully!"
+          curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" -H "Content-Type: application/json" -d "{\"body\":\"$COMMENT_BODY\"}" $COMMENT_URL/comments

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,14 +20,18 @@ endif()
 project(serac LANGUAGES CXX C)
 
 # MPI is required in Serac.
-set(ENABLE_MPI ON CACHE BOOL "")
+# Note: for the style only mode, which doesn't need to actually build, we need to ignore this
+if (NOT SERAC_STYLE_ONLY)
+    set(ENABLE_MPI ON CACHE BOOL "")
 
-if (NOT MPI_C_COMPILER OR NOT MPI_CXX_COMPILER)
-    message(FATAL_ERROR 
-            "Serac requires MPI.  It is required to provide the MPI C/C++ "
-            "compiler wrappers via the CMake variables, "
-            "MPI_C_COMPILER and MPI_CXX_COMPILER.")
-endif()
+    if (NOT MPI_C_COMPILER OR NOT MPI_CXX_COMPILER)
+        message(FATAL_ERROR 
+                "Serac requires MPI.  It is required to provide the MPI C/C++ "
+                "compiler wrappers via the CMake variables, "
+                "MPI_C_COMPILER and MPI_CXX_COMPILER.")
+    endif()
+endif
+
 
 # Save off "raw" flags before they are modified by serac/BLT
 set(RAW_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS}   CACHE STRING "")
@@ -114,12 +118,38 @@ endif()
 include(${BLT_SOURCE_DIR}/SetupBLT.cmake)
 
 #------------------------------------------------------------------------------
-# Setup Macros and dependencies
+# Setup Macros/Basics
 #------------------------------------------------------------------------------
 
 include(${PROJECT_SOURCE_DIR}/cmake/SeracMacros.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/SeracBasics.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/SeracCompilerFlags.cmake)
+
+#------------------------------------------------------------------------------
+# Add Code Checks
+#------------------------------------------------------------------------------
+
+message(STATUS "Serac Code Checks: ${SERAC_ENABLE_CODE_CHECKS}")
+
+# Add extra file extensions for code styling
+# Note: Add them also to serac_add_code_checks in cmake/SeracMacros.cmake
+
+# CUDA
+list(APPEND BLT_C_FILE_EXTS ".cuh")
+# Configured C++ files
+list(APPEND BLT_C_FILE_EXTS ".cpp.in" ".hpp.in")
+
+if (SERAC_STYLE_ONLY OR SERAC_ENABLE_CODE_CHECKS)
+    serac_add_code_checks(PREFIX serac)
+endif()
+
+if (SERAC_STYLE_ONLY)
+    return()
+endif()
+
+#------------------------------------------------------------------------------
+# Setup Dependencies
+#------------------------------------------------------------------------------
 
 # Restore raw compiler flags so subprojects don't end up using Serac's flags
 set(SERAC_CMAKE_C_FLAGS   ${CMAKE_C_FLAGS})
@@ -148,24 +178,6 @@ add_subdirectory(examples)
 configure_file(
     ${PROJECT_SOURCE_DIR}/scripts/testing/ats.sh.in
     ${CMAKE_BINARY_DIR}/ats.sh)
-
-#------------------------------------------------------------------------------
-# Add Code Checks
-#------------------------------------------------------------------------------
-
-message(STATUS "Serac Code Checks: ${SERAC_ENABLE_CODE_CHECKS}")
-
-# Add extra file extensions for code styling
-# Note: Add them also to serac_add_code_checks in cmake/SeracMacros.cmake
-
-# CUDA
-list(APPEND BLT_C_FILE_EXTS ".cuh")
-# Configured C++ files
-list(APPEND BLT_C_FILE_EXTS ".cpp.in" ".hpp.in")
-
-if (SERAC_ENABLE_CODE_CHECKS)
-    serac_add_code_checks(PREFIX serac)
-endif()
 
 #------------------------------------------------------------------------------
 # Export Targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,10 @@ if (SERAC_STYLE_ONLY OR SERAC_ENABLE_CODE_CHECKS)
 endif()
 
 if (SERAC_STYLE_ONLY)
+    # Exit processing the rest of the build in style only build to avoid any possible
+    # CMake configuration issues outside of just enabling `make style`. This build,
+    # is not capable of building Serac and should not be advertised. It is for CI 
+    # purposes only.
     return()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ project(serac LANGUAGES CXX C)
 
 # MPI is required in Serac.
 # Note: for the style only mode, which doesn't need to actually build, we need to ignore this
-if (NOT SERAC_STYLE_ONLY)
+if (NOT SERAC_STYLE_CI_ONLY)
     set(ENABLE_MPI ON CACHE BOOL "")
 
     if (NOT MPI_C_COMPILER OR NOT MPI_CXX_COMPILER)
@@ -139,11 +139,11 @@ list(APPEND BLT_C_FILE_EXTS ".cuh")
 # Configured C++ files
 list(APPEND BLT_C_FILE_EXTS ".cpp.in" ".hpp.in")
 
-if (SERAC_STYLE_ONLY OR SERAC_ENABLE_CODE_CHECKS)
+if (SERAC_STYLE_CI_ONLY OR SERAC_ENABLE_CODE_CHECKS)
     serac_add_code_checks(PREFIX serac)
 endif()
 
-if (SERAC_STYLE_ONLY)
+if (SERAC_STYLE_CI_ONLY)
     # Exit processing the rest of the build in style only build to avoid any possible
     # CMake configuration issues outside of just enabling `make style`. This build,
     # is not capable of building Serac and should not be advertised. It is for CI 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if (NOT SERAC_STYLE_ONLY)
                 "compiler wrappers via the CMake variables, "
                 "MPI_C_COMPILER and MPI_CXX_COMPILER.")
     endif()
-endif
+endif()
 
 
 # Save off "raw" flags before they are modified by serac/BLT


### PR DESCRIPTION
Thanks to the Umpire team for the basic structure of this. I tweaked it in the following ways:

* Uses the clang-14 ubuntu 22 RADIUSS container
* Triggers on PR comment `/style`
* Style's the code and commits it to your branch

Unfortunately this needs to be in the default branch, `develop` in our case, to enable. I tested this in a fork and should be working at this case.

Gotcha: This grabs the head commit of the PR then searches for the branch that contains that commit. If more than one branch has that commit, the GitHub Action will error with a helpful message.