### PR TITLE
Provide a way to disable Serac benchmarks

### DIFF
--- a/cmake/SeracBasics.cmake
+++ b/cmake/SeracBasics.cmake
@@ -43,9 +43,10 @@ endif()
 
 option(SERAC_ENABLE_PROFILING "Enable profiling functionality" OFF)
 
-if (ENABLE_BENCHMARKS)
-    set(SERAC_ENABLE_BENCHMARKS ON)
-endif()
+# ENABLE_BENCHMARKS must be ON in order to modify SERAC_ENABLE_BENCHMARKS.
+# SERAC_ENABLE_BENCHMARKS will automatically be set to ON if ENABLE_BENCHMARKS is ON.
+# SERAC_ENABLE_BENCHMARKS is an option to allow external projects to disable Serac benchmarks while enabling theirs.
+cmake_dependent_option(SERAC_ENABLE_BENCHMARKS "Enable benchmark executables" ON "ENABLE_BENCHMARKS" OFF)
 
 # User turned on benchmarking but explicitly turned off profiling. Error out.
 if ((ENABLE_BENCHMARKS OR SERAC_ENABLE_BENCHMARKS) AND NOT SERAC_ENABLE_PROFILING)


### PR DESCRIPTION
@tupek2 is adding Smith benchmarks. Smith needs a way to disable Serac benchmarks while running Smith's.

Serac benchmarks should not be run within Smith, since because Smith doesn't update Serac very often, so they won't be as accurate.

Eventually we should look into better cmake options https://github.com/LLNL/serac/issues/1282, but for now `cmake_dependent_option` should be re-added, imo.