### PR TITLE
Multi-material solid mechanics

### DIFF
--- a/src/serac/numerics/functional/functional.hpp
+++ b/src/serac/numerics/functional/functional.hpp
@@ -301,7 +301,7 @@ public:
 
   /// @overload
   template <int dim, int... args, typename lambda, typename qpt_data_type = Nothing>
-  void AddDomainIntegral(Dimension<dim>, DependsOn<args...>, const lambda& integrand, Domain& domain,
+  void AddDomainIntegral(Dimension<dim>, DependsOn<args...>, const lambda& integrand, const Domain& domain,
                          std::shared_ptr<QuadratureData<qpt_data_type>> qdata = NoQData)
   {
     if (domain.mesh_.GetNE() == 0) return;

--- a/src/serac/numerics/functional/geometry.hpp
+++ b/src/serac/numerics/functional/geometry.hpp
@@ -86,12 +86,11 @@ inline std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> geometry_counts(cons
 {
   std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> counts{};
 
-  counts[mfem::Geometry::SEGMENT] = uint32_t(domain.edge_ids_.size());
-  counts[mfem::Geometry::TRIANGLE] = uint32_t(domain.tri_ids_.size());
-  counts[mfem::Geometry::SQUARE] = uint32_t(domain.quad_ids_.size());
-  counts[mfem::Geometry::TETRAHEDRON] = uint32_t(domain.tet_ids_.size());
-  counts[mfem::Geometry::CUBE] = uint32_t(domain.hex_ids_.size());
-
+  constexpr std::array geometries = {mfem::Geometry::SEGMENT, mfem::Geometry::TRIANGLE, mfem::Geometry::SQUARE,
+                                     mfem::Geometry::TETRAHEDRON, mfem::Geometry::CUBE};
+  for (auto geom : geometries) {
+    counts[uint32_t(geom)] = uint32_t(domain.get(geom).size());
+  }
   return counts;
 }
 

--- a/src/serac/numerics/functional/geometry.hpp
+++ b/src/serac/numerics/functional/geometry.hpp
@@ -2,6 +2,8 @@
 
 #include "mfem.hpp"
 
+#include "serac/numerics/functional/domain.hpp"
+
 namespace serac {
 
 /**
@@ -73,6 +75,23 @@ inline std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> geometry_counts(cons
   for (int i = 0; i < mesh.GetNE(); i++) {
     counts[uint64_t(mesh.GetElementGeometry(i))]++;
   }
+  return counts;
+}
+
+/**
+ * @brief count the number of elements of each geometry in a domain
+ * @param mesh the domain to count
+ */
+inline std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> geometry_counts(const Domain& domain)
+{
+  std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> counts{};
+
+  counts[mfem::Geometry::SEGMENT] = uint32_t(domain.edge_ids_.size());
+  counts[mfem::Geometry::TRIANGLE] = uint32_t(domain.tri_ids_.size());
+  counts[mfem::Geometry::SQUARE] = uint32_t(domain.quad_ids_.size());
+  counts[mfem::Geometry::TETRAHEDRON] = uint32_t(domain.tet_ids_.size());
+  counts[mfem::Geometry::CUBE] = uint32_t(domain.hex_ids_.size());
+
   return counts;
 }
 

--- a/src/serac/numerics/functional/geometry.hpp
+++ b/src/serac/numerics/functional/geometry.hpp
@@ -80,7 +80,7 @@ inline std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> geometry_counts(cons
 
 /**
  * @brief count the number of elements of each geometry in a domain
- * @param mesh the domain to count
+ * @param domain the domain to count
  */
 inline std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> geometry_counts(const Domain& domain)
 {

--- a/src/serac/numerics/functional/geometry.hpp
+++ b/src/serac/numerics/functional/geometry.hpp
@@ -86,8 +86,9 @@ inline std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> geometry_counts(cons
 {
   std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> counts{};
 
-  constexpr std::array geometries = {mfem::Geometry::SEGMENT, mfem::Geometry::TRIANGLE, mfem::Geometry::SQUARE,
-                                     mfem::Geometry::TETRAHEDRON, mfem::Geometry::CUBE};
+  constexpr std::array<mfem::Geometry::Type, 5> geometries = {mfem::Geometry::SEGMENT, mfem::Geometry::TRIANGLE,
+                                                              mfem::Geometry::SQUARE, mfem::Geometry::TETRAHEDRON,
+                                                              mfem::Geometry::CUBE};
   for (auto geom : geometries) {
     counts[uint32_t(geom)] = uint32_t(domain.get(geom).size());
   }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -882,7 +882,7 @@ public:
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
   void setMaterial(DependsOn<active_parameters...>, const MaterialType& material,
                    const std::optional<Domain>& optional_domain = std::nullopt,
-                   qdata_type<StateType> qdata = EmptyQData)
+                   qdata_type<StateType>        qdata           = EmptyQData)
   {
     Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
@@ -900,8 +900,7 @@ public:
 
   /// @overload
   template <typename MaterialType, typename StateType = Empty>
-  void setMaterial(const MaterialType& material,
-                   const std::optional<Domain>& domain = std::nullopt,
+  void setMaterial(const MaterialType& material, const std::optional<Domain>& domain = std::nullopt,
                    std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
     setMaterial(DependsOn<>{}, material, domain, qdata);
@@ -909,8 +908,7 @@ public:
 
   /// @overload
   template <typename MaterialType, typename StateType>
-  void setMaterial(const MaterialType& material,
-                   std::shared_ptr<QuadratureData<StateType>> qdata)
+  void setMaterial(const MaterialType& material, std::shared_ptr<QuadratureData<StateType>> qdata)
   {
     setMaterial(DependsOn<>{}, material, EntireDomain(mesh_), qdata);
   }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -418,9 +418,10 @@ public:
    * @return std::shared_ptr< QuadratureData<T> >
    */
   template <typename T>
-  qdata_type<T> createQuadratureDataBuffer(T initial_state)
+  qdata_type<T> createQuadratureDataBuffer(T initial_state, const std::optional<Domain>& optional_domain = std::nullopt)
   {
-    return StateManager::newQuadratureDataBuffer(mesh_tag_, order, dim, initial_state);
+    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
+    return StateManager::newQuadratureDataBuffer(domain, order, dim, initial_state);
   }
 
   /**

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -871,8 +871,7 @@ public:
    *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
    * 3>`)
    *
-   * @param optional_domain The subdomain which will use this material. Must be a domain of elements. If
-   * no argument is provided, it defaults to the entire mesh.
+   * @param domain The subdomain which will use this material. Must be a domain of elements.
    * @param qdata the buffer of material internal variables at each quadrature point
    *
    * @pre MaterialType must have a public member variable `density`
@@ -882,10 +881,9 @@ public:
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
   void setMaterial(DependsOn<active_parameters...>, const MaterialType& material,
-                   const std::optional<Domain>& optional_domain = std::nullopt,
-                   qdata_type<StateType>        qdata           = EmptyQData)
+                   const Domain& domain,
+                   qdata_type<StateType> qdata = EmptyQData)
   {
-    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
     MaterialStressFunctor<MaterialType> material_functor(material, geom_nonlin_);
@@ -900,16 +898,25 @@ public:
   }
 
   /// @overload
+  template <int... active_parameters, typename MaterialType, typename StateType = Empty>
+  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material,
+                   qdata_type<StateType> qdata = EmptyQData)
+  {
+    setMaterial(DependsOn<active_parameters...>{}, material, EntireDomain(mesh_), qdata);
+  }
+
+  /// @overload
   template <typename MaterialType, typename StateType = Empty>
-  void setMaterial(const MaterialType& material, const std::optional<Domain>& domain = std::nullopt,
+  void setMaterial(const MaterialType& material, const Domain& domain,
                    std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
     setMaterial(DependsOn<>{}, material, domain, qdata);
   }
 
   /// @overload
-  template <typename MaterialType, typename StateType>
-  void setMaterial(const MaterialType& material, std::shared_ptr<QuadratureData<StateType>> qdata)
+  template <typename MaterialType, typename StateType = Empty >
+  void setMaterial(const MaterialType& material, 
+                   std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
     setMaterial(DependsOn<>{}, material, EntireDomain(mesh_), qdata);
   }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -880,8 +880,7 @@ public:
    * @note This method must be called prior to completeSetup()
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
-  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material,
-                   const Domain& domain,
+  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material, const Domain& domain,
                    qdata_type<StateType> qdata = EmptyQData)
   {
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
@@ -914,9 +913,8 @@ public:
   }
 
   /// @overload
-  template <typename MaterialType, typename StateType = Empty >
-  void setMaterial(const MaterialType& material, 
-                   std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
+  template <typename MaterialType, typename StateType = Empty>
+  void setMaterial(const MaterialType& material, std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
     setMaterial(DependsOn<>{}, material, EntireDomain(mesh_), qdata);
   }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -907,6 +907,14 @@ public:
     setMaterial(DependsOn<>{}, material, domain, qdata);
   }
 
+  /// @overload
+  template <typename MaterialType, typename StateType>
+  void setMaterial(const MaterialType& material,
+                   std::shared_ptr<QuadratureData<StateType>> qdata)
+  {
+    setMaterial(DependsOn<>{}, material, EntireDomain(mesh_), qdata);
+  }
+
   /**
    * @brief Set the underlying finite element state to a prescribed displacement
    *

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -869,6 +869,8 @@ public:
    *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
    * 3>`)
    *
+   * @param optional_domain The subdomain which will use this material. Must be a domain of elements. If
+   * no argument is provided, it defaults to the entire mesh.
    * @param qdata the buffer of material internal variables at each quadrature point
    *
    * @pre MaterialType must have a public member variable `density`
@@ -877,9 +879,11 @@ public:
    * @note This method must be called prior to completeSetup()
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
-  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material, const Domain& domain,
+  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material,
+                   const std::optional<Domain>& optional_domain = std::nullopt,
                    qdata_type<StateType> qdata = EmptyQData)
   {
+    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
     MaterialStressFunctor<MaterialType> material_functor(material, geom_nonlin_);
@@ -895,7 +899,9 @@ public:
 
   /// @overload
   template <typename MaterialType, typename StateType = Empty>
-  void setMaterial(const MaterialType& material, const Domain& domain, std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
+  void setMaterial(const MaterialType& material,
+                   const std::optional<Domain>& domain = std::nullopt,
+                   std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
     setMaterial(DependsOn<>{}, material, domain, qdata);
   }

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -415,6 +415,7 @@ public:
    *
    * @tparam T the type to be created at each quadrature point
    * @param initial_state the value to be broadcast to each quadrature point
+   * @param optional_domain restricts the quadrature buffer to the given domain
    * @return std::shared_ptr< QuadratureData<T> >
    */
   template <typename T>

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -877,7 +877,7 @@ public:
    * @note This method must be called prior to completeSetup()
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
-  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material,
+  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material, const Domain& domain,
                    qdata_type<StateType> qdata = EmptyQData)
   {
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
@@ -890,14 +890,14 @@ public:
                                                              // fact that the displacement, acceleration, and shape
                                                              // fields are always-on and come first, so the `n`th
                                                              // parameter will actually be argument `n + NUM_STATE_VARS`
-        std::move(material_functor), mesh_, qdata);
+        std::move(material_functor), domain, qdata);
   }
 
   /// @overload
   template <typename MaterialType, typename StateType = Empty>
-  void setMaterial(const MaterialType& material, std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
+  void setMaterial(const MaterialType& material, const Domain& domain, std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
-    setMaterial(DependsOn<>{}, material, qdata);
+    setMaterial(DependsOn<>{}, material, domain, qdata);
   }
 
   /**

--- a/src/serac/physics/state/state_manager.hpp
+++ b/src/serac/physics/state/state_manager.hpp
@@ -130,6 +130,30 @@ public:
     return std::make_shared<QuadratureData<T>>(elems, qpts_per_elem, initial_state);
   }
 
+  // make qdata by domain
+  template <typename T>
+  static std::shared_ptr<QuadratureData<T>> newQuadratureDataBuffer(const Domain& domain, int order, int dim,
+                                                                    T initial_state)
+  {
+    int Q = order + 1;
+
+    std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> elems = geometry_counts(domain);
+    std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> qpts_per_elem{};
+
+    std::vector<mfem::Geometry::Type> geometries;
+    if (dim == 2) {
+      geometries = {mfem::Geometry::TRIANGLE, mfem::Geometry::SQUARE};
+    } else {
+      geometries = {mfem::Geometry::TETRAHEDRON, mfem::Geometry::CUBE};
+    }
+
+    for (auto geom : geometries) {
+      qpts_per_elem[size_t(geom)] = uint32_t(num_quadrature_points(geom, Q));
+    }
+
+    return std::make_shared<QuadratureData<T>>(elems, qpts_per_elem, initial_state);
+  }
+
   /**
    * @brief Checks if StateManager has a dual with the given name
    * @param name A string that uniquely identifies the name

--- a/src/serac/physics/state/state_manager.hpp
+++ b/src/serac/physics/state/state_manager.hpp
@@ -130,7 +130,16 @@ public:
     return std::make_shared<QuadratureData<T>>(elems, qpts_per_elem, initial_state);
   }
 
-  // make qdata by domain
+  /**
+   * @overload
+   *
+   * @tparam T the type to be created at each quadrature point
+   * @param domain The domain to which this buffer will pertain
+   * @param order The order of the discretization of the displacement and velocity fields
+   * @param dim The spatial dimension of the mesh
+   * @param initial_state the value to be broadcast to each quadrature point
+   * @return shared pointer to quadrature data buffer
+   */
   template <typename T>
   static std::shared_ptr<QuadratureData<T>> newQuadratureDataBuffer(const Domain& domain, int order, int dim,
                                                                     T initial_state)

--- a/src/serac/physics/state/state_manager.hpp
+++ b/src/serac/physics/state/state_manager.hpp
@@ -99,43 +99,8 @@ public:
    * @brief Create a shared ptr to a quadrature data buffer for the given material type
    *
    * @tparam T the type to be created at each quadrature point
-   * @param mesh_tag The tag for the stored mesh used to construct the finite element state
-   * @param order The order of the discretization of the displacement and velocity fields
-   * @param dim The spatial dimension of the mesh
-   * @param initial_state the value to be broadcast to each quadrature point
-   * @return shared pointer to quadrature data buffer
-   */
-  template <typename T>
-  static std::shared_ptr<QuadratureData<T>> newQuadratureDataBuffer(const std::string& mesh_tag, int order, int dim,
-                                                                    T initial_state)
-  {
-    SLIC_ERROR_ROOT_IF(!hasMesh(mesh_tag), axom::fmt::format("Mesh tag '{}' not found in the data store", mesh_tag));
-
-    int Q = order + 1;
-
-    std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> elems = geometry_counts(mesh(mesh_tag));
-    std::array<uint32_t, mfem::Geometry::NUM_GEOMETRIES> qpts_per_elem{};
-
-    std::vector<mfem::Geometry::Type> geometries;
-    if (dim == 2) {
-      geometries = {mfem::Geometry::TRIANGLE, mfem::Geometry::SQUARE};
-    } else {
-      geometries = {mfem::Geometry::TETRAHEDRON, mfem::Geometry::CUBE};
-    }
-
-    for (auto geom : geometries) {
-      qpts_per_elem[size_t(geom)] = uint32_t(num_quadrature_points(geom, Q));
-    }
-
-    return std::make_shared<QuadratureData<T>>(elems, qpts_per_elem, initial_state);
-  }
-
-  /**
-   * @overload
-   *
-   * @tparam T the type to be created at each quadrature point
-   * @param domain The domain to which this buffer will pertain
-   * @param order The order of the discretization of the displacement and velocity fields
+   * @param domain The spatial domain over which to allocate the quadrature data
+   * @param order The order of the discretization of the primal fields
    * @param dim The spatial dimension of the mesh
    * @param initial_state the value to be broadcast to each quadrature point
    * @return shared pointer to quadrature data buffer

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ set(physics_serial_test_sources
     dynamic_solid_adjoint.cpp
     quasistatic_solid_adjoint.cpp
     finite_element_vector_set_over_domain.cpp
+    solid_multi_material.cpp
     )
 
 serac_add_tests(SOURCES       ${physics_serial_test_sources}

--- a/src/serac/physics/tests/solid_multi_material.cpp
+++ b/src/serac/physics/tests/solid_multi_material.cpp
@@ -78,11 +78,11 @@ TEST(Solid, MultiMaterial)
 
   constexpr double E_left = 1.0;
   constexpr double nu_left = 0.125;
-  Material mat_left{.K = E_left/3.0/(1 - 2*nu_left), .G = 0.5*E_left/(1 + nu_left)};
+  Material mat_left{.density = 1.0, .K = E_left/3.0/(1 - 2*nu_left), .G = 0.5*E_left/(1 + nu_left)};
 
   constexpr double E_right = 2.0*E_left;
   constexpr double nu_right = 2*nu_left;
-  Material mat_right{.K = E_right/3.0/(1 - 2*nu_right), .G = 0.5*E_right/(1 + nu_right)};
+  Material mat_right{.density = 1.0, .K = E_right/3.0/(1 - 2*nu_right), .G = 0.5*E_right/(1 + nu_right)};
 //   using Hardening = solid_mechanics::LinearHardening;
 //   using MaterialB  = solid_mechanics::J2SmallStrain<Hardening>;
 
@@ -128,7 +128,7 @@ TEST(Solid, MultiMaterial)
 
   constexpr double subdomain_volume = 0.5*VOLUME;
 
-  auto average_strain_integrand = [](auto, auto, auto displacement) {
+  auto average_strain_integrand = [subdomain_volume](auto, auto, auto displacement) {
     auto strain = get<1>(displacement);
     return strain[0][0]/subdomain_volume;
   };
@@ -143,6 +143,138 @@ TEST(Solid, MultiMaterial)
 
   EXPECT_NEAR(average_strain_left(solid.time(), solid.displacement()), stress/E_left, 1e-10);
   EXPECT_NEAR(average_strain_right(solid.time(), solid.displacement()), stress/E_right, 1e-10);
+}
+
+TEST(Solid, MultiMaterialWithState)
+{
+  /*
+   * Checks multi-material case with the following uniaxial problem:
+   *              MATERIAL 1            MATERIAL 2
+   *               E = 2                 E = 2
+   *               nu_1                 nu_2 = 0
+   *                                   sigma_y = 0.5*stress
+   *                                    Hi = E / 3.6 (linear hardening modulus)
+   * u = 0   --------------------|-------------------- stress = 1
+   * 
+   * The solution for the strain is:
+   * strain =       stress/E     |   (Hi + E)/(Hi*E)*stress - sigma_y/Hi
+   * 
+   * nu_1 is chosen so that the problem is uniaxial. That is, the lateral contraction in the
+   * elastic side exactly matches the contraction in the plastic side. For the values given
+   * above, this corresponds to nu_1 = 0.45.
+   * 
+   * This problem checks that both materials models are correctly called for their subdomains, and
+   * that the internal variables are correctly indexed for the multi-material case.
+   * 
+   */
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  constexpr int p                   = 2;
+  constexpr int dim                 = 3;
+  int           serial_refinement   = 0;
+  int           parallel_refinement = 0;
+
+  // Create DataStore
+  axom::sidre::DataStore datastore;
+  serac::StateManager::initialize(datastore, "solid_mechanics_multimaterial");
+
+  constexpr double L = 8.0;
+  constexpr double W = 1.0;
+  constexpr double H = 1.0;
+  constexpr double VOLUME = L*W*H;
+
+  constexpr double applied_stress = 1.0;
+
+  auto mesh = mesh::refineAndDistribute(buildCuboidMesh(8, 1, 1, L, W, H), serial_refinement, parallel_refinement);
+
+  const std::string mesh_tag{"mesh"};
+
+  auto& pmesh = serac::StateManager::setMesh(std::move(mesh), mesh_tag);
+
+  // _solver_params_start
+  serac::LinearSolverOptions linear_options{.linear_solver = LinearSolver::SuperLU};
+
+  serac::NonlinearSolverOptions nonlinear_options{.nonlin_solver  = NonlinearSolver::Newton,
+                                                  .relative_tol   = 1.0e-12,
+                                                  .absolute_tol   = 1.0e-12,
+                                                  .max_iterations = 5000,
+                                                  .print_level    = 1};
+
+  SolidMechanics<p, dim> solid(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
+                               GeometricNonlinearities::Off, "solid_mechanics", mesh_tag);
+  // _solver_params_end
+
+  auto is_in_left = [](std::vector<tensor<double, dim>> coords, int /* attribute */) {
+    return average(coords)[0] < 0.5*L;
+  };
+  Domain left = Domain::ofElements(pmesh, is_in_left);
+  Domain right = EntireDomain(pmesh) - left;
+
+  using Hardening = solid_mechanics::LinearHardening;
+  using MaterialRight  = solid_mechanics::J2SmallStrain<Hardening>;
+
+  constexpr double E_right = 2.0;
+  constexpr double nu_right = 0.0;
+  constexpr double Hi = E_right/3.6;
+  constexpr double sigma_y = 0.75*applied_stress;
+
+  Hardening hardening{.sigma_y = sigma_y, .Hi = Hi};
+  MaterialRight mat_right{
+       .E         = E_right,  // Young's modulus
+       .nu        = nu_right,   // Poisson's ratio
+       .hardening = hardening,
+       .Hk        = 0.0,  // kinematic hardening constant
+       .density   = 1.0   // mass density
+  };
+
+  using MaterialLeft = solid_mechanics::LinearIsotropic;
+
+  constexpr double E_left = 2.0;
+  constexpr double nu_left = 0.5*E_left/Hi*(1 - sigma_y/applied_stress);
+  MaterialLeft mat_left{.density = 1.0, .K = E_left/3.0/(1 - 2*nu_left), .G = 0.5*E_left/(1 + nu_left)};
+
+  MaterialRight::State initial_state{};
+  auto qdata = solid.createQuadratureDataBuffer(initial_state, right);
+
+  solid.setMaterial(mat_left, left);
+  solid.setMaterial(mat_right, right, qdata);
+
+  Domain end_face = Domain::ofBoundaryElements(pmesh, by_attr<dim>(3));
+  solid.setTraction(DependsOn<>{}, [applied_stress](auto, auto n, auto){ return applied_stress*n; }, end_face);
+
+  solid.setDisplacementBCs({2}, [](auto){ return 0.0; }, 1);
+  solid.setDisplacementBCs({5}, [](auto){ return 0.0; }, 0);
+  solid.setDisplacementBCs({1}, [](auto){ return 0.0; }, 2);
+
+  solid.completeSetup();
+
+  std::cout << "setup complete " << std::endl;
+
+  // Perform the quasi-static solve
+  solid.advanceTimestep(1.0);
+  solid.outputStateToDisk("paraview");
+
+  // Define output functionals for verification
+
+  constexpr double subdomain_volume = 0.5*VOLUME;
+
+  auto average_strain_integrand = [subdomain_volume](auto, auto, auto displacement) {
+    auto strain = get<1>(displacement);
+    return strain[0][0]/subdomain_volume;
+  };
+
+  Functional<double(H1<p, dim>)> average_strain_left({&solid.displacement().space()});
+  average_strain_left.AddDomainIntegral(Dimension<dim>{}, DependsOn<0>{}, average_strain_integrand,
+    left);
+
+  Functional<double(H1<p, dim>)> average_strain_right({&solid.displacement().space()});
+  average_strain_right.AddDomainIntegral(Dimension<dim>{}, DependsOn<0>{}, average_strain_integrand,
+    right);
+
+  EXPECT_NEAR(average_strain_left(solid.time(), solid.displacement()), applied_stress/E_left, 1e-10);
+
+  double exact = (E_right + Hi)/(E_right*Hi)*applied_stress - sigma_y/Hi;
+  EXPECT_NEAR(average_strain_right(solid.time(), solid.displacement()), exact, 1e-10);
 }
 
 } // namespace serac

--- a/src/serac/physics/tests/solid_multi_material.cpp
+++ b/src/serac/physics/tests/solid_multi_material.cpp
@@ -154,10 +154,12 @@ TEST(Solid, MultiMaterialWithState)
    *               nu_1                 nu_2 = 0
    *                                   sigma_y = 0.5*stress
    *                                    Hi = E / 3.6 (linear hardening modulus)
+   * x = 0                       x = L/2               x = L
    * u = 0   --------------------|-------------------- stress = 1
    * 
    * The solution for the strain is:
-   * strain =       stress/E     |   (Hi + E)/(Hi*E)*stress - sigma_y/Hi
+   * strain = | stress/E,                            x in (0, L/2)
+   *          | (Hi + E)/(Hi*E)*stress - sigma_y/Hi, x in (L/2, L)
    * 
    * nu_1 is chosen so that the problem is uniaxial. That is, the lateral contraction in the
    * elastic side exactly matches the contraction in the plastic side. For the values given

--- a/src/serac/physics/tests/solid_multi_material.cpp
+++ b/src/serac/physics/tests/solid_multi_material.cpp
@@ -35,6 +35,7 @@ TEST(Solid, MultiMaterial)
    *               E = 1                 E = 2
    * u = 0   --------------------|-------------------- stress = 1
    *
+   * Solution:
    * strain =       1                    0.5
    *
    */
@@ -82,29 +83,12 @@ TEST(Solid, MultiMaterial)
   constexpr double E_right  = 2.0 * E_left;
   constexpr double nu_right = 2 * nu_left;
   Material mat_right{.density = 1.0, .K = E_right / 3.0 / (1 - 2 * nu_right), .G = 0.5 * E_right / (1 + nu_right)};
-  //   using Hardening = solid_mechanics::LinearHardening;
-  //   using MaterialB  = solid_mechanics::J2SmallStrain<Hardening>;
-
-  //   Hardening hardening{.sigma_y = 10.0, .Hi = 0.1, .density = 1.0;};
-  //   Material  mat{
-  //        .E         = 2.0,  // Young's modulus
-  //        .nu        = 0.25,   // Poisson's ratio
-  //        .hardening = hardening,
-  //        .Hk        = 0.0,  // kinematic hardening constant
-  //        .density   = 1.0   // mass density
-  //   };
-
-  //   MaterialB::State initial_state{};
-
-  // auto qdata = solid_solver.createQuadratureDataBuffer(initial_state);
 
   auto is_in_left = [](std::vector<tensor<double, dim>> coords, int /* attribute */) {
     return average(coords)[0] < 0.5 * L;
   };
-  Domain left = Domain::ofElements(pmesh, is_in_left);
-
-  auto   is_in_right = [=](std::vector<tensor<double, dim>> coords, int attr) { return !is_in_left(coords, attr); };
-  Domain right       = Domain::ofElements(pmesh, is_in_right);
+  Domain left  = Domain::ofElements(pmesh, is_in_left);
+  Domain right = EntireDomain(pmesh) - left;
 
   solid.setMaterial(mat_left, left);
   solid.setMaterial(mat_right, right);
@@ -179,7 +163,7 @@ TEST(Solid, MultiMaterialWithState)
 
   // Create DataStore
   axom::sidre::DataStore datastore;
-  serac::StateManager::initialize(datastore, "solid_mechanics_multimaterial");
+  serac::StateManager::initialize(datastore, "solid_mechanics_multimaterial_with_state");
 
   constexpr double L      = 8.0;
   constexpr double W      = 1.0;

--- a/src/serac/physics/tests/solid_multi_material.cpp
+++ b/src/serac/physics/tests/solid_multi_material.cpp
@@ -1,0 +1,121 @@
+// Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "serac/physics/solid_mechanics.hpp"
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include <gtest/gtest.h>
+
+#include "serac/mesh/mesh_utils.hpp"
+#include "serac/physics/state/state_manager.hpp"
+#include "serac/physics/materials/solid_material.hpp"
+#include "serac/infrastructure/initialize.hpp"
+#include "serac/infrastructure/terminator.hpp"
+
+namespace serac {
+
+template <int dim>
+tensor<double, dim> average(std::vector<tensor<double, dim> >& positions)
+{
+  tensor<double, dim> total{};
+  for (auto x : positions) {
+    total += x;
+  }
+  return total / double(positions.size());
+}
+
+
+TEST(Solid, MultiMaterial)
+{
+  MPI_Barrier(MPI_COMM_WORLD);
+
+  constexpr int p                   = 2;
+  constexpr int dim                 = 3;
+  int           serial_refinement   = 0;
+  int           parallel_refinement = 0;
+
+  // Create DataStore
+  axom::sidre::DataStore datastore;
+  serac::StateManager::initialize(datastore, "solid_mechanics_multimaterial");
+
+  auto mesh = mesh::refineAndDistribute(buildCuboidMesh(8, 1, 1, 8.0, 1.0, 1.0), serial_refinement, parallel_refinement);
+
+  const std::string mesh_tag{"mesh"};
+
+  auto& pmesh = serac::StateManager::setMesh(std::move(mesh), mesh_tag);
+
+  // _solver_params_start
+  serac::LinearSolverOptions linear_options{.linear_solver = LinearSolver::SuperLU};
+
+  serac::NonlinearSolverOptions nonlinear_options{.nonlin_solver  = NonlinearSolver::Newton,
+                                                  .relative_tol   = 1.0e-12,
+                                                  .absolute_tol   = 1.0e-12,
+                                                  .max_iterations = 5000,
+                                                  .print_level    = 1};
+
+  SolidMechanics<p, dim> solid(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
+                               GeometricNonlinearities::Off, "solid_mechanics", mesh_tag);
+  // _solver_params_end
+
+  using Material = solid_mechanics::LinearIsotropic;
+
+  constexpr double E_left = 1.0;
+  constexpr double nu = 0.25;
+  Material mat_left{.K = E_left/3.0/(1 - 2*nu), .G = 0.5*E_left/(1 + nu)};
+
+  constexpr double E_right = 2.0;
+  Material mat_right{.K = E_right/3.0/(1 - 2*nu), .G = 0.5*E_right/(1 + nu)};
+//   using Hardening = solid_mechanics::LinearHardening;
+//   using MaterialB  = solid_mechanics::J2SmallStrain<Hardening>;
+
+//   Hardening hardening{.sigma_y = 10.0, .Hi = 0.1, .density = 1.0;};
+//   Material  mat{
+//        .E         = 2.0,  // Young's modulus
+//        .nu        = 0.25,   // Poisson's ratio
+//        .hardening = hardening,
+//        .Hk        = 0.0,  // kinematic hardening constant
+//        .density   = 1.0   // mass density
+//   };
+
+//   MaterialB::State initial_state{};
+
+  //auto qdata = solid_solver.createQuadratureDataBuffer(initial_state);
+
+  auto is_in_left = [](std::vector<tensor<double, dim>> coords, int /* attribute */) {
+    return average(coords)[0] < 4.0;
+  };
+  Domain left = Domain::ofElements(pmesh, is_in_left);
+
+  auto is_in_right = [=](std::vector<tensor<double, dim>> coords, int attr){ return !is_in_left(coords, attr); };
+  Domain right = Domain::ofElements(pmesh, is_in_right);
+
+  solid.setMaterial(mat_left, left);
+  solid.setMaterial(mat_right, right);
+
+  solid.setDisplacementBCs({2}, [](auto){ return 0.0; }, 2);
+  solid.setDisplacementBCs({3}, [](auto){ return 1.0; }, 0);
+  solid.setDisplacementBCs({5}, [](auto){ return 0.0; }, 0);
+  solid.setDisplacementBCs({6}, [](auto){ return 0.0; }, 1);
+
+  solid.completeSetup();
+
+  // Perform the quasi-static solve
+  solid.advanceTimestep(1.0);
+  solid.outputStateToDisk("paraview");
+}
+
+} // namespace serac
+
+int main(int argc, char* argv[])
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  serac::initialize(argc, argv);
+
+  int result = RUN_ALL_TESTS();
+
+  serac::exitGracefully(result);
+}

--- a/src/serac/physics/tests/solid_multi_material.cpp
+++ b/src/serac/physics/tests/solid_multi_material.cpp
@@ -6,7 +6,6 @@
 
 #include "serac/physics/solid_mechanics.hpp"
 
-#include "axom/slic/core/SimpleLogger.hpp"
 #include <gtest/gtest.h>
 
 #include "serac/mesh/mesh_utils.hpp"
@@ -178,7 +177,6 @@ TEST(Solid, MultiMaterialWithState)
 
   auto& pmesh = serac::StateManager::setMesh(std::move(mesh), mesh_tag);
 
-  // _solver_params_start
   serac::LinearSolverOptions linear_options{.linear_solver = LinearSolver::SuperLU};
 
   serac::NonlinearSolverOptions nonlinear_options{.nonlin_solver  = NonlinearSolver::Newton,
@@ -189,7 +187,6 @@ TEST(Solid, MultiMaterialWithState)
 
   SolidMechanics<p, dim> solid(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
                                GeometricNonlinearities::Off, "solid_mechanics", mesh_tag);
-  // _solver_params_end
 
   auto is_in_left = [](std::vector<tensor<double, dim>> coords, int /* attribute */) {
     return average(coords)[0] < 0.5 * L;


### PR DESCRIPTION
Enable solid mechanics to work with materials defined on different domains. Includes materials with internal state variables.

For now, I added this without breaking changes. This means I overloaded the `setMaterial` several times and left in place the old ones that do not take a domain. Eventually, I'd prefer the domain to be required. We can map this out later.