### PR TITLE
Name CI jobs by their SYS_TYPE rather than machine name

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,7 +32,7 @@ variables:
     # integration tests
     - echo -e "section_start:$(date +%s):src_build_and_unit_test\r\e[0K
       Source Build and Unit Tests ${CI_PROJECT_NAME}"
-    - ${ALLOC_COMMAND} scripts/gitlab/build_and_test.sh
+    - ./scripts/gitlab/build_and_test.sh
     - echo -e "section_end:$(date +%s):src_build_and_unit_test\r\e[0K"
   artifacts:
     expire_in: 2 weeks
@@ -65,10 +65,9 @@ variables:
     reports:
       junit: ${FULL_BUILD_ROOT}/${SYS_TYPE}/*/_serac_build_and_test_*/build-*/junit.xml
 
-# This is where jobs are included for each machine
+# This is where jobs are included for each system
 include:
-  - local: .gitlab/build_lassen.yml
-  # Note: Cannot move to ruby until users have access to eng bank
-  - local: .gitlab/build_quartz.yml
+  - local: .gitlab/build_blueos.yml
+  - local: .gitlab/build_toss4.yml
   - project: 'lc-templates/id_tokens'
     file: 'id_tokens.yml'

--- a/.gitlab/build_blueos.yml
+++ b/.gitlab/build_blueos.yml
@@ -1,17 +1,17 @@
 ####
-# This is the share configuration of jobs for lassen
-.on_lassen:
+# This is the share configuration of jobs for blueos
+.on_blueos:
   variables:
     SCHEDULER_PARAMETERS: -nnodes ${ALLOC_NODES} -W ${ALLOC_TIME} -q pci -G ${ALLOC_BANK}
   tags:
     - batch
     - lassen
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_LASSEN == "OFF"' #run except if ...
+    - if: '$CI_COMMIT_BRANCH =~ /_lnone/ || $ON_BLUEOS == "OFF"' #run except if ...
       when: never
     - when: on_success
   before_script:
-    # python3.8 is needed on lassen to avoid trampling on the x86 clingo wheel
+    # python3.8 is needed on blueos to avoid trampling on the x86 clingo wheel
     - module load python/3.8
     # CMake >= 3.17 is needed for FindCUDAToolkit with caliper
     # We could also extract the CMake executable location from the hostconfig in common_build_functions
@@ -29,32 +29,32 @@
 
 ####
 # Template
-.src_build_on_lassen:
-  extends: [.src_build_script, .on_lassen, .src_workflow]
+.src_build_on_blueos:
+  extends: [.src_build_script, .on_blueos, .src_workflow]
   needs: []
 
-.full_build_on_lassen:
-  extends: [.full_build_script, .on_lassen, .full_workflow]
+.full_build_on_blueos:
+  extends: [.full_build_script, .on_blueos, .full_workflow]
   needs: []
 
 ####
 # Build jobs
-lassen-clang_10_0_1-src:
+blueos-clang_10_0_1-src:
   variables:
     COMPILER: "clang@10.0.1"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -DENABLE_DOCS=OFF"
     ALLOC_NODES: "1"
     ALLOC_TIME: "30"
-  extends: [.src_build_on_lassen, .with_cuda]
+  extends: [.src_build_on_blueos, .with_cuda]
 
 # Note: to reduce duplication SPEC is not defined here, if we move to more than one
-# spec on lassen add it back like quartz
-lassen-clang_10_0_1-full:
+# spec on blueos add it back like toss4
+blueos-clang_10_0_1-full:
   variables:
     COMPILER: "clang@10.0.1"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -DENABLE_DOCS=OFF"
     ALLOC_NODES: "1"
     ALLOC_TIME: "55"
-  extends: [.full_build_on_lassen, .with_cuda]
+  extends: [.full_build_on_blueos, .with_cuda]

--- a/.gitlab/build_toss4.yml
+++ b/.gitlab/build_toss4.yml
@@ -1,6 +1,6 @@
 ####
-# This is the shared configuration of jobs for quartz
-.on_quartz:
+# This is the shared configuration of jobs for toss4
+.on_toss4:
   variables:
     # TODO Re-add eng bank to scheduler parameters once all users have the bank on ruby
     # -A ${ALLOC_BANK}
@@ -9,7 +9,7 @@
     - batch
     - ruby
   rules:
-    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_QUARTZ == "OFF"' #run except if ...
+    - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_TOSS4 == "OFF"' #run except if ...
       when: never
   before_script:
     # We could also extract the CMake executable location from the hostconfig in common_build_functions
@@ -19,12 +19,12 @@
 
 ####
 # Templates
-.src_build_on_quartz:
-  extends: [.src_build_script, .on_quartz, .src_workflow]
+.src_build_on_toss4:
+  extends: [.src_build_script, .on_toss4, .src_workflow]
   needs: []
 
-.full_build_on_quartz:
-  extends: [.full_build_script, .on_quartz, .full_workflow]
+.full_build_on_toss4:
+  extends: [.full_build_script, .on_toss4, .full_workflow]
   needs: []
   before_script:
     # LC version of pip is ancient
@@ -35,7 +35,7 @@
 # Build jobs
 
 # Only run integration tests on one spec
-quartz-clang_14_0_6-src:
+toss4-clang_14_0_6-src:
   variables:
     COMPILER: "clang@14.0.6"
     HOST_CONFIG: "quartz-toss_4_x86_64_ib-${COMPILER}.cmake"
@@ -43,49 +43,49 @@ quartz-clang_14_0_6-src:
     DO_INTEGRATION_TESTS: "yes"
     ALLOC_NODES: "2"
     ALLOC_TIME: "30"
-  extends: .src_build_on_quartz
+  extends: .src_build_on_toss4
 
-quartz-gcc_10_3_1-src:
+toss4-gcc_10_3_1-src:
   variables:
     COMPILER: "gcc@10.3.1"
     HOST_CONFIG: "quartz-toss_4_x86_64_ib-${COMPILER}.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON"
     ALLOC_NODES: "1"
     ALLOC_TIME: "30"
-  extends: .src_build_on_quartz
+  extends: .src_build_on_toss4
 
-quartz-gcc_10_3_1-src-no-tribol:
+toss4-gcc_10_3_1-src-no-tribol:
   variables:
     COMPILER: "gcc@10.3.1"
     HOST_CONFIG: "quartz-toss_4_x86_64_ib-${COMPILER}.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -UTRIBOL_DIR"
     ALLOC_NODES: "1"
     ALLOC_TIME: "30"
-  extends: .src_build_on_quartz
+  extends: .src_build_on_toss4
 
-quartz-gcc_10_3_1-src-no-sundials:
+toss4-gcc_10_3_1-src-no-sundials:
   variables:
     COMPILER: "gcc@10.3.1"
     HOST_CONFIG: "quartz-toss_4_x86_64_ib-${COMPILER}.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -USUNDIALS_DIR"
     ALLOC_NODES: "1"
     ALLOC_TIME: "20"
-  extends: .src_build_on_quartz
+  extends: .src_build_on_toss4
 
-quartz-clang_14_0_6-full:
+toss4-clang_14_0_6-full:
   variables:
     COMPILER: "clang@14.0.6"
     SPEC: "--spec=%${COMPILER}"
     ALLOC_NODES: "1"
     ALLOC_TIME: "45"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON"
-  extends: .full_build_on_quartz
+  extends: .full_build_on_toss4
 
-quartz-gcc_10_3_1-full:
+toss4-gcc_10_3_1-full:
   variables:
     COMPILER: "gcc@10.3.1"
     SPEC: "--spec=%${COMPILER}"
     ALLOC_NODES: "1"
     ALLOC_TIME: "45"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON"
-  extends: .full_build_on_quartz
+  extends: .full_build_on_toss4


### PR DESCRIPTION
On TOSS4 machines especially, we are frequently switching to different machines (e.g. quartz, ruby, and eventually dane). To prevent the inconvenience of changing the machine name everywhere, this PR names CI jobs and YAML files to their associated system, rather than machine name. That way, when we need to switch machines, we just need to update the `tag` section of the YAML files.

Let me know if this is a good change. Otherwise, I don't mind renaming things back to `ruby` and `lassen`.