### PR TITLE
Track serac version and compiler when benchmarking

### DIFF
--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -221,4 +221,6 @@ std::string version(bool add_SHA)
   return version;
 }
 
+std::string compiler() { return axom::fmt::format("{0} version {1}", SERAC_COMPILER_NAME, SERAC_COMPILER_VERSION); }
+
 }  // namespace serac

--- a/src/serac/infrastructure/about.hpp
+++ b/src/serac/infrastructure/about.hpp
@@ -49,4 +49,11 @@ void printRunInfo();
  */
 std::string version(bool add_SHA = true);
 
+/**
+ * @brief Returns a string for the current compiler name and version
+ *
+ * @return string value of the the current compiler name and version
+ */
+std::string compiler();
+
 }  // namespace serac

--- a/src/serac/infrastructure/profiling.cpp
+++ b/src/serac/infrastructure/profiling.cpp
@@ -34,6 +34,8 @@ void initialize([[maybe_unused]] MPI_Comm comm, [[maybe_unused]] std::string opt
   adiak::walltime();
   adiak::cputime();
   adiak::systime();
+  SERAC_SET_METADATA("serac_version", serac::version(true));
+  SERAC_SET_METADATA("serac_compiler", serac::compiler());
 #endif
 
 #ifdef SERAC_USE_CALIPER

--- a/src/serac/infrastructure/profiling.cpp
+++ b/src/serac/infrastructure/profiling.cpp
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: (BSD-3-Clause)
 
+#include "serac/infrastructure/about.hpp"
 #include "serac/infrastructure/profiling.hpp"
-
 #include "serac/infrastructure/logger.hpp"
 
 #ifdef SERAC_USE_CALIPER

--- a/src/serac/serac_config.hpp.in
+++ b/src/serac/serac_config.hpp.in
@@ -22,6 +22,10 @@
 #define SERAC_REPO_DIR "@SERAC_REPO_DIR@"
 #define SERAC_BIN_DIR "@SERAC_BIN_DIR@"
 
+// Compiler Information
+#define SERAC_COMPILER_NAME "@CMAKE_CXX_COMPILER_ID@"
+#define SERAC_COMPILER_VERSION "@CMAKE_CXX_COMPILER_VERSION@"
+
 // General defines
 #cmakedefine SERAC_DEBUG
 


### PR DESCRIPTION
Would be useful to track serac version and compiler for each generated caliper file. Especially version, once we start tracking benchmarks over a period of time.

Screenshot a benchmark's metadata from SPOT:

![Screenshot 2024-09-26 at 1 36 39 PM](https://github.com/user-attachments/assets/092e04cb-86f7-4598-b254-98376f2ea3b8)

A step towards #1226