### PR TITLE
Re-add petsc/ slepc vars to Serac config

### DIFF
--- a/cmake/SeracConfigHeader.cmake
+++ b/cmake/SeracConfigHeader.cmake
@@ -36,7 +36,7 @@ message(STATUS "Configuring Serac version ${SERAC_VERSION_FULL}")
 #------------------------------------------------------------------------------
 # Create variable for every TPL
 #------------------------------------------------------------------------------
-set(TPL_DEPS ADIAK AXOM CAMP CONDUIT CUDA FMT HDF5 LUA MFEM MPI TRIBOL CALIPER RAJA STRUMPACK SUNDIALS UMPIRE)
+set(TPL_DEPS ADIAK AXOM CALIPER CAMP CONDUIT CUDA FMT HDF5 LUA MFEM MPI PETSC RAJA SLEPC STRUMPACK SUNDIALS TRIBOL UMPIRE)
 foreach(dep ${TPL_DEPS})
     if( ${dep}_FOUND OR ENABLE_${dep} )
         set(SERAC_USE_${dep} TRUE)

--- a/cmake/serac-config.cmake.in
+++ b/cmake/serac-config.cmake.in
@@ -13,7 +13,7 @@ if(NOT SERAC_FOUND)
   #----------------------------------------------------------------------------
   # Set version and paths
   #----------------------------------------------------------------------------
-  
+
   set(SERAC_VERSION       "@SERAC_VERSION_FULL@")
   set(SERAC_VERSION_MAJOR "@SERAC_VERSION_MAJOR@")
   set(SERAC_VERSION_MINOR "@SERAC_VERSION_MINOR@")
@@ -37,7 +37,9 @@ if(NOT SERAC_FOUND)
   set(SERAC_USE_HDF5           @SERAC_USE_HDF5@)
   set(SERAC_USE_MFEM           @SERAC_USE_MFEM@)
   set(SERAC_USE_MPI            @SERAC_USE_MPI@)
+  set(SERAC_USE_PETSC          @SERAC_USE_PETSC@)
   set(SERAC_USE_RAJA           @SERAC_USE_RAJA@)
+  set(SERAC_USE_SLEPC          @SERAC_USE_SLEPC@)
   set(SERAC_USE_STRUMPACK      @SERAC_USE_STRUMPACK@)
   set(SERAC_USE_SUNDIALS       @SERAC_USE_SUNDIALS@)
   set(SERAC_USE_TRIBOL         @SERAC_USE_TRIBOL@)
@@ -50,7 +52,9 @@ if(NOT SERAC_FOUND)
   set(SERAC_CONDUIT_DIR        "@CONDUIT_DIR@")
   set(SERAC_HDF5_DIR           "@HDF5_DIR@")
   set(SERAC_MFEM_DIR           "@MFEM_DIR@")
+  set(SERAC_PETSC_DIR          "@PETSC_DIR@")
   set(SERAC_RAJA_DIR           "@RAJA_DIR@")
+  set(SERAC_SLEPC_DIR          "@SLEPC_DIR@")
   set(SERAC_STRUMPACK_DIR      "@STRUMPACK_DIR@")
   set(SERAC_SUNDIALS_DIR       "@SUNDIALS_DIR@")
   set(SERAC_TRIBOL_DIR         "@TRIBOL_DIR@")
@@ -63,7 +67,7 @@ if(NOT SERAC_FOUND)
   endif()
 
   # Set to real variable unless user overrode it
-  foreach(dep ADIAK AXOM CAMP CALIPER CONDUIT HDF5 MFEM RAJA STRUMPACK SUNDIALS TRIBOL UMPIRE)
+  foreach(dep ADIAK AXOM CAMP CALIPER CONDUIT HDF5 MFEM PETSC RAJA SLEPC STRUMPACK SUNDIALS TRIBOL UMPIRE)
     if (NOT ${dep}_DIR)
       set(${dep}_DIR "${SERAC_${dep}_DIR}")
     endif()
@@ -149,11 +153,6 @@ if(NOT SERAC_FOUND)
   # Tribol
   if(SERAC_USE_TRIBOL)
     find_dependency(tribol REQUIRED PATHS "${TRIBOL_DIR}/lib/cmake")
-  endif()
-
-  # SUNDIALS
-  if(SERAC_USE_SUNDIALS)
-    find_dependency(SUNDIALS REQUIRED NO_DEFAULT_PATH PATHS "${SUNDIALS_DIR}")
   endif()
 
   #----------------------------------------------------------------------------


### PR DESCRIPTION
In my previous [mfem petsc wrapper PR](https://github.com/LLNL/serac/pull/1138), I removed the petsc/ slepc cmake variables (e.g. `SERAC_USE_PETSC`) from `serac-config.cmake.in`, which might prevent downstream users of Serac from being able to check whether Serac has been configured with petsc/ slepc support (since mfem installed without petsc/ slepc is still allowed).

This is just a small PR that re-adds those cmake variables. I also removed the sundials `find_dependency` section, since sundials is built through MFEM (just like petsc/ slepc), and is therefore not required.