### PR TITLE
Re-add eng bank, switch toss4 CI machine to dane

### DIFF
--- a/.gitlab/build_toss4.yml
+++ b/.gitlab/build_toss4.yml
@@ -2,12 +2,10 @@
 # This is the shared configuration of jobs for toss4
 .on_toss4:
   variables:
-    # TODO Re-add eng bank to scheduler parameters once all users have the bank on ruby
-    # -A ${ALLOC_BANK}
-    SCHEDULER_PARAMETERS: "--res=ci --exclusive=user --deadline=now+1hour -N ${ALLOC_NODES} -t ${ALLOC_TIME}"
+    SCHEDULER_PARAMETERS: "--res=ci --exclusive=user --deadline=now+1hour -N ${ALLOC_NODES} -t ${ALLOC_TIME} -A ${ALLOC_BANK}"
   tags:
     - batch
-    - ruby
+    - dane
   rules:
     - if: '$CI_COMMIT_BRANCH =~ /_qnone/ || $ON_TOSS4 == "OFF"' #run except if ...
       when: never


### PR DESCRIPTION
My commit says `ruby` accidentally, since I'm so used to writing "switch to ruby", I guess. But this PR will move CI to test on `dane` with the `eng` bank.

Does everyone have dane+eng access? Or should we stick with ruby?