### PR TITLE
No Optional Solvers CI Job

### DIFF
--- a/.gitlab/build_toss4.yml
+++ b/.gitlab/build_toss4.yml
@@ -61,11 +61,11 @@ toss4-gcc_10_3_1-src-no-tribol:
     ALLOC_TIME: "30"
   extends: .src_build_on_toss4
 
-toss4-gcc_10_3_1-src-no-sundials:
+toss4-gcc_10_3_1-src-no-optional-solvers:
   variables:
     COMPILER: "gcc@10.3.1"
     HOST_CONFIG: "ruby-toss_4_x86_64_ib-${COMPILER}.cmake"
-    EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -USUNDIALS_DIR"
+    EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -USUNDIALS_DIR -UPETSC_DIR"
     ALLOC_NODES: "1"
     ALLOC_TIME: "20"
   extends: .src_build_on_toss4


### PR DESCRIPTION
Additionally disables petsc with the no-sundials job, and renames the job to "no solvers".

The motivation is to test as many options as we can with as few jobs as possible.

Fixes #1221