### PR TITLE
Change git strategy to start from a clean slate each time

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,7 @@
 variables:
   #TODO: uncomment this when everyone has service user access across all the machines
   #LLNL_SERVICE_USER: asmith
+  GIT_STRATEGY: clone
   GIT_SUBMODULE_STRATEGY: recursive
   PROJECT_ALLOC_NAME: ${CI_PROJECT_NAME}_ci_${CI_PIPELINE_ID}
   BUILD_ROOT: ${CI_PROJECT_DIR}


### PR DESCRIPTION
The default `GIT_STRATEGY` for Gitlab is `fetch`, which reuses the git repo if it is present. This changes it to `clone` which will start from a clean slate.

Hopefully this fixes #1233 but we won't know for a while due to this being intermittent.

https://docs.gitlab.com/ee/ci/runners/configure_runners.html#git-strategy