### PR TITLE
Fix acquisition of dof lists from Domains

### DIFF
--- a/src/serac/numerics/functional/domain.cpp
+++ b/src/serac/numerics/functional/domain.cpp
@@ -460,71 +460,32 @@ mfem::Array<int> Domain::dof_list(mfem::FiniteElementSpace* fes) const
 
 Domain EntireDomain(const mfem::Mesh& mesh)
 {
-  Domain output{mesh, mesh.SpaceDimension() /* elems can be 2 or 3 dimensional */};
-
-  int tri_id  = 0;
-  int quad_id = 0;
-  int tet_id  = 0;
-  int hex_id  = 0;
-
-  // faces that satisfy the predicate are added to the domain
-  int num_elems = mesh.GetNE();
-  for (int i = 0; i < num_elems; i++) {
-    auto geom = mesh.GetElementGeometry(i);
-
-    switch (geom) {
-      case mfem::Geometry::TRIANGLE:
-        output.tri_ids_.push_back(tri_id++);
-        break;
-      case mfem::Geometry::SQUARE:
-        output.quad_ids_.push_back(quad_id++);
-        break;
-      case mfem::Geometry::TETRAHEDRON:
-        output.tet_ids_.push_back(tet_id++);
-        break;
-      case mfem::Geometry::CUBE:
-        output.hex_ids_.push_back(hex_id++);
-        break;
-      default:
-        SLIC_ERROR("unsupported element type");
-        break;
-    }
+  switch (mesh.SpaceDimension()) {
+    case 2: 
+      return Domain::ofElements(mesh, [](std::vector<vec2>, int) {  return true; });
+      break;
+    case 3: 
+      return Domain::ofElements(mesh, [](std::vector<vec3>, int) {  return true; });
+      break;
+    default:
+      SLIC_ERROR("In valid spatial dimension. Domains may only be created on 2D or 3D meshes.");
+      exit(-1);
   }
-
-  return output;
 }
 
 Domain EntireBoundary(const mfem::Mesh& mesh)
 {
-  Domain output{mesh, mesh.SpaceDimension() - 1, Domain::Type::BoundaryElements};
-
-  int edge_id = 0;
-  int tri_id  = 0;
-  int quad_id = 0;
-
-  for (int f = 0; f < mesh.GetNumFaces(); f++) {
-    // discard faces with the wrong type
-    if (mesh.GetFaceInformation(f).IsInterior()) continue;
-
-    auto geom = mesh.GetFaceGeometry(f);
-
-    switch (geom) {
-      case mfem::Geometry::SEGMENT:
-        output.edge_ids_.push_back(edge_id++);
-        break;
-      case mfem::Geometry::TRIANGLE:
-        output.tri_ids_.push_back(tri_id++);
-        break;
-      case mfem::Geometry::SQUARE:
-        output.quad_ids_.push_back(quad_id++);
-        break;
-      default:
-        SLIC_ERROR("unsupported element type");
-        break;
-    }
+  switch (mesh.SpaceDimension()) {
+    case 2: 
+      return Domain::ofBoundaryElements(mesh, [](std::vector<vec2>, int) {  return true; });
+      break;
+    case 3: 
+      return Domain::ofBoundaryElements(mesh, [](std::vector<vec3>, int) {  return true; });
+      break;
+    default:
+      SLIC_ERROR("In valid spatial dimension. Domains may only be created on 2D or 3D meshes.");
+      exit(-1);
   }
-
-  return output;
 }
 
 /// @cond

--- a/src/serac/numerics/functional/domain.cpp
+++ b/src/serac/numerics/functional/domain.cpp
@@ -319,9 +319,11 @@ void Domain::addElement(int geom_id, int elem_id, mfem::Geometry::Type element_g
   }
 }
 
-void Domain::addElements(const std::vector<int>& geom_ids, const std::vector<int>& elem_ids, mfem::Geometry::Type element_geometry)
+void Domain::addElements(const std::vector<int>& geom_ids, const std::vector<int>& elem_ids,
+                         mfem::Geometry::Type element_geometry)
 {
-  SLIC_ERROR_IF(geom_ids.size() != elem_ids.size(), "To add elements, you must specify a geom_id AND an elem_id for each element");
+  SLIC_ERROR_IF(geom_ids.size() != elem_ids.size(),
+                "To add elements, you must specify a geom_id AND an elem_id for each element");
 
   for (std::vector<int>::size_type i = 0; i < geom_ids.size(); ++i) {
     addElement(geom_ids[i], elem_ids[i], element_geometry);
@@ -484,11 +486,11 @@ mfem::Array<int> Domain::dof_list(mfem::FiniteElementSpace* fes) const
 Domain EntireDomain(const mfem::Mesh& mesh)
 {
   switch (mesh.SpaceDimension()) {
-    case 2: 
-      return Domain::ofElements(mesh, [](std::vector<vec2>, int) {  return true; });
+    case 2:
+      return Domain::ofElements(mesh, [](std::vector<vec2>, int) { return true; });
       break;
-    case 3: 
-      return Domain::ofElements(mesh, [](std::vector<vec3>, int) {  return true; });
+    case 3:
+      return Domain::ofElements(mesh, [](std::vector<vec3>, int) { return true; });
       break;
     default:
       SLIC_ERROR("In valid spatial dimension. Domains may only be created on 2D or 3D meshes.");
@@ -499,11 +501,11 @@ Domain EntireDomain(const mfem::Mesh& mesh)
 Domain EntireBoundary(const mfem::Mesh& mesh)
 {
   switch (mesh.SpaceDimension()) {
-    case 2: 
-      return Domain::ofBoundaryElements(mesh, [](std::vector<vec2>, int) {  return true; });
+    case 2:
+      return Domain::ofBoundaryElements(mesh, [](std::vector<vec2>, int) { return true; });
       break;
-    case 3: 
-      return Domain::ofBoundaryElements(mesh, [](std::vector<vec3>, int) {  return true; });
+    case 3:
+      return Domain::ofBoundaryElements(mesh, [](std::vector<vec3>, int) { return true; });
       break;
     default:
       SLIC_ERROR("In valid spatial dimension. Domains may only be created on 2D or 3D meshes.");
@@ -537,18 +539,18 @@ Domain set_operation(set_op op, const Domain& a, const Domain& b)
 
   Domain output{a.mesh_, a.dim_};
 
-  using Ids = std::vector<int>;
+  using Ids         = std::vector<int>;
   auto apply_set_op = [&op](const Ids& x, const Ids& y) { return set_operation(op, x, y); };
 
   if (output.dim_ == 0) {
     output.vertex_ids_ = apply_set_op(a.vertex_ids_, b.vertex_ids_);
   }
 
-  auto fill_output_lists = [apply_set_op, &output](const Ids& a_ids, const Ids& a_mfem_ids, 
-    const Ids& b_ids, const Ids& b_mfem_ids, mfem::Geometry::Type g) {
-      auto output_ids = apply_set_op(a_ids, b_ids);
-      auto output_mfem_ids = apply_set_op(a_mfem_ids, b_mfem_ids);
-      output.addElements(output_ids, output_mfem_ids, g);
+  auto fill_output_lists = [apply_set_op, &output](const Ids& a_ids, const Ids& a_mfem_ids, const Ids& b_ids,
+                                                   const Ids& b_mfem_ids, mfem::Geometry::Type g) {
+    auto output_ids      = apply_set_op(a_ids, b_ids);
+    auto output_mfem_ids = apply_set_op(a_mfem_ids, b_mfem_ids);
+    output.addElements(output_ids, output_mfem_ids, g);
   };
 
   if (output.dim_ == 1) {

--- a/src/serac/numerics/functional/domain.cpp
+++ b/src/serac/numerics/functional/domain.cpp
@@ -362,22 +362,19 @@ static Domain domain_of_boundary_elems(const mfem::Mesh&                        
     switch (geom) {
       case mfem::Geometry::SEGMENT:
         if (add) {
-          output.edge_ids_.push_back(edge_id);
-          output.mfem_edge_ids_.push_back(f);
+          output.addBoundaryElement(edge_id, f, geom);
         }
         edge_id++;
         break;
       case mfem::Geometry::TRIANGLE:
         if (add) {
-          output.tri_ids_.push_back(tri_id);
-          output.mfem_tri_ids_.push_back(f);
+          output.addBoundaryElement(edge_id, f, geom);
         }
         tri_id++;
         break;
       case mfem::Geometry::SQUARE:
         if (add) {
-          output.quad_ids_.push_back(quad_id);
-          output.mfem_quad_ids_.push_back(f);
+          output.addBoundaryElement(edge_id, f, geom);
         }
         quad_id++;
         break;
@@ -398,6 +395,22 @@ Domain Domain::ofBoundaryElements(const mfem::Mesh& mesh, std::function<bool(std
 Domain Domain::ofBoundaryElements(const mfem::Mesh& mesh, std::function<bool(std::vector<vec3>, int)> func)
 {
   return domain_of_boundary_elems<3>(mesh, func);
+}
+
+void Domain::addBoundaryElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry)
+{
+  if (element_geometry == mfem::Geometry::SEGMENT) {
+    edge_ids_.push_back(geom_id);
+    mfem_edge_ids_.push_back(elem_id);
+  } else if (element_geometry == mfem::Geometry::TRIANGLE) {
+    tri_ids_.push_back(geom_id);
+    mfem_tri_ids_.push_back(elem_id);
+  } else if (element_geometry == mfem::Geometry::SQUARE) {
+    quad_ids_.push_back(geom_id);
+    mfem_quad_ids_.push_back(elem_id);
+  } else {
+    SLIC_ERROR("unsupported boundary element type");
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////

--- a/src/serac/numerics/functional/domain.cpp
+++ b/src/serac/numerics/functional/domain.cpp
@@ -258,31 +258,27 @@ static Domain domain_of_elems(const mfem::Mesh&                                 
     switch (x.size()) {
       case 3:
         if (add) {
-          output.tri_ids_.push_back(tri_id);
-          output.mfem_tri_ids_.push_back(i);
+          output.addElement(tri_id, i, mfem::Geometry::TRIANGLE);
         }
         tri_id++;
         break;
       case 4:
         if constexpr (d == 2) {
           if (add) {
-            output.quad_ids_.push_back(quad_id);
-            output.mfem_quad_ids_.push_back(i);
+            output.addElement(quad_id, i, mfem::Geometry::SQUARE);
           }
           quad_id++;
         }
         if constexpr (d == 3) {
           if (add) {
-            output.tet_ids_.push_back(tet_id);
-            output.mfem_tet_ids_.push_back(i);
+            output.addElement(tet_id, i, mfem::Geometry::TETRAHEDRON);
           }
           tet_id++;
         }
         break;
       case 8:
         if (add) {
-          output.hex_ids_.push_back(hex_id);
-          output.mfem_hex_ids_.push_back(i);
+          output.addElement(hex_id, i, mfem::Geometry::CUBE);
         }
         hex_id++;
         break;
@@ -303,6 +299,25 @@ Domain Domain::ofElements(const mfem::Mesh& mesh, std::function<bool(std::vector
 Domain Domain::ofElements(const mfem::Mesh& mesh, std::function<bool(std::vector<vec3>, int)> func)
 {
   return domain_of_elems<3>(mesh, func);
+}
+
+void Domain::addElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry)
+{
+  if (element_geometry == mfem::Geometry::TRIANGLE) {
+    tri_ids_.push_back(geom_id);
+    mfem_tri_ids_.push_back(elem_id);
+  } else if (element_geometry == mfem::Geometry::SQUARE) {
+    quad_ids_.push_back(geom_id);
+    mfem_quad_ids_.push_back(elem_id);
+  } else if (element_geometry == mfem::Geometry::TETRAHEDRON) {
+    tet_ids_.push_back(geom_id);
+    mfem_tet_ids_.push_back(elem_id);
+  } else if (element_geometry == mfem::Geometry::CUBE) {
+    hex_ids_.push_back(geom_id);
+    mfem_hex_ids_.push_back(elem_id);
+  } else {
+    SLIC_ERROR("unsupported element type");
+  }
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////
@@ -384,6 +399,9 @@ Domain Domain::ofBoundaryElements(const mfem::Mesh& mesh, std::function<bool(std
 {
   return domain_of_boundary_elems<3>(mesh, func);
 }
+
+///////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////
 
 mfem::Array<int> Domain::dof_list(mfem::FiniteElementSpace* fes) const
 {

--- a/src/serac/numerics/functional/domain.cpp
+++ b/src/serac/numerics/functional/domain.cpp
@@ -319,6 +319,15 @@ void Domain::addElement(int geom_id, int elem_id, mfem::Geometry::Type element_g
   }
 }
 
+void Domain::addElements(const std::vector<int>& geom_ids, const std::vector<int>& elem_ids, mfem::Geometry::Type element_geometry)
+{
+  SLIC_ERROR_IF(geom_ids.size() != elem_ids.size(), "To add elements, you must specify a geom_id AND an elem_id for each element");
+
+  for (std::vector<int>::size_type i = 0; i < geom_ids.size(); ++i) {
+    addElement(geom_ids[i], elem_ids[i], element_geometry);
+  }
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////
 
@@ -532,52 +541,32 @@ Domain set_operation(set_op op, const Domain& a, const Domain& b)
     output.vertex_ids_ = set_operation(op, a.vertex_ids_, b.vertex_ids_);
   }
 
-  // make helper function to populate id lists in output
-  using Ids = std::vector<int>;
-  auto apply_op = [&](const Ids& x, const Ids& y) { return set_operation(op, x, y); };
-  auto fill_output_members = [&apply_op, &output](const Ids& a_ids, const Ids& b_ids, const Ids& a_mfem_ids, const Ids& b_mfem_ids, mfem::Geometry::Type g) {
-    auto output_ids = apply_op(a_ids, b_ids);
-    auto output_mfem_ids = apply_op(a_mfem_ids, b_mfem_ids);
-    SLIC_ERROR_IF(output_ids.size() != output_mfem_ids.size(),
-      "Domain object has an invalid state");
-
-      for (Ids::size_type i = 0; i < output_ids.size(); ++i) {
-        output.addElement(output_ids[i], output_mfem_ids[i], g);
-      }
-  };
-
   if (output.dim_ == 1) {
     // BT: if this were Python, I'd use zip() here to iterate through
     // both vectors simultaneously. Looks like C++23 will have this.
-    fill_output_members(a.edge_ids_, b.edge_ids_, a.mfem_edge_ids_, b.mfem_edge_ids_, mfem::Geometry::SEGMENT);
+    auto edge_ids = set_operation(op, a.edge_ids_, b.edge_ids_);
+    auto mfem_edge_ids = set_operation(op, a.mfem_edge_ids_, b.edge_ids_);
+    output.addElements(edge_ids, mfem_edge_ids, mfem::Geometry::SEGMENT);
   }
 
   if (output.dim_ == 2) {
     auto tris = set_operation(op, a.tri_ids_, b.tri_ids_);
     auto mfem_tris = set_operation(op, a.mfem_tri_ids_, b.mfem_tri_ids_);
-    for (std::vector<int>::size_type i = 0; i < tris.size(); ++i) {
-      output.addElement(tris[i], mfem_tris[i], mfem::Geometry::TRIANGLE);
-    }
+    output.addElements(tris, mfem_tris, mfem::Geometry::TRIANGLE);
 
     auto quads = set_operation(op, a.quad_ids_, b.quad_ids_);
     auto mfem_quads = set_operation(op, a.mfem_quad_ids_, b.mfem_quad_ids_);
-    for (std::vector<int>::size_type i = 0; i < quads.size(); ++i) {
-      output.addElement(quads[i], mfem_quads[i], mfem::Geometry::SQUARE);
-    }
+    output.addElements(quads, mfem_quads, mfem::Geometry::SQUARE);
   }
 
   if (output.dim_ == 3) {
     auto tets = set_operation(op, a.tet_ids_, b.tet_ids_);
     auto mfem_tets = set_operation(op, a.mfem_tet_ids_, b.mfem_tet_ids_);
-    for (std::vector<int>::size_type i = 0; i < tets.size(); ++i) {
-      output.addElement(tets[i], mfem_tets[i], mfem::Geometry::TETRAHEDRON);
-    }
+    output.addElements(tets, mfem_tets, mfem::Geometry::TETRAHEDRON);
 
     auto hexes = set_operation(op, a.hex_ids_, b.hex_ids_);
     auto mfem_hexes = set_operation(op, a.mfem_hex_ids_, b.mfem_hex_ids_);
-    for (std::vector<int>::size_type i = 0; i < hexes.size(); ++i) {
-      output.addElement(hexes[i], mfem_hexes[i], mfem::Geometry::CUBE);
-    }
+    output.addElements(hexes, mfem_hexes, mfem::Geometry::CUBE);
   }
 
   return output;

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -132,6 +132,8 @@ struct Domain {
 
   void addElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
 
+  void addElements(const std::vector<int>& geom_id, const std::vector<int>& elem_id, mfem::Geometry::Type element_geometry);
+
   /// @brief get mfem degree of freedom list for a given FiniteElementSpace
   mfem::Array<int> dof_list(mfem::FiniteElementSpace* fes) const;
 };

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -130,8 +130,6 @@ struct Domain {
     exit(1);
   }
 
-  void addBoundaryElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
-
   void addElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
 
   /// @brief get mfem degree of freedom list for a given FiniteElementSpace

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -130,6 +130,8 @@ struct Domain {
     exit(1);
   }
 
+  void addBoundaryElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
+
   void addElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
 
   /// @brief get mfem degree of freedom list for a given FiniteElementSpace

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -37,12 +37,10 @@ struct Domain {
   /// @brief whether the elements in this domain are on the boundary or not
   Type type_;
 
-  std::vector<int> vertex_ids_;
-
   ///@{
   /// @name ElementIds
   /// Indices of elements contained in the domain.
-  /// The first set, (vertex_ids_, edge_ids_, ...) hold the index of an element in
+  /// The first set, (edge_ids_, tri_ids, ...) hold the index of an element in
   /// this Domain in the set of all elements of like geometry in the mesh.
   /// For example, if edge_ids_[0] = 5, then element 0 in this domain is element
   /// 5 in the grouping of all edges in the mesh. In other words, these lists
@@ -68,6 +66,9 @@ struct Domain {
   /// methods to add new entities, as this requires you to add both entries and
   /// keep the corresponding lists in sync. You are discouraged from
   /// manipulating these lists directly.
+  ///@}
+
+  /// @cond
   std::vector<int> edge_ids_;
   std::vector<int> tri_ids_;
   std::vector<int> quad_ids_;
@@ -79,8 +80,9 @@ struct Domain {
   std::vector<int> mfem_quad_ids_;
   std::vector<int> mfem_tet_ids_;
   std::vector<int> mfem_hex_ids_;
-  ///@}
+  /// @endcond
 
+  /// @brief construct an "empty" domain, to later be populated later with addElement member functions
   Domain(const mfem::Mesh& m, int d, Type type = Domain::Type::Elements) : mesh_(m), dim_(d), type_(type) {}
 
   /**
@@ -143,7 +145,6 @@ struct Domain {
   /// @brief get elements by geometry type
   const std::vector<int>& get(mfem::Geometry::Type geom) const
   {
-    if (geom == mfem::Geometry::POINT) return vertex_ids_;
     if (geom == mfem::Geometry::SEGMENT) return edge_ids_;
     if (geom == mfem::Geometry::TRIANGLE) return tri_ids_;
     if (geom == mfem::Geometry::SQUARE) return quad_ids_;

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -130,8 +130,10 @@ struct Domain {
     exit(1);
   }
 
+  /// @brief Add an element to the domain
   void addElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
 
+  /// @brief Add a batch of elements to the domain
   void addElements(const std::vector<int>& geom_id, const std::vector<int>& elem_id, mfem::Geometry::Type element_geometry);
 
   /// @brief get mfem degree of freedom list for a given FiniteElementSpace

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -37,14 +37,37 @@ struct Domain {
   /// @brief whether the elements in this domain are on the boundary or not
   Type type_;
 
-  /// note: only lists with appropriate dimension (see dim_) will be populated
-  ///       for example, a 2D Domain may have `tri_ids_` and `quad_ids_` non-nonempty,
-  ///       but all other lists will be empty
-  ///
-  /// these lists hold indices into the "E-vector" of the appropriate geometry
-  ///
-  /// @cond
   std::vector<int> vertex_ids_;
+
+  ///@{
+  /// @name ElementIds
+  /// Indices of elements contained in the domain.
+  /// The first set, (vertex_ids_, edge_ids_, ...) hold the index of an element in
+  /// this Domain in the set of all elements of like geometry in the mesh.
+  /// For example, if edge_ids_[0] = 5, then element 0 in this domain is element
+  /// 5 in the grouping of all edges in the mesh. In other words, these lists
+  /// hold indices into the "E-vector" of the appropriate geometry. These are
+  /// used primarily for identifying elements in the domain for participation
+  /// in integrals.
+  ///
+  /// The second set, (mfem_edge_ids_, mfem_tri_ids_, ...), gives the ids of
+  /// elements in this domain in the global mfem::Mesh data structure. These
+  /// maps are needed to find the dofs that live on a Domain.
+  /// 
+  /// Instances of Domain are meant to be homogeneous: only lists with 
+  /// appropriate dimension (see dim_) will be populated by the factory
+  /// functions. For example, a 2D Domain may have `tri_ids_` and `quad_ids_`
+  /// non-empty, but all other lists will be empty.
+  ///
+  /// @note For every entry in the first group (say, edge_ids_), there should
+  /// be a corresponding entry into the second group (mfem_edge_ids_). This
+  /// is an intended invariant of the class, but it's not enforced by the data
+  /// structures. Prefer to use the factory methods (eg, \ref ofElements(...))
+  /// to populate these lists automatically, as they repsect this invariant and
+  /// are tested. Otherwise, use the \ref addElements(...) or addElements(...)
+  /// methods to add new entities, as this requires you to add both entries and
+  /// keep the corresponding lists in sync. You are discouraged from
+  /// manipulating these lists directly.
   std::vector<int> edge_ids_;
   std::vector<int> tri_ids_;
   std::vector<int> quad_ids_;
@@ -56,7 +79,7 @@ struct Domain {
   std::vector<int> mfem_quad_ids_;
   std::vector<int> mfem_tet_ids_;
   std::vector<int> mfem_hex_ids_;
-  /// @endcond
+  ///@}
 
   Domain(const mfem::Mesh& m, int d, Type type = Domain::Type::Elements) : mesh_(m), dim_(d), type_(type) {}
 
@@ -130,14 +153,22 @@ struct Domain {
     exit(1);
   }
 
+  /// @brief get mfem degree of freedom list for a given FiniteElementSpace
+  mfem::Array<int> dof_list(mfem::FiniteElementSpace* fes) const;
+
   /// @brief Add an element to the domain
+  ///
+  /// This is meant for internal use on the class. Prefer to use the factory
+  /// methods (ofElements, ofBoundaryElements, etc) to create domains and
+  /// thereby populate the element lists.
   void addElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
 
   /// @brief Add a batch of elements to the domain
+  ///
+  /// This is meant for internal use on the class. Prefer to use the factory
+  /// methods (ofElements, ofBoundaryElements, etc) to create domains and
+  /// thereby populate the element lists.
   void addElements(const std::vector<int>& geom_id, const std::vector<int>& elem_id, mfem::Geometry::Type element_geometry);
-
-  /// @brief get mfem degree of freedom list for a given FiniteElementSpace
-  mfem::Array<int> dof_list(mfem::FiniteElementSpace* fes) const;
 };
 
 /// @brief constructs a domain from all the elements in a mesh

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -130,6 +130,8 @@ struct Domain {
     exit(1);
   }
 
+  void addElement(int geom_id, int elem_id, mfem::Geometry::Type element_geometry);
+
   /// @brief get mfem degree of freedom list for a given FiniteElementSpace
   mfem::Array<int> dof_list(mfem::FiniteElementSpace* fes) const;
 };

--- a/src/serac/numerics/functional/domain.hpp
+++ b/src/serac/numerics/functional/domain.hpp
@@ -53,8 +53,8 @@ struct Domain {
   /// The second set, (mfem_edge_ids_, mfem_tri_ids_, ...), gives the ids of
   /// elements in this domain in the global mfem::Mesh data structure. These
   /// maps are needed to find the dofs that live on a Domain.
-  /// 
-  /// Instances of Domain are meant to be homogeneous: only lists with 
+  ///
+  /// Instances of Domain are meant to be homogeneous: only lists with
   /// appropriate dimension (see dim_) will be populated by the factory
   /// functions. For example, a 2D Domain may have `tri_ids_` and `quad_ids_`
   /// non-empty, but all other lists will be empty.
@@ -168,7 +168,8 @@ struct Domain {
   /// This is meant for internal use on the class. Prefer to use the factory
   /// methods (ofElements, ofBoundaryElements, etc) to create domains and
   /// thereby populate the element lists.
-  void addElements(const std::vector<int>& geom_id, const std::vector<int>& elem_id, mfem::Geometry::Type element_geometry);
+  void addElements(const std::vector<int>& geom_id, const std::vector<int>& elem_id,
+                   mfem::Geometry::Type element_geometry);
 };
 
 /// @brief constructs a domain from all the elements in a mesh

--- a/src/serac/numerics/functional/tests/domain_tests.cpp
+++ b/src/serac/numerics/functional/tests/domain_tests.cpp
@@ -338,130 +338,130 @@ TEST(domain, of_elements)
 
 TEST(domain, entireDomain2d)
 {
-    constexpr int dim  = 2;
-    constexpr int p = 1;
-    auto          mesh = import_mesh("patch2D_tris_and_quads.mesh");
+  constexpr int dim  = 2;
+  constexpr int p    = 1;
+  auto          mesh = import_mesh("patch2D_tris_and_quads.mesh");
 
-    Domain d0 = EntireDomain(mesh);
+  Domain d0 = EntireDomain(mesh);
 
-    EXPECT_EQ(d0.dim_, 2);
-    EXPECT_EQ(d0.tri_ids_.size(), 2);
-    EXPECT_EQ(d0.quad_ids_.size(), 4);
+  EXPECT_EQ(d0.dim_, 2);
+  EXPECT_EQ(d0.tri_ids_.size(), 2);
+  EXPECT_EQ(d0.quad_ids_.size(), 4);
 
-    auto fec = mfem::H1_FECollection(p, dim);
-    auto fes = mfem::FiniteElementSpace(&mesh, &fec);
+  auto fec = mfem::H1_FECollection(p, dim);
+  auto fes = mfem::FiniteElementSpace(&mesh, &fec);
 
-    mfem::Array<int> dof_indices = d0.dof_list(&fes);
-    EXPECT_EQ(dof_indices.Size(), 8);
+  mfem::Array<int> dof_indices = d0.dof_list(&fes);
+  EXPECT_EQ(dof_indices.Size(), 8);
 }
 
 TEST(domain, entireDomain3d)
 {
-    constexpr int dim  = 3;
-    constexpr int p = 1;
-    auto          mesh = import_mesh("patch3D_tets_and_hexes.mesh");
+  constexpr int dim  = 3;
+  constexpr int p    = 1;
+  auto          mesh = import_mesh("patch3D_tets_and_hexes.mesh");
 
-    Domain d0 = EntireDomain(mesh);
+  Domain d0 = EntireDomain(mesh);
 
-    EXPECT_EQ(d0.dim_, 3);
-    EXPECT_EQ(d0.tet_ids_.size(), 12);
-    EXPECT_EQ(d0.hex_ids_.size(), 7);
+  EXPECT_EQ(d0.dim_, 3);
+  EXPECT_EQ(d0.tet_ids_.size(), 12);
+  EXPECT_EQ(d0.hex_ids_.size(), 7);
 
-    auto fec = mfem::H1_FECollection(p, dim);
-    auto fes = mfem::FiniteElementSpace(&mesh, &fec);
+  auto fec = mfem::H1_FECollection(p, dim);
+  auto fes = mfem::FiniteElementSpace(&mesh, &fec);
 
-    mfem::Array<int> dof_indices = d0.dof_list(&fes);
-    EXPECT_EQ(dof_indices.Size(), 25);
+  mfem::Array<int> dof_indices = d0.dof_list(&fes);
+  EXPECT_EQ(dof_indices.Size(), 25);
 }
 
 TEST(domain, of2dElementsFindsDofs)
 {
-    constexpr int dim  = 2;
-    constexpr int p = 2;
-    auto          mesh = import_mesh("patch2D_tris_and_quads.mesh");
+  constexpr int dim  = 2;
+  constexpr int p    = 2;
+  auto          mesh = import_mesh("patch2D_tris_and_quads.mesh");
 
-    auto fec = mfem::H1_FECollection(p, dim);
-    auto fes = mfem::FiniteElementSpace(&mesh, &fec);
-    
-    auto find_element_0 = [](std::vector<vec2> vertices, int /* attr */) {
-      auto centroid = average(vertices);
-      return (centroid[0] < 0.5) && (centroid[1] < 0.25);
-    };
+  auto fec = mfem::H1_FECollection(p, dim);
+  auto fes = mfem::FiniteElementSpace(&mesh, &fec);
 
-    Domain d0 = Domain::ofElements(mesh, find_element_0);
+  auto find_element_0 = [](std::vector<vec2> vertices, int /* attr */) {
+    auto centroid = average(vertices);
+    return (centroid[0] < 0.5) && (centroid[1] < 0.25);
+  };
 
-    mfem::Array<int> dof_indices = d0.dof_list(&fes);
+  Domain d0 = Domain::ofElements(mesh, find_element_0);
 
-    EXPECT_EQ(dof_indices.Size(), 9);
+  mfem::Array<int> dof_indices = d0.dof_list(&fes);
 
-    ///////////////////////////////////////
+  EXPECT_EQ(dof_indices.Size(), 9);
 
-    auto find_element_4 = [](std::vector<vec2> vertices, int) {
-      auto centroid = average(vertices);
-      tensor<double, 2> target{{0.533, 0.424}};
-      return norm(centroid - target) < 1e-2;
-    };
-    Domain d1 = Domain::ofElements(mesh, find_element_4);
+  ///////////////////////////////////////
 
-    Domain elements_0_and_4 = d0 | d1;
+  auto find_element_4 = [](std::vector<vec2> vertices, int) {
+    auto              centroid = average(vertices);
+    tensor<double, 2> target{{0.533, 0.424}};
+    return norm(centroid - target) < 1e-2;
+  };
+  Domain d1 = Domain::ofElements(mesh, find_element_4);
 
-    dof_indices = elements_0_and_4.dof_list(&fes);
-    EXPECT_EQ(dof_indices.Size(), 12);
+  Domain elements_0_and_4 = d0 | d1;
 
-    ///////////////////////////////////////
+  dof_indices = elements_0_and_4.dof_list(&fes);
+  EXPECT_EQ(dof_indices.Size(), 12);
 
-    Domain d2 = EntireDomain(mesh) - elements_0_and_4;
+  ///////////////////////////////////////
 
-    dof_indices = d2.dof_list(&fes);
+  Domain d2 = EntireDomain(mesh) - elements_0_and_4;
 
-    EXPECT_EQ(dof_indices.Size(), 22);
+  dof_indices = d2.dof_list(&fes);
+
+  EXPECT_EQ(dof_indices.Size(), 22);
 }
 
 TEST(domain, of3dElementsFindsDofs)
 {
-    constexpr int dim  = 3;
-    constexpr int p = 2;
-    auto          mesh = import_mesh("patch3D_tets_and_hexes.mesh");
+  constexpr int dim  = 3;
+  constexpr int p    = 2;
+  auto          mesh = import_mesh("patch3D_tets_and_hexes.mesh");
 
-    auto fec = mfem::H1_FECollection(p, dim);
-    auto fes = mfem::FiniteElementSpace(&mesh, &fec);
-    
-    auto find_element_0 = [](std::vector<vec3> vertices, int /* attr */) {
-      auto centroid = average(vertices);
-      vec3 target{{3.275, 0.7  , 1.225}};
-      return norm(centroid - target) < 1e-2;
-    };
+  auto fec = mfem::H1_FECollection(p, dim);
+  auto fes = mfem::FiniteElementSpace(&mesh, &fec);
 
-    Domain d0 = Domain::ofElements(mesh, find_element_0);
+  auto find_element_0 = [](std::vector<vec3> vertices, int /* attr */) {
+    auto centroid = average(vertices);
+    vec3 target{{3.275, 0.7, 1.225}};
+    return norm(centroid - target) < 1e-2;
+  };
 
-    mfem::Array<int> dof_indices = d0.dof_list(&fes);
+  Domain d0 = Domain::ofElements(mesh, find_element_0);
 
-    // element 0 is a P2 tetrahedron, so it should have 10 dofs
-    EXPECT_EQ(dof_indices.Size(), 10);
+  mfem::Array<int> dof_indices = d0.dof_list(&fes);
 
-    ///////////////////////////////////////
+  // element 0 is a P2 tetrahedron, so it should have 10 dofs
+  EXPECT_EQ(dof_indices.Size(), 10);
 
-    auto find_element_1 = [](std::vector<vec3> vertices, int) {
-      auto centroid = average(vertices);
-      vec3 target{{3.275, 1.2  , 0.725}};
-      return norm(centroid - target) < 1e-2;
-    };
-    Domain d1 = Domain::ofElements(mesh, find_element_1);
+  ///////////////////////////////////////
 
-    Domain elements_0_and_1 = d0 | d1;
+  auto find_element_1 = [](std::vector<vec3> vertices, int) {
+    auto centroid = average(vertices);
+    vec3 target{{3.275, 1.2, 0.725}};
+    return norm(centroid - target) < 1e-2;
+  };
+  Domain d1 = Domain::ofElements(mesh, find_element_1);
 
-    dof_indices = elements_0_and_1.dof_list(&fes);
+  Domain elements_0_and_1 = d0 | d1;
 
-    // Elements 0 and 1 are P2 tets that share one face -> 14 dofs
-    EXPECT_EQ(dof_indices.Size(), 14);
+  dof_indices = elements_0_and_1.dof_list(&fes);
 
-    /////////////////////////////////////////
+  // Elements 0 and 1 are P2 tets that share one face -> 14 dofs
+  EXPECT_EQ(dof_indices.Size(), 14);
 
-    Domain d2 = EntireDomain(mesh) - elements_0_and_1;
+  /////////////////////////////////////////
 
-    dof_indices = d2.dof_list(&fes);
+  Domain d2 = EntireDomain(mesh) - elements_0_and_1;
 
-    EXPECT_EQ(dof_indices.Size(), 113);
+  dof_indices = d2.dof_list(&fes);
+
+  EXPECT_EQ(dof_indices.Size(), 113);
 }
 
 int main(int argc, char* argv[])

--- a/src/serac/numerics/functional/tests/domain_tests.cpp
+++ b/src/serac/numerics/functional/tests/domain_tests.cpp
@@ -31,66 +31,6 @@ tensor<double, dim> average(std::vector<tensor<double, dim> >& positions)
   return total / double(positions.size());
 }
 
-TEST(domain, of_vertices)
-{
-  {
-    auto   mesh = import_mesh("onehex.mesh");
-    Domain d0   = Domain::ofVertices(mesh, std::function([](vec3 x) { return x[0] < 0.5; }));
-    EXPECT_EQ(d0.vertex_ids_.size(), 4);
-    EXPECT_EQ(d0.dim_, 0);
-
-    Domain d1 = Domain::ofVertices(mesh, std::function([](vec3 x) { return x[1] < 0.5; }));
-    EXPECT_EQ(d1.vertex_ids_.size(), 4);
-    EXPECT_EQ(d1.dim_, 0);
-
-    Domain d2 = d0 | d1;
-    EXPECT_EQ(d2.vertex_ids_.size(), 6);
-    EXPECT_EQ(d2.dim_, 0);
-
-    Domain d3 = d0 & d1;
-    EXPECT_EQ(d3.vertex_ids_.size(), 2);
-    EXPECT_EQ(d3.dim_, 0);
-  }
-
-  {
-    auto   mesh = import_mesh("onetet.mesh");
-    Domain d0   = Domain::ofVertices(mesh, std::function([](vec3 x) { return x[0] < 0.5; }));
-    EXPECT_EQ(d0.vertex_ids_.size(), 3);
-    EXPECT_EQ(d0.dim_, 0);
-
-    Domain d1 = Domain::ofVertices(mesh, std::function([](vec3 x) { return x[1] < 0.5; }));
-    EXPECT_EQ(d1.vertex_ids_.size(), 3);
-    EXPECT_EQ(d1.dim_, 0);
-
-    Domain d2 = d0 | d1;
-    EXPECT_EQ(d2.vertex_ids_.size(), 4);
-    EXPECT_EQ(d2.dim_, 0);
-
-    Domain d3 = d0 & d1;
-    EXPECT_EQ(d3.vertex_ids_.size(), 2);
-    EXPECT_EQ(d3.dim_, 0);
-  }
-
-  {
-    auto   mesh = import_mesh("beam-quad.mesh");
-    Domain d0   = Domain::ofVertices(mesh, std::function([](vec2 x) { return x[0] < 0.5; }));
-    EXPECT_EQ(d0.vertex_ids_.size(), 2);
-    EXPECT_EQ(d0.dim_, 0);
-
-    Domain d1 = Domain::ofVertices(mesh, std::function([](vec2 x) { return x[1] < 0.5; }));
-    EXPECT_EQ(d1.vertex_ids_.size(), 9);
-    EXPECT_EQ(d1.dim_, 0);
-
-    Domain d2 = d0 | d1;
-    EXPECT_EQ(d2.vertex_ids_.size(), 10);
-    EXPECT_EQ(d2.dim_, 0);
-
-    Domain d3 = d0 & d1;
-    EXPECT_EQ(d3.vertex_ids_.size(), 1);
-    EXPECT_EQ(d3.dim_, 0);
-  }
-}
-
 TEST(domain, of_edges)
 {
   {


### PR DESCRIPTION
There are two sets of books in `Domain`:

- Element index lists that are broken out by element geometry, answering questions like "for this tetrahedron in the Domain, where does it go in the list of all tetrahedra in the mesh?". This is used by `Functional` to identify entities that should be integrated over.
- Global element indices, for answering "which element is this in the `mfem::Mesh` data structure?" (which does not segregate by element geometry). These are used to be able to grab dofs that live on a `Domain`.

As noted in #1272, some of the factory methods and operators on `Domain` did not populate all the required data. The omissions were the second group, the global element data, so grabbing dofs were broken in some cases. 

Fundamentally, this class should enforce that every time an entry is added to the first group, a corresponding entry is also added to the second. That's an interface-breaking change I don't want to undertake now. I fixed the bug and moved the class one step closer to the ideal by adding `addElement(...)` and `addElements(...)` methods that require both indices to be supplied at once. In sum this PR does the following:

- I changed all the factory methods to use the `addElement(...)` and `addElements(...)` methods, which fixes the bug, and sets a pattern that makes it less likely a modifier of this class will do the wrong thing.
- I added documentation to discourage a future modifier from manipulating the lists individually
- I added tests that would have caught the missing functionality.

Fixes #1272.