### PR TITLE
Switch Convention to First Piola stress and remove GeometricNonlinearities flag

### DIFF
--- a/data/input_files/tests/solid/qs_linear.lua
+++ b/data/input_files/tests/solid/qs_linear.lua
@@ -39,12 +39,6 @@ solid = {
     -- neo-Hookean material parameters
     materials = { { model = "NeoHookean", mu = 0.25, K = 10.0, density = 1.0 }, },
 
-    -- Turn the material nonlinearities off
-    -- TODO: this should be replaced with a proper material definition
-    -- BT 11/5/24: I think this option is outdated and no longer used, can an inlet
-    -- expert confirm?
-    material_nonlin = false,
-
     -- boundary condition parameters
     boundary_conds = {
         ['displacement'] = {

--- a/data/input_files/tests/solid/qs_linear.lua
+++ b/data/input_files/tests/solid/qs_linear.lua
@@ -39,11 +39,10 @@ solid = {
     -- neo-Hookean material parameters
     materials = { { model = "NeoHookean", mu = 0.25, K = 10.0, density = 1.0 }, },
 
-    -- Turn the geometric nonlinearities off
-    geometric_nonlin = false,
-
     -- Turn the material nonlinearities off
     -- TODO: this should be replaced with a proper material definition
+    -- BT 11/5/24: I think this option is outdated and no longer used, can an inlet
+    -- expert confirm?
     material_nonlin = false,
 
     -- boundary condition parameters

--- a/examples/buckling/cylinder.cpp
+++ b/examples/buckling/cylinder.cpp
@@ -138,8 +138,7 @@ int main(int argc, char* argv[])
   std::unique_ptr<SolidMechanics<p, dim>> solid_solver;
   if (use_contact) {
     auto solid_contact_solver = std::make_unique<serac::SolidMechanicsContact<p, dim>>(
-        nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-        name, mesh_tag);
+        nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options, name, mesh_tag);
 
     // Add the contact interaction
     serac::ContactOptions contact_options{.method      = serac::ContactMethod::SingleMortar,
@@ -150,11 +149,10 @@ int main(int argc, char* argv[])
     solid_contact_solver->addContactInteraction(contact_interaction_id, xpos, xneg, contact_options);
     solid_solver = std::move(solid_contact_solver);
   } else {
-    solid_solver = std::make_unique<serac::SolidMechanics<p, dim>>(nonlinear_options, linear_options,
-                                                                   serac::solid_mechanics::default_quasistatic_options,
-                                                                   name, mesh_tag);
-    auto domain  = serac::Domain::ofBoundaryElements(
-         StateManager::mesh(mesh_tag), [&](std::vector<vec3>, int attr) { return xpos.find(attr) != xpos.end(); });
+    solid_solver = std::make_unique<serac::SolidMechanics<p, dim>>(
+        nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options, name, mesh_tag);
+    auto domain = serac::Domain::ofBoundaryElements(
+        StateManager::mesh(mesh_tag), [&](std::vector<vec3>, int attr) { return xpos.find(attr) != xpos.end(); });
     solid_solver->setPressure([&](auto&, double t) { return 0.01 * t; }, domain);
   }
 

--- a/examples/buckling/cylinder.cpp
+++ b/examples/buckling/cylinder.cpp
@@ -139,7 +139,7 @@ int main(int argc, char* argv[])
   if (use_contact) {
     auto solid_contact_solver = std::make_unique<serac::SolidMechanicsContact<p, dim>>(
         nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-        serac::GeometricNonlinearities::On, name, mesh_tag);
+        name, mesh_tag);
 
     // Add the contact interaction
     serac::ContactOptions contact_options{.method      = serac::ContactMethod::SingleMortar,
@@ -152,7 +152,7 @@ int main(int argc, char* argv[])
   } else {
     solid_solver = std::make_unique<serac::SolidMechanics<p, dim>>(nonlinear_options, linear_options,
                                                                    serac::solid_mechanics::default_quasistatic_options,
-                                                                   serac::GeometricNonlinearities::On, name, mesh_tag);
+                                                                   name, mesh_tag);
     auto domain  = serac::Domain::ofBoundaryElements(
          StateManager::mesh(mesh_tag), [&](std::vector<vec3>, int attr) { return xpos.find(attr) != xpos.end(); });
     solid_solver->setPressure([&](auto&, double t) { return 0.01 * t; }, domain);

--- a/examples/contact/beam_bending.cpp
+++ b/examples/contact/beam_bending.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
 
   serac::SolidMechanicsContact<p, dim, serac::Parameters<serac::L2<0>, serac::L2<0>>> solid_solver(
       nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      serac::GeometricNonlinearities::On, name, "beam_mesh", {"bulk_mod", "shear_mod"});
+      name, "beam_mesh", {"bulk_mod", "shear_mod"});
 
   serac::FiniteElementState K_field(serac::StateManager::newState(serac::L2<0>{}, "bulk_mod", "beam_mesh"));
   // each vector value corresponds to a different element attribute:

--- a/examples/contact/beam_bending.cpp
+++ b/examples/contact/beam_bending.cpp
@@ -56,8 +56,8 @@ int main(int argc, char* argv[])
                                         .penalty     = 1.0e3};
 
   serac::SolidMechanicsContact<p, dim, serac::Parameters<serac::L2<0>, serac::L2<0>>> solid_solver(
-      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      name, "beam_mesh", {"bulk_mod", "shear_mod"});
+      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options, name, "beam_mesh",
+      {"bulk_mod", "shear_mod"});
 
   serac::FiniteElementState K_field(serac::StateManager::newState(serac::L2<0>{}, "bulk_mod", "beam_mesh"));
   // each vector value corresponds to a different element attribute:

--- a/examples/contact/ironing.cpp
+++ b/examples/contact/ironing.cpp
@@ -56,8 +56,8 @@ int main(int argc, char* argv[])
                                         .penalty     = 1.0e3};
 
   serac::SolidMechanicsContact<p, dim, serac::Parameters<serac::L2<0>, serac::L2<0>>> solid_solver(
-      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      name, "ironing_mesh", {"bulk_mod", "shear_mod"});
+      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options, name, "ironing_mesh",
+      {"bulk_mod", "shear_mod"});
 
   serac::FiniteElementState K_field(serac::StateManager::newState(serac::L2<0>{}, "bulk_mod", "ironing_mesh"));
   // each vector value corresponds to a different element attribute:

--- a/examples/contact/ironing.cpp
+++ b/examples/contact/ironing.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
 
   serac::SolidMechanicsContact<p, dim, serac::Parameters<serac::L2<0>, serac::L2<0>>> solid_solver(
       nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      serac::GeometricNonlinearities::On, name, "ironing_mesh", {"bulk_mod", "shear_mod"});
+      name, "ironing_mesh", {"bulk_mod", "shear_mod"});
 
   serac::FiniteElementState K_field(serac::StateManager::newState(serac::L2<0>{}, "bulk_mod", "ironing_mesh"));
   // each vector value corresponds to a different element attribute:

--- a/examples/contact/sphere.cpp
+++ b/examples/contact/sphere.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
 
   serac::SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
                                                     serac::solid_mechanics::default_quasistatic_options,
-                                                    serac::GeometricNonlinearities::On, name, "sphere_mesh");
+                                                    name, "sphere_mesh");
 
   serac::solid_mechanics::NeoHookean mat{1.0, 10.0, 0.25};
   solid_solver.setMaterial(mat);

--- a/examples/contact/sphere.cpp
+++ b/examples/contact/sphere.cpp
@@ -71,9 +71,8 @@ int main(int argc, char* argv[])
                                         .type        = serac::ContactType::Frictionless,
                                         .penalty     = 1.0e4};
 
-  serac::SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
-                                                    serac::solid_mechanics::default_quasistatic_options,
-                                                    name, "sphere_mesh");
+  serac::SolidMechanicsContact<p, dim> solid_solver(
+      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options, name, "sphere_mesh");
 
   serac::solid_mechanics::NeoHookean mat{1.0, 10.0, 0.25};
   solid_solver.setMaterial(mat);

--- a/examples/contact/twist.cpp
+++ b/examples/contact/twist.cpp
@@ -57,9 +57,8 @@ int main(int argc, char* argv[])
                                         .type        = serac::ContactType::Frictionless,
                                         .penalty     = 1.0e5};
 
-  serac::SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
-                                                    serac::solid_mechanics::default_quasistatic_options,
-                                                    name, "twist_mesh");
+  serac::SolidMechanicsContact<p, dim> solid_solver(
+      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options, name, "twist_mesh");
 
   serac::solid_mechanics::NeoHookean mat{1.0, 10.0, 10.0};
   solid_solver.setMaterial(mat);

--- a/examples/contact/twist.cpp
+++ b/examples/contact/twist.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
 
   serac::SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
                                                     serac::solid_mechanics::default_quasistatic_options,
-                                                    serac::GeometricNonlinearities::On, name, "twist_mesh");
+                                                    name, "twist_mesh");
 
   serac::solid_mechanics::NeoHookean mat{1.0, 10.0, 10.0};
   solid_solver.setMaterial(mat);

--- a/src/docs/sphinx/user_guide/input_schema.rst
+++ b/src/docs/sphinx/user_guide/input_schema.rst
@@ -212,11 +212,6 @@ Description: Finite deformation solid mechanics module
      - Default Value
      - Range/Valid Values
      - Required
-   * - geometric_nonlin
-     - Flag to include geometric nonlinearities in the residual calculation.
-     - True
-     - 
-     - |uncheck|
    * - order
      - polynomial order of the basis functions.
      - 1
@@ -1479,11 +1474,6 @@ Description: Finite deformation solid mechanics module
      - Default Value
      - Range/Valid Values
      - Required
-   * - geometric_nonlin
-     - Flag to include geometric nonlinearities in the residual calculation.
-     - True
-     - 
-     - |uncheck|
    * - order
      - polynomial order of the basis functions.
      - 1

--- a/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
+++ b/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
@@ -238,9 +238,9 @@ void functional_solid_test_euler(NonlinSolve nonlinSolve, Prec prec)
 
   auto [nonlinear_options, linear_options] = get_opts(nonlinSolve, prec, 3 * Nx * Ny * Nz, 1e-9);
 
-  auto seracSolid = std::make_unique<seracSolidType>(
-      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      "serac_solid", meshTag, std::vector<std::string>{});
+  auto seracSolid = std::make_unique<seracSolidType>(nonlinear_options, linear_options,
+                                                     serac::solid_mechanics::default_quasistatic_options, "serac_solid",
+                                                     meshTag, std::vector<std::string>{});
 
   serac::solid_mechanics::NeoHookean material{density, bulkMod, shearMod};
   seracSolid->setMaterial(serac::DependsOn<>{}, material);
@@ -316,9 +316,9 @@ void functional_solid_test_nonlinear_buckle(NonlinSolve nonlinSolve, Prec prec, 
 
   auto [nonlinear_options, linear_options] = get_opts(nonlinSolve, prec, 3 * Nx * Ny * Nz, 1e-11);
 
-  auto seracSolid = std::make_unique<seracSolidType>(
-      nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      "serac_solid", meshTag, std::vector<std::string>{});
+  auto seracSolid = std::make_unique<seracSolidType>(nonlinear_options, linear_options,
+                                                     serac::solid_mechanics::default_quasistatic_options, "serac_solid",
+                                                     meshTag, std::vector<std::string>{});
 
   serac::solid_mechanics::NeoHookean material{density, bulkMod, shearMod};
   seracSolid->setMaterial(serac::DependsOn<>{}, material);

--- a/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
+++ b/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
@@ -240,7 +240,7 @@ void functional_solid_test_euler(NonlinSolve nonlinSolve, Prec prec)
 
   auto seracSolid = std::make_unique<seracSolidType>(
       nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      serac::GeometricNonlinearities::On, "serac_solid", meshTag, std::vector<std::string>{});
+      "serac_solid", meshTag, std::vector<std::string>{});
 
   serac::solid_mechanics::NeoHookean material{density, bulkMod, shearMod};
   seracSolid->setMaterial(serac::DependsOn<>{}, material);
@@ -318,7 +318,7 @@ void functional_solid_test_nonlinear_buckle(NonlinSolve nonlinSolve, Prec prec, 
 
   auto seracSolid = std::make_unique<seracSolidType>(
       nonlinear_options, linear_options, serac::solid_mechanics::default_quasistatic_options,
-      serac::GeometricNonlinearities::On, "serac_solid", meshTag, std::vector<std::string>{});
+      "serac_solid", meshTag, std::vector<std::string>{});
 
   serac::solid_mechanics::NeoHookean material{density, bulkMod, shearMod};
   seracSolid->setMaterial(serac::DependsOn<>{}, material);

--- a/src/serac/physics/common.hpp
+++ b/src/serac/physics/common.hpp
@@ -24,14 +24,4 @@ struct Parameters {
   static constexpr int n = sizeof...(T);  ///< how many parameters were specified
 };
 
-/**
- * @brief Enum to set the geometric nonlinearity flag
- *
- */
-enum class GeometricNonlinearities
-{
-  On, /**< Include geometric nonlinearities */
-  Off /**< Do not include geometric nonlinearities */
-};
-
 }  // namespace serac

--- a/src/serac/physics/materials/parameterized_solid_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_material.hpp
@@ -90,9 +90,14 @@ struct ParameterizedNeoHookeanSolid {
     auto           G         = G0 + get<0>(DeltaG);
     auto           lambda    = K - (2.0 / dim) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    auto           J_minus_1 = detApIm1(du_dX);
-    auto           J         = J_minus_1 + 1;
-    return (lambda * log1p(J_minus_1) * I + G * B_minus_I) / J;
+    auto logJ = log1p(detApIm1(du_dX));
+
+    // Kirchoff stress, in form that avoids cancellation error when F is near I
+    auto TK = lambda * logJ * I + G * B_minus_I;
+
+    // Pull back to Piola
+    auto F = du_dX + I;
+    return dot(TK, inv(transpose(F)));
   }
 
   /**

--- a/src/serac/physics/materials/parameterized_solid_material.hpp
+++ b/src/serac/physics/materials/parameterized_solid_material.hpp
@@ -90,7 +90,7 @@ struct ParameterizedNeoHookeanSolid {
     auto           G         = G0 + get<0>(DeltaG);
     auto           lambda    = K - (2.0 / dim) * G;
     auto           B_minus_I = du_dX * transpose(du_dX) + transpose(du_dX) + du_dX;
-    auto logJ = log1p(detApIm1(du_dX));
+    auto           logJ      = log1p(detApIm1(du_dX));
 
     // Kirchoff stress, in form that avoids cancellation error when F is near I
     auto TK = lambda * logJ * I + G * B_minus_I;

--- a/src/serac/physics/materials/tests/J2_material.cpp
+++ b/src/serac/physics/materials/tests/J2_material.cpp
@@ -211,10 +211,10 @@ TEST(J2, Uniaxial)
 
   for (auto r : response_history) {
     auto [t, dudx, P, state] = r;
-    auto TK = dot(P, transpose(dudx + Identity<3>()));
-    double e  = std::log1p(get<1>(r)[0][0]);       // log strain
-    double s  = TK[0][0];                          // Kirchhoff stress
-    double pe = -std::log(get<3>(r).Fpinv[0][0]);  // plastic strain
+    auto   TK                = dot(P, transpose(dudx + Identity<3>()));
+    double e                 = std::log1p(get<1>(r)[0][0]);       // log strain
+    double s                 = TK[0][0];                          // Kirchhoff stress
+    double pe                = -std::log(get<3>(r).Fpinv[0][0]);  // plastic strain
     ASSERT_NEAR(s, stress_exact(e), 1e-6 * std::abs(stress_exact(e)));
     ASSERT_NEAR(pe, plastic_strain_exact(e), 1e-6 * std::abs(plastic_strain_exact(e)));
   }

--- a/src/serac/physics/materials/tests/J2_material.cpp
+++ b/src/serac/physics/materials/tests/J2_material.cpp
@@ -210,9 +210,10 @@ TEST(J2, Uniaxial)
   };
 
   for (auto r : response_history) {
-    double J  = detApIm1(get<1>(r)) + 1;
+    auto [t, dudx, P, state] = r;
+    auto TK = dot(P, transpose(dudx + Identity<3>()));
     double e  = std::log1p(get<1>(r)[0][0]);       // log strain
-    double s  = get<2>(r)[0][0] * J;               // Kirchhoff stress
+    double s  = TK[0][0];                          // Kirchhoff stress
     double pe = -std::log(get<3>(r).Fpinv[0][0]);  // plastic strain
     ASSERT_NEAR(s, stress_exact(e), 1e-6 * std::abs(stress_exact(e)));
     ASSERT_NEAR(pe, plastic_strain_exact(e), 1e-6 * std::abs(plastic_strain_exact(e)));
@@ -304,8 +305,8 @@ TEST(J2, FrameIndifference)
   // initialize internal state variables
   auto internal_state = Material::State{};
 
-  // stress components in original coordinate frame
-  auto sigma = material(internal_state, H);
+  // Piola stress components in original coordinate frame
+  auto P = material(internal_state, H);
 
   // make sure that this load case is actually yielding
   ASSERT_GT(internal_state.accumulated_plastic_strain, 1e-3);
@@ -320,10 +321,10 @@ TEST(J2, FrameIndifference)
   auto internal_state_star = Material::State{};
 
   // stress in second coordinate frame
-  auto sigma_star = material(internal_state_star, H_star);
+  auto P_star = material(internal_state_star, H_star);
 
-  auto error = sigma_star - dot(dot(Q, sigma), transpose(Q));
-  ASSERT_LT(norm(error), 1e-13*norm(sigma));
+  auto error = P_star - dot(Q, P);
+  ASSERT_LT(norm(error), 1e-13*norm(P));
 
   // The plastic distortion Fp has no legs in the observed space and should be invariant
   error = internal_state.Fpinv - internal_state_star.Fpinv;

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -868,15 +868,7 @@ public:
 
       auto stress = material_(state, du_dX, params...);
 
-      auto dx_dX = 0.0 * du_dX + I;
-
-      if (geom_nonlin_ == GeometricNonlinearities::On) {
-        dx_dX += du_dX;
-      }
-
-      auto flux = dot(stress, transpose(inv(dx_dX))) * det(dx_dX);
-
-      return serac::tuple{material_.density * d2u_dt2, flux};
+      return serac::tuple{material_.density * d2u_dt2, stress};
     }
   };
 

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -135,13 +135,12 @@ public:
    *       writing and reading the needed trainsient states to disk for adjoint solves
    */
   SolidMechanics(const NonlinearSolverOptions nonlinear_opts, const LinearSolverOptions lin_opts,
-                 const serac::TimesteppingOptions timestepping_opts,
-                 const std::string& physics_name, std::string mesh_tag, std::vector<std::string> parameter_names = {},
-                 int cycle = 0, double time = 0.0, bool checkpoint_to_disk = false, bool use_warm_start = true)
+                 const serac::TimesteppingOptions timestepping_opts, const std::string& physics_name,
+                 std::string mesh_tag, std::vector<std::string> parameter_names = {}, int cycle = 0, double time = 0.0,
+                 bool checkpoint_to_disk = false, bool use_warm_start = true)
       : SolidMechanics(
             std::make_unique<EquationSolver>(nonlinear_opts, lin_opts, StateManager::mesh(mesh_tag).GetComm()),
-            timestepping_opts, physics_name, mesh_tag, parameter_names, cycle, time, checkpoint_to_disk,
-            use_warm_start)
+            timestepping_opts, physics_name, mesh_tag, parameter_names, cycle, time, checkpoint_to_disk, use_warm_start)
   {
   }
 
@@ -163,9 +162,8 @@ public:
    *       writing and reading the needed trainsient states to disk for adjoint solves
    */
   SolidMechanics(std::unique_ptr<serac::EquationSolver> solver, const serac::TimesteppingOptions timestepping_opts,
-                 const std::string& physics_name, std::string mesh_tag,
-                 std::vector<std::string> parameter_names = {}, int cycle = 0, double time = 0.0,
-                 bool checkpoint_to_disk = false, bool use_warm_start = true)
+                 const std::string& physics_name, std::string mesh_tag, std::vector<std::string> parameter_names = {},
+                 int cycle = 0, double time = 0.0, bool checkpoint_to_disk = false, bool use_warm_start = true)
       : BasePhysics(physics_name, mesh_tag, cycle, time, checkpoint_to_disk),
         displacement_(
             StateManager::newState(H1<order, dim>{}, detail::addPrefix(physics_name, "displacement"), mesh_tag_)),
@@ -277,8 +275,7 @@ public:
   SolidMechanics(const SolidMechanicsInputOptions& input_options, const std::string& physics_name, std::string mesh_tag,
                  int cycle = 0, double time = 0.0)
       : SolidMechanics(input_options.nonlin_solver_options, input_options.lin_solver_options,
-                       input_options.timestepping_options, physics_name, mesh_tag, {}, cycle,
-                       time)
+                       input_options.timestepping_options, physics_name, mesh_tag, {}, cycle, time)
   {
     for (auto& mat : input_options.materials) {
       if (std::holds_alternative<serac::solid_mechanics::NeoHookean>(mat)) {
@@ -833,7 +830,7 @@ public:
   template <typename Material>
   struct MaterialStressFunctor {
     /// @brief Constructor for the functor
-    MaterialStressFunctor(Material material) : material_(material){}
+    MaterialStressFunctor(Material material) : material_(material) {}
 
     /// @brief Material model
     Material material_;

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -122,7 +122,6 @@ public:
    * @param nonlinear_opts The nonlinear solver options for solving the nonlinear residual equations
    * @param lin_opts The linear solver options for solving the linearized Jacobian equations
    * @param timestepping_opts The timestepping options for the solid mechanics time evolution operator
-   * @param geom_nonlin Flag to include geometric nonlinearities
    * @param physics_name A name for the physics module instance
    * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
    * @param parameter_names A vector of the names of the requested parameter fields
@@ -136,12 +135,12 @@ public:
    *       writing and reading the needed trainsient states to disk for adjoint solves
    */
   SolidMechanics(const NonlinearSolverOptions nonlinear_opts, const LinearSolverOptions lin_opts,
-                 const serac::TimesteppingOptions timestepping_opts, const GeometricNonlinearities geom_nonlin,
+                 const serac::TimesteppingOptions timestepping_opts,
                  const std::string& physics_name, std::string mesh_tag, std::vector<std::string> parameter_names = {},
                  int cycle = 0, double time = 0.0, bool checkpoint_to_disk = false, bool use_warm_start = true)
       : SolidMechanics(
             std::make_unique<EquationSolver>(nonlinear_opts, lin_opts, StateManager::mesh(mesh_tag).GetComm()),
-            timestepping_opts, geom_nonlin, physics_name, mesh_tag, parameter_names, cycle, time, checkpoint_to_disk,
+            timestepping_opts, physics_name, mesh_tag, parameter_names, cycle, time, checkpoint_to_disk,
             use_warm_start)
   {
   }
@@ -151,7 +150,6 @@ public:
    *
    * @param solver The nonlinear equation solver for the implicit solid mechanics equations
    * @param timestepping_opts The timestepping options for the solid mechanics time evolution operator
-   * @param geom_nonlin Flag to include geometric nonlinearities
    * @param physics_name A name for the physics module instance
    * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
    * @param parameter_names A vector of the names of the requested parameter fields
@@ -165,7 +163,7 @@ public:
    *       writing and reading the needed trainsient states to disk for adjoint solves
    */
   SolidMechanics(std::unique_ptr<serac::EquationSolver> solver, const serac::TimesteppingOptions timestepping_opts,
-                 const GeometricNonlinearities geom_nonlin, const std::string& physics_name, std::string mesh_tag,
+                 const std::string& physics_name, std::string mesh_tag,
                  std::vector<std::string> parameter_names = {}, int cycle = 0, double time = 0.0,
                  bool checkpoint_to_disk = false, bool use_warm_start = true)
       : BasePhysics(physics_name, mesh_tag, cycle, time, checkpoint_to_disk),
@@ -187,7 +185,6 @@ public:
         ode2_(displacement_.space().TrueVSize(),
               {.time = time_, .c0 = c0_, .c1 = c1_, .u = u_, .du_dt = v_, .d2u_dt2 = acceleration_}, *nonlin_solver_,
               bcs_),
-        geom_nonlin_(geom_nonlin),
         use_warm_start_(use_warm_start)
   {
     SERAC_MARK_FUNCTION;
@@ -280,7 +277,7 @@ public:
   SolidMechanics(const SolidMechanicsInputOptions& input_options, const std::string& physics_name, std::string mesh_tag,
                  int cycle = 0, double time = 0.0)
       : SolidMechanics(input_options.nonlin_solver_options, input_options.lin_solver_options,
-                       input_options.timestepping_options, input_options.geom_nonlin, physics_name, mesh_tag, {}, cycle,
+                       input_options.timestepping_options, physics_name, mesh_tag, {}, cycle,
                        time)
   {
     for (auto& mat : input_options.materials) {
@@ -836,13 +833,10 @@ public:
   template <typename Material>
   struct MaterialStressFunctor {
     /// @brief Constructor for the functor
-    MaterialStressFunctor(Material material, GeometricNonlinearities gn) : material_(material), geom_nonlin_(gn) {}
+    MaterialStressFunctor(Material material) : material_(material){}
 
     /// @brief Material model
     Material material_;
-
-    /// @brief Enum value for geometric nonlinearities
-    GeometricNonlinearities geom_nonlin_;
 
     /**
      * @brief Material stress response call
@@ -903,7 +897,7 @@ public:
   {
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
-    MaterialStressFunctor<MaterialType> material_functor(material, geom_nonlin_);
+    MaterialStressFunctor<MaterialType> material_functor(material);
     residual_->AddDomainIntegral(
         Dimension<dim>{},
         DependsOn<0, 1,
@@ -1081,7 +1075,7 @@ public:
   }
 
   /**
-   * @brief Set the pressure boundary condition
+   * @brief Apply a pressure-type follower load
    *
    * @tparam PressureType The type of the pressure load
    * @param pressure_function A function describing the pressure applied to a boundary
@@ -1098,7 +1092,8 @@ public:
    *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
    * 3>`)
    *
-   * @note This pressure is applied in the deformed (current) configuration if GeometricNonlinearities are on.
+   * @note Pressure is always applied in the deformed (current) configuration, normal to the deformed surface.
+   *   This only makes sense for finite deformations. Use the `setTraction` method for linearized kinematics.
    *
    * @note This method must be called prior to completeSetup()
    */
@@ -1110,14 +1105,9 @@ public:
 
     residual_->AddBoundaryIntegral(
         Dimension<dim - 1>{}, DependsOn<0, 1, active_parameters + NUM_STATE_VARS...>{},
-        [pressure_function, geom_nonlin = geom_nonlin_](double t, auto X, auto displacement, auto /* acceleration */,
-                                                        auto... params) {
+        [pressure_function](double t, auto X, auto displacement, auto /* acceleration */, auto... params) {
           // Calculate the position and normal in the shape perturbed deformed configuration
-          auto x = X + 0.0 * displacement;
-
-          if (geom_nonlin == GeometricNonlinearities::On) {
-            x = x + displacement;
-          }
+          auto x = X + displacement;
 
           auto n = cross(get<DERIVATIVE>(x));
 
@@ -1614,9 +1604,6 @@ protected:
   /// @brief End of step time used in reverse mode so that the time can be decremented on reverse steps
   /// @note This time is important to save to evaluate various parameter sensitivities after each reverse step
   double time_end_step_;
-
-  /// @brief A flag denoting whether to compute geometric nonlinearities in the residual
-  GeometricNonlinearities geom_nonlin_;
 
   /// @brief A flag denoting whether to compute the warm start for improved robustness
   bool use_warm_start_;

--- a/src/serac/physics/solid_mechanics_contact.hpp
+++ b/src/serac/physics/solid_mechanics_contact.hpp
@@ -45,7 +45,6 @@ public:
    * @param nonlinear_opts The nonlinear solver options for solving the nonlinear residual equations
    * @param lin_opts The linear solver options for solving the linearized Jacobian equations
    * @param timestepping_opts The timestepping options for the solid mechanics time evolution operator
-   * @param geom_nonlin Flag to include geometric nonlinearities
    * @param physics_name A name for the physics module instance
    * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
    * @param parameter_names A vector of the names of the requested parameter fields
@@ -53,12 +52,12 @@ public:
    * @param time The simulation time to initialize the physics module to
    */
   SolidMechanicsContact(const NonlinearSolverOptions nonlinear_opts, const LinearSolverOptions lin_opts,
-                        const serac::TimesteppingOptions timestepping_opts, const GeometricNonlinearities geom_nonlin,
+                        const serac::TimesteppingOptions timestepping_opts,
                         const std::string& physics_name, std::string mesh_tag,
                         std::vector<std::string> parameter_names = {}, int cycle = 0, double time = 0.0)
       : SolidMechanicsContact(
             std::make_unique<EquationSolver>(nonlinear_opts, lin_opts, StateManager::mesh(mesh_tag).GetComm()),
-            timestepping_opts, geom_nonlin, physics_name, mesh_tag, parameter_names, cycle, time)
+            timestepping_opts, physics_name, mesh_tag, parameter_names, cycle, time)
   {
   }
 
@@ -67,7 +66,6 @@ public:
    *
    * @param solver The nonlinear equation solver for the implicit solid mechanics equations
    * @param timestepping_opts The timestepping options for the solid mechanics time evolution operator
-   * @param geom_nonlin Flag to include geometric nonlinearities
    * @param physics_name A name for the physics module instance
    * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
    * @param parameter_names A vector of the names of the requested parameter fields
@@ -75,10 +73,10 @@ public:
    * @param time The simulation time to initialize the physics module to
    */
   SolidMechanicsContact(std::unique_ptr<serac::EquationSolver> solver,
-                        const serac::TimesteppingOptions timestepping_opts, const GeometricNonlinearities geom_nonlin,
+                        const serac::TimesteppingOptions timestepping_opts,
                         const std::string& physics_name, std::string mesh_tag,
                         std::vector<std::string> parameter_names = {}, int cycle = 0, double time = 0.0)
-      : SolidMechanicsBase(std::move(solver), timestepping_opts, geom_nonlin, physics_name, mesh_tag, parameter_names,
+      : SolidMechanicsBase(std::move(solver), timestepping_opts, physics_name, mesh_tag, parameter_names,
                            cycle, time),
         contact_(mesh_),
         forces_(StateManager::newDual(displacement_.space(), detail::addPrefix(physics_name, "contact_forces")))

--- a/src/serac/physics/solid_mechanics_contact.hpp
+++ b/src/serac/physics/solid_mechanics_contact.hpp
@@ -52,9 +52,9 @@ public:
    * @param time The simulation time to initialize the physics module to
    */
   SolidMechanicsContact(const NonlinearSolverOptions nonlinear_opts, const LinearSolverOptions lin_opts,
-                        const serac::TimesteppingOptions timestepping_opts,
-                        const std::string& physics_name, std::string mesh_tag,
-                        std::vector<std::string> parameter_names = {}, int cycle = 0, double time = 0.0)
+                        const serac::TimesteppingOptions timestepping_opts, const std::string& physics_name,
+                        std::string mesh_tag, std::vector<std::string> parameter_names = {}, int cycle = 0,
+                        double time = 0.0)
       : SolidMechanicsContact(
             std::make_unique<EquationSolver>(nonlinear_opts, lin_opts, StateManager::mesh(mesh_tag).GetComm()),
             timestepping_opts, physics_name, mesh_tag, parameter_names, cycle, time)
@@ -73,11 +73,10 @@ public:
    * @param time The simulation time to initialize the physics module to
    */
   SolidMechanicsContact(std::unique_ptr<serac::EquationSolver> solver,
-                        const serac::TimesteppingOptions timestepping_opts,
-                        const std::string& physics_name, std::string mesh_tag,
-                        std::vector<std::string> parameter_names = {}, int cycle = 0, double time = 0.0)
-      : SolidMechanicsBase(std::move(solver), timestepping_opts, physics_name, mesh_tag, parameter_names,
-                           cycle, time),
+                        const serac::TimesteppingOptions timestepping_opts, const std::string& physics_name,
+                        std::string mesh_tag, std::vector<std::string> parameter_names = {}, int cycle = 0,
+                        double time = 0.0)
+      : SolidMechanicsBase(std::move(solver), timestepping_opts, physics_name, mesh_tag, parameter_names, cycle, time),
         contact_(mesh_),
         forces_(StateManager::newDual(displacement_.space(), detail::addPrefix(physics_name, "contact_forces")))
   {

--- a/src/serac/physics/solid_mechanics_input.cpp
+++ b/src/serac/physics/solid_mechanics_input.cpp
@@ -16,10 +16,6 @@ void SolidMechanicsInputOptions::defineInputFileSchema(axom::inlet::Container& c
   auto& material_container = container.addStructArray("materials", "Container for array of materials");
   SolidMaterialInputOptions::defineInputFileSchema(material_container);
 
-  // Geometric nonlinearities flag
-  container.addBool("geometric_nonlin", "Flag to include geometric nonlinearities in the residual calculation.")
-      .defaultValue(true);
-
   auto& equation_solver_container =
       container.addStruct("equation_solver", "Linear and Nonlinear stiffness Solver Parameters.");
   EquationSolver::defineInputFileSchema(equation_solver_container);
@@ -77,14 +73,6 @@ serac::SolidMechanicsInputOptions FromInlet<serac::SolidMechanicsInputOptions>::
   }
 
   result.materials = base["materials"].get<std::vector<serac::var_solid_material_t>>();
-
-  // Set the geometric nonlinearities flag
-  bool input_geom_nonlin = base["geometric_nonlin"];
-  if (input_geom_nonlin) {
-    result.geom_nonlin = serac::GeometricNonlinearities::On;
-  } else {
-    result.geom_nonlin = serac::GeometricNonlinearities::Off;
-  }
 
   if (base.contains("boundary_conds")) {
     result.boundary_conditions =

--- a/src/serac/physics/solid_mechanics_input.hpp
+++ b/src/serac/physics/solid_mechanics_input.hpp
@@ -55,12 +55,6 @@ struct SolidMechanicsInputOptions {
   TimesteppingOptions timestepping_options;
 
   /**
-   * @brief Geometric nonlinearities flag
-   *
-   */
-  GeometricNonlinearities geom_nonlin;
-
-  /**
    * @brief The material options
    *
    */

--- a/src/serac/physics/tests/beam_bending.cpp
+++ b/src/serac/physics/tests/beam_bending.cpp
@@ -64,7 +64,7 @@ TEST(BeamBending, TwoDimensional)
 #endif
 
   SolidMechanics<p, dim> solid_solver(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-                                      GeometricNonlinearities::On, "solid_mechanics", mesh_tag);
+                                      "solid_mechanics", mesh_tag);
 
   double                             K = 1.91666666666667;
   double                             G = 1.0;

--- a/src/serac/physics/tests/contact_beam.cpp
+++ b/src/serac/physics/tests/contact_beam.cpp
@@ -66,8 +66,7 @@ TEST_P(ContactTest, beam)
                                  .penalty     = 1.0e2};
 
   SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
-                                             solid_mechanics::default_quasistatic_options,
-                                             name, "beam_mesh");
+                                             solid_mechanics::default_quasistatic_options, name, "beam_mesh");
 
   double                      K = 10.0;
   double                      G = 0.25;

--- a/src/serac/physics/tests/contact_beam.cpp
+++ b/src/serac/physics/tests/contact_beam.cpp
@@ -66,7 +66,7 @@ TEST_P(ContactTest, beam)
                                  .penalty     = 1.0e2};
 
   SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
-                                             solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On,
+                                             solid_mechanics::default_quasistatic_options,
                                              name, "beam_mesh");
 
   double                      K = 10.0;

--- a/src/serac/physics/tests/contact_patch.cpp
+++ b/src/serac/physics/tests/contact_patch.cpp
@@ -73,8 +73,7 @@ TEST_P(ContactTest, patch)
                                  .penalty     = 1.0e4};
 
   SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
-                                             solid_mechanics::default_quasistatic_options,
-                                             name, "patch_mesh");
+                                             solid_mechanics::default_quasistatic_options, name, "patch_mesh");
 
   double                      K = 10.0;
   double                      G = 0.25;

--- a/src/serac/physics/tests/contact_patch.cpp
+++ b/src/serac/physics/tests/contact_patch.cpp
@@ -73,7 +73,7 @@ TEST_P(ContactTest, patch)
                                  .penalty     = 1.0e4};
 
   SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
-                                             solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On,
+                                             solid_mechanics::default_quasistatic_options,
                                              name, "patch_mesh");
 
   double                      K = 10.0;

--- a/src/serac/physics/tests/dynamic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/dynamic_solid_adjoint.cpp
@@ -28,7 +28,6 @@ const std::string mesh_tag       = "mesh";
 const std::string physics_prefix = "solid";
 
 using SolidMaterial = solid_mechanics::NeoHookean;
-auto geoNonlinear   = GeometricNonlinearities::On;
 
 struct TimeSteppingInfo {
   TimeSteppingInfo() : dts({0.0, 0.2, 0.4, 0.24, 0.12, 0.0}) {}

--- a/src/serac/physics/tests/dynamic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/dynamic_solid_adjoint.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<SolidMechanics<p, dim>> createNonlinearSolidMechanicsSolver(
                                               .print_level    = 0};
 
   bool checkpoint_to_disk = true;
-  auto solid = std::make_unique<SolidMechanics<p, dim>>(nonlinear_opts, linear_options, dyn_opts, geoNonlinear,
+  auto solid = std::make_unique<SolidMechanics<p, dim>>(nonlinear_opts, linear_options, dyn_opts,
                                                         physics_prefix + std::to_string(iter++), mesh_tag,
                                                         std::vector<std::string>{}, 0, 0.0, checkpoint_to_disk, false);
   solid->setMaterial(mat);

--- a/src/serac/physics/tests/dynamic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/dynamic_solid_adjoint.cpp
@@ -98,7 +98,7 @@ std::unique_ptr<SolidMechanics<p, dim>> createNonlinearSolidMechanicsSolver(
                                               .print_level    = 0};
 
   bool checkpoint_to_disk = true;
-  auto solid = std::make_unique<SolidMechanics<p, dim>>(nonlinear_opts, linear_options, dyn_opts,
+  auto solid              = std::make_unique<SolidMechanics<p, dim>>(nonlinear_opts, linear_options, dyn_opts,
                                                         physics_prefix + std::to_string(iter++), mesh_tag,
                                                         std::vector<std::string>{}, 0, 0.0, checkpoint_to_disk, false);
   solid->setMaterial(mat);

--- a/src/serac/physics/tests/fit_test.cpp
+++ b/src/serac/physics/tests/fit_test.cpp
@@ -58,7 +58,7 @@ void stress_extrapolation_test()
   FiniteElementState sigma_J2(pmesh, output_space{}, "sigma_J2");
 
   SolidMechanics<p, dim, serac::Parameters<output_space> > solid_solver(
-      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options, GeometricNonlinearities::Off,
+      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
       "solid_mechanics", mesh_tag, {"sigma_J2"});
 
   solid_mechanics::NeoHookean mat{

--- a/src/serac/physics/tests/fit_test.cpp
+++ b/src/serac/physics/tests/fit_test.cpp
@@ -57,9 +57,9 @@ void stress_extrapolation_test()
 
   FiniteElementState sigma_J2(pmesh, output_space{}, "sigma_J2");
 
-  SolidMechanics<p, dim, serac::Parameters<output_space> > solid_solver(
-      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-      "solid_mechanics", mesh_tag, {"sigma_J2"});
+  SolidMechanics<p, dim, serac::Parameters<output_space> > solid_solver(nonlinear_options, linear_options,
+                                                                        solid_mechanics::default_quasistatic_options,
+                                                                        "solid_mechanics", mesh_tag, {"sigma_J2"});
 
   solid_mechanics::NeoHookean mat{
       1.0,    // density

--- a/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
+++ b/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
@@ -76,8 +76,8 @@ TEST(LiquidCrystalElastomer, Bertoldi)
 #endif
 
   SolidMechanics<p, dim, Parameters<H1<p>, L2<p>, L2<p> > > solid_solver(
-      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-      "lce_solid_functional", mesh_tag, {"order", "eta", "gamma"});
+      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options, "lce_solid_functional", mesh_tag,
+      {"order", "eta", "gamma"});
 
   // Material properties
   double density         = 1.0;

--- a/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
+++ b/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
@@ -76,7 +76,7 @@ TEST(LiquidCrystalElastomer, Bertoldi)
 #endif
 
   SolidMechanics<p, dim, Parameters<H1<p>, L2<p>, L2<p> > > solid_solver(
-      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options, GeometricNonlinearities::Off,
+      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
       "lce_solid_functional", mesh_tag, {"order", "eta", "gamma"});
 
   // Material properties

--- a/src/serac/physics/tests/lce_Brighenti_tensile.cpp
+++ b/src/serac/physics/tests/lce_Brighenti_tensile.cpp
@@ -94,7 +94,7 @@ TEST(LiquidCrystalElastomer, Brighenti)
 #endif
 
   SolidMechanics<p, dim, Parameters<H1<p>, L2<p> > > solid_solver(
-      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options, GeometricNonlinearities::Off,
+      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
       "lce_solid_functional", mesh_tag, {"temperature", "gamma"});
 
   constexpr int TEMPERATURE_INDEX = 0;

--- a/src/serac/physics/tests/lce_Brighenti_tensile.cpp
+++ b/src/serac/physics/tests/lce_Brighenti_tensile.cpp
@@ -94,8 +94,8 @@ TEST(LiquidCrystalElastomer, Brighenti)
 #endif
 
   SolidMechanics<p, dim, Parameters<H1<p>, L2<p> > > solid_solver(
-      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-      "lce_solid_functional", mesh_tag, {"temperature", "gamma"});
+      nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options, "lce_solid_functional", mesh_tag,
+      {"temperature", "gamma"});
 
   constexpr int TEMPERATURE_INDEX = 0;
   constexpr int GAMMA_INDEX       = 1;

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -99,7 +99,7 @@ TEST(Thermomechanics, ParameterizedMaterial)
 #endif
 
   SolidMechanics<p, dim, Parameters<H1<p>, H1<p>>> simulation(
-      nonlinear_opts, linear_opts, solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On,
+      nonlinear_opts, linear_opts, solid_mechanics::default_quasistatic_options,
       "thermomechanics_simulation", mesh_tag, {"theta", "alpha"});
 
   double density   = 1.0;     ///< density

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -99,8 +99,8 @@ TEST(Thermomechanics, ParameterizedMaterial)
 #endif
 
   SolidMechanics<p, dim, Parameters<H1<p>, H1<p>>> simulation(
-      nonlinear_opts, linear_opts, solid_mechanics::default_quasistatic_options,
-      "thermomechanics_simulation", mesh_tag, {"theta", "alpha"});
+      nonlinear_opts, linear_opts, solid_mechanics::default_quasistatic_options, "thermomechanics_simulation", mesh_tag,
+      {"theta", "alpha"});
 
   double density   = 1.0;     ///< density
   double E         = 1000.0;  ///< Young's modulus

--- a/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
@@ -152,8 +152,8 @@ TEST(quasistatic, finiteDifference)
                                                          .max_iterations = 10,
                                                          .print_level    = 1};
   auto seracSolid = ::std::make_unique<solidType>(nonlinear_options, serac::solid_mechanics::direct_linear_options,
-                                                  ::serac::solid_mechanics::default_quasistatic_options,
-                                                  physics_prefix, mesh_tag, std::vector<std::string>{"E", "v"});
+                                                  ::serac::solid_mechanics::default_quasistatic_options, physics_prefix,
+                                                  mesh_tag, std::vector<std::string>{"E", "v"});
 
   using materialType = ParameterizedNeoHookeanSolid;
   materialType material;

--- a/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
+++ b/src/serac/physics/tests/quasistatic_solid_adjoint.cpp
@@ -153,8 +153,7 @@ TEST(quasistatic, finiteDifference)
                                                          .print_level    = 1};
   auto seracSolid = ::std::make_unique<solidType>(nonlinear_options, serac::solid_mechanics::direct_linear_options,
                                                   ::serac::solid_mechanics::default_quasistatic_options,
-                                                  ::serac::GeometricNonlinearities::On, physics_prefix, mesh_tag,
-                                                  std::vector<std::string>{"E", "v"});
+                                                  physics_prefix, mesh_tag, std::vector<std::string>{"E", "v"});
 
   using materialType = ParameterizedNeoHookeanSolid;
   materialType material;

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -138,9 +138,9 @@ void functional_solid_spatial_essential_bc()
   serac::StateManager::setMesh(std::move(mesh), mesh_tag);
 
   // Construct a functional-based solid mechanics solver
-  SolidMechanics<p, dim> solid_solver(
-      solid_mechanics::default_nonlinear_options, solid_mechanics::direct_linear_options,
-      solid_mechanics::default_quasistatic_options, "solid_mechanics", mesh_tag);
+  SolidMechanics<p, dim> solid_solver(solid_mechanics::default_nonlinear_options,
+                                      solid_mechanics::direct_linear_options,
+                                      solid_mechanics::default_quasistatic_options, "solid_mechanics", mesh_tag);
 
   solid_mechanics::LinearIsotropic mat{1.0, 1.0, 1.0};
   solid_solver.setMaterial(mat);
@@ -293,9 +293,9 @@ void functional_parameterized_solid_test(double expected_disp_norm)
   auto equation_solver = std::make_unique<EquationSolver>(std::move(nonlinear_solver), std::move(linear_solver),
                                                           std::move(preconditioner));
 
-  SolidMechanics<p, dim, Parameters<H1<1>, H1<1>>> solid_solver(
-      std::move(equation_solver), solid_mechanics::default_quasistatic_options,
-      "parameterized_solid", mesh_tag, {"shear", "bulk"});
+  SolidMechanics<p, dim, Parameters<H1<1>, H1<1>>> solid_solver(std::move(equation_solver),
+                                                                solid_mechanics::default_quasistatic_options,
+                                                                "parameterized_solid", mesh_tag, {"shear", "bulk"});
   // _custom_solver_end
 
   solid_solver.setParameter(0, user_defined_bulk_modulus);

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -57,7 +57,7 @@ void functional_solid_test_static_J2()
                                                   .print_level    = 1};
 
   SolidMechanics<p, dim> solid_solver(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-                                      GeometricNonlinearities::Off, "solid_mechanics", mesh_tag);
+                                      "solid_mechanics", mesh_tag);
   // _solver_params_end
 
   using Hardening = solid_mechanics::LinearHardening;
@@ -140,7 +140,7 @@ void functional_solid_spatial_essential_bc()
   // Construct a functional-based solid mechanics solver
   SolidMechanics<p, dim> solid_solver(
       solid_mechanics::default_nonlinear_options, solid_mechanics::direct_linear_options,
-      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::Off, "solid_mechanics", mesh_tag);
+      solid_mechanics::default_quasistatic_options, "solid_mechanics", mesh_tag);
 
   solid_mechanics::LinearIsotropic mat{1.0, 1.0, 1.0};
   solid_solver.setMaterial(mat);
@@ -294,7 +294,7 @@ void functional_parameterized_solid_test(double expected_disp_norm)
                                                           std::move(preconditioner));
 
   SolidMechanics<p, dim, Parameters<H1<1>, H1<1>>> solid_solver(
-      std::move(equation_solver), solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On,
+      std::move(equation_solver), solid_mechanics::default_quasistatic_options,
       "parameterized_solid", mesh_tag, {"shear", "bulk"});
   // _custom_solver_end
 

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -362,7 +362,7 @@ void functional_parameterized_solid_test(double expected_disp_norm)
   EXPECT_NEAR(expected_disp_norm, norm(solid_solver.displacement()), 1.0e-6);
 }
 
-TEST(SolidMechanics, 2DQuadParameterizedStatic) { functional_parameterized_solid_test<2, 2>(2.1773851975471392); }
+TEST(SolidMechanics, 2DQuadParameterizedStatic) { functional_parameterized_solid_test<2, 2>(2.2378592112148716); }
 
 TEST(SolidMechanics, 3DQuadStaticJ2) { functional_solid_test_static_J2(); }
 

--- a/src/serac/physics/tests/solid_dynamics_patch.cpp
+++ b/src/serac/physics/tests/solid_dynamics_patch.cpp
@@ -307,7 +307,7 @@ double solution_error(solution_type exact_solution, PatchBoundaryCondition bc)
 
   SolidMechanics<p, dim> solid(nonlin_opts, serac::solid_mechanics::default_linear_options,
                                TimesteppingOptions{TimestepMethod::Newmark, DirichletEnforcementMethod::DirectControl},
-                               GeometricNonlinearities::On, "solid_dynamics", mesh_tag);
+                               "solid_dynamics", mesh_tag);
 
   solid_mechanics::NeoHookean mat{.density = 1.0, .K = 1.0, .G = 1.0};
   solid.setMaterial(mat);

--- a/src/serac/physics/tests/solid_dynamics_patch.cpp
+++ b/src/serac/physics/tests/solid_dynamics_patch.cpp
@@ -142,10 +142,8 @@ public:
     auto traction = [material, Hdot](auto, auto n0, auto t) {
       auto                     H = Hdot * t;
       typename Material::State state;  // needs to be reconfigured for mats with state
-      tensor<double, dim, dim> sigma = material(state, H);
-      auto                     F     = Identity<dim>() + H;
-      auto                     J     = det(F);
-      auto                     P     = J * dot(sigma, inv(transpose(F)));
+      tensor<double, dim, dim> P = material(state, H);
+
       // We don't have a good way to restrict the tractions to the
       // complement of the essential boundary segments.
       // The following matches the case when the top and left surfaces

--- a/src/serac/physics/tests/solid_finite_diff.cpp
+++ b/src/serac/physics/tests/solid_finite_diff.cpp
@@ -218,8 +218,7 @@ void finite_difference_shape_test(LoadingType load)
 
   // Construct a functional-based solid solver
   SolidMechanics<p, dim> solid_solver(nonlin_options, solid_mechanics::direct_linear_options,
-                                      solid_mechanics::default_quasistatic_options,
-                                      "solid_functional", mesh_tag);
+                                      solid_mechanics::default_quasistatic_options, "solid_functional", mesh_tag);
 
   solid_mechanics::NeoHookean mat{1.0, 1.0, 1.0};
   solid_solver.setMaterial(mat);

--- a/src/serac/physics/tests/solid_finite_diff.cpp
+++ b/src/serac/physics/tests/solid_finite_diff.cpp
@@ -63,7 +63,7 @@ TEST(SolidMechanics, FiniteDifferenceParameter)
 
   SolidMechanics<p, dim, Parameters<H1<1>, H1<1>>> solid_solver(
       solid_mechanics::default_nonlinear_options, lin_options, solid_mechanics::default_quasistatic_options,
-      GeometricNonlinearities::On, "solid_functional", mesh_tag, {"shear modulus", "bulk modulus"});
+      "solid_functional", mesh_tag, {"shear modulus", "bulk modulus"});
 
   solid_solver.setParameter(0, user_defined_bulk_modulus);
   solid_solver.setParameter(1, user_defined_shear_modulus);
@@ -218,7 +218,7 @@ void finite_difference_shape_test(LoadingType load)
 
   // Construct a functional-based solid solver
   SolidMechanics<p, dim> solid_solver(nonlin_options, solid_mechanics::direct_linear_options,
-                                      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On,
+                                      solid_mechanics::default_quasistatic_options,
                                       "solid_functional", mesh_tag);
 
   solid_mechanics::NeoHookean mat{1.0, 1.0, 1.0};

--- a/src/serac/physics/tests/solid_multi_material.cpp
+++ b/src/serac/physics/tests/solid_multi_material.cpp
@@ -70,7 +70,7 @@ TEST(Solid, MultiMaterial)
                                                   .print_level    = 1};
 
   SolidMechanics<p, dim> solid(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-                               GeometricNonlinearities::Off, "solid_mechanics", mesh_tag);
+                               "solid_mechanics", mesh_tag);
   // _solver_params_end
 
   using Material = solid_mechanics::LinearIsotropic;
@@ -186,7 +186,7 @@ TEST(Solid, MultiMaterialWithState)
                                                   .print_level    = 1};
 
   SolidMechanics<p, dim> solid(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-                               GeometricNonlinearities::Off, "solid_mechanics", mesh_tag);
+                               "solid_mechanics", mesh_tag);
 
   auto is_in_left = [](std::vector<tensor<double, dim>> coords, int /* attribute */) {
     return average(coords)[0] < 0.5 * L;

--- a/src/serac/physics/tests/solid_periodic.cpp
+++ b/src/serac/physics/tests/solid_periodic.cpp
@@ -70,7 +70,7 @@ void periodic_test(mfem::Element::Type element_type)
   // Construct a functional-based solid solver
   SolidMechanics<p, dim, Parameters<L2<p>, L2<p>>> solid_solver(
       solid_mechanics::default_nonlinear_options, solid_mechanics::default_linear_options,
-      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On, "solid_periodic", mesh_tag,
+      solid_mechanics::default_quasistatic_options, "solid_periodic", mesh_tag,
       {"bulk", "shear"});
 
   solid_solver.setParameter(0, user_defined_bulk_modulus);

--- a/src/serac/physics/tests/solid_periodic.cpp
+++ b/src/serac/physics/tests/solid_periodic.cpp
@@ -70,8 +70,7 @@ void periodic_test(mfem::Element::Type element_type)
   // Construct a functional-based solid solver
   SolidMechanics<p, dim, Parameters<L2<p>, L2<p>>> solid_solver(
       solid_mechanics::default_nonlinear_options, solid_mechanics::default_linear_options,
-      solid_mechanics::default_quasistatic_options, "solid_periodic", mesh_tag,
-      {"bulk", "shear"});
+      solid_mechanics::default_quasistatic_options, "solid_periodic", mesh_tag, {"bulk", "shear"});
 
   solid_solver.setParameter(0, user_defined_bulk_modulus);
   solid_solver.setParameter(1, user_defined_shear_modulus);

--- a/src/serac/physics/tests/solid_reaction_adjoint.cpp
+++ b/src/serac/physics/tests/solid_reaction_adjoint.cpp
@@ -32,7 +32,6 @@ const std::string physics_prefix = "solid";
 
 using SolidMaterial = solid_mechanics::ParameterizedNeoHookeanSolid;
 // using SolidMaterial = solid_mechanics::ParameterizedLinearIsotropicSolid;
-auto geoNonlinear = GeometricNonlinearities::Off;
 
 constexpr double boundary_disp       = 0.013;
 constexpr double shear_modulus_value = 1.0;

--- a/src/serac/physics/tests/solid_reaction_adjoint.cpp
+++ b/src/serac/physics/tests/solid_reaction_adjoint.cpp
@@ -43,7 +43,7 @@ std::unique_ptr<SolidMechanicsType> createNonlinearSolidMechanicsSolver(mfem::Pa
 {
   static int iter  = 0;
   auto       solid = std::make_unique<SolidMechanicsType>(nonlinear_opts, solid_mechanics::direct_linear_options,
-                                                    solid_mechanics::default_quasistatic_options, geoNonlinear,
+                                                    solid_mechanics::default_quasistatic_options,
                                                     physics_prefix + std::to_string(iter++), mesh_tag,
                                                     std::vector<std::string>{"shear modulus", "bulk modulus"});
 

--- a/src/serac/physics/tests/solid_reaction_adjoint.cpp
+++ b/src/serac/physics/tests/solid_reaction_adjoint.cpp
@@ -42,10 +42,9 @@ std::unique_ptr<SolidMechanicsType> createNonlinearSolidMechanicsSolver(mfem::Pa
                                                                         const SolidMaterial&          mat)
 {
   static int iter  = 0;
-  auto       solid = std::make_unique<SolidMechanicsType>(nonlinear_opts, solid_mechanics::direct_linear_options,
-                                                    solid_mechanics::default_quasistatic_options,
-                                                    physics_prefix + std::to_string(iter++), mesh_tag,
-                                                    std::vector<std::string>{"shear modulus", "bulk modulus"});
+  auto       solid = std::make_unique<SolidMechanicsType>(
+      nonlinear_opts, solid_mechanics::direct_linear_options, solid_mechanics::default_quasistatic_options,
+      physics_prefix + std::to_string(iter++), mesh_tag, std::vector<std::string>{"shear modulus", "bulk modulus"});
 
   // Construct and initialized the user-defined moduli to be used as a differentiable parameter in
   // the solid physics module.

--- a/src/serac/physics/tests/solid_robin_condition.cpp
+++ b/src/serac/physics/tests/solid_robin_condition.cpp
@@ -52,7 +52,7 @@ void functional_solid_test_robin_condition()
                                                   .print_level    = 1};
 
   SolidMechanics<p, dim> solid_solver(nonlinear_options, solid_mechanics::default_linear_options,
-                                      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::Off,
+                                      solid_mechanics::default_quasistatic_options,
                                       "solid_mechanics", mesh_tag);
   // _solver_params_end
 

--- a/src/serac/physics/tests/solid_robin_condition.cpp
+++ b/src/serac/physics/tests/solid_robin_condition.cpp
@@ -52,8 +52,7 @@ void functional_solid_test_robin_condition()
                                                   .print_level    = 1};
 
   SolidMechanics<p, dim> solid_solver(nonlinear_options, solid_mechanics::default_linear_options,
-                                      solid_mechanics::default_quasistatic_options,
-                                      "solid_mechanics", mesh_tag);
+                                      solid_mechanics::default_quasistatic_options, "solid_mechanics", mesh_tag);
   // _solver_params_end
 
   solid_mechanics::LinearIsotropic mat{

--- a/src/serac/physics/tests/solid_shape.cpp
+++ b/src/serac/physics/tests/solid_shape.cpp
@@ -187,8 +187,7 @@ void shape_test()
   EXPECT_LT(relative_error, 4.5e-12);
 }
 
-TEST(SolidMechanics, MoveShapeLinear) { shape_test(); }
-TEST(SolidMechanics, MoveShapeNonlinear) { shape_test(); }
+TEST(SolidMechanics, MoveShape) { shape_test(); }
 
 }  // namespace serac
 

--- a/src/serac/physics/tests/solid_shape.cpp
+++ b/src/serac/physics/tests/solid_shape.cpp
@@ -156,8 +156,8 @@ void shape_test()
 
     // Construct a functional-based solid mechanics solver including references to the shape velocity field.
     SolidMechanics<p, dim> solid_solver_no_shape(nonlinear_options, linear_options,
-                                                 solid_mechanics::default_quasistatic_options,
-                                                 "solid_functional", new_mesh_tag);
+                                                 solid_mechanics::default_quasistatic_options, "solid_functional",
+                                                 new_mesh_tag);
 
     mfem::VisItDataCollection visit_dc("pure_version", const_cast<mfem::ParMesh*>(&solid_solver_no_shape.mesh()));
     visit_dc.RegisterField("displacement", &solid_solver_no_shape.displacement().gridFunction());

--- a/src/serac/physics/tests/solid_shape.cpp
+++ b/src/serac/physics/tests/solid_shape.cpp
@@ -20,7 +20,7 @@
 
 namespace serac {
 
-void shape_test(GeometricNonlinearities geo_nonlin)
+void shape_test()
 {
   MPI_Barrier(MPI_COMM_WORLD);
 
@@ -112,7 +112,7 @@ void shape_test(GeometricNonlinearities geo_nonlin)
 
     // Construct a functional-based solid mechanics solver including references to the shape velocity field.
     SolidMechanics<p, dim> solid_solver(nonlinear_options, linear_options, solid_mechanics::default_quasistatic_options,
-                                        geo_nonlin, "solid_functional", mesh_tag);
+                                        "solid_functional", mesh_tag);
 
     // Set the initial displacement and boundary condition
     solid_solver.setDisplacementBCs(ess_bdr, bc);
@@ -156,7 +156,7 @@ void shape_test(GeometricNonlinearities geo_nonlin)
 
     // Construct a functional-based solid mechanics solver including references to the shape velocity field.
     SolidMechanics<p, dim> solid_solver_no_shape(nonlinear_options, linear_options,
-                                                 solid_mechanics::default_quasistatic_options, geo_nonlin,
+                                                 solid_mechanics::default_quasistatic_options,
                                                  "solid_functional", new_mesh_tag);
 
     mfem::VisItDataCollection visit_dc("pure_version", const_cast<mfem::ParMesh*>(&solid_solver_no_shape.mesh()));
@@ -187,8 +187,8 @@ void shape_test(GeometricNonlinearities geo_nonlin)
   EXPECT_LT(relative_error, 4.5e-12);
 }
 
-TEST(SolidMechanics, MoveShapeLinear) { shape_test(GeometricNonlinearities::Off); }
-TEST(SolidMechanics, MoveShapeNonlinear) { shape_test(GeometricNonlinearities::On); }
+TEST(SolidMechanics, MoveShapeLinear) { shape_test(); }
+TEST(SolidMechanics, MoveShapeNonlinear) { shape_test(); }
 
 }  // namespace serac
 

--- a/src/serac/physics/tests/solid_statics_patch.cpp
+++ b/src/serac/physics/tests/solid_statics_patch.cpp
@@ -88,8 +88,7 @@ public:
     // natural BCs
     typename Material::State state;
     auto H = make_tensor<dim, dim>([&](int i, int j) { return A(i,j); });
-    tensor<double, dim, dim> sigma = material(state, H);
-    auto P = solid_mechanics::CauchyToPiola(sigma, H);
+    tensor<double, dim, dim> P = material(state, H);
     auto traction = [P](auto, auto n0, auto) { return dot(P, n0); };
     sf.setTraction(traction);
   }
@@ -188,8 +187,7 @@ public:
     auto traction = [=](auto X, auto n0, auto) {
       auto H = gradient(get_value(X));
       typename material_type::State state{};
-      auto sigma = material(state, H);
-      auto P = solid_mechanics::CauchyToPiola(sigma, H);
+      auto P = material(state, H);
       return dot(P, n0);
     };
 
@@ -199,8 +197,7 @@ public:
       auto X_val = get_value(X);
       auto H = gradient(make_dual(X_val));
       solid_mechanics::LinearIsotropic::State state{};
-      auto sigma = material(state, H);
-      auto P = solid_mechanics::CauchyToPiola(sigma, H);
+      auto P = material(state, H);
       auto dPdX = get_gradient(P);
       tensor<double,dim> divP{};
       for (int i = 0; i < dim; i++) {

--- a/src/serac/physics/tests/solid_statics_patch.cpp
+++ b/src/serac/physics/tests/solid_statics_patch.cpp
@@ -321,7 +321,7 @@ double solution_error(PatchBoundaryCondition bc)
 
   auto equation_solver = std::make_unique<EquationSolver>(nonlin_solver_options, serac::solid_mechanics::default_linear_options, pmesh.GetComm());
 
-  SolidMechanics<p, dim> solid(std::move(equation_solver), solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On, "solid", mesh_tag);
+  SolidMechanics<p, dim> solid(std::move(equation_solver), solid_mechanics::default_quasistatic_options, "solid", mesh_tag);
 
   solid_mechanics::NeoHookean mat{.density=1.0, .K=1.0, .G=1.0};
   solid.setMaterial(mat);
@@ -396,7 +396,7 @@ double pressure_error()
 
   auto equation_solver = std::make_unique<EquationSolver>(nonlin_solver_options, serac::solid_mechanics::default_linear_options, pmesh.GetComm());
 
-  SolidMechanics<p, dim> solid(std::move(equation_solver), solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On, "solid", mesh_tag);
+  SolidMechanics<p, dim> solid(std::move(equation_solver), solid_mechanics::default_quasistatic_options, "solid", mesh_tag);
 
   solid_mechanics::NeoHookean mat{.density=1.0, .K=1.0, .G=1.0};
   solid.setMaterial(mat);

--- a/src/serac/physics/tests/thermal_mechanics.cpp
+++ b/src/serac/physics/tests/thermal_mechanics.cpp
@@ -60,7 +60,7 @@ void functional_test_static_3D(double expected_norm)
   Thermomechanics<p, dim> thermal_solid_solver(
       heat_transfer::default_nonlinear_options, heat_transfer::default_linear_options,
       heat_transfer::default_static_options, default_nonlinear_options, default_linear_options,
-      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On, "thermal_solid_functional", mesh_tag);
+      solid_mechanics::default_quasistatic_options, "thermal_solid_functional", mesh_tag);
 
   double rho       = 1.0;
   double E         = 1.0;
@@ -143,7 +143,7 @@ void functional_test_shrinking_3D(double expected_norm)
   Thermomechanics<p, dim> thermal_solid_solver(
       heat_transfer::default_nonlinear_options, heat_transfer::default_linear_options,
       heat_transfer::default_static_options, default_nonlinear_options, default_linear_options,
-      solid_mechanics::default_quasistatic_options, GeometricNonlinearities::On, "thermal_solid_functional", mesh_tag);
+      solid_mechanics::default_quasistatic_options, "thermal_solid_functional", mesh_tag);
 
   double                                       rho       = 1.0;
   double                                       E         = 1.0;
@@ -237,7 +237,7 @@ void parameterized()
       heat_transfer::default_nonlinear_options, heat_transfer::default_linear_options,
       heat_transfer::default_static_options, solid_mechanics::default_nonlinear_options,
       solid_mechanics::default_linear_options, solid_mechanics::default_quasistatic_options,
-      GeometricNonlinearities::On, "thermal_solid_functional", mesh_tag);
+      "thermal_solid_functional", mesh_tag);
 
   double rho       = 1.0;
   double E         = 1.0;

--- a/src/serac/physics/tests/thermal_mechanics.cpp
+++ b/src/serac/physics/tests/thermal_mechanics.cpp
@@ -236,8 +236,8 @@ void parameterized()
   Thermomechanics<p, dim, H1<p>> thermal_solid_solver(
       heat_transfer::default_nonlinear_options, heat_transfer::default_linear_options,
       heat_transfer::default_static_options, solid_mechanics::default_nonlinear_options,
-      solid_mechanics::default_linear_options, solid_mechanics::default_quasistatic_options,
-      "thermal_solid_functional", mesh_tag);
+      solid_mechanics::default_linear_options, solid_mechanics::default_quasistatic_options, "thermal_solid_functional",
+      mesh_tag);
 
   double rho       = 1.0;
   double E         = 1.0;

--- a/src/serac/physics/thermomechanics.hpp
+++ b/src/serac/physics/thermomechanics.hpp
@@ -48,8 +48,7 @@ public:
   Thermomechanics(const NonlinearSolverOptions thermal_nonlin_opts, const LinearSolverOptions thermal_lin_opts,
                   TimesteppingOptions thermal_timestepping, const NonlinearSolverOptions solid_nonlin_opts,
                   const LinearSolverOptions solid_lin_opts, TimesteppingOptions solid_timestepping,
-                  const std::string& physics_name, std::string mesh_tag,
-                  int cycle = 0, double time = 0.0)
+                  const std::string& physics_name, std::string mesh_tag, int cycle = 0, double time = 0.0)
       : Thermomechanics(
             std::make_unique<EquationSolver>(thermal_nonlin_opts, thermal_lin_opts,
                                              StateManager::mesh(mesh_tag).GetComm()),
@@ -73,13 +72,12 @@ public:
    */
   Thermomechanics(std::unique_ptr<EquationSolver> thermal_solver, TimesteppingOptions thermal_timestepping,
                   std::unique_ptr<EquationSolver> solid_solver, TimesteppingOptions solid_timestepping,
-                  const std::string& physics_name, std::string mesh_tag,
-                  int cycle = 0, double time = 0.0)
+                  const std::string& physics_name, std::string mesh_tag, int cycle = 0, double time = 0.0)
       : BasePhysics(physics_name, mesh_tag),
         thermal_(std::move(thermal_solver), thermal_timestepping, physics_name + "thermal", mesh_tag, {"displacement"},
                  cycle, time),
-        solid_(std::move(solid_solver), solid_timestepping, physics_name + "mechanical", mesh_tag,
-               {"temperature"}, cycle, time)
+        solid_(std::move(solid_solver), solid_timestepping, physics_name + "mechanical", mesh_tag, {"temperature"},
+               cycle, time)
   {
     SLIC_ERROR_ROOT_IF(mesh_.Dimension() != dim,
                        axom::fmt::format("Compile time dimension and runtime mesh dimension mismatch"));
@@ -103,8 +101,8 @@ public:
                   const std::string& physics_name, std::string mesh_tag, int cycle = 0, double time = 0.0)
       : Thermomechanics(thermal_options.nonlin_solver_options, thermal_options.lin_solver_options,
                         thermal_options.timestepping_options, solid_options.nonlin_solver_options,
-                        solid_options.lin_solver_options, solid_options.timestepping_options,
-                        physics_name, mesh_tag, cycle, time)
+                        solid_options.lin_solver_options, solid_options.timestepping_options, physics_name, mesh_tag,
+                        cycle, time)
   {
   }
 

--- a/src/serac/physics/thermomechanics.hpp
+++ b/src/serac/physics/thermomechanics.hpp
@@ -40,7 +40,6 @@ public:
    * @param solid_nonlin_opts The options for solving the nonlinear solid mechanics residual equations
    * @param solid_lin_opts The options for solving the linearized Jacobian solid mechanics equations
    * @param solid_timestepping The timestepping options for the solid solver
-   * @param geom_nonlin Flag to include geometric nonlinearities
    * @param physics_name A name for the physics module instance
    * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
    * @param cycle The simulation cycle (i.e. timestep iteration) to intialize the physics module to
@@ -49,14 +48,14 @@ public:
   Thermomechanics(const NonlinearSolverOptions thermal_nonlin_opts, const LinearSolverOptions thermal_lin_opts,
                   TimesteppingOptions thermal_timestepping, const NonlinearSolverOptions solid_nonlin_opts,
                   const LinearSolverOptions solid_lin_opts, TimesteppingOptions solid_timestepping,
-                  GeometricNonlinearities geom_nonlin, const std::string& physics_name, std::string mesh_tag,
+                  const std::string& physics_name, std::string mesh_tag,
                   int cycle = 0, double time = 0.0)
       : Thermomechanics(
             std::make_unique<EquationSolver>(thermal_nonlin_opts, thermal_lin_opts,
                                              StateManager::mesh(mesh_tag).GetComm()),
             thermal_timestepping,
             std::make_unique<EquationSolver>(solid_nonlin_opts, solid_lin_opts, StateManager::mesh(mesh_tag).GetComm()),
-            solid_timestepping, geom_nonlin, physics_name, mesh_tag, cycle, time)
+            solid_timestepping, physics_name, mesh_tag, cycle, time)
   {
   }
 
@@ -67,7 +66,6 @@ public:
    * @param thermal_timestepping The timestepping options for the thermal solver
    * @param solid_solver The nonlinear equation solver for the solid mechanics equations
    * @param solid_timestepping The timestepping options for the solid solver
-   * @param geom_nonlin Flag to include geometric nonlinearities
    * @param physics_name A name for the physics module instance
    * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
    * @param cycle The simulation cycle (i.e. timestep iteration) to intialize the physics module to
@@ -75,12 +73,12 @@ public:
    */
   Thermomechanics(std::unique_ptr<EquationSolver> thermal_solver, TimesteppingOptions thermal_timestepping,
                   std::unique_ptr<EquationSolver> solid_solver, TimesteppingOptions solid_timestepping,
-                  GeometricNonlinearities geom_nonlin, const std::string& physics_name, std::string mesh_tag,
+                  const std::string& physics_name, std::string mesh_tag,
                   int cycle = 0, double time = 0.0)
       : BasePhysics(physics_name, mesh_tag),
         thermal_(std::move(thermal_solver), thermal_timestepping, physics_name + "thermal", mesh_tag, {"displacement"},
                  cycle, time),
-        solid_(std::move(solid_solver), solid_timestepping, geom_nonlin, physics_name + "mechanical", mesh_tag,
+        solid_(std::move(solid_solver), solid_timestepping, physics_name + "mechanical", mesh_tag,
                {"temperature"}, cycle, time)
   {
     SLIC_ERROR_ROOT_IF(mesh_.Dimension() != dim,
@@ -105,7 +103,7 @@ public:
                   const std::string& physics_name, std::string mesh_tag, int cycle = 0, double time = 0.0)
       : Thermomechanics(thermal_options.nonlin_solver_options, thermal_options.lin_solver_options,
                         thermal_options.timestepping_options, solid_options.nonlin_solver_options,
-                        solid_options.lin_solver_options, solid_options.timestepping_options, solid_options.geom_nonlin,
+                        solid_options.lin_solver_options, solid_options.timestepping_options,
                         physics_name, mesh_tag, cycle, time)
   {
   }


### PR DESCRIPTION
Shift our convention for the material models in solid mechanics from using Cauchy stress to the first Piola stress (aka first Piola-Kirchhoff stress). There are several motivations for this:

- **Removes the** `GeometricNonlinearities` **flag and the possible inconsistent states this allowed.** Now, if you set a geometrically linear material model, you get linear behavior, and if you set a geometrically nonlinear material model, you get the nonlinear behavior. Before, you set a material, linear or nonlinear, and had to set the `GeometricNonlinearities` flag correspondingly, or else nonsensical results would follow. I'm not aware of any meaningful use of having the flag set differently than the material model. This was just a big footgun and a common point of confusion from our users.
- **Brings consistency between the material model and the other input data.** Our methods for setting tractions and body forces expected reference configuration (Piola) forces. Our boundary conditions functors also pass reference configuration coordinates. The old constitutive model convention bucked this pattern.
- **The output of the constitutitve model (stress) is now conjugate to the main input to the constitutive model (displacement gradient).** This is just a nice symmetry to have. This means that the output stress is the derivative of the strain energy density with respect to its argument, so if we ever extend our AD capabilities to multiple derivatives, we're in a better position to use minimization solvers directly.

I did not update the documentation in this PR to limit the breadth of changes. I'm doing that in a sister PR, #1264.