### PR TITLE
Tupek/test quasi static checkpoint

### DIFF
--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -101,7 +101,7 @@ public:
       if (print_options.iterations) {
         mfem::out << "Newton iteration " << std::setw(3) << it << " : ||r|| = " << std::setw(13) << norm;
         if (it > 0) {
-          mfem::out << ", ||r||/||r_0|| = " << std::setw(13) << norm / initial_norm;
+          mfem::out << ", ||r||/||r_0|| = " << std::setw(13) << (initial_norm != 0.0 ? norm / initial_norm : norm);
         }
         mfem::out << '\n';
       }
@@ -387,7 +387,7 @@ public:
     for (cgIter = 1; cgIter <= settings.maxCgIterations; ++cgIter) {
       hess_vec_func(d, Hd);
       const double curvature = Dot(d, Hd);
-      const double alphaCg   = rPr / curvature;
+      const double alphaCg   = curvature != 0.0 ? rPr / curvature : 0.0;
 
       auto& zPred = Hd;  // re-use Hd, this is where bugs come from
       add(z, alphaCg, d, zPred);
@@ -498,7 +498,7 @@ public:
       if (print_options.iterations) {
         mfem::out << "Newton iteration " << std::setw(3) << it << " : ||r|| = " << std::setw(13) << norm;
         if (it > 0) {
-          mfem::out << ", ||r||/||r_0|| = " << std::setw(13) << norm / initial_norm;
+          mfem::out << ", ||r||/||r_0|| = " << std::setw(13) << (initial_norm != 0.0 ? norm / initial_norm : norm);
         }
         mfem::out << '\n';
       }

--- a/src/serac/physics/base_physics.cpp
+++ b/src/serac/physics/base_physics.cpp
@@ -356,26 +356,26 @@ FiniteElementState BasePhysics::loadCheckpointedState(const std::string& state_n
   return checkpoint_states_.at(state_name)[static_cast<size_t>(cycle)];
 }
 
-  std::unordered_map<std::string, FiniteElementState> BasePhysics::getCheckpointedStates(int cycle_to_load) const
-  {
-    std::unordered_map<std::string, FiniteElementState> previous_states_map;
-    std::vector<FiniteElementState*> previous_states_ptrs;
+std::unordered_map<std::string, FiniteElementState> BasePhysics::getCheckpointedStates(int cycle_to_load) const
+{
+  std::unordered_map<std::string, FiniteElementState> previous_states_map;
+  std::vector<FiniteElementState*>                    previous_states_ptrs;
 
-    if (checkpoint_to_disk_) {
-      for (const auto& state_name : stateNames()) {
-        previous_states_map.emplace(state_name, state(state_name));
-        previous_states_ptrs.emplace_back(const_cast<FiniteElementState*>(&state(state_name)));
-      }
-      StateManager::loadCheckpointedStates(cycle_to_load, previous_states_ptrs);
-      return previous_states_map;
-    } else {
-      for (const auto& state_name : stateNames()) {
-        previous_states_map.emplace(state_name, checkpoint_states_.at(state_name)[static_cast<size_t>(cycle_to_load)]);
-      }
+  if (checkpoint_to_disk_) {
+    for (const auto& state_name : stateNames()) {
+      previous_states_map.emplace(state_name, state(state_name));
+      previous_states_ptrs.emplace_back(const_cast<FiniteElementState*>(&state(state_name)));
     }
-
+    StateManager::loadCheckpointedStates(cycle_to_load, previous_states_ptrs);
     return previous_states_map;
+  } else {
+    for (const auto& state_name : stateNames()) {
+      previous_states_map.emplace(state_name, checkpoint_states_.at(state_name)[static_cast<size_t>(cycle_to_load)]);
+    }
   }
+
+  return previous_states_map;
+}
 
 double BasePhysics::getCheckpointedTimestep(int cycle) const
 {

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -475,7 +475,6 @@ public:
   mfem::ParMesh& mesh() { return mesh_; }
 
 protected:
-
   /**
    * @brief Create a paraview data collection for the physics package if requested
    */

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -123,7 +123,7 @@ public:
    *
    * @return The vector of timestep sizes taken by the foward solver
    */
-  virtual std::vector<double> timesteps() const;
+  virtual const std::vector<double>& timesteps() const;
 
   /**
    * @brief Base method to reset physics states to zero.  This does not reset design parameters or shape.
@@ -475,6 +475,7 @@ public:
   mfem::ParMesh& mesh() { return mesh_; }
 
 protected:
+
   /**
    * @brief Create a paraview data collection for the physics package if requested
    */
@@ -503,7 +504,7 @@ protected:
    * @param cycle The cycle to retrieve state from
    * @return A map containing the primal field names and their associated FiniteElementStates at the requested cycle
    */
-  virtual std::unordered_map<std::string, FiniteElementState> getCheckpointedStates(int cycle) const;
+  std::unordered_map<std::string, FiniteElementState> getCheckpointedStates(int cycle) const;
 
   /// @brief Name of the physics module
   std::string name_ = {};

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -134,12 +134,13 @@ public:
   virtual void resetStates(int cycle = 0, double time = 0.0) = 0;
 
   /**
-   * @brief Base method to reset physics states back to the end of time to start adjoint calculations again.  This does not reset design parameters or shape.
+   * @brief Base method to reset physics states back to the end of time to start adjoint calculations again.  This does
+   * not reset design parameters or shape.
    *
    */
   virtual void resetAdjointStates()
   {
-    time_ = max_time_;
+    time_  = max_time_;
     cycle_ = max_cycle_;
   }
 

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -126,12 +126,22 @@ public:
   virtual const std::vector<double>& timesteps() const;
 
   /**
-   * @brief Base method to reset physics states to zero.  This does not reset design parameters or shape.
+   * @brief Base method to reset physics states to the initial time.  This does not reset design parameters or shape.
    *
    * @param[in] cycle The simulation cycle (i.e. timestep iteration) to intialize the physics module to
    * @param[in] time The simulation time to initialize the physics module to
    */
   virtual void resetStates(int cycle = 0, double time = 0.0) = 0;
+
+  /**
+   * @brief Base method to reset physics states back to the end of time to start adjoint calculations again.  This does not reset design parameters or shape.
+   *
+   */
+  virtual void resetAdjointStates()
+  {
+    time_ = max_time_;
+    cycle_ = max_cycle_;
+  }
 
   /**
    * @brief Complete the setup and allocate the necessary data structures

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -923,32 +923,6 @@ public:
   }
 
   /**
-   * @brief Accessor for getting named finite element state primal solution from the physics modules at a given
-   * checkpointed cycle index
-   *
-   * @param cycle_to_load The previous timestep where the state solution is requested
-   * @return The named primal Finite Element State
-   */
-  std::unordered_map<std::string, FiniteElementState> getCheckpointedStates(int cycle_to_load) const override
-  {
-    std::unordered_map<std::string, FiniteElementState> previous_states;
-
-    if (checkpoint_to_disk_) {
-      previous_states.emplace("temperature", temperature_);
-      previous_states.emplace("temperature_rate", temperature_rate_);
-      StateManager::loadCheckpointedStates(cycle_to_load,
-                                           {previous_states.at("temperature"), previous_states.at("temperature_rate")});
-      return previous_states;
-    } else {
-      previous_states.emplace("temperature", checkpoint_states_.at("temperature")[static_cast<size_t>(cycle_to_load)]);
-      previous_states.emplace("temperature_rate",
-                              checkpoint_states_.at("temperature_rate")[static_cast<size_t>(cycle_to_load)]);
-    }
-
-    return previous_states;
-  }
-
-  /**
    * @brief Compute the implicit sensitivity of the quantity of interest used in defining the load for the adjoint
    * problem with respect to the parameter field for the last computed adjoint timestep
    *

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -344,6 +344,13 @@ public:
     } else {
       // Step the time integrator
       // Note that the ODE solver handles the essential boundary condition application itself
+      
+      // The current ode interface tracks 2 times, one internally which we have a handle to via time_,
+      // and one here via the step interface.
+      // We are ignoring this one, and just using the internal version for now.
+      // This may need to be revisited when more complex time integrators are required,
+      // but at the moment, the double times creates a lot of confusion, so 
+      // we short circuit the extra time here by passing a dummy time and ignoring it.
       double time_tmp = time_;
       ode_.Step(temperature_, time_tmp, dt);
     }

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -344,12 +344,12 @@ public:
     } else {
       // Step the time integrator
       // Note that the ODE solver handles the essential boundary condition application itself
-      
+
       // The current ode interface tracks 2 times, one internally which we have a handle to via time_,
       // and one here via the step interface.
       // We are ignoring this one, and just using the internal version for now.
       // This may need to be revisited when more complex time integrators are required,
-      // but at the moment, the double times creates a lot of confusion, so 
+      // but at the moment, the double times creates a lot of confusion, so
       // we short circuit the extra time here by passing a dummy time and ignoring it.
       double time_tmp = time_;
       ode_.Step(temperature_, time_tmp, dt);

--- a/src/serac/physics/heat_transfer.hpp
+++ b/src/serac/physics/heat_transfer.hpp
@@ -841,6 +841,23 @@ public:
     mfem::HypreParVector adjoint_essential(temperature_adjoint_load_);
     adjoint_essential = 0.0;
 
+    SLIC_ERROR_ROOT_IF(cycle_ <= min_cycle_,
+                       "Maximum number of adjoint timesteps exceeded! The number of adjoint timesteps must equal the "
+                       "number of forward timesteps");
+
+    cycle_--; // cycle is now at n \in [0,N-1]
+
+    double dt_np1_to_np2 = cycle_ < getCheckpointedTimestep(cycle_+1);
+    time_ -= dt_np1_to_np2; // this is the time at the end of forward step n
+    ode_time_point_ = time_;
+
+    auto end_step_solution = getCheckpointedStates(cycle_+1);
+
+    temperature_      = end_step_solution.at("temperature");
+    temperature_rate_ = end_step_solution.at("temperature_rate");
+
+    double dt = getCheckpointedTimestep(cycle_);
+
     if (is_quasistatic_) {
       // We store the previous timestep's temperature as the current temperature for use in the lambdas computing the
       // sensitivities.
@@ -858,68 +875,48 @@ public:
       lin_solver.Mult(temperature_adjoint_load_, adjoint_temperature_);
 
       return;
+    } else {
+
+      SLIC_ERROR_ROOT_IF(ode_.GetTimestepper() != TimestepMethod::BackwardEuler,
+                        "Only backward Euler implemented for transient adjoint heat conduction.");
+
+      // K := dR/du
+      auto K = serac::get<DERIVATIVE>((*residual_)(ode_time_point_, shape_displacement_, differentiate_wrt(temperature_),
+                                                  temperature_rate_, *parameters_[parameter_indices].state...));
+      std::unique_ptr<mfem::HypreParMatrix> k_mat(assemble(K));
+
+      // M := dR/du_dot
+      auto M = serac::get<DERIVATIVE>((*residual_)(ode_time_point_, shape_displacement_, temperature_,
+                                                  differentiate_wrt(temperature_rate_),
+                                                  *parameters_[parameter_indices].state...));
+      std::unique_ptr<mfem::HypreParMatrix> m_mat(assemble(M));
+
+      J_.reset(mfem::Add(1.0, *m_mat, dt, *k_mat));
+      auto J_T = std::unique_ptr<mfem::HypreParMatrix>(J_->Transpose());
+
+      // recall that temperature_adjoint_load_vector and d_temperature_dt_adjoint_load_vector were already multiplied by
+      // -1 above
+      mfem::HypreParVector modified_RHS(temperature_adjoint_load_);
+      modified_RHS *= dt;
+      modified_RHS.Add(1.0, temperature_rate_adjoint_load_);
+      modified_RHS.Add(-dt, implicit_sensitivity_temperature_start_of_step_);
+
+      for (const auto& bc : bcs_.essentials()) {
+        bc.apply(*J_T, modified_RHS, adjoint_essential);
+      }
+
+      lin_solver.SetOperator(*J_T);
+      lin_solver.Mult(modified_RHS, adjoint_temperature_);
+
+      // This multiply is technically on M transposed.  However, this matrix should be symmetric unless
+      // the thermal capacity is a function of the temperature rate of change, which is thermodynamically
+      // impossible, and fortunately not possible with our material interface.
+      // Not doing the transpose here to avoid doing unnecessary work.
+      m_mat->Mult(adjoint_temperature_, implicit_sensitivity_temperature_start_of_step_);
+      implicit_sensitivity_temperature_start_of_step_ *= -1.0 / dt;
+      implicit_sensitivity_temperature_start_of_step_.Add(1.0 / dt,
+                                                          temperature_rate_adjoint_load_);  // already multiplied by -1
     }
-
-    SLIC_ERROR_ROOT_IF(ode_.GetTimestepper() != TimestepMethod::BackwardEuler,
-                       "Only backward Euler implemented for transient adjoint heat conduction.");
-
-    SLIC_ERROR_ROOT_IF(cycle_ <= min_cycle_,
-                       "Maximum number of adjoint timesteps exceeded! The number of adjoint timesteps must equal the "
-                       "number of forward timesteps");
-
-    // Load the temperature from the previous cycle from disk
-    serac::FiniteElementState temperature_n_minus_1(temperature_);
-
-    {
-      auto previous_states_n         = getCheckpointedStates(cycle_);
-      auto previous_states_n_minus_1 = getCheckpointedStates(cycle_ - 1);
-
-      temperature_          = previous_states_n.at("temperature");
-      temperature_rate_     = previous_states_n.at("temperature_rate");
-      temperature_n_minus_1 = previous_states_n_minus_1.at("temperature");
-    }
-
-    double dt = getCheckpointedTimestep(cycle_ - 1);
-
-    // K := dR/du
-    auto K = serac::get<DERIVATIVE>((*residual_)(ode_time_point_, shape_displacement_, differentiate_wrt(temperature_),
-                                                 temperature_rate_, *parameters_[parameter_indices].state...));
-    std::unique_ptr<mfem::HypreParMatrix> k_mat(assemble(K));
-
-    // M := dR/du_dot
-    auto M = serac::get<DERIVATIVE>((*residual_)(ode_time_point_, shape_displacement_, temperature_,
-                                                 differentiate_wrt(temperature_rate_),
-                                                 *parameters_[parameter_indices].state...));
-    std::unique_ptr<mfem::HypreParMatrix> m_mat(assemble(M));
-
-    J_.reset(mfem::Add(1.0, *m_mat, dt, *k_mat));
-    auto J_T = std::unique_ptr<mfem::HypreParMatrix>(J_->Transpose());
-
-    // recall that temperature_adjoint_load_vector and d_temperature_dt_adjoint_load_vector were already multiplied by
-    // -1 above
-    mfem::HypreParVector modified_RHS(temperature_adjoint_load_);
-    modified_RHS *= dt;
-    modified_RHS.Add(1.0, temperature_rate_adjoint_load_);
-    modified_RHS.Add(-dt, implicit_sensitivity_temperature_start_of_step_);
-
-    for (const auto& bc : bcs_.essentials()) {
-      bc.apply(*J_T, modified_RHS, adjoint_essential);
-    }
-
-    lin_solver.SetOperator(*J_T);
-    lin_solver.Mult(modified_RHS, adjoint_temperature_);
-
-    // This multiply is technically on M transposed.  However, this matrix should be symmetric unless
-    // the thermal capacity is a function of the temperature rate of change, which is thermodynamically
-    // impossible, and fortunately not possible with our material interface.
-    // Not doing the transpose here to avoid doing unnecessary work.
-    m_mat->Mult(adjoint_temperature_, implicit_sensitivity_temperature_start_of_step_);
-    implicit_sensitivity_temperature_start_of_step_ *= -1.0 / dt;
-    implicit_sensitivity_temperature_start_of_step_.Add(1.0 / dt,
-                                                        temperature_rate_adjoint_load_);  // already multiplied by -1
-
-    time_ -= dt;
-    cycle_--;
   }
 
   /**

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -137,10 +137,11 @@ public:
   SolidMechanics(const NonlinearSolverOptions nonlinear_opts, const LinearSolverOptions lin_opts,
                  const serac::TimesteppingOptions timestepping_opts, const GeometricNonlinearities geom_nonlin,
                  const std::string& physics_name, std::string mesh_tag, std::vector<std::string> parameter_names = {},
-                 int cycle = 0, double time = 0.0, bool checkpoint_to_disk = false)
+                 int cycle = 0, double time = 0.0, bool checkpoint_to_disk = false, bool use_warm_start = true)
       : SolidMechanics(
             std::make_unique<EquationSolver>(nonlinear_opts, lin_opts, StateManager::mesh(mesh_tag).GetComm()),
-            timestepping_opts, geom_nonlin, physics_name, mesh_tag, parameter_names, cycle, time, checkpoint_to_disk)
+            timestepping_opts, geom_nonlin, physics_name, mesh_tag, parameter_names, cycle, time, checkpoint_to_disk,
+            use_warm_start)
   {
   }
 
@@ -183,8 +184,8 @@ public:
         reactions_adjoint_load_(reactions_.space(), "reactions_shape_sensitivity"),
         nonlin_solver_(std::move(solver)),
         ode2_(displacement_.space().TrueVSize(),
-              {.time = time_, .c0 = c0_, .c1 = c1_, .u = u_, .du_dt = v_, .d2u_dt2 = acceleration_},
-              *nonlin_solver_, bcs_),
+              {.time = time_, .c0 = c0_, .c1 = c1_, .u = u_, .du_dt = v_, .d2u_dt2 = acceleration_}, *nonlin_solver_,
+              bcs_),
         geom_nonlin_(geom_nonlin),
         use_warm_start_(use_warm_start)
   {

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -1269,7 +1269,7 @@ public:
     }
 
     cycle_ += 1;
-    
+
     if (checkpoint_to_disk_) {
       outputStateToDisk();
     } else {
@@ -1353,12 +1353,12 @@ public:
                        "Maximum number of adjoint timesteps exceeded! The number of adjoint timesteps must equal the "
                        "number of forward timesteps");
 
-    cycle_--; // cycle is now at n \in [0,N-1]
+    cycle_--;  // cycle is now at n \in [0,N-1]
 
-    double dt_np1_to_np2 = getCheckpointedTimestep(cycle_+1);
+    double dt_np1_to_np2 = getCheckpointedTimestep(cycle_ + 1);
     time_ -= dt_np1_to_np2;
 
-    auto end_step_solution = getCheckpointedStates(cycle_+1);
+    auto end_step_solution = getCheckpointedStates(cycle_ + 1);
     // Load the end of step disp
     displacement_ = end_step_solution.at("displacement");
 

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -1273,7 +1273,7 @@ public:
       // and one here via the step interface.
       // We are ignoring this one, and just using the internal version for now.
       // This may need to be revisited when more complex time integrators are required,
-      // but at the moment, the double times creates a lot of confusion, so 
+      // but at the moment, the double times creates a lot of confusion, so
       // we short circuit the extra time here by passing a dummy time and ignoring it.
       double time_tmp = time_;
       ode2_.Step(displacement_, velocity_, time_tmp, dt);

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -130,6 +130,8 @@ public:
    * @param time The simulation time to initialize the physics module to
    * @param checkpoint_to_disk A flag to save the transient states on disk instead of memory for the transient adjoint
    * solves
+   * @param use_warm_start A flag to turn on or off the displacement warm start predictor which helps robustness for
+   * large deformation problems
    *
    * @note On parallel file systems (e.g. lustre), significant slowdowns and occasional errors were observed when
    *       writing and reading the needed trainsient states to disk for adjoint solves

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -1269,6 +1269,12 @@ public:
     if (is_quasistatic_) {
       quasiStaticSolve(dt);
     } else {
+      // The current ode interface tracks 2 times, one internally which we have a handle to via time_,
+      // and one here via the step interface.
+      // We are ignoring this one, and just using the internal version for now.
+      // This may need to be revisited when more complex time integrators are required,
+      // but at the moment, the double times creates a lot of confusion, so 
+      // we short circuit the extra time here by passing a dummy time and ignoring it.
       double time_tmp = time_;
       ode2_.Step(displacement_, velocity_, time_tmp, dt);
     }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -1130,8 +1130,8 @@ public:
 
         // residual function
         [this](const mfem::Vector& u, mfem::Vector& r) {
-          const mfem::Vector res = (*residual_)(time_, shape_displacement_, u, acceleration_,
-                                                *parameters_[parameter_indices].state...);
+          const mfem::Vector res =
+              (*residual_)(time_, shape_displacement_, u, acceleration_, *parameters_[parameter_indices].state...);
 
           // TODO this copy is required as the sundials solvers do not allow move assignments because of their memory
           // tracking strategy
@@ -1185,8 +1185,8 @@ public:
 
           [this](const mfem::Vector& d2u_dt2, mfem::Vector& r) {
             add(1.0, u_, c0_, d2u_dt2, predicted_displacement_);
-            const mfem::Vector res = (*residual_)(time_, shape_displacement_, predicted_displacement_,
-                                                  d2u_dt2, *parameters_[parameter_indices].state...);
+            const mfem::Vector res = (*residual_)(time_, shape_displacement_, predicted_displacement_, d2u_dt2,
+                                                  *parameters_[parameter_indices].state...);
 
             // TODO this copy is required as the sundials solvers do not allow move assignments because of their memory
             // tracking strategy
@@ -1199,7 +1199,7 @@ public:
             add(1.0, u_, c0_, d2u_dt2, predicted_displacement_);
 
             // K := dR/du
-            auto K = serac::get<DERIVATIVE>((*residual_)(time_, shape_displacement_,
+            auto                                  K = serac::get<DERIVATIVE>((*residual_)(time_, shape_displacement_,
                                                          differentiate_wrt(predicted_displacement_), d2u_dt2,
                                                          *parameters_[parameter_indices].state...));
             std::unique_ptr<mfem::HypreParMatrix> k_mat(assemble(K));
@@ -1353,7 +1353,7 @@ public:
                        "number of forward timesteps");
 
     double dt_np1 = cycle_ < static_cast<int>(timesteps().size()) ? getCheckpointedTimestep(cycle_) : 0.0;
-    auto previous_state_solution = getCheckpointedStates(cycle_);
+    auto   previous_state_solution = getCheckpointedStates(cycle_);
 
     time_ -= dt_np1;
     cycle_--;
@@ -1361,11 +1361,11 @@ public:
     // Load the end of step disp
     displacement_ = previous_state_solution.at("displacement");
 
-    const double dt_n   = getCheckpointedTimestep(cycle_);
+    const double dt_n = getCheckpointedTimestep(cycle_);
 
     if (is_quasistatic_) {
-      auto [_, drdu] = (*residual_)(time_, shape_displacement_, differentiate_wrt(displacement_),
-                                    acceleration_, *parameters_[parameter_indices].state...);
+      auto [_, drdu] = (*residual_)(time_, shape_displacement_, differentiate_wrt(displacement_), acceleration_,
+                                    *parameters_[parameter_indices].state...);
       auto jacobian  = assemble(drdu);
       auto J_T       = std::unique_ptr<mfem::HypreParMatrix>(jacobian->Transpose());
 
@@ -1381,9 +1381,8 @@ public:
 
       return;
     } else {
-
       SLIC_ERROR_ROOT_IF(ode2_.GetTimestepper() != TimestepMethod::Newmark,
-                        "Only Newmark implemented for transient adjoint solid mechanics.");
+                         "Only Newmark implemented for transient adjoint solid mechanics.");
 
       // Load the end of step velo, accel from the previous cycle
 
@@ -1392,20 +1391,19 @@ public:
 
       // K := dR/du
       auto K = serac::get<DERIVATIVE>((*residual_)(time_, shape_displacement_, differentiate_wrt(displacement_),
-                                                  acceleration_, *parameters_[parameter_indices].state...));
+                                                   acceleration_, *parameters_[parameter_indices].state...));
       std::unique_ptr<mfem::HypreParMatrix> k_mat(assemble(K));
 
       // M := dR/da
       auto M = serac::get<DERIVATIVE>((*residual_)(time_, shape_displacement_, displacement_,
-                                                  differentiate_wrt(acceleration_),
-                                                  *parameters_[parameter_indices].state...));
+                                                   differentiate_wrt(acceleration_),
+                                                   *parameters_[parameter_indices].state...));
       std::unique_ptr<mfem::HypreParMatrix> m_mat(assemble(M));
 
       solid_mechanics::detail::adjoint_integrate(
           dt_n, dt_np1, m_mat.get(), k_mat.get(), displacement_adjoint_load_, velocity_adjoint_load_,
           acceleration_adjoint_load_, adjoint_displacement_, implicit_sensitivity_displacement_start_of_step_,
           implicit_sensitivity_velocity_start_of_step_, adjoint_essential, bcs_, lin_solver);
-
     }
   }
 
@@ -1426,9 +1424,8 @@ public:
   /// @overload
   FiniteElementDual& computeTimestepShapeSensitivity() override
   {
-    auto drdshape =
-        serac::get<DERIVATIVE>((*residual_)(time_, differentiate_wrt(shape_displacement_), displacement_,
-                                            acceleration_, *parameters_[parameter_indices].state...));
+    auto drdshape = serac::get<DERIVATIVE>((*residual_)(time_, differentiate_wrt(shape_displacement_), displacement_,
+                                                        acceleration_, *parameters_[parameter_indices].state...));
 
     auto drdshape_mat = assemble(drdshape);
 
@@ -1501,9 +1498,8 @@ public:
   const serac::FiniteElementDual& computeDualShapeSensitivity(
       const serac::FiniteElementState& reaction_direction) override
   {
-    auto drdshape =
-        serac::get<DERIVATIVE>((*residual_)(time_, differentiate_wrt(shape_displacement_), displacement_,
-                                            acceleration_, *parameters_[parameter_indices].state...));
+    auto drdshape = serac::get<DERIVATIVE>((*residual_)(time_, differentiate_wrt(shape_displacement_), displacement_,
+                                                        acceleration_, *parameters_[parameter_indices].state...));
     auto drdshape_mat = assemble(drdshape);
     drdshape_mat->MultTranspose(reaction_direction, *shape_displacement_sensitivity_);
     return *shape_displacement_sensitivity_;

--- a/src/serac/physics/state/state_manager.cpp
+++ b/src/serac/physics/state/state_manager.cpp
@@ -91,28 +91,6 @@ double StateManager::newDataCollection(const std::string& name, const std::optio
   return datacoll.GetTime();
 }
 
-void StateManager::loadCheckpointedStates(int                                                     cycle_to_load,
-                                          std::vector<std::reference_wrapper<FiniteElementState>> states_to_load)
-{
-  std::string mesh_name = collectionID(&states_to_load.begin()->get().mesh());
-
-  std::string coll_name = mesh_name + "_datacoll";
-
-  axom::sidre::MFEMSidreDataCollection previous_datacoll(coll_name);
-
-  previous_datacoll.SetComm(states_to_load.begin()->get().mesh().GetComm());
-  previous_datacoll.SetPrefixPath(output_dir_);
-  previous_datacoll.Load(cycle_to_load);
-
-  for (auto state : states_to_load) {
-    SLIC_ERROR_ROOT_IF(collectionID(&state.get().mesh()) != mesh_name,
-                       "Loading FiniteElementStates from two different meshes at one time is not allowed.");
-    mfem::ParGridFunction* datacoll_owned_grid_function = previous_datacoll.GetParField(state.get().name());
-
-    state.get().setFromGridFunction(*datacoll_owned_grid_function);
-  }
-}
-
 void StateManager::loadCheckpointedStates(int                              cycle_to_load,
                                           std::vector<FiniteElementState*> states_to_load)
 {

--- a/src/serac/physics/state/state_manager.cpp
+++ b/src/serac/physics/state/state_manager.cpp
@@ -91,12 +91,10 @@ double StateManager::newDataCollection(const std::string& name, const std::optio
   return datacoll.GetTime();
 }
 
-void StateManager::loadCheckpointedStates(int                              cycle_to_load,
-                                          std::vector<FiniteElementState*> states_to_load)
+void StateManager::loadCheckpointedStates(int cycle_to_load, std::vector<FiniteElementState*> states_to_load)
 {
-
-  mfem::ParMesh* meshPtr = &(*states_to_load.begin())->mesh();
-  std::string mesh_name = collectionID(meshPtr);
+  mfem::ParMesh* meshPtr   = &(*states_to_load.begin())->mesh();
+  std::string    mesh_name = collectionID(meshPtr);
 
   std::string coll_name = mesh_name + "_datacoll";
 

--- a/src/serac/physics/state/state_manager.hpp
+++ b/src/serac/physics/state/state_manager.hpp
@@ -235,15 +235,6 @@ public:
    * @param cycle_to_load
    * @param states_to_load
    */
-  static void loadCheckpointedStates(int                                                     cycle_to_load,
-                                     std::vector<std::reference_wrapper<FiniteElementState>> states_to_load);
-
-  /**
-   * @brief loads the finite element states from a previously checkpointed cycle
-   *
-   * @param cycle_to_load
-   * @param states_to_load
-   */
   static void loadCheckpointedStates(int                              cycle_to_load,
                                      std::vector<FiniteElementState*> states_to_load);
 

--- a/src/serac/physics/state/state_manager.hpp
+++ b/src/serac/physics/state/state_manager.hpp
@@ -239,6 +239,15 @@ public:
                                      std::vector<std::reference_wrapper<FiniteElementState>> states_to_load);
 
   /**
+   * @brief loads the finite element states from a previously checkpointed cycle
+   *
+   * @param cycle_to_load
+   * @param states_to_load
+   */
+  static void loadCheckpointedStates(int                              cycle_to_load,
+                                     std::vector<FiniteElementState*> states_to_load);
+
+  /**
    * @brief Get the shape displacement sensitivity finite element dual
    *
    * This is the vector-valued H1 dual of order 1 representing sensitivities of the shape displacement field of the

--- a/src/serac/physics/state/state_manager.hpp
+++ b/src/serac/physics/state/state_manager.hpp
@@ -235,8 +235,7 @@ public:
    * @param cycle_to_load
    * @param states_to_load
    */
-  static void loadCheckpointedStates(int                              cycle_to_load,
-                                     std::vector<FiniteElementState*> states_to_load);
+  static void loadCheckpointedStates(int cycle_to_load, std::vector<FiniteElementState*> states_to_load);
 
   /**
    * @brief Get the shape displacement sensitivity finite element dual

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(physics_serial_test_sources
     solid_statics_patch.cpp
     solid_dynamics_patch.cpp
     dynamic_solid_adjoint.cpp
+    quasistatic_solid_adjoint.cpp
     finite_element_vector_set_over_domain.cpp
     )
 

--- a/src/serac/physics/tests/dynamic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/dynamic_solid_adjoint.cpp
@@ -82,8 +82,8 @@ void applyInitialAndBoundaryConditions(SolidMechanics<p, dim>& solid_solver)
   solid_solver.setDisplacement(disp);
 }
 
-std::unique_ptr<SolidMechanics<p, dim>> createNonlinearSolidMechanicsSolver(const NonlinearSolverOptions& nonlinear_opts,
-    const TimesteppingOptions& dyn_opts, const SolidMaterial& mat)
+std::unique_ptr<SolidMechanics<p, dim>> createNonlinearSolidMechanicsSolver(
+    const NonlinearSolverOptions& nonlinear_opts, const TimesteppingOptions& dyn_opts, const SolidMaterial& mat)
 {
   static int iter = 0;
   auto       solid =
@@ -247,7 +247,7 @@ struct SolidMechanicsSensitivityFixture : public ::testing::Test {
 
 TEST_F(SolidMechanicsSensitivityFixture, InitialDisplacementSensitivities)
 {
-  auto solid_solver = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
+  auto solid_solver                             = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
   auto [qoi_base, init_disp_sensitivity, _, __] = computeSolidMechanicsQoiSensitivities(*solid_solver, tsInfo);
 
   solid_solver->resetStates();
@@ -264,7 +264,7 @@ TEST_F(SolidMechanicsSensitivityFixture, InitialDisplacementSensitivities)
 
 TEST_F(SolidMechanicsSensitivityFixture, InitialVelocitySensitivities)
 {
-  auto solid_solver = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
+  auto solid_solver                             = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
   auto [qoi_base, _, init_velo_sensitivity, __] = computeSolidMechanicsQoiSensitivities(*solid_solver, tsInfo);
 
   solid_solver->resetStates();
@@ -280,7 +280,7 @@ TEST_F(SolidMechanicsSensitivityFixture, InitialVelocitySensitivities)
 
 TEST_F(SolidMechanicsSensitivityFixture, ShapeSensitivities)
 {
-  auto solid_solver = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
+  auto solid_solver                         = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
   auto [qoi_base, _, __, shape_sensitivity] = computeSolidMechanicsQoiSensitivities(*solid_solver, tsInfo);
 
   solid_solver->resetStates();
@@ -296,8 +296,8 @@ TEST_F(SolidMechanicsSensitivityFixture, ShapeSensitivities)
 
 TEST_F(SolidMechanicsSensitivityFixture, QuasiStaticShapeSensitivities)
 {
-  dyn_opts.timestepper=TimestepMethod::QuasiStatic;
-  auto solid_solver = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
+  dyn_opts.timestepper                      = TimestepMethod::QuasiStatic;
+  auto solid_solver                         = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
   auto [qoi_base, _, __, shape_sensitivity] = computeSolidMechanicsQoiSensitivities(*solid_solver, tsInfo);
 
   solid_solver->resetStates();
@@ -313,7 +313,7 @@ TEST_F(SolidMechanicsSensitivityFixture, QuasiStaticShapeSensitivities)
 
 TEST_F(SolidMechanicsSensitivityFixture, WhenShapeSensitivitiesCalledTwice_GetSameObjectiveAndGradient)
 {
-  auto solid_solver = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
+  auto solid_solver                      = createNonlinearSolidMechanicsSolver(nonlinear_opts, dyn_opts, mat);
   auto [qoi1, _, __, shape_sensitivity1] = computeSolidMechanicsQoiSensitivities(*solid_solver, tsInfo);
 
   solid_solver->resetStates();

--- a/src/serac/physics/tests/dynamic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/dynamic_solid_adjoint.cpp
@@ -90,7 +90,8 @@ std::unique_ptr<SolidMechanics<p, dim>> createNonlinearSolidMechanicsSolver(
       std::make_unique<SolidMechanics<p, dim>>(nonlinear_opts, solid_mechanics::direct_linear_options, dyn_opts,
                                                geoNonlinear, physics_prefix + std::to_string(iter++), mesh_tag);
   solid->setMaterial(mat);
-  solid->setDisplacementBCs({1}, [](const mfem::Vector&, double t, mfem::Vector& disp) { disp = (1.0 + 10 * t) * boundary_disp; });
+  solid->setDisplacementBCs(
+      {1}, [](const mfem::Vector&, double t, mfem::Vector& disp) { disp = (1.0 + 10 * t) * boundary_disp; });
   solid->addBodyForce([](auto X, auto t) {
     auto Y = X;
     Y[0]   = 0.1 + 0.1 * X[0] + 0.3 * X[1] - 0.2 * t;

--- a/src/serac/physics/tests/dynamic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/dynamic_solid_adjoint.cpp
@@ -90,12 +90,12 @@ std::unique_ptr<SolidMechanics<p, dim>> createNonlinearSolidMechanicsSolver(
       std::make_unique<SolidMechanics<p, dim>>(nonlinear_opts, solid_mechanics::direct_linear_options, dyn_opts,
                                                geoNonlinear, physics_prefix + std::to_string(iter++), mesh_tag);
   solid->setMaterial(mat);
-  solid->setDisplacementBCs({1}, [](const mfem::Vector&, mfem::Vector& disp) { disp = boundary_disp; });
+  solid->setDisplacementBCs({1}, [](const mfem::Vector&, double t, mfem::Vector& disp) { disp = (1.0 + 10 * t) * boundary_disp; });
   solid->addBodyForce([](auto X, auto t) {
     auto Y = X;
     Y[0]   = 0.1 + 0.1 * X[0] + 0.3 * X[1] - 0.2 * t;
     Y[1]   = -0.05 - 0.08 * X[0] + 0.15 * X[1] + 0.3 * t;
-    return 0.1 * X + Y;
+    return 0.4 * X + Y;
   });
   solid->completeSetup();
 

--- a/src/serac/physics/tests/dynamic_thermal_adjoint.cpp
+++ b/src/serac/physics/tests/dynamic_thermal_adjoint.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<HeatTransfer<p, dim>> createNonlinearHeatTransfer(
   // Note that we are testing the non-default checkpoint to disk capability here
   auto thermal = std::make_unique<HeatTransfer<p, dim>>(nonlinear_opts, heat_transfer::direct_linear_options, dyn_opts,
                                                         thermal_prefix + std::to_string(iter++), mesh_tag,
-                                                        std::vector<std::string>{}, 0, 0.0, true);
+                                                        std::vector<std::string>{}, 0, 0.0);
   thermal->setMaterial(mat);
   thermal->setTemperature([](const mfem::Vector&, double) { return 0.0; });
   thermal->setTemperatureBCs({1}, [](const mfem::Vector&, double) { return 0.0; });

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -77,30 +77,33 @@ TEST(Thermomechanics, ParameterizedMaterial)
   double outer_radius = 1.25;
   double height       = 2.0;
 
-  // clang-format off
-    auto mesh = mesh::refineAndDistribute(build_hollow_quarter_cylinder(radial_divisions,
-                                                                        angular_divisions,
-                                                                        vertical_divisions,
-                                                                        inner_radius,
-                                                                        outer_radius,
-                                                                        height), serial_refinement, parallel_refinement);
+  auto mesh = mesh::refineAndDistribute(build_hollow_quarter_cylinder(radial_divisions, 
+                                                                      angular_divisions, 
+                                                                      vertical_divisions,
+                                                                      inner_radius, 
+                                                                      outer_radius, 
+                                                                      height), serial_refinement, parallel_refinement);
 
-  // clang-format on
   std::string mesh_tag{"mesh"};
   auto&       pmesh = serac::StateManager::setMesh(std::move(mesh), mesh_tag);
 
   NonlinearSolverOptions nonlinear_opts = solid_mechanics::default_nonlinear_options;
-  LinearSolverOptions    linear_opts    = solid_mechanics::default_linear_options;
+  LinearSolverOptions   linear_opts    = solid_mechanics::default_linear_options;
+
+  nonlinear_opts.relative_tol = 1e-8;
+  nonlinear_opts.absolute_tol = 1e-10;
+
 #ifdef SERAC_USE_PETSC
   nonlinear_opts.nonlin_solver = NonlinearSolver::PetscNewton;
-
   linear_opts.linear_solver        = LinearSolver::PetscGMRES;
   linear_opts.preconditioner       = Preconditioner::Petsc;
   linear_opts.petsc_preconditioner = PetscPCType::HMG;
 #endif
+
   SolidMechanics<p, dim, Parameters<H1<p>, H1<p>>> simulation(
-      nonlinear_opts, linear_opts, solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On,
-      "thermomechanics_simulation", mesh_tag, {"theta", "alpha"});
+      nonlinear_opts, linear_opts,
+      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On, "thermomechanics_simulation", mesh_tag,
+      {"theta", "alpha"});
 
   double density   = 1.0;     ///< density
   double E         = 1000.0;  ///< Young's modulus

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -77,33 +77,30 @@ TEST(Thermomechanics, ParameterizedMaterial)
   double outer_radius = 1.25;
   double height       = 2.0;
 
-  auto mesh = mesh::refineAndDistribute(build_hollow_quarter_cylinder(radial_divisions, 
-                                                                      angular_divisions, 
-                                                                      vertical_divisions,
-                                                                      inner_radius, 
-                                                                      outer_radius, 
-                                                                      height), serial_refinement, parallel_refinement);
+  auto mesh =
+      mesh::refineAndDistribute(build_hollow_quarter_cylinder(radial_divisions, angular_divisions, vertical_divisions,
+                                                              inner_radius, outer_radius, height),
+                                serial_refinement, parallel_refinement);
 
   std::string mesh_tag{"mesh"};
   auto&       pmesh = serac::StateManager::setMesh(std::move(mesh), mesh_tag);
 
   NonlinearSolverOptions nonlinear_opts = solid_mechanics::default_nonlinear_options;
-  LinearSolverOptions   linear_opts    = solid_mechanics::default_linear_options;
+  LinearSolverOptions    linear_opts    = solid_mechanics::default_linear_options;
 
   nonlinear_opts.relative_tol = 1e-8;
   nonlinear_opts.absolute_tol = 1e-10;
 
 #ifdef SERAC_USE_PETSC
-  nonlinear_opts.nonlin_solver = NonlinearSolver::PetscNewton;
+  nonlinear_opts.nonlin_solver     = NonlinearSolver::PetscNewton;
   linear_opts.linear_solver        = LinearSolver::PetscGMRES;
   linear_opts.preconditioner       = Preconditioner::Petsc;
   linear_opts.petsc_preconditioner = PetscPCType::HMG;
 #endif
 
   SolidMechanics<p, dim, Parameters<H1<p>, H1<p>>> simulation(
-      nonlinear_opts, linear_opts,
-      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On, "thermomechanics_simulation", mesh_tag,
-      {"theta", "alpha"});
+      nonlinear_opts, linear_opts, solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On,
+      "thermomechanics_simulation", mesh_tag, {"theta", "alpha"});
 
   double density   = 1.0;     ///< density
   double E         = 1000.0;  ///< Young's modulus

--- a/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
@@ -244,8 +244,8 @@ TEST(quasistatic, finiteDifference)
   seracSolid->setParameter(1, vstate);
   double fmv = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fmv");
 
-  ASSERT_NEAR(Ederiv, (fpE - fmE) / (2. * h), 1e-8);
-  ASSERT_NEAR(vderiv, (fpv - fmv) / (2. * h), 1e-8);
+  ASSERT_NEAR(Ederiv, (fpE - fmE) / (2. * h), 1e-7);
+  ASSERT_NEAR(vderiv, (fpv - fmv) / (2. * h), 1e-7);
 }
 
 }  // namespace serac

--- a/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
@@ -19,27 +19,29 @@
 #include "serac/serac_config.hpp"
 
 struct ParameterizedLinearIsotropicSolid {
-  using State = ::serac::Empty; ///< this material has no internal variables
+  using State = ::serac::Empty;  ///< this material has no internal variables
 
-  template<int dim, typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(State &, const ::serac::tensor<T1, dim, dim> &u_grad, const T2 &E_tuple, const T3 &v_tuple) const
+  template <int dim, typename T1, typename T2, typename T3>
+  SERAC_HOST_DEVICE auto operator()(State&, const ::serac::tensor<T1, dim, dim>& u_grad, const T2& E_tuple,
+                                    const T3& v_tuple) const
   {
-    auto E = ::serac::get<0>(E_tuple); // Young's modulus VALUE
-    auto v = ::serac::get<0>(v_tuple); // Poisson's ratio VALUE
-    auto lambda = E * v / ((1.0 + v) * (1.0 - 2.0 * v)); // Lamé's first parameter
-    auto mu = E / (2.0 * (1.0 + v)); // Lamé's second parameter
-    const auto I = ::serac::Identity<dim>(); // identity matrix
-    auto strain = ::serac::sym(u_grad); // small strain tensor
-    return lambda * ::serac::tr(strain) * I + 2.0 * mu * strain; // Cauchy stress
+    auto       E      = ::serac::get<0>(E_tuple);                 // Young's modulus VALUE
+    auto       v      = ::serac::get<0>(v_tuple);                 // Poisson's ratio VALUE
+    auto       lambda = E * v / ((1.0 + v) * (1.0 - 2.0 * v));    // Lamé's first parameter
+    auto       mu     = E / (2.0 * (1.0 + v));                    // Lamé's second parameter
+    const auto I      = ::serac::Identity<dim>();                 // identity matrix
+    auto       strain = ::serac::sym(u_grad);                     // small strain tensor
+    return lambda * ::serac::tr(strain) * I + 2.0 * mu * strain;  // Cauchy stress
   }
-  static constexpr double density {1.0}; ///< mass density, for dynamics problems
+  static constexpr double density{1.0};  ///< mass density, for dynamics problems
 };
 
 struct ParameterizedNeoHookeanSolid {
   using State = ::serac::Empty;  // this material has no internal variables
 
   template <int dim, typename T1, typename T2, typename T3>
-  SERAC_HOST_DEVICE auto operator()(State&, const ::serac::tensor<T1, dim, dim>& du_dX, const T2& E_tuple, const T3& v_tuple) const
+  SERAC_HOST_DEVICE auto operator()(State&, const ::serac::tensor<T1, dim, dim>& du_dX, const T2& E_tuple,
+                                    const T3& v_tuple) const
   {
     using std::log1p;
     constexpr auto I         = serac::Identity<dim>();
@@ -52,206 +54,198 @@ struct ParameterizedNeoHookeanSolid {
     auto           J         = J_minus_1 + 1;
     return (lambda * log1p(J_minus_1) * I + G * B_minus_I) / J;
   }
-  static constexpr double density {1.0}; ///< mass density, for dynamics problems
+  static constexpr double density{1.0};  ///< mass density, for dynamics problems
 };
-
 
 namespace serac {
 
-constexpr int DIM = 3;
+constexpr int DIM   = 3;
 constexpr int ORDER = 1;
 
 const std::string mesh_tag       = "mesh";
 const std::string physics_prefix = "solid";
 
 using paramFES = serac::L2<0>;
-using uFES = serac::H1<ORDER, DIM>;
-using qoiType = serac::Functional<double(paramFES, paramFES, uFES)>;
+using uFES     = serac::H1<ORDER, DIM>;
+using qoiType  = serac::Functional<double(paramFES, paramFES, uFES)>;
 
-double forwardPass(serac::BasePhysics *solid, qoiType *qoi, mfem::ParMesh *meshPtr, int nTimeSteps, double timeStep, std::string saveName)
+double forwardPass(serac::BasePhysics* solid, qoiType* qoi, mfem::ParMesh* /*meshPtr*/, int nTimeSteps, double timeStep,
+                   std::string /*saveName*/)
 {
-    solid->resetStates();
+  solid->resetStates();
 
-    // set up plotting
-    mfem::ParGridFunction uGF(const_cast<mfem::ParFiniteElementSpace*>(&solid->state("displacement").space()));
-    solid->state("displacement").fillGridFunction(uGF);
-    mfem::VisItDataCollection visit_dc(saveName, meshPtr);
-    visit_dc.RegisterField("u", &uGF);
-    visit_dc.SetCycle(0);
+  // set up plotting
+  /*
+  mfem::ParGridFunction uGF(const_cast<mfem::ParFiniteElementSpace*>(&solid->state("displacement").space()));
+  solid->state("displacement").fillGridFunction(uGF);
+  mfem::VisItDataCollection visit_dc(saveName, meshPtr);
+  visit_dc.RegisterField("u", &uGF);
+  visit_dc.SetCycle(0);
+  visit_dc.Save();
+  */
+
+  double                           qoiValue = 0.0;
+  const serac::FiniteElementState& E        = solid->parameter("E");
+  const serac::FiniteElementState& v        = solid->parameter("v");
+  const serac::FiniteElementState& u        = solid->state("displacement");
+
+  double prev = (*qoi)(solid->time(), E, v, u);
+  for (int i = 0; i < nTimeSteps; i++) {
+    // solve
+    solid->advanceTimestep(timeStep);
+
+    // plot
+    /*
+    u.fillGridFunction(uGF);
+    visit_dc.SetCycle(i + 1);
     visit_dc.Save();
+    */
 
-    double qoiValue = 0.0;
-    const serac::FiniteElementState &E = solid->parameter("E");
-    const serac::FiniteElementState &v = solid->parameter("v");
-    const serac::FiniteElementState &u = solid->state("displacement");
-
-    double time = 0.0;
-    std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
-    double prev = (*qoi)(solid->time(), E, v, u);
-    for (int i=0; i<nTimeSteps; i++) {
-        // solve
-        solid->advanceTimestep(timeStep);
-        time += timeStep;
-        std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
-
-        // plot
-        u.fillGridFunction(uGF);
-        visit_dc.SetCycle(i+1);
-        visit_dc.Save();
-
-        // accumulate
-        double curr = (*qoi)(solid->time(), E, v, u);
-        qoiValue += timeStep * 0.5*(prev+curr); // trapezoid
-        prev = curr;
-    }
-    return qoiValue;
+    // accumulate
+    double curr = (*qoi)(solid->time(), E, v, u);
+    qoiValue += timeStep * 0.5 * (prev + curr);  // trapezoid
+    prev = curr;
+  }
+  return qoiValue;
 }
 
-void adjointPass(serac::BasePhysics *solid, qoiType *qoi, int nTimeSteps, double timeStep, mfem::ParFiniteElementSpace &param_space, double &Ederiv, double &vderiv)
+void adjointPass(serac::BasePhysics* solid, qoiType* qoi, int nTimeSteps, double timeStep,
+                 mfem::ParFiniteElementSpace& param_space, double& Ederiv, double& vderiv)
 {
-     double time = nTimeSteps*timeStep;
-    std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
+  serac::FiniteElementDual         Egrad(param_space);
+  serac::FiniteElementDual         vgrad(param_space);
+  const serac::FiniteElementState& E = solid->parameter("E");
+  const serac::FiniteElementState& v = solid->parameter("v");
+  for (int i = nTimeSteps; i > 0; i--) {
+    const serac::FiniteElementState& u      = solid->loadCheckpointedState("displacement", i);
+    double                           scalar = (i == nTimeSteps) ? 0.5 * timeStep : timeStep;
 
-    serac::FiniteElementDual Egrad(param_space);
-    serac::FiniteElementDual vgrad(param_space);
-    const serac::FiniteElementState &E = solid->parameter("E");
-    const serac::FiniteElementState &v = solid->parameter("v");
-    for (int i=nTimeSteps; i>0; i--) {
-        
-        const serac::FiniteElementState &u = solid->loadCheckpointedState("displacement", i);
-        double scalar = (i==nTimeSteps)? 0.5 * timeStep : timeStep;
+    auto dQoI_dE = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<0>{}, solid->time(), E, v, u));
+    std::unique_ptr<::mfem::HypreParVector> assembled_Egrad = dQoI_dE.assemble();
+    *assembled_Egrad *= scalar;
+    Egrad += *assembled_Egrad;
 
-        auto dQoI_dE = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<0> {}, solid->time(), E, v, u));
-        std::unique_ptr<::mfem::HypreParVector> assembled_Egrad = dQoI_dE.assemble();
-        *assembled_Egrad *= scalar;
-        Egrad += *assembled_Egrad;
+    auto dQoI_dv = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<1>{}, solid->time(), E, v, u));
+    std::unique_ptr<::mfem::HypreParVector> assembled_vgrad = dQoI_dv.assemble();
+    *assembled_vgrad *= scalar;
+    vgrad += *assembled_vgrad;
 
-        auto dQoI_dv = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<1> {}, solid->time(), E, v, u));
-        std::unique_ptr<::mfem::HypreParVector> assembled_vgrad = dQoI_dv.assemble();
-        *assembled_vgrad *= scalar;
-        vgrad += *assembled_vgrad;
+    auto dQoI_du = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<2>{}, solid->time(), E, v, u));
+    std::unique_ptr<::mfem::HypreParVector> assembled_ugrad = dQoI_du.assemble();
 
-        auto dQoI_du = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<2> {}, solid->time(), E, v, u));
-        std::unique_ptr<::mfem::HypreParVector> assembled_ugrad = dQoI_du.assemble();
+    serac::FiniteElementDual adjointLoad(u.space());
+    adjointLoad = *assembled_ugrad;
+    adjointLoad *= scalar;
+    solid->setAdjointLoad({{"displacement", adjointLoad}});
 
-        serac::FiniteElementDual adjointLoad(u.space());
-        adjointLoad = *assembled_ugrad;
-        adjointLoad *= scalar;
-        solid->setAdjointLoad({{"displacement", adjointLoad}});
+    solid->reverseAdjointTimestep();
 
-        solid->reverseAdjointTimestep();
-
-        serac::FiniteElementDual const &Edual = solid->computeTimestepSensitivity(0);
-        Egrad += Edual;
-        serac::FiniteElementDual const &vdual = solid->computeTimestepSensitivity(1);
-        vgrad += vdual;
-
-        time -= timeStep;
-        std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
-    }
-    Ederiv = Egrad(0);
-    vderiv = vgrad(0);
+    serac::FiniteElementDual const& Edual = solid->computeTimestepSensitivity(0);
+    Egrad += Edual;
+    serac::FiniteElementDual const& vdual = solid->computeTimestepSensitivity(1);
+    vgrad += vdual;
+  }
+  Ederiv = Egrad(0);
+  vderiv = vgrad(0);
 }
 
 TEST(quasistatic, finiteDifference)
 {
-    // set up mesh
-    ::axom::sidre::DataStore datastore;
-    ::serac::StateManager::initialize(datastore, "sidreDataStore");
+  // set up mesh
+  ::axom::sidre::DataStore datastore;
+  ::serac::StateManager::initialize(datastore, "sidreDataStore");
 
-    mfem::Mesh mesh = mfem::Mesh::MakeCartesian3D(1, 1, 1, mfem::Element::HEXAHEDRON);
-    assert(mesh.SpaceDimension() == DIM);
-    auto pmesh = ::std::make_unique<::mfem::ParMesh>(MPI_COMM_WORLD, mesh);
-    ::mfem::ParMesh *meshPtr = &::serac::StateManager::setMesh(::std::move(pmesh), mesh_tag);
-    
-    // set up solver
-    using solidType = serac::SolidMechanics<ORDER, DIM, ::serac::Parameters<paramFES, paramFES>>;
-    auto nonlinear_options = serac::NonlinearSolverOptions {
-        .nonlin_solver  = ::serac::NonlinearSolver::Newton,
-        .relative_tol   = 1e-6,
-        .absolute_tol   = 1e-8,
-        .max_iterations = 10,
-        .print_level    = 1};
-    auto seracSolid = ::std::make_unique<solidType>(
-        nonlinear_options, serac::solid_mechanics::direct_linear_options, ::serac::solid_mechanics::default_quasistatic_options,
-        ::serac::GeometricNonlinearities::Off, physics_prefix, mesh_tag, std::vector<std::string> {"E", "v"});
+  mfem::Mesh mesh = mfem::Mesh::MakeCartesian3D(1, 1, 1, mfem::Element::HEXAHEDRON);
+  assert(mesh.SpaceDimension() == DIM);
+  auto             pmesh   = ::std::make_unique<::mfem::ParMesh>(MPI_COMM_WORLD, mesh);
+  ::mfem::ParMesh* meshPtr = &::serac::StateManager::setMesh(::std::move(pmesh), mesh_tag);
 
-    using materialType = ParameterizedLinearIsotropicSolid;
-    materialType material;
-    seracSolid->setMaterial(::serac::DependsOn<0, 1> {}, material);
+  // set up solver
+  using solidType        = serac::SolidMechanics<ORDER, DIM, ::serac::Parameters<paramFES, paramFES>>;
+  auto nonlinear_options = serac::NonlinearSolverOptions{.nonlin_solver  = ::serac::NonlinearSolver::Newton,
+                                                         .relative_tol   = 1e-6,
+                                                         .absolute_tol   = 1e-8,
+                                                         .max_iterations = 10,
+                                                         .print_level    = 1};
+  auto seracSolid = ::std::make_unique<solidType>(nonlinear_options, serac::solid_mechanics::direct_linear_options,
+                                                  ::serac::solid_mechanics::default_quasistatic_options,
+                                                  ::serac::GeometricNonlinearities::Off, physics_prefix, mesh_tag,
+                                                  std::vector<std::string>{"E", "v"});
 
-    seracSolid->setDisplacementBCs({3}, [](const mfem::Vector&){ return 0.0; }, 0);
-    seracSolid->setDisplacementBCs({4}, [](const mfem::Vector&){ return 0.0; }, 1);
-    seracSolid->setDisplacementBCs({1}, [](const mfem::Vector&){ return 0.0; }, 2);
+  using materialType = ParameterizedLinearIsotropicSolid;
+  materialType material;
+  seracSolid->setMaterial(::serac::DependsOn<0, 1>{}, material);
 
-    //serac::Domain loadRegion = serac::Domain::ofBoundaryElements(*meshPtr, serac::by_attr<DIM>(6));
-    //seracSolid->setTraction([](auto, auto n, auto) {return 1.0*n;}, loadRegion);
-    seracSolid->setDisplacementBCs({6}, [](const mfem::Vector&, double time, mfem::Vector &u) { return u[2] = time; });
+  seracSolid->setDisplacementBCs(
+      {3}, [](const mfem::Vector&) { return 0.0; }, 0);
+  seracSolid->setDisplacementBCs(
+      {4}, [](const mfem::Vector&) { return 0.0; }, 1);
+  seracSolid->setDisplacementBCs(
+      {1}, [](const mfem::Vector&) { return 0.0; }, 2);
 
-    double E0 = 1.0;
-    double v0 = 0.3;
-    ::serac::FiniteElementState Estate(seracSolid->parameter(seracSolid->parameterNames()[0]));
-    ::serac::FiniteElementState vstate(seracSolid->parameter(seracSolid->parameterNames()[1]));
-    Estate = E0;
-    vstate = v0;
-    seracSolid->setParameter(0, Estate);
-    seracSolid->setParameter(1, vstate);
+  // serac::Domain loadRegion = serac::Domain::ofBoundaryElements(*meshPtr, serac::by_attr<DIM>(6));
+  // seracSolid->setTraction([](auto, auto n, auto) {return 1.0*n;}, loadRegion);
+  seracSolid->setDisplacementBCs({6}, [](const mfem::Vector&, double time, mfem::Vector& u) { return u[2] = time; });
 
-    seracSolid->completeSetup();
+  double                      E0 = 1.0;
+  double                      v0 = 0.3;
+  ::serac::FiniteElementState Estate(seracSolid->parameter(seracSolid->parameterNames()[0]));
+  ::serac::FiniteElementState vstate(seracSolid->parameter(seracSolid->parameterNames()[1]));
+  Estate = E0;
+  vstate = v0;
+  seracSolid->setParameter(0, Estate);
+  seracSolid->setParameter(1, vstate);
 
-    // set up QoI
-    auto [param_space, _] = ::serac::generateParFiniteElementSpace<paramFES>(meshPtr);
-    const ::mfem::ParFiniteElementSpace *u_space = &seracSolid->state("displacement").space();
-    
-    std::array<const ::mfem::ParFiniteElementSpace *, 3> qoiFES = {param_space.get(), param_space.get(), u_space};
-    auto qoi = std::make_unique<qoiType>(qoiFES);
-    qoi->AddDomainIntegral(serac::Dimension<DIM>{}, serac::DependsOn<0, 1, 2>{},
-        [&](auto time, auto, auto E, auto v, auto u) {
-            auto du_dx = ::serac::get<1>(u);
-            auto state = ::serac::Empty {};
-            auto stress = material(state, du_dx, E, v);
-            return stress[2][2]*time;
-        }, *meshPtr);
+  seracSolid->completeSetup();
 
-    int nTimeSteps = 2;
-    double timeStep = 0.8;
-    std::cout << "starting forward pass" << std::endl;
-    forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "f0");
+  // set up QoI
+  auto [param_space, _]                        = ::serac::generateParFiniteElementSpace<paramFES>(meshPtr);
+  const ::mfem::ParFiniteElementSpace* u_space = &seracSolid->state("displacement").space();
 
-    // ADJOINT GRADIENT
-    double Ederiv, vderiv;
-    std::cout << "starting adjoint pass" << std::endl;
-    adjointPass(seracSolid.get(), qoi.get(), nTimeSteps, timeStep, *param_space, Ederiv, vderiv);
-    
-    // FINITE DIFFERENCE GRADIENT
-    double h = 1e-7;
-    
-    Estate = E0+h;
-    seracSolid->setParameter(0, Estate);
-    std::cout << "starting Ep pass" << std::endl;
-    double fpE = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fpE");
+  std::array<const ::mfem::ParFiniteElementSpace*, 3> qoiFES = {param_space.get(), param_space.get(), u_space};
+  auto                                                qoi    = std::make_unique<qoiType>(qoiFES);
+  qoi->AddDomainIntegral(
+      serac::Dimension<DIM>{}, serac::DependsOn<0, 1, 2>{},
+      [&](auto time, auto, auto E, auto v, auto u) {
+        auto du_dx  = ::serac::get<1>(u);
+        auto state  = ::serac::Empty{};
+        auto stress = material(state, du_dx, E, v);
+        return stress[2][2] * time;
+      },
+      *meshPtr);
 
-    Estate = E0-h;
-    seracSolid->setParameter(0, Estate);
-    std::cout << "starting Em pass" << std::endl;
-    double fmE = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fmE");
+  int    nTimeSteps = 3;
+  double timeStep   = 0.8;
+  forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "f0");
 
-    Estate = E0;
-    seracSolid->setParameter(0, Estate);
+  // ADJOINT GRADIENT
+  double Ederiv, vderiv;
+  adjointPass(seracSolid.get(), qoi.get(), nTimeSteps, timeStep, *param_space, Ederiv, vderiv);
 
-    vstate = v0+h;
-    seracSolid->setParameter(1, vstate);
-    std::cout << "starting vp pass" << std::endl;
-    double fpv = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fpv");
+  // FINITE DIFFERENCE GRADIENT
+  double h = 1e-7;
 
-    vstate = v0-h;
-    seracSolid->setParameter(1, vstate);
-    std::cout << "starting vm pass" << std::endl;
-    double fmv = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fmv");
+  Estate = E0 + h;
+  seracSolid->setParameter(0, Estate);
+  double fpE = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fpE");
 
-    std::cout << std::endl << std::endl;
-    std::cout << "analytical gradient = " << Ederiv << " " << vderiv << std::endl;
-    std::cout << "numerical gradient  = " << (fpE-fmE)/(2.*h) << " " << (fpv-fmv)/(2.*h) << std::endl;
+  Estate = E0 - h;
+  seracSolid->setParameter(0, Estate);
+  double fmE = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fmE");
+
+  Estate = E0;
+  seracSolid->setParameter(0, Estate);
+
+  vstate = v0 + h;
+  seracSolid->setParameter(1, vstate);
+  double fpv = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fpv");
+
+  vstate = v0 - h;
+  seracSolid->setParameter(1, vstate);
+  double fmv = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fmv");
+
+  ASSERT_NEAR(Ederiv, (fpE - fmE) / (2. * h), 1e-8);
+  ASSERT_NEAR(vderiv, (fpv - fmv) / (2. * h), 1e-8);
 }
 
 }  // namespace serac
@@ -260,7 +254,7 @@ int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
   MPI_Init(&argc, &argv);
-  
+
   axom::slic::SimpleLogger logger;
   std::cout << std::setprecision(16);
   int result = RUN_ALL_TESTS();

--- a/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
@@ -1,0 +1,270 @@
+// Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+#include <functional>
+#include <set>
+#include <string>
+
+#include "serac/physics/solid_mechanics.hpp"
+#include "serac/physics/materials/solid_material.hpp"
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include <gtest/gtest.h>
+#include "mfem.hpp"
+
+#include "serac/mesh/mesh_utils.hpp"
+#include "serac/physics/state/state_manager.hpp"
+#include "serac/serac_config.hpp"
+
+struct ParameterizedLinearIsotropicSolid {
+  using State = ::serac::Empty; ///< this material has no internal variables
+
+  template<int dim, typename T1, typename T2, typename T3>
+  SERAC_HOST_DEVICE auto operator()(State &, const ::serac::tensor<T1, dim, dim> &u_grad, const T2 &E_tuple, const T3 &v_tuple) const
+  {
+    auto E = ::serac::get<0>(E_tuple); // Young's modulus VALUE
+    auto v = ::serac::get<0>(v_tuple); // Poisson's ratio VALUE
+    auto lambda = E * v / ((1.0 + v) * (1.0 - 2.0 * v)); // Lamé's first parameter
+    auto mu = E / (2.0 * (1.0 + v)); // Lamé's second parameter
+    const auto I = ::serac::Identity<dim>(); // identity matrix
+    auto strain = ::serac::sym(u_grad); // small strain tensor
+    return lambda * ::serac::tr(strain) * I + 2.0 * mu * strain; // Cauchy stress
+  }
+  static constexpr double density {1.0}; ///< mass density, for dynamics problems
+};
+
+struct ParameterizedNeoHookeanSolid {
+  using State = ::serac::Empty;  // this material has no internal variables
+
+  template <int dim, typename T1, typename T2, typename T3>
+  SERAC_HOST_DEVICE auto operator()(State&, const ::serac::tensor<T1, dim, dim>& du_dX, const T2& E_tuple, const T3& v_tuple) const
+  {
+    using std::log1p;
+    constexpr auto I         = serac::Identity<dim>();
+    auto           E         = serac::get<0>(E_tuple);
+    auto           v         = serac::get<0>(v_tuple);
+    auto           G         = E / (2.0 * (1.0 + v));
+    auto           lambda    = (E * v) / ((1.0 + v) * (1.0 - 2.0 * v));
+    auto           B_minus_I = du_dX * serac::transpose(du_dX) + serac::transpose(du_dX) + du_dX;
+    auto           J_minus_1 = serac::detApIm1(du_dX);
+    auto           J         = J_minus_1 + 1;
+    return (lambda * log1p(J_minus_1) * I + G * B_minus_I) / J;
+  }
+  static constexpr double density {1.0}; ///< mass density, for dynamics problems
+};
+
+
+namespace serac {
+
+constexpr int DIM = 3;
+constexpr int ORDER = 1;
+
+const std::string mesh_tag       = "mesh";
+const std::string physics_prefix = "solid";
+
+using paramFES = serac::L2<0>;
+using uFES = serac::H1<ORDER, DIM>;
+using qoiType = serac::Functional<double(paramFES, paramFES, uFES)>;
+
+double forwardPass(serac::BasePhysics *solid, qoiType *qoi, mfem::ParMesh *meshPtr, int nTimeSteps, double timeStep, std::string saveName)
+{
+    solid->resetStates();
+
+    // set up plotting
+    mfem::ParGridFunction uGF(const_cast<mfem::ParFiniteElementSpace*>(&solid->state("displacement").space()));
+    solid->state("displacement").fillGridFunction(uGF);
+    mfem::VisItDataCollection visit_dc(saveName, meshPtr);
+    visit_dc.RegisterField("u", &uGF);
+    visit_dc.SetCycle(0);
+    visit_dc.Save();
+
+    double qoiValue = 0.0;
+    const serac::FiniteElementState &E = solid->parameter("E");
+    const serac::FiniteElementState &v = solid->parameter("v");
+    const serac::FiniteElementState &u = solid->state("displacement");
+
+    double time = 0.0;
+    std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
+    double prev = (*qoi)(solid->time(), E, v, u);
+    for (int i=0; i<nTimeSteps; i++) {
+        // solve
+        solid->advanceTimestep(timeStep);
+        time += timeStep;
+        std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
+
+        // plot
+        u.fillGridFunction(uGF);
+        visit_dc.SetCycle(i+1);
+        visit_dc.Save();
+
+        // accumulate
+        double curr = (*qoi)(solid->time(), E, v, u);
+        qoiValue += timeStep * 0.5*(prev+curr); // trapezoid
+        prev = curr;
+    }
+    return qoiValue;
+}
+
+void adjointPass(serac::BasePhysics *solid, qoiType *qoi, int nTimeSteps, double timeStep, mfem::ParFiniteElementSpace &param_space, double &Ederiv, double &vderiv)
+{
+     double time = nTimeSteps*timeStep;
+    std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
+
+    serac::FiniteElementDual Egrad(param_space);
+    serac::FiniteElementDual vgrad(param_space);
+    const serac::FiniteElementState &E = solid->parameter("E");
+    const serac::FiniteElementState &v = solid->parameter("v");
+    for (int i=nTimeSteps; i>0; i--) {
+        
+        const serac::FiniteElementState &u = solid->loadCheckpointedState("displacement", i);
+        double scalar = (i==nTimeSteps)? 0.5 * timeStep : timeStep;
+
+        auto dQoI_dE = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<0> {}, solid->time(), E, v, u));
+        std::unique_ptr<::mfem::HypreParVector> assembled_Egrad = dQoI_dE.assemble();
+        *assembled_Egrad *= scalar;
+        Egrad += *assembled_Egrad;
+
+        auto dQoI_dv = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<1> {}, solid->time(), E, v, u));
+        std::unique_ptr<::mfem::HypreParVector> assembled_vgrad = dQoI_dv.assemble();
+        *assembled_vgrad *= scalar;
+        vgrad += *assembled_vgrad;
+
+        auto dQoI_du = ::serac::get<1>((*qoi)(::serac::DifferentiateWRT<2> {}, solid->time(), E, v, u));
+        std::unique_ptr<::mfem::HypreParVector> assembled_ugrad = dQoI_du.assemble();
+
+        serac::FiniteElementDual adjointLoad(u.space());
+        adjointLoad = *assembled_ugrad;
+        adjointLoad *= scalar;
+        solid->setAdjointLoad({{"displacement", adjointLoad}});
+
+        solid->reverseAdjointTimestep();
+
+        serac::FiniteElementDual const &Edual = solid->computeTimestepSensitivity(0);
+        Egrad += Edual;
+        serac::FiniteElementDual const &vdual = solid->computeTimestepSensitivity(1);
+        vgrad += vdual;
+
+        time -= timeStep;
+        std::cout << "expected time = " << time << " serac time = " << solid->time() << std::endl;
+    }
+    Ederiv = Egrad(0);
+    vderiv = vgrad(0);
+}
+
+TEST(quasistatic, finiteDifference)
+{
+    // set up mesh
+    ::axom::sidre::DataStore datastore;
+    ::serac::StateManager::initialize(datastore, "sidreDataStore");
+
+    mfem::Mesh mesh = mfem::Mesh::MakeCartesian3D(1, 1, 1, mfem::Element::HEXAHEDRON);
+    assert(mesh.SpaceDimension() == DIM);
+    auto pmesh = ::std::make_unique<::mfem::ParMesh>(MPI_COMM_WORLD, mesh);
+    ::mfem::ParMesh *meshPtr = &::serac::StateManager::setMesh(::std::move(pmesh), mesh_tag);
+    
+    // set up solver
+    using solidType = serac::SolidMechanics<ORDER, DIM, ::serac::Parameters<paramFES, paramFES>>;
+    auto nonlinear_options = serac::NonlinearSolverOptions {
+        .nonlin_solver  = ::serac::NonlinearSolver::Newton,
+        .relative_tol   = 1e-6,
+        .absolute_tol   = 1e-8,
+        .max_iterations = 10,
+        .print_level    = 1};
+    auto seracSolid = ::std::make_unique<solidType>(
+        nonlinear_options, serac::solid_mechanics::direct_linear_options, ::serac::solid_mechanics::default_quasistatic_options,
+        ::serac::GeometricNonlinearities::Off, physics_prefix, mesh_tag, std::vector<std::string> {"E", "v"});
+
+    using materialType = ParameterizedLinearIsotropicSolid;
+    materialType material;
+    seracSolid->setMaterial(::serac::DependsOn<0, 1> {}, material);
+
+    seracSolid->setDisplacementBCs({3}, [](const mfem::Vector&){ return 0.0; }, 0);
+    seracSolid->setDisplacementBCs({4}, [](const mfem::Vector&){ return 0.0; }, 1);
+    seracSolid->setDisplacementBCs({1}, [](const mfem::Vector&){ return 0.0; }, 2);
+
+    //serac::Domain loadRegion = serac::Domain::ofBoundaryElements(*meshPtr, serac::by_attr<DIM>(6));
+    //seracSolid->setTraction([](auto, auto n, auto) {return 1.0*n;}, loadRegion);
+    seracSolid->setDisplacementBCs({6}, [](const mfem::Vector&, double time, mfem::Vector &u) { return u[2] = time; });
+
+    double E0 = 1.0;
+    double v0 = 0.3;
+    ::serac::FiniteElementState Estate(seracSolid->parameter(seracSolid->parameterNames()[0]));
+    ::serac::FiniteElementState vstate(seracSolid->parameter(seracSolid->parameterNames()[1]));
+    Estate = E0;
+    vstate = v0;
+    seracSolid->setParameter(0, Estate);
+    seracSolid->setParameter(1, vstate);
+
+    seracSolid->completeSetup();
+
+    // set up QoI
+    auto [param_space, _] = ::serac::generateParFiniteElementSpace<paramFES>(meshPtr);
+    const ::mfem::ParFiniteElementSpace *u_space = &seracSolid->state("displacement").space();
+    
+    std::array<const ::mfem::ParFiniteElementSpace *, 3> qoiFES = {param_space.get(), param_space.get(), u_space};
+    auto qoi = std::make_unique<qoiType>(qoiFES);
+    qoi->AddDomainIntegral(serac::Dimension<DIM>{}, serac::DependsOn<0, 1, 2>{},
+        [&](auto time, auto, auto E, auto v, auto u) {
+            auto du_dx = ::serac::get<1>(u);
+            auto state = ::serac::Empty {};
+            auto stress = material(state, du_dx, E, v);
+            return stress[2][2]*time;
+        }, *meshPtr);
+
+    int nTimeSteps = 2;
+    double timeStep = 0.8;
+    std::cout << "starting forward pass" << std::endl;
+    forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "f0");
+
+    // ADJOINT GRADIENT
+    double Ederiv, vderiv;
+    std::cout << "starting adjoint pass" << std::endl;
+    adjointPass(seracSolid.get(), qoi.get(), nTimeSteps, timeStep, *param_space, Ederiv, vderiv);
+    
+    // FINITE DIFFERENCE GRADIENT
+    double h = 1e-7;
+    
+    Estate = E0+h;
+    seracSolid->setParameter(0, Estate);
+    std::cout << "starting Ep pass" << std::endl;
+    double fpE = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fpE");
+
+    Estate = E0-h;
+    seracSolid->setParameter(0, Estate);
+    std::cout << "starting Em pass" << std::endl;
+    double fmE = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fmE");
+
+    Estate = E0;
+    seracSolid->setParameter(0, Estate);
+
+    vstate = v0+h;
+    seracSolid->setParameter(1, vstate);
+    std::cout << "starting vp pass" << std::endl;
+    double fpv = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fpv");
+
+    vstate = v0-h;
+    seracSolid->setParameter(1, vstate);
+    std::cout << "starting vm pass" << std::endl;
+    double fmv = forwardPass(seracSolid.get(), qoi.get(), meshPtr, nTimeSteps, timeStep, "fmv");
+
+    std::cout << std::endl << std::endl;
+    std::cout << "analytical gradient = " << Ederiv << " " << vderiv << std::endl;
+    std::cout << "numerical gradient  = " << (fpE-fmE)/(2.*h) << " " << (fpv-fmv)/(2.*h) << std::endl;
+}
+
+}  // namespace serac
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  MPI_Init(&argc, &argv);
+  
+  axom::slic::SimpleLogger logger;
+  std::cout << std::setprecision(16);
+  int result = RUN_ALL_TESTS();
+  MPI_Finalize();
+
+  return result;
+}


### PR DESCRIPTION
The checkpointing was not being done for quasi-static problems.  Now, it is written a bit more generically with a bit more responsibility on base_physics and loops over states so that it will work for any physics and dynamic or quasi-static.  In addition, we were not decrementing the time correctly, so any time dependent load was not being accounted for in the reverse pass correctly.  This tries to clear up some of the logic and naming, and fix these know failing situations.  Tests were added to check time varying loads and quasi-static evolution.

Additional things in this: remove ode_time_point_, as it was very confusingly intertwined with  time_.  If there is a case to keep both, we can undo this.  Also, the checkpoint to disk capability is a bit subtle.  Now it is always writing to disk.  If the user externally also writes state to disk, it will mess up the checkpointing.  I think we can considered deleting the writing to disk checkpointing altogether at some point.  For now, it is fairly hard to use.