### PR TITLE
Increase CI time for full build blueos

### DIFF
--- a/.gitlab/build_blueos.yml
+++ b/.gitlab/build_blueos.yml
@@ -60,7 +60,7 @@ blueos-clang_10_0_1-full:
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}_cuda.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -DENABLE_DOCS=OFF"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "55"
+    ALLOC_TIME: "65"
   extends: [.full_build_on_blueos, .with_cuda]
 
 blueos-clang_10_0_1-benchmarks:


### PR DESCRIPTION
Full builds of blueos have been timing out somewhat regularly so adding 10 minutes makes sense. https://lc.llnl.gov/gitlab/smith/serac/-/jobs/2234957

