### PR TITLE
lazily evaluate sparse matrix LUTs

### DIFF
--- a/src/serac/numerics/functional/dof_numbering.hpp
+++ b/src/serac/numerics/functional/dof_numbering.hpp
@@ -276,9 +276,9 @@ struct GradientAssemblyLookupTables {
       }
     };
   };
-  
+
   /// dummy default ctor to enable deferred initialization
-  GradientAssemblyLookupTables() : initialized{false} {}; 
+  GradientAssemblyLookupTables() : initialized{false} {};
 
   /**
    * @param block_test_dofs object containing information about dofs for the test space
@@ -375,7 +375,6 @@ struct GradientAssemblyLookupTables {
   std::unordered_map<Entry, uint32_t, Entry::Hasher> nz_LUT;
 
   bool initialized;
-
 };
 
 }  // namespace serac

--- a/src/serac/numerics/functional/dof_numbering.hpp
+++ b/src/serac/numerics/functional/dof_numbering.hpp
@@ -276,6 +276,9 @@ struct GradientAssemblyLookupTables {
       }
     };
   };
+  
+  /// dummy default ctor to enable deferred initialization
+  GradientAssemblyLookupTables() : initialized{false} {}; 
 
   /**
    * @param block_test_dofs object containing information about dofs for the test space
@@ -284,8 +287,8 @@ struct GradientAssemblyLookupTables {
    * @brief create lookup tables describing which degrees of freedom
    * correspond to each domain/boundary element
    */
-  GradientAssemblyLookupTables(const serac::BlockElementRestriction& block_test_dofs,
-                               const serac::BlockElementRestriction& block_trial_dofs)
+  void init(const serac::BlockElementRestriction& block_test_dofs,
+            const serac::BlockElementRestriction& block_trial_dofs)
   {
     // we start by having each element and boundary element emit the (i,j) entry that it
     // touches in the global "stiffness matrix", and also keep track of some metadata about
@@ -342,6 +345,8 @@ struct GradientAssemblyLookupTables {
     }
 
     row_ptr.back() = static_cast<int>(nnz);
+
+    initialized = true;
   }
 
   /**
@@ -368,6 +373,9 @@ struct GradientAssemblyLookupTables {
    * corresponding to the (i,j) entry
    */
   std::unordered_map<Entry, uint32_t, Entry::Hasher> nz_LUT;
+
+  bool initialized;
+
 };
 
 }  // namespace serac

--- a/src/serac/numerics/functional/dof_numbering.hpp
+++ b/src/serac/numerics/functional/dof_numbering.hpp
@@ -374,6 +374,7 @@ struct GradientAssemblyLookupTables {
    */
   std::unordered_map<Entry, uint32_t, Entry::Hasher> nz_LUT;
 
+  /// @brief specifies if the table has already been initialized or not
   bool initialized;
 };
 

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -576,7 +576,8 @@ private:
       constexpr bool col_ind_is_sorted = true;
 
       if (!lookup_tables.initialized) {
-        lookup_tables.init(form_.G_test_[Domain::Type::Elements], form_.G_trial_[Domain::Type::Elements][which_argument]);
+        lookup_tables.init(form_.G_test_[Domain::Type::Elements],
+                           form_.G_trial_[Domain::Type::Elements][which_argument]);
       }
 
       double* values = new double[lookup_tables.nnz]{};

--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -537,7 +537,6 @@ private:
     Gradient(Functional<test(trials...), exec>& f, uint32_t which = 0)
         : mfem::Operator(f.test_space_->GetTrueVSize(), f.trial_space_[which]->GetTrueVSize()),
           form_(f),
-          lookup_tables(f.G_test_[Domain::Type::Elements], f.G_trial_[Domain::Type::Elements][which]),
           which_argument(which),
           test_space_(f.test_space_),
           trial_space_(f.trial_space_[which]),
@@ -574,6 +573,10 @@ private:
       constexpr bool sparse_matrix_frees_values_ptr = true;
 
       constexpr bool col_ind_is_sorted = true;
+
+      if (!lookup_tables.initialized) {
+        lookup_tables.init(form_.G_test_[Domain::Type::Elements], form_.G_trial_[Domain::Type::Elements][which_argument]);
+      }
 
       double* values = new double[lookup_tables.nnz]{};
 


### PR DESCRIPTION
Before this PR, `serac::Functional` eagerly initialized its member variables. Some of those member variables required for the sparse matrix assembly are expensive (both in compute and memory) to initialize. In many analyses, users never create sparse matrices for some of the trial space derivatives (like the parameter fields) which means that some of those member variables were never needed after all.

This PR changes the behavior so that the expensive bits are initialized just-in-time, rather than when a `serac::Functional` is created, to be more consistent with the mantra "don't pay for what you don't use". The end result is a much smaller memory footprint (about ~50-75% smaller, depending on number of parameter fields) and shorter time to initialize.

The implementation is crude, but we're planning to remove much of this code in the coming months anyway.