### PR TITLE
Re-add Serac Cali macros

### DIFF
--- a/src/docs/sphinx/dev_guide/profiling.rst
+++ b/src/docs/sphinx/dev_guide/profiling.rst
@@ -87,8 +87,8 @@ of the  ``i`` th iteration of a loop, and ``SERAC_MARK_LOOP_END(id)`` immediatel
   SERAC_MARK_END("region_name");
 
 
-Note that the ``id`` argument to the ``CALI_CXX_MARK_LOOP_*`` macros can be any identifier as long as it is consistent
-between all uses of ``CALI_CXX_MARK_LOOP_*`` for a given loop.  
+Note that the ``id`` argument to the ``SERAC_MARK_LOOP_*`` macros can be any identifier as long as it is consistent
+between all uses of ``SERAC_MARK_LOOP_*`` for a given loop.  
 
 To reduce the amount of annotation for regions bounded by a particular scope, use ``SERAC_MARK_SCOPE(name)``. This will follow RAII and works with graceful exception handling. When ``SERAC_MARK_SCOPE`` is instantiated, profiling of this region starts, and when the scope exits, profiling of this region will end.
 

--- a/src/docs/sphinx/dev_guide/profiling.rst
+++ b/src/docs/sphinx/dev_guide/profiling.rst
@@ -65,38 +65,38 @@ integrals, floating points, and strings. Note that this macro is a no-op if the
 To add profile regions and ensure that Caliper is only used when it has been enabled
 through Spack, only use the macros described below to instrument your code:
 
-Use ``CALI_CXX_MARK_FUNCTION`` at the very top of a function to mark it for profiling.
+Use ``SERAC_MARK_FUNCTION`` at the very top of a function to mark it for profiling.
 
-Use ``CALI_MARK_BEGIN(name)`` at the beginning of a region and ``CALI_MARK_END(name)`` at the end of the region.
+Use ``SERAC_MARK_BEGIN(name)`` at the beginning of a region and ``SERAC_MARK_END(name)`` at the end of the region.
 
-Use ``CALI_CXX_MARK_LOOP_BEGIN(id, name)`` before a loop to mark it for profiling, ``CALI_CXX_MARK_LOOP_ITERATION(id, i)`` at the beginning
-of the  ``i`` th iteration of a loop, and ``CALI_CXX_MARK_LOOP_END(id)`` immediately after the loop ends:
+Use ``SERAC_MARK_LOOP_BEGIN(id, name)`` before a loop to mark it for profiling, ``SERAC_MARK_LOOP_ITERATION(id, i)`` at the beginning
+of the  ``i`` th iteration of a loop, and ``SERAC_MARK_LOOP_END(id)`` immediately after the loop ends:
 
 .. code-block:: c++
 
-  CALI_MARK_BEGIN("region_name");
+  SERAC_MARK_BEGIN("region_name");
    
-  CALI_CXX_MARK_LOOP_BEGIN(doubling_loop, "doubling_loop");
+  SERAC_MARK_LOOP_BEGIN(doubling_loop, "doubling_loop");
   for (int i = 0; i < input.size(); i++)
   {
-    CALI_CXX_MARK_LOOP_ITERATION(doubling_loop, i);
+    SERAC_MARK_LOOP_ITERATION(doubling_loop, i);
     output[i] = input[i] * 2;
   }
-  CALI_CXX_MARK_LOOP_END(doubling_loop);
+  SERAC_MARK_LOOP_END(doubling_loop);
 
-  CALI_MARK_END("region_name");
+  SERAC_MARK_END("region_name");
 
 
 Note that the ``id`` argument to the ``CALI_CXX_MARK_LOOP_*`` macros can be any identifier as long as it is consistent
 between all uses of ``CALI_CXX_MARK_LOOP_*`` for a given loop.  
 
-To reduce the amount of annotation for regions bounded by a particular scope, use ``CALI_CXX_MARK_SCOPE(name)``. This will follow RAII and works with graceful exception handling. When ``CALI_CXX_MARK_SCOPE`` is instantiated, profiling of this region starts, and when the scope exits, profiling of this region will end.
+To reduce the amount of annotation for regions bounded by a particular scope, use ``SERAC_MARK_SCOPE(name)``. This will follow RAII and works with graceful exception handling. When ``SERAC_MARK_SCOPE`` is instantiated, profiling of this region starts, and when the scope exits, profiling of this region will end.
 
 .. code-block:: c++
 
-   // Refine once more and utilize CALI_CXX_MARK_SCOPE
+   // Refine once more and utilize SERAC_MARK_SCOPE
   {
-    CALI_CXX_MARK_SCOPE("RefineOnceMore");
+    SERAC_MARK_SCOPE("RefineOnceMore");
     pmesh->UniformRefinement();
   }
 

--- a/src/serac/infrastructure/profiling.hpp
+++ b/src/serac/infrastructure/profiling.hpp
@@ -74,6 +74,9 @@
  * Marks a particular scope for Caliper profiling
  */
 
+// NOTE: The motivation behind wrapping Caliper macros to avoid conflicting macro definitions in the no-op case, and
+// give downstream users the option to disable profiling Serac if it pollutes their timings.
+
 #ifdef SERAC_USE_CALIPER
 #define SERAC_MARK_FUNCTION CALI_CXX_MARK_FUNCTION
 #define SERAC_MARK_LOOP_BEGIN(id, name) CALI_CXX_MARK_LOOP_BEGIN(id, name)
@@ -90,7 +93,7 @@
 #define SERAC_MARK_LOOP_END(id)
 #define SERAC_MARK_BEGIN(name)
 #define SERAC_MARK_END(name)
-#define SERAC_CXX_MARK_SCOPE(name)
+#define SERAC_MARK_SCOPE(name)
 #endif
 
 /// profiling namespace

--- a/src/serac/infrastructure/profiling.hpp
+++ b/src/serac/infrastructure/profiling.hpp
@@ -50,7 +50,7 @@
  */
 
 /**
- * @def SERAC_MARK_LOOP_ITER(id, i)
+ * @def SERAC_MARK_LOOP_ITERATION(id, i)
  * Marks the beginning of a loop iteration for Caliper profiling
  */
 
@@ -70,7 +70,7 @@
  */
 
 /**
- * @def SERAC_PROFILE_SCOPE(name)
+ * @def SERAC_MARK_SCOPE(name)
  * Marks a particular scope for Caliper profiling
  */
 

--- a/src/serac/infrastructure/profiling.hpp
+++ b/src/serac/infrastructure/profiling.hpp
@@ -41,37 +41,37 @@
 
 /**
  * @def SERAC_MARK_FUNCTION
- * Marks a function for Caliper profiling
+ * Marks a function for Caliper profiling. No-op macro when ENABLE_PROFILING is off.
  */
 
 /**
  * @def SERAC_MARK_LOOP_BEGIN(id, name)
- * Marks the beginning of a loop block for Caliper profiling
+ * Marks the beginning of a loop block for Caliper profiling. No-op macro when ENABLE_PROFILING is off.
  */
 
 /**
  * @def SERAC_MARK_LOOP_ITERATION(id, i)
- * Marks the beginning of a loop iteration for Caliper profiling
+ * Marks the beginning of a loop iteration for Caliper profiling. No-op macro when ENABLE_PROFILING is off.
  */
 
 /**
  * @def SERAC_MARK_LOOP_END(id)
- * Marks the end of a loop block for Caliper profiling
+ * Marks the end of a loop block for Caliper profiling. No-op macro when ENABLE_PROFILING is off.
  */
 
 /**
  * @def SERAC_MARK_BEGIN(id)
- * Marks the start of a region Caliper profiling
+ * Marks the start of a region Caliper profiling. No-op macro when ENABLE_PROFILING is off.
  */
 
 /**
  * @def SERAC_MARK_END(id)
- * Marks the end of a region Caliper profiling
+ * Marks the end of a region Caliper profiling. No-op macro when ENABLE_PROFILING is off.
  */
 
 /**
  * @def SERAC_MARK_SCOPE(name)
- * Marks a particular scope for Caliper profiling
+ * Marks a particular scope for Caliper profiling. No-op macro when ENABLE_PROFILING is off.
  */
 
 // NOTE: The motivation behind wrapping Caliper macros to avoid conflicting macro definitions in the no-op case, and

--- a/src/serac/infrastructure/profiling.hpp
+++ b/src/serac/infrastructure/profiling.hpp
@@ -40,48 +40,57 @@
 #endif
 
 /**
- * @def CALI_CXX_MARK_FUNCTION
- * No-op macro in case Serac is not built with Caliper
+ * @def SERAC_MARK_FUNCTION
+ * Marks a function for Caliper profiling
  */
 
 /**
- * @def CALI_CXX_MARK_LOOP_BEGIN(id, name)
- * No-op macro in case Serac is not built with Caliper
+ * @def SERAC_MARK_LOOP_BEGIN(id, name)
+ * Marks the beginning of a loop block for Caliper profiling
  */
 
 /**
- * @def CALI_CXX_MARK_LOOP_ITERATION(id, i)
- * No-op macro in case Serac is not built with Caliper
+ * @def SERAC_MARK_LOOP_ITER(id, i)
+ * Marks the beginning of a loop iteration for Caliper profiling
  */
 
 /**
- * @def CALI_CXX_MARK_LOOP_END(id)
- * No-op macro in case Serac is not built with Caliper
+ * @def SERAC_MARK_LOOP_END(id)
+ * Marks the end of a loop block for Caliper profiling
  */
 
 /**
- * @def CALI_MARK_BEGIN(name)
- * No-op macro in case Serac is not built with Caliper
+ * @def SERAC_MARK_BEGIN(id)
+ * Marks the start of a region Caliper profiling
  */
 
 /**
- * @def CALI_MARK_END(name)
- * No-op macro in case Serac is not built with Caliper
+ * @def SERAC_MARK_END(id)
+ * Marks the end of a region Caliper profiling
  */
 
 /**
- * @def CALI_CXX_MARK_SCOPE(name)
- * No-op macro in case Serac is not built with Caliper
+ * @def SERAC_PROFILE_SCOPE(name)
+ * Marks a particular scope for Caliper profiling
  */
 
-#ifndef SERAC_USE_CALIPER
-#define CALI_CXX_MARK_FUNCTION
-#define CALI_CXX_MARK_LOOP_BEGIN(id, name)
-#define CALI_CXX_MARK_LOOP_ITERATION(id, i)
-#define CALI_CXX_MARK_LOOP_END(id)
-#define CALI_MARK_BEGIN(name)
-#define CALI_MARK_END(name)
-#define CALI_CXX_MARK_SCOPE(name)
+#ifdef SERAC_USE_CALIPER
+#define SERAC_MARK_FUNCTION CALI_CXX_MARK_FUNCTION
+#define SERAC_MARK_LOOP_BEGIN(id, name) CALI_CXX_MARK_LOOP_BEGIN(id, name)
+#define SERAC_MARK_LOOP_ITERATION(id, i) CALI_CXX_MARK_LOOP_ITERATION(id, i)
+#define SERAC_MARK_LOOP_END(id) CALI_CXX_MARK_LOOP_END(id)
+#define SERAC_MARK_BEGIN(name) CALI_MARK_BEGIN(name)
+#define SERAC_MARK_END(name) CALI_MARK_END(name)
+#define SERAC_MARK_SCOPE(name) CALI_CXX_MARK_SCOPE(name)
+#else
+// Define no-op macros in case Serac has not been configured with Caliper
+#define SERAC_MARK_FUNCTION
+#define SERAC_MARK_LOOP_BEGIN(id, name)
+#define SERAC_MARK_LOOP_ITERATION(id, i)
+#define SERAC_MARK_LOOP_END(id)
+#define SERAC_MARK_BEGIN(name)
+#define SERAC_MARK_END(name)
+#define SERAC_CXX_MARK_SCOPE(name)
 #endif
 
 /// profiling namespace

--- a/src/serac/infrastructure/tests/profiling.cpp
+++ b/src/serac/infrastructure/tests/profiling.cpp
@@ -21,7 +21,7 @@ namespace serac {
 TEST(Profiling, MeshRefinement)
 {
   // profile mesh refinement
-  CALI_CXX_MARK_FUNCTION;
+  SERAC_MARK_FUNCTION;
   MPI_Barrier(MPI_COMM_WORLD);
   serac::profiling::initialize();
 
@@ -30,20 +30,20 @@ TEST(Profiling, MeshRefinement)
   // the following string is a proxy for templated test names
   std::string test_name = "_profiling";
 
-  CALI_MARK_BEGIN(profiling::concat("RefineAndLoadMesh", test_name).c_str());
+  SERAC_MARK_BEGIN(profiling::concat("RefineAndLoadMesh", test_name).c_str());
   auto pmesh = mesh::refineAndDistribute(buildMeshFromFile(mesh_file));
-  CALI_MARK_END(profiling::concat("RefineAndLoadMesh", test_name).c_str());
+  SERAC_MARK_END(profiling::concat("RefineAndLoadMesh", test_name).c_str());
 
-  CALI_CXX_MARK_LOOP_BEGIN(refinement_loop, "refinement_loop");
+  SERAC_MARK_LOOP_BEGIN(refinement_loop, "refinement_loop");
   for (int i = 0; i < 2; i++) {
-    CALI_CXX_MARK_LOOP_ITERATION(refinement_loop, i);
+    SERAC_MARK_LOOP_ITERATION(refinement_loop, i);
     pmesh->UniformRefinement();
   }
-  CALI_CXX_MARK_LOOP_END(refinement_loop);
+  SERAC_MARK_LOOP_END(refinement_loop);
 
-  // Refine once more and utilize CALI_CXX_MARK_SCOPE
+  // Refine once more and utilize SERAC_MARK_SCOPE
   {
-    CALI_CXX_MARK_SCOPE("RefineOnceMore");
+    SERAC_MARK_SCOPE("RefineOnceMore");
     pmesh->UniformRefinement();
   }
 
@@ -83,9 +83,9 @@ TEST(Profiling, Exception)
   serac::profiling::initialize();
 
   {
-    CALI_CXX_MARK_SCOPE("Non-exceptionScope");
+    SERAC_MARK_SCOPE("Non-exceptionScope");
     try {
-      CALI_CXX_MARK_SCOPE("Exception scope");
+      SERAC_MARK_SCOPE("Exception scope");
       throw std::runtime_error("Caliper to verify RAII");
     } catch (std::exception& e) {
       std::cout << e.what() << "\n";

--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -41,7 +41,7 @@ public:
   /// Evaluate the residual, put in rOut and return its norm.
   double evaluateNorm(const mfem::Vector& x, mfem::Vector& rOut) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     double normEval = std::numeric_limits<double>::max();
     try {
       oper->Mult(x, rOut);
@@ -55,21 +55,21 @@ public:
   /// assemble the jacobian
   void assembleJacobian(const mfem::Vector& x) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     grad = &oper->GetGradient(x);
   }
 
   /// set the preconditioner for the linear solver
   void setPreconditioner() const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     prec->SetOperator(*grad);
   }
 
   /// solve the linear system
   void solveLinearSystem(const mfem::Vector& r_, mfem::Vector& c_) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     prec->Mult(r_, c_);  // c = [DF(x_i)]^{-1} [F(x_i)-b]
   }
 
@@ -323,7 +323,7 @@ public:
   /// take a dogleg step in direction s, solution norm must be within trSize
   void dogleg_step(const mfem::Vector& cp, const mfem::Vector& newtonP, double trSize, mfem::Vector& s) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     // MRT, could optimize some of these eventually, compute on the outside and save
     double cc = Dot(cp, cp);
     double nn = Dot(newtonP, newtonP);
@@ -352,7 +352,7 @@ public:
                                        PrecondFunc precond, const TrustRegionSettings& settings, double& trSize,
                                        TrustRegionResults& results) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     // minimize r@z + 0.5*z@J@z
     results.interiorStatus    = TrustRegionResults::Status::Interior;
     results.cgIterationsCount = 0;
@@ -426,14 +426,14 @@ public:
   /// assemble the jacobian
   void assemble_jacobian(const mfem::Vector& x) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     grad = &oper->GetGradient(x);
   }
 
   /// evaluate the nonlinear residual
   mfem::real_t computeResidual(const mfem::Vector& x_, mfem::Vector& r_) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     oper->Mult(x_, r_);
     return Norm(r_);
   }
@@ -441,14 +441,14 @@ public:
   /// apply the action of the assembled Jacobian matrix to a vector
   void hess_vec(const mfem::Vector& x_, mfem::Vector& v_) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     grad->Mult(x_, v_);
   }
 
   /// apply trust region specific preconditioner
   void precond(const mfem::Vector& x_, mfem::Vector& v_) const
   {
-    CALI_CXX_MARK_FUNCTION;
+    SERAC_MARK_FUNCTION;
     trPrecond.Mult(x_, v_);
   };
 

--- a/src/serac/numerics/functional/tests/functional_comparisons_cuda.cu
+++ b/src/serac/numerics/functional/tests/functional_comparisons_cuda.cu
@@ -113,7 +113,7 @@ void functional_test(H1<p> test, H1<p> trial, Dimension<dim>)
 
   // Assemble the bilinear form into a matrix
   {
-    CALI_CXX_MARK_SCOPE(concat("mfem_localAssemble", postfix));
+    SERAC_MARK_SCOPE(concat("mfem_localAssemble", postfix));
     A.Assemble(0);
   }
 
@@ -229,7 +229,7 @@ void functional_test(H1<p, dim> test, H1<p, dim> trial, Dimension<dim>)
   mfem::ConstantCoefficient mu_coef(b);
   A.AddDomainIntegrator(new mfem::ElasticityIntegrator(lambda_coef, mu_coef));
   {
-    CALI_CXX_MARK_SCOPE(concat("mfem_localAssemble", postfix));
+    SERAC_MARK_SCOPE(concat("mfem_localAssemble", postfix));
     A.Assemble(0);
   }
   A.Finalize();
@@ -245,7 +245,7 @@ void functional_test(H1<p, dim> test, H1<p, dim> trial, Dimension<dim>)
 
   f.AddDomainIntegrator(new mfem::VectorDomainLFIntegrator(load_func));
   {
-    CALI_CXX_MARK_SCOPE(concat("mfem_fAssemble", postfix));
+    SERAC_MARK_SCOPE(concat("mfem_fAssemble", postfix));
     f.Assemble();
   }
 
@@ -321,7 +321,7 @@ void functional_test(Hcurl<p> test, Hcurl<p> trial, Dimension<dim>)
   mfem::ConstantCoefficient b_coef(b);
   B.AddDomainIntegrator(new mfem::CurlCurlIntegrator(b_coef));
   {
-    CALI_CXX_MARK_SCOPE(concat("mfem_localAssemble", postfix));
+    SERAC_MARK_SCOPE(concat("mfem_localAssemble", postfix));
     B.Assemble(0);
   }
   B.Finalize();
@@ -339,7 +339,7 @@ void functional_test(Hcurl<p> test, Hcurl<p> trial, Dimension<dim>)
 
   f.AddDomainIntegrator(new mfem::VectorFEDomainLFIntegrator(load_func));
   {
-    CALI_CXX_MARK_SCOPE(concat("mfem_fAssemble", postfix));
+    SERAC_MARK_SCOPE(concat("mfem_fAssemble", postfix));
     f.Assemble();
   }
   std::unique_ptr<mfem::HypreParVector> F(
@@ -363,7 +363,7 @@ void functional_test(Hcurl<p> test, Hcurl<p> trial, Dimension<dim>)
   // Compute the residual using standard MFEM methods
   mfem::Vector r1(U.Size());
   {
-    CALI_CXX_MARK_SCOPE(concat("mfem_Apply", postfix));
+    SERAC_MARK_SCOPE(concat("mfem_Apply", postfix));
     J->Mult(U, r1);
     r1 -= *F;
   }

--- a/src/serac/physics/benchmarks/benchmark_functional.cpp
+++ b/src/serac/physics/benchmarks/benchmark_functional.cpp
@@ -60,21 +60,21 @@ void functional_test(int parallel_refinement)
   // Compute the residual using functional
   double t = 0.0;
 
-  CALI_MARK_BEGIN("residual evaluation");
+  SERAC_MARK_BEGIN("residual evaluation");
   mfem::Vector r1 = residual(t, U);
-  CALI_MARK_END("residual evaluation");
+  SERAC_MARK_END("residual evaluation");
 
-  CALI_MARK_BEGIN("compute gradient");
+  SERAC_MARK_BEGIN("compute gradient");
   auto [r2, drdU] = residual(t, serac::differentiate_wrt(U));
-  CALI_MARK_END("compute gradient");
+  SERAC_MARK_END("compute gradient");
 
-  CALI_MARK_BEGIN("apply gradient");
+  SERAC_MARK_BEGIN("apply gradient");
   mfem::Vector g = drdU(U);
-  CALI_MARK_END("apply gradient");
+  SERAC_MARK_END("apply gradient");
 
-  CALI_MARK_BEGIN("assemble gradient");
+  SERAC_MARK_BEGIN("assemble gradient");
   auto g_mat = assemble(drdU);
-  CALI_MARK_END("assemble gradient");
+  SERAC_MARK_END("assemble gradient");
 }
 
 int main(int argc, char* argv[])
@@ -88,45 +88,45 @@ int main(int argc, char* argv[])
   // Initialize profiling
   serac::profiling::initialize();
 
-  CALI_MARK_BEGIN("scalar H1");
+  SERAC_MARK_BEGIN("scalar H1");
 
-  CALI_MARK_BEGIN("dimension 2, order 1");
+  SERAC_MARK_BEGIN("dimension 2, order 1");
   functional_test<1, 2, 1>(parallel_refinement);
-  CALI_MARK_END("dimension 2, order 1");
+  SERAC_MARK_END("dimension 2, order 1");
 
-  CALI_MARK_BEGIN("dimension 2, order 2");
+  SERAC_MARK_BEGIN("dimension 2, order 2");
   functional_test<2, 2, 1>(parallel_refinement);
-  CALI_MARK_END("dimension 2, order 2");
+  SERAC_MARK_END("dimension 2, order 2");
 
-  CALI_MARK_BEGIN("dimension 3, order 1");
+  SERAC_MARK_BEGIN("dimension 3, order 1");
   functional_test<1, 3, 1>(parallel_refinement);
-  CALI_MARK_END("dimension 3, order 1");
+  SERAC_MARK_END("dimension 3, order 1");
 
-  CALI_MARK_BEGIN("dimension 3, order 2");
+  SERAC_MARK_BEGIN("dimension 3, order 2");
   functional_test<2, 3, 1>(parallel_refinement);
-  CALI_MARK_END("dimension 3, order 2");
+  SERAC_MARK_END("dimension 3, order 2");
 
-  CALI_MARK_END("scalar H1");
+  SERAC_MARK_END("scalar H1");
 
-  CALI_MARK_BEGIN("vector H1");
+  SERAC_MARK_BEGIN("vector H1");
 
-  CALI_MARK_BEGIN("dimension 2, order 1");
+  SERAC_MARK_BEGIN("dimension 2, order 1");
   functional_test<1, 2, 2>(parallel_refinement);
-  CALI_MARK_END("dimension 2, order 1");
+  SERAC_MARK_END("dimension 2, order 1");
 
-  CALI_MARK_BEGIN("dimension 2, order 2");
+  SERAC_MARK_BEGIN("dimension 2, order 2");
   functional_test<2, 2, 2>(parallel_refinement);
-  CALI_MARK_END("dimension 2, order 2");
+  SERAC_MARK_END("dimension 2, order 2");
 
-  CALI_MARK_BEGIN("dimension 3, order 1");
+  SERAC_MARK_BEGIN("dimension 3, order 1");
   functional_test<1, 3, 3>(parallel_refinement);
-  CALI_MARK_END("dimension 3, order 1");
+  SERAC_MARK_END("dimension 3, order 1");
 
-  CALI_MARK_BEGIN("dimension 3, order 2");
+  SERAC_MARK_BEGIN("dimension 3, order 2");
   functional_test<2, 3, 3>(parallel_refinement);
-  CALI_MARK_END("dimension 3, order 2");
+  SERAC_MARK_END("dimension 3, order 2");
 
-  CALI_MARK_END("vector H1");
+  SERAC_MARK_END("vector H1");
 
   // Finalize profiling
   serac::profiling::finalize();

--- a/src/serac/physics/benchmarks/benchmark_thermal.cpp
+++ b/src/serac/physics/benchmarks/benchmark_thermal.cpp
@@ -166,37 +166,37 @@ int main(int argc, char* argv[])
   // Add metadata
   SERAC_SET_METADATA("test", "thermal_functional");
 
-  CALI_MARK_BEGIN("2D Linear Static");
+  SERAC_MARK_BEGIN("2D Linear Static");
   functional_test_static<1, 2>();
-  CALI_MARK_END("2D Linear Static");
+  SERAC_MARK_END("2D Linear Static");
 
-  CALI_MARK_BEGIN("2D Quadratic Static");
+  SERAC_MARK_BEGIN("2D Quadratic Static");
   functional_test_static<2, 2>();
-  CALI_MARK_END("2D Quadratic Static");
+  SERAC_MARK_END("2D Quadratic Static");
 
-  CALI_MARK_BEGIN("3D Linear Static");
+  SERAC_MARK_BEGIN("3D Linear Static");
   functional_test_static<1, 3>();
-  CALI_MARK_END("3D Linear Static");
+  SERAC_MARK_END("3D Linear Static");
 
-  CALI_MARK_BEGIN("3D Quadratic Static");
+  SERAC_MARK_BEGIN("3D Quadratic Static");
   functional_test_static<2, 3>();
-  CALI_MARK_END("3D Quadratic Static");
+  SERAC_MARK_END("3D Quadratic Static");
 
-  CALI_MARK_BEGIN("2D Linear Dynamic");
+  SERAC_MARK_BEGIN("2D Linear Dynamic");
   functional_test_dynamic<1, 2>();
-  CALI_MARK_END("2D Linear Dynamic");
+  SERAC_MARK_END("2D Linear Dynamic");
 
-  CALI_MARK_BEGIN("2D Quadratic Dynamic");
+  SERAC_MARK_BEGIN("2D Quadratic Dynamic");
   functional_test_dynamic<2, 2>();
-  CALI_MARK_END("2D Quadratic Dynamic");
+  SERAC_MARK_END("2D Quadratic Dynamic");
 
-  CALI_MARK_BEGIN("3D Linear Dynamic");
+  SERAC_MARK_BEGIN("3D Linear Dynamic");
   functional_test_dynamic<1, 3>();
-  CALI_MARK_END("3D Linear Dynamic");
+  SERAC_MARK_END("3D Linear Dynamic");
 
-  CALI_MARK_BEGIN("3D Quadratic Dynamic");
+  SERAC_MARK_BEGIN("3D Quadratic Dynamic");
   functional_test_dynamic<2, 3>();
-  CALI_MARK_END("3D Quadratic Dynamic");
+  SERAC_MARK_END("3D Quadratic Dynamic");
 
   // Finalize profiling
   serac::profiling::finalize();


### PR DESCRIPTION
This PR re-adds the serac caliper wrapper macros.

The motivation is handling the case where benchmarking is disabled. In this case, we defined no-op versions of caliper macros, so marked code can still compile. However, if a Serac user (e.g. LiDO) does the same thing, we have a double define of macros, which results in a compiler error.

TODO
- [x] Re-add macros
- [x] Add comment mentioning motivation in profiling.hpp

Fixes #1164