### PR TITLE
Switch TOSS4 CI to ruby, remove eng bank

### DIFF
--- a/.gitlab/build_quartz.yml
+++ b/.gitlab/build_quartz.yml
@@ -2,10 +2,12 @@
 # This is the shared configuration of jobs for quartz
 .on_quartz:
   variables:
-    SCHEDULER_PARAMETERS: "--res=ci --exclusive=user -A ${ALLOC_BANK} --deadline=now+1hour -N ${ALLOC_NODES} -t ${ALLOC_TIME}"
+    # TODO Re-add eng bank to scheduler parameters once all users have the bank on ruby
+    # -A ${ALLOC_BANK}
+    SCHEDULER_PARAMETERS: "--res=ci --exclusive=user --deadline=now+1hour -N ${ALLOC_NODES} -t ${ALLOC_TIME}"
   tags:
     - batch
-    - quartz
+    - ruby
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
       when: never


### PR DESCRIPTION
Quartz is retiring next week, so we need to switch to ruby.

Until all users have the `eng` bank on ruby, we cannot use it. As a result CI queue times may be longer.