### PR TITLE
Option to increase problem size of nonlinear solve benchmark (small or large)

### DIFF
--- a/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
+++ b/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
@@ -69,7 +69,8 @@ std::map<std::string, NonlinSolve> nonlinSolveMap = {
     {"none", NonlinSolve::NONE},
 };
 std::map<std::string, ProblemSize> problemSizeMap = {
-    {"small", ProblemSize::SMALL}, {"large", ProblemSize::LARGE},
+    {"small", ProblemSize::SMALL},
+    {"large", ProblemSize::LARGE},
 };
 
 const std::string precToString(Prec prec)
@@ -277,8 +278,7 @@ void functional_solid_test_nonlinear_buckle(NonlinSolve nonlinSolve, Prec prec, 
   static constexpr int DIM{3};
 
   int Nx, Ny, Nz;
-  switch(problemSize)
-  {
+  switch (problemSize) {
     case ProblemSize::SMALL:
       Nx = 500;
       Ny = 6;


### PR DESCRIPTION
This is a part of improving performance analysis #1226.

This PR...

Adds a `-s` option to the solid nonlinear solve benchmark, where you can specify the problem size of the benchmark. A `SMALL` problem size takes under 5 seconds. This could be used to test whether the benchmark is working as intended. A `LARGE` problem size takes about 5 minutes with 16 tasks. This should be used to measure performance.

The motivation behind increasing the problem size is we want our benchmarks to be large enough to give us more accurate timing information. I figured I would do this before I start [adding benchmarks to CI](https://github.com/LLNL/serac/pull/1245).

I tried adding an extra 0 to the large problem size and got `std::bad_alloc`:

```cpp
Nx = 10000;
Ny = 60;
Nz = 50;
```