### PR TITLE
Add `SERAC_ENABLE_TESTS` CMake option

### DIFF
--- a/cmake/SeracBasics.cmake
+++ b/cmake/SeracBasics.cmake
@@ -27,6 +27,8 @@ else()
 endif()
 option(SERAC_ENABLE_CODE_CHECKS "Enable Serac's code checks" ${_enable_serac_code_checks})
 
+cmake_dependent_option(SERAC_ENABLE_TESTS "Enables Serac Tests" ON "ENABLE_TESTS" OFF)
+
 #------------------------------------------------------------------------------
 # Profiling options
 #------------------------------------------------------------------------------

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,6 @@ if (ENABLE_DOCS)
     add_subdirectory(docs)
 endif()
 
-if(ENABLE_TESTS)
+if(SERAC_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()

--- a/src/docs/sphinx/quickstart.rst
+++ b/src/docs/sphinx/quickstart.rst
@@ -202,7 +202,7 @@ one of the following commands:
 
 If you built the dependencies using Spack/uberenv, the host-config file is output at the
 project root. To use the pre-built dependencies on LC, you must be in the appropriate
-LC group. Contact `Jamie Bramwell <bramwell1@llnl.gov>`_ for access.
+LC group. Contact `Brandon Talamini <talamini1@llnl.gov>`_ for access.
 
 Some build options frequently used by Serac include:
 
@@ -210,6 +210,7 @@ Some build options frequently used by Serac include:
 * ``ENABLE_BENCHMARKS``: Enables Google Benchmark performance tests, defaults to ``OFF``
 * ``ENABLE_WARNINGS_AS_ERRORS``: Turns compiler warnings into errors, defaults to ``ON``
 * ``ENABLE_ASAN``: Enables the Address Sanitizer for memory safety inspections, defaults to ``OFF``
+* ``SERAC_ENABLE_TESTS``: Enables Serac unit tests, defaults to ``ON``
 * ``SERAC_ENABLE_CODEVELOP``: Enables local development build of MFEM/Axom, see :ref:`codevelop-label`, defaults to ``OFF``
 * ``SERAC_USE_VDIM_ORDERING``: Sets the vector ordering to be ``byVDIM``, which is significantly faster for algebraic multigrid,
    but may conflict with other packages if Serac is being used as a dependency, defaults to ``OFF``.

--- a/src/drivers/CMakeLists.txt
+++ b/src/drivers/CMakeLists.txt
@@ -10,7 +10,7 @@ blt_add_executable( NAME        serac_driver
                     OUTPUT_NAME serac
                     )
 
-if (ENABLE_TESTS)
+if (SERAC_ENABLE_TESTS)
     set(input_files_dir ${CMAKE_CURRENT_SOURCE_DIR}/../../data/input_files)
 
     # Make sure running serac driver doesn't completely fail

--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if(ENABLE_TESTS)
-    add_subdirectory(tests)
-endif()
-
 # This file contains metadata that often changes (ie. git sha).
 # Hide these changes in the source file so we do not force
 # a full rebuild.
@@ -73,3 +69,7 @@ install(TARGETS              serac_infrastructure
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+if(SERAC_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/serac/infrastructure/tests/CMakeLists.txt
+++ b/src/serac/infrastructure/tests/CMakeLists.txt
@@ -4,12 +4,12 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-set(test_dependencies gtest serac_physics serac_mesh)
+set(infrastructure_test_depends serac_physics serac_mesh gtest)
 
-set(infrastructure_tests
+set(infrastructure_test_sources
     error_handling.cpp
     input.cpp
     profiling.cpp)
 
-serac_add_tests( SOURCES ${infrastructure_tests}
-                 DEPENDS_ON ${test_dependencies})
+serac_add_tests( SOURCES    ${infrastructure_test_sources}
+                 DEPENDS_ON ${infrastructure_test_depends})

--- a/src/serac/mesh/CMakeLists.txt
+++ b/src/serac/mesh/CMakeLists.txt
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if(ENABLE_TESTS)
-    add_subdirectory(tests)
-endif()
-
 set(mesh_headers
     mesh_utils.hpp
     mesh_utils_base.hpp
@@ -32,3 +28,7 @@ install(TARGETS              serac_mesh
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+if(SERAC_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/serac/mesh/tests/CMakeLists.txt
+++ b/src/serac/mesh/tests/CMakeLists.txt
@@ -4,20 +4,20 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-set(test_dependencies gtest serac_numerics serac_mesh serac_boundary_conditions)
+set(mesh_test_depends serac_numerics serac_mesh serac_boundary_conditions gtest)
 
-set(mesh_parallel_tests
+set(mesh_parallel_test_sources
     mesh_test.cpp
     )
 
-serac_add_tests( SOURCES ${mesh_parallel_tests}
-                 DEPENDS_ON ${test_dependencies}
+serac_add_tests( SOURCES       ${mesh_parallel_test_sources}
+                 DEPENDS_ON    ${mesh_test_depends}
                  NUM_MPI_TASKS 2)
 
-set(mesh_serial_tests
+set(mesh_serial_test_sources
     mesh_generation.cpp
     )
 
-serac_add_tests( SOURCES ${mesh_serial_tests}
-                 DEPENDS_ON ${test_dependencies}
+serac_add_tests( SOURCES       ${mesh_serial_test_sources}
+                 DEPENDS_ON    ${mesh_test_depends}
                  NUM_MPI_TASKS 1)

--- a/src/serac/numerics/CMakeLists.txt
+++ b/src/serac/numerics/CMakeLists.txt
@@ -39,4 +39,3 @@ install(TARGETS              serac_numerics
 if(SERAC_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
-

--- a/src/serac/numerics/CMakeLists.txt
+++ b/src/serac/numerics/CMakeLists.txt
@@ -39,4 +39,4 @@ install(TARGETS              serac_numerics
 if(SERAC_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
-        
+

--- a/src/serac/numerics/CMakeLists.txt
+++ b/src/serac/numerics/CMakeLists.txt
@@ -6,10 +6,6 @@
 
 add_subdirectory(functional)
 
-if(ENABLE_TESTS)
-    add_subdirectory(tests)
-endif()
-
 set(numerics_headers
     equation_solver.hpp
     odes.hpp
@@ -39,3 +35,8 @@ install(TARGETS              serac_numerics
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+if(SERAC_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()
+        

--- a/src/serac/numerics/functional/CMakeLists.txt
+++ b/src/serac/numerics/functional/CMakeLists.txt
@@ -80,6 +80,6 @@ install(TARGETS              serac_functional
         DESTINATION          lib
         )
 
-if(ENABLE_TESTS)
+if(SERAC_ENABLE_TESTS)
    add_subdirectory(tests)
 endif()

--- a/src/serac/numerics/functional/tests/CMakeLists.txt
+++ b/src/serac/numerics/functional/tests/CMakeLists.txt
@@ -4,16 +4,18 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
+set(functional_test_depends gtest serac_functional ${functional_depends})
+
 # This test is all constexpr-evaluated, so it doesn't
 # actually need to run, if it compiles without error, the tests have passed
 blt_add_executable(NAME        tensor_unit_tests
                    SOURCES     tensor_unit_tests.cpp
                    OUTPUT_DIR  ${TEST_OUTPUT_DIRECTORY}
-                   DEPENDS_ON  gtest serac_functional ${functional_depends}
+                   DEPENDS_ON  ${functional_test_depends}
                    FOLDER      serac/tests)
 
 # Then add the examples/tests
-set(functional_tests_serial
+set(functional_serial_test_sources
     functional_shape_derivatives.cpp
     simplex_basis_function_unit_tests.cpp
     bug_boundary_qoi.cpp
@@ -25,13 +27,13 @@ set(functional_tests_serial
     tuple_arithmetic_unit_tests.cpp
     test_newton.cpp)
 
-serac_add_tests( SOURCES ${functional_tests_serial}
-                 DEPENDS_ON gtest serac_functional ${functional_depends})
+serac_add_tests(SOURCES    ${functional_serial_test_sources}
+                DEPENDS_ON ${functional_test_depends})
 
 set_source_files_properties(functional_tet_quality PROPERTIES LANGUAGE CXX)
 
 # Then add the examples/tests
-set(functional_tests_mpi
+set(functional_parallel_test_sources
     #functional_basic_hcurl.cpp
     functional_with_domain.cpp
     functional_basic_h1_scalar.cpp
@@ -44,11 +46,11 @@ set(functional_tests_mpi
     functional_comparison_L2.cpp
     )
 
-serac_add_tests( SOURCES ${functional_tests_mpi}
-                 DEPENDS_ON gtest serac_functional serac_state ${functional_depends}
-                 NUM_MPI_TASKS 4 )
+serac_add_tests(SOURCES       ${functional_parallel_test_sources}
+                DEPENDS_ON    ${functional_test_depends}
+                NUM_MPI_TASKS 4 )
 
-foreach(filename ${functional_tests_mpi})
+foreach(filename ${functional_parallel_test_sources})
     set_source_files_properties(${filename} PROPERTIES LANGUAGE CXX)
 endforeach()
 
@@ -56,7 +58,7 @@ target_link_libraries(bug_boundary_qoi PUBLIC serac_physics)
 
 if(ENABLE_CUDA)
 
-    set(functional_tests_cuda 
+    set(functional_cuda_test_sources 
         tensor_unit_tests_cuda.cu 
 #        some of the GPU functionality is temporarily disabled to 
 #        help incrementally roll-out the variadic implementation of Functional
@@ -64,7 +66,7 @@ if(ENABLE_CUDA)
 #        functional_comparisons_cuda.cu
        )
 
-    serac_add_tests( SOURCES ${functional_tests_cuda}
-                     DEPENDS_ON gtest serac_functional serac_state ${functional_depends})
+    serac_add_tests( SOURCES    ${functional_cuda_test_sources}
+                     DEPENDS_ON ${functional_test_depends})
 
 endif()

--- a/src/serac/numerics/tests/CMakeLists.txt
+++ b/src/serac/numerics/tests/CMakeLists.txt
@@ -4,20 +4,20 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-set(test_dependencies gtest serac_numerics serac_boundary_conditions)
+set(numerics_test_dependencies serac_numerics serac_boundary_conditions gtest)
 
-set(numerics_serial_tests
+set(numerics_serial_test_sources
     equationsolver.cpp
     operator.cpp
     odes.cpp
     )
 
-serac_add_tests( SOURCES ${numerics_serial_tests}
-                 DEPENDS_ON ${test_dependencies}
+serac_add_tests( SOURCES       ${numerics_serial_test_sources}
+                 DEPENDS_ON    ${numerics_test_dependencies}
                  NUM_MPI_TASKS 1)
 
 if(PETSC_FOUND)
     serac_add_tests(SOURCES       equationsolver_petsc.cpp
-                    DEPENDS_ON    ${test_dependencies}
+                    DEPENDS_ON    ${numerics_test_dependencies}
                     NUM_MPI_TASKS 1)
 endif()

--- a/src/serac/physics/CMakeLists.txt
+++ b/src/serac/physics/CMakeLists.txt
@@ -9,14 +9,6 @@ add_subdirectory(state)
 add_subdirectory(boundary_conditions)
 add_subdirectory(contact)
 
-if(ENABLE_TESTS)
-    add_subdirectory(tests)
-endif()
-
-if(SERAC_ENABLE_BENCHMARKS)
-    add_subdirectory(benchmarks)
-endif()
-
 set(physics_sources
     base_physics.cpp
     solid_mechanics.cpp
@@ -37,7 +29,7 @@ set(physics_headers
     thermomechanics_input.hpp
     )
 
-set(physics_dependencies
+set(physics_depends
     serac_state
     serac_boundary_conditions
     serac_contact
@@ -49,7 +41,7 @@ blt_add_library(
     NAME        serac_physics
     SOURCES     ${physics_sources}
     HEADERS     ${physics_headers}
-    DEPENDS_ON  ${physics_dependencies}
+    DEPENDS_ON  ${physics_depends}
     )
 
 install(FILES ${physics_headers} DESTINATION include/serac/physics )
@@ -58,3 +50,12 @@ install(TARGETS              serac_physics
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+if(SERAC_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()
+    
+if(SERAC_ENABLE_BENCHMARKS)
+    add_subdirectory(benchmarks)
+endif()
+    

--- a/src/serac/physics/CMakeLists.txt
+++ b/src/serac/physics/CMakeLists.txt
@@ -58,4 +58,4 @@ endif()
 if(SERAC_ENABLE_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()
-    
+

--- a/src/serac/physics/CMakeLists.txt
+++ b/src/serac/physics/CMakeLists.txt
@@ -58,4 +58,3 @@ endif()
 if(SERAC_ENABLE_BENCHMARKS)
     add_subdirectory(benchmarks)
 endif()
-

--- a/src/serac/physics/benchmarks/CMakeLists.txt
+++ b/src/serac/physics/benchmarks/CMakeLists.txt
@@ -4,16 +4,16 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-set(benchmark_dependencies serac_physics)
+set(benchmark_depends serac_physics)
 
 blt_add_executable(NAME benchmark_thermal
                    SOURCES benchmark_thermal.cpp
-                   DEPENDS_ON ${benchmark_dependencies}
+                   DEPENDS_ON ${benchmark_depends}
                    OUTPUT_DIR ${PROJECT_BINARY_DIR}/benchmarks
                    FOLDER serac/benchmarks)
 
 blt_add_executable(NAME benchmark_functional
                    SOURCES benchmark_functional.cpp
-                   DEPENDS_ON ${benchmark_dependencies}
+                   DEPENDS_ON ${benchmark_depends}
                    OUTPUT_DIR ${PROJECT_BINARY_DIR}/benchmarks
                    FOLDER serac/benchmarks)

--- a/src/serac/physics/boundary_conditions/CMakeLists.txt
+++ b/src/serac/physics/boundary_conditions/CMakeLists.txt
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if(ENABLE_TESTS)
-    add_subdirectory(tests)
-endif()
-
 set(boundary_conditions_headers
     boundary_condition.hpp
     boundary_condition_helper.hpp
@@ -35,3 +31,7 @@ install(TARGETS              serac_boundary_conditions
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+if(SERAC_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/serac/physics/boundary_conditions/tests/CMakeLists.txt
+++ b/src/serac/physics/boundary_conditions/tests/CMakeLists.txt
@@ -4,11 +4,11 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-set(test_dependencies serac_boundary_conditions gtest)
+set(boundary_cond_test_depends serac_boundary_conditions gtest)
 
-set(boundary_cond_tests
+set(boundary_cond_test_sources
     boundary_cond.cpp)
 
-serac_add_tests( SOURCES ${boundary_cond_tests}
-                 DEPENDS_ON ${test_dependencies}
+serac_add_tests( SOURCES       ${boundary_cond_test_sources}
+                 DEPENDS_ON    ${boundary_cond_test_depends}
                  NUM_MPI_TASKS 2)

--- a/src/serac/physics/contact/CMakeLists.txt
+++ b/src/serac/physics/contact/CMakeLists.txt
@@ -36,4 +36,3 @@ install(TARGETS              serac_contact
 # if(ENABLE_TESTS)
 #     add_subdirectory(tests)
 # endif()
-

--- a/src/serac/physics/contact/CMakeLists.txt
+++ b/src/serac/physics/contact/CMakeLists.txt
@@ -33,6 +33,6 @@ install(TARGETS              serac_contact
         DESTINATION          lib
         )
 
-# if(ENABLE_TESTS)
+# if(SERAC_ENABLE_TESTS)
 #     add_subdirectory(tests)
 # endif()

--- a/src/serac/physics/contact/CMakeLists.txt
+++ b/src/serac/physics/contact/CMakeLists.txt
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-# if(ENABLE_TESTS)
-#     add_subdirectory(tests)
-# endif()
-
 set(contact_headers
     contact_config.hpp
     contact_data.hpp
@@ -36,3 +32,8 @@ install(TARGETS              serac_contact
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+# if(ENABLE_TESTS)
+#     add_subdirectory(tests)
+# endif()
+

--- a/src/serac/physics/materials/CMakeLists.txt
+++ b/src/serac/physics/materials/CMakeLists.txt
@@ -4,10 +4,6 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-if(ENABLE_TESTS)
-    add_subdirectory(tests)
-endif()
-
 set(materials_sources
     hardening_input.cpp
     thermal_material_input.cpp
@@ -44,3 +40,9 @@ install(TARGETS              serac_physics_materials
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+if(SERAC_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()
+    
+    

--- a/src/serac/physics/materials/CMakeLists.txt
+++ b/src/serac/physics/materials/CMakeLists.txt
@@ -44,4 +44,3 @@ install(TARGETS              serac_physics_materials
 if(SERAC_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
-

--- a/src/serac/physics/materials/CMakeLists.txt
+++ b/src/serac/physics/materials/CMakeLists.txt
@@ -44,5 +44,4 @@ install(TARGETS              serac_physics_materials
 if(SERAC_ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
-    
-    
+

--- a/src/serac/physics/materials/tests/CMakeLists.txt
+++ b/src/serac/physics/materials/tests/CMakeLists.txt
@@ -4,14 +4,13 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause)
 
-set(test_dependencies serac_physics_materials gtest)
+set(material_test_depends serac_physics_materials gtest)
 
-set(material_tests
+set(material_test_sources
     thermomechanical_material.cpp
     J2_material.cpp
     parameterized_nonlinear_J2_material.cpp
 )
 
-serac_add_tests( SOURCES ${material_tests}
-                 DEPENDS_ON ${test_dependencies})
- 
+serac_add_tests( SOURCES    ${material_test_sources}
+                 DEPENDS_ON ${material_test_depends})

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -4,9 +4,9 @@
 #
 # SPDX-License-Identifier: (BSD-3-Clause) 
 
-set(test_dependencies serac_physics serac_mesh gtest)
+set(physics_test_depends serac_physics serac_mesh gtest)
 
-set(serial_solver_tests
+set(physics_serial_test_sources
     beam_bending.cpp
     thermal_finite_diff.cpp
     thermal_statics_patch.cpp
@@ -18,11 +18,11 @@ set(serial_solver_tests
     finite_element_vector_set_over_domain.cpp
     )
 
-serac_add_tests( SOURCES ${serial_solver_tests}
-    DEPENDS_ON ${test_dependencies}
-    NUM_MPI_TASKS 1)
+serac_add_tests(SOURCES       ${physics_serial_test_sources}
+                DEPENDS_ON    ${physics_test_depends}
+                NUM_MPI_TASKS 1)
 
-set(solver_tests
+set(physics_parallel_test_sources
     lce_Brighenti_tensile.cpp
     lce_Bertoldi_lattice.cpp
     parameterized_thermomechanics_example.cpp
@@ -39,8 +39,8 @@ set(solver_tests
     thermal_nonlinear_solve.cpp
     solid_nonlinear_solve.cpp
     )
-blt_list_append(TO solver_tests ELEMENTS contact_patch.cpp contact_beam.cpp IF TRIBOL_FOUND)
+blt_list_append(TO physics_parallel_test_sources ELEMENTS contact_patch.cpp contact_beam.cpp IF TRIBOL_FOUND)
 
-serac_add_tests( SOURCES ${solver_tests}
-                 DEPENDS_ON ${test_dependencies}
-                 NUM_MPI_TASKS 2)
+serac_add_tests(SOURCES       ${physics_parallel_test_sources}
+                DEPENDS_ON    ${physics_test_depends}
+                NUM_MPI_TASKS 2)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,15 +12,15 @@ set(language_tests
     copy_elision.cpp
     mfem_array_std_algo.cpp)
 
-set(language_dependencies
+set(language_depends
     gtest
     mfem
     blt::mpi)
 
-blt_list_append(TO language_dependencies ELEMENTS blt::openmp IF ENABLE_OPENMP)
+blt_list_append(TO language_depends ELEMENTS blt::openmp IF ENABLE_OPENMP)
 
-serac_add_tests( SOURCES ${language_tests}
-                 DEPENDS_ON ${language_dependencies})
+serac_add_tests( SOURCES    ${language_tests}
+                 DEPENDS_ON ${language_depends})
 
 if(ENABLE_CUDA)
     blt_add_library( NAME       cuda_smoketest_kernel


### PR DESCRIPTION
This allows projects to toggle Serac tests if they include us in their project.

Note: I also did some naming and consistency changes around the places I touched.