### PR TITLE
Fix error in conversion of Mandel stress to Cauchy stress

### DIFF
--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -378,7 +378,8 @@ struct J2FiniteDeformationNonlinear {
     // Mandel stress
     auto M = s + p * I;
     // convert to Cauchy
-    return dot(dot(Fe, M), inv(Fe)) / det(F);
+    auto FeT = transpose(Fe);
+    return dot(dot(inv(FeT), M), FeT) / det(F);
   }
 };
 


### PR DESCRIPTION
One-line fix. Actually, "fix" is not quite the right word, since the results obtained before were numerically correct by a coincidence. The conversion from the Mandel stress (conjugate to the elastic log strain) to the Cauchy stress was incorrect for the general case. However, for the special case of isotropic behavior (as in the implemented model), the expression in the code would work because of some matrix commuting and cancellation. Sorry, I should have checked this more closely when I implemented the model.