### PR TITLE
Docs update: Outline how to use SPOT with Serac caliper data

### DIFF
--- a/src/docs/sphinx/dev_guide/profiling.rst
+++ b/src/docs/sphinx/dev_guide/profiling.rst
@@ -136,12 +136,12 @@ files:
 - `SPOT CZ <https://lc.llnl.gov/spot2>`_
 - `SPOT RZ <https://rzlc.llnl.gov/spot2>`_
 
-Serac benchmarks are run weekly to track changes over time. The following are steps to view this data in a meaningful
+Serac benchmarks are run weekly to track changes over time. The following are steps to visualize this data in a meaningful
 way:
 
 - Go to https://lc.llnl.gov/spot2/?sf=/usr/WS2/smithdev/califiles
 - Click the check mark button on the top right to view additional data categories
-- Ensure ``mpi.world.size``, ``executable``, ``cluster``, and ``compilers`` are ticked on
+- Ensure ``mpi.world.size``, ``executable``, ``cluster``, and ``compilers`` are enabled
 - Find the pie and bar charts associated with those categories
 - Select one option from each category to filter the graph
 - Scroll down to the table and and select the "compare" tab to view the graph

--- a/src/docs/sphinx/dev_guide/profiling.rst
+++ b/src/docs/sphinx/dev_guide/profiling.rst
@@ -109,7 +109,11 @@ of this file, use `cali-query <https://software.llnl.gov/Caliper/tools.html#cali
 
 To view this data with SPOT, open a browser, navigate to the SPOT server (e.g. `LC <https://lc.llnl.gov/spot2>`_), and open the directory containing one or more ``.cali`` files.  For more information, watch this recorded `tutorial <https://www.youtube.com/watch?v=p8gjA6rbpvo>`_.
 
+==================
 Benchmarking Serac
+==================
+
+Running Benchmarks
 ------------------
 
 To run all of Serac's benchmarks in one command, first make sure Serac is configured
@@ -136,7 +140,18 @@ files:
 - `SPOT CZ <https://lc.llnl.gov/spot2>`_
 - `SPOT RZ <https://rzlc.llnl.gov/spot2>`_
 
-The shared Caliper files for Serac are located here: https://lc.llnl.gov/spot2/?sf=/usr/WS2/smithdev/califiles
+Serac benchmarks are run weekly to track changes over time. The following are steps to view this data in a meaningful
+way:
+
+- Go to https://lc.llnl.gov/spot2/?sf=/usr/WS2/smithdev/califiles
+- Click the check mark button on the top right to view additional data categories
+- Ensure ``mpi.world.size``, ``executable``, ``cluster``, and ``compilers`` are ticked on
+- Find the pie and bar charts associated with those categories
+- Select one option from each category to filter the graph
+- Scroll down to the table and and select the "compare" tab to view the graph
+
+When changing the filter options in the pie charts, ensure you deselect the previous options, so you don't view two of
+one single category.
 
 .. note::
   There is a bug in SPOT where if you remove Caliper files from a directory, they still show up on SPOT - if you've

--- a/src/docs/sphinx/dev_guide/profiling.rst
+++ b/src/docs/sphinx/dev_guide/profiling.rst
@@ -109,11 +109,7 @@ of this file, use `cali-query <https://software.llnl.gov/Caliper/tools.html#cali
 
 To view this data with SPOT, open a browser, navigate to the SPOT server (e.g. `LC <https://lc.llnl.gov/spot2>`_), and open the directory containing one or more ``.cali`` files.  For more information, watch this recorded `tutorial <https://www.youtube.com/watch?v=p8gjA6rbpvo>`_.
 
-==================
 Benchmarking Serac
-==================
-
-Running Benchmarks
 ------------------
 
 To run all of Serac's benchmarks in one command, first make sure Serac is configured
@@ -150,8 +146,9 @@ way:
 - Select one option from each category to filter the graph
 - Scroll down to the table and and select the "compare" tab to view the graph
 
-When changing the filter options in the pie charts, ensure you deselect the previous options, so you don't view two of
-one single category.
+Filtering benchmarks in this way will allow you to see changes of one benchmark over time, rather than a mix of many
+different ones. When changing the filter options in the pie and bar charts, ensure you deselect the previous options, so
+you don't view two of one single category.
 
 .. note::
   There is a bug in SPOT where if you remove Caliper files from a directory, they still show up on SPOT - if you've


### PR DESCRIPTION
In this PR I explain how to use SPOT to visualize Serac benchmarks in a meaningful way. Related to #1226

https://serac.readthedocs.io/en/docs-chapman39-how-to-spot/sphinx/dev_guide/profiling.html#benchmarking-serac