### PR TITLE
Talamini/another neohookean

### DIFF
--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -128,6 +128,41 @@ struct NeoHookean {
   double G;        ///< shear modulus
 };
 
+/// Neo-Hookean material version with additive split of deviatoric and volumetric behavior
+struct NeoHookeanAdditiveSplit {
+  using State = Empty;  ///< this material has no internal variables
+
+  /**
+   * @brief Piola stress calculation
+   *
+   * @tparam dim Dimensionality of space
+   * @param du_dX displacement gradient with respect to the reference configuration
+   * @return The first Piola stress
+   */
+  template <typename T, int dim>
+  SERAC_HOST_DEVICE auto operator()(State& /* state */, const tensor<T, dim, dim>& du_dX) const
+  {
+    using std::pow;
+    constexpr auto I = Identity<dim>();
+    auto F = I + du_dX;
+    auto J = det(F);
+    auto Jm13 = pow(J, -1.0/3.0);
+    auto F_bar = Jm13*F;
+    auto Pdev = G*Jm13*(F_bar - 1.0/3.0*inner(F_bar, F_bar)*inv(transpose(F_bar)));
+    
+    // any volumetric model could be substituted here
+    using std::log1p;
+    auto logJ = log1p(detApIm1(du_dX));
+    auto Pvol = K*logJ*inv(transpose(F));
+
+    return Pdev + Pvol;
+  }
+
+  double density;  ///< mass density
+  double K;        ///< bulk modulus
+  double G;        ///< shear modulus
+};
+
 /**
  * @brief Linear isotropic hardening law
  */

--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -143,17 +143,17 @@ struct NeoHookeanAdditiveSplit {
   SERAC_HOST_DEVICE auto operator()(State& /* state */, const tensor<T, dim, dim>& du_dX) const
   {
     using std::pow;
-    constexpr auto I = Identity<dim>();
-    auto F = I + du_dX;
-    auto J = det(F);
-    auto Jm13 = pow(J, -1.0/3.0);
-    auto F_bar = Jm13*F;
-    auto Pdev = G*Jm13*(F_bar - 1.0/3.0*inner(F_bar, F_bar)*inv(transpose(F_bar)));
-    
+    constexpr auto I     = Identity<dim>();
+    auto           F     = I + du_dX;
+    auto           J     = det(F);
+    auto           Jm13  = pow(J, -1.0 / 3.0);
+    auto           F_bar = Jm13 * F;
+    auto           Pdev  = G * Jm13 * (F_bar - 1.0 / 3.0 * inner(F_bar, F_bar) * inv(transpose(F_bar)));
+
     // any volumetric model could be substituted here
     using std::log1p;
     auto logJ = log1p(detApIm1(du_dX));
-    auto Pvol = K*logJ*inv(transpose(F));
+    auto Pvol = K * logJ * inv(transpose(F));
 
     return Pdev + Pvol;
   }

--- a/src/serac/physics/materials/tests/CMakeLists.txt
+++ b/src/serac/physics/materials/tests/CMakeLists.txt
@@ -7,9 +7,10 @@
 set(material_test_depends serac_physics_materials gtest)
 
 set(material_test_sources
-    thermomechanical_material.cpp
     J2_material.cpp
+    neohookean_additive_split.cpp
     parameterized_nonlinear_J2_material.cpp
+    thermomechanical_material.cpp
 )
 
 serac_add_tests( SOURCES    ${material_test_sources}

--- a/src/serac/physics/materials/tests/neohookean_additive_split.cpp
+++ b/src/serac/physics/materials/tests/neohookean_additive_split.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file neohookean_additive_split.cpp
+ * 
+ * Test of addivtive split version of neo-Hookean model
+ */
+
+#include "serac/physics/materials/solid_material.hpp"
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include <gtest/gtest.h>
+
+#include "serac/numerics/functional/tensor.hpp"
+#include "serac/physics/materials/material_verification_tools.hpp"
+
+namespace serac {
+
+TEST(NeoHookeanSplit, zeroPoint)
+{    
+    constexpr int dim = 3;
+    double G = 1.0;
+    double K = 2.0;
+    solid_mechanics::NeoHookeanAdditiveSplit mat{.density = 1.0, .K = K, .G = G};
+    solid_mechanics::NeoHookeanAdditiveSplit::State state{};
+    tensor<double, dim, dim> H{};
+    auto P = mat(state, H);
+    EXPECT_LT(norm(P), 1e-10);
+};
+
+TEST(NeoHookeanSplit, materialFrameIndifference)
+{
+    constexpr int dim = 3;
+    double G = 1.0;
+    double K = 2.0;
+    solid_mechanics::NeoHookeanAdditiveSplit mat{.density = 1.0, .K = K, .G = G};
+    solid_mechanics::NeoHookeanAdditiveSplit::State state{};
+
+    // clang-format off
+    // random rotation matrix
+    tensor<double, dim, dim> Q{{{ 0.85293210845696,  0.40557741669729, -0.32865449552427},
+                                {-0.51876824611259,  0.72872528356249, -0.44703351990878},
+                                { 0.05819214026331,  0.55178475890688,  0.83195387771778}}};
+    auto should_be_identity = dot(Q, transpose(Q));
+    // make sure it's a rotation
+    EXPECT_LT(norm(should_be_identity - Identity<dim>()), 1e-10);
+    tensor<double, dim, dim> H{{{0.33749426589249, 0.19423845458191, 0.30783257318134},
+                                {0.0901473654803 , 0.6104025179124 , 0.45897891871615},
+                                {0.68930932313059, 0.19832140905316, 0.90197331346206}}};
+    // clang-format on
+
+    auto P = mat(state, H);
+    auto H_star = dot(Q, H + Identity<dim>()) - Identity<dim>();
+    auto P_star = mat(state, H_star);
+    auto error = P_star - dot(Q, P);
+    EXPECT_LT(norm(error), 1e-12);
+};
+
+TEST(NeoHookeanSplit, deviatoricPartIsCorrectlySplit)
+{
+    // When the bulk modulus is zero, the Cauchy stress should be strictly symmetric
+    
+    constexpr int dim = 3;
+    double G = 1.0;
+    double K = 0.0;
+    solid_mechanics::NeoHookeanAdditiveSplit mat{.density = 1.0, .K = K, .G = G};
+    solid_mechanics::NeoHookeanAdditiveSplit::State state{};
+
+    // clang-format off
+    tensor<double, dim, dim> H{{{0.33749426589249, 0.19423845458191, 0.30783257318134},
+                                {0.0901473654803 , 0.6104025179124 , 0.45897891871615},
+                                {0.68930932313059, 0.19832140905316, 0.90197331346206}}};
+    // clang-format on
+
+    auto P = mat(state, H);
+    auto F = H + Identity<dim>();
+    auto T = dot(P, transpose(F))/det(F); // Cauchy stress
+    EXPECT_LT(std::abs(tr(T)), 1e-12);
+};
+
+
+} //namespace serac
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+
+  axom::slic::SimpleLogger logger;
+
+  int result = RUN_ALL_TESTS();
+
+  return result;
+}

--- a/src/serac/physics/materials/tests/neohookean_additive_split.cpp
+++ b/src/serac/physics/materials/tests/neohookean_additive_split.cpp
@@ -6,7 +6,7 @@
 
 /**
  * @file neohookean_additive_split.cpp
- * 
+ *
  * Test of addivtive split version of neo-Hookean model
  */
 
@@ -21,26 +21,26 @@
 namespace serac {
 
 TEST(NeoHookeanSplit, zeroPoint)
-{    
-    constexpr int dim = 3;
-    double G = 1.0;
-    double K = 2.0;
-    solid_mechanics::NeoHookeanAdditiveSplit mat{.density = 1.0, .K = K, .G = G};
-    solid_mechanics::NeoHookeanAdditiveSplit::State state{};
-    tensor<double, dim, dim> H{};
-    auto P = mat(state, H);
-    EXPECT_LT(norm(P), 1e-10);
+{
+  constexpr int                                   dim = 3;
+  double                                          G   = 1.0;
+  double                                          K   = 2.0;
+  solid_mechanics::NeoHookeanAdditiveSplit        mat{.density = 1.0, .K = K, .G = G};
+  solid_mechanics::NeoHookeanAdditiveSplit::State state{};
+  tensor<double, dim, dim>                        H{};
+  auto                                            P = mat(state, H);
+  EXPECT_LT(norm(P), 1e-10);
 };
 
 TEST(NeoHookeanSplit, materialFrameIndifference)
 {
-    constexpr int dim = 3;
-    double G = 1.0;
-    double K = 2.0;
-    solid_mechanics::NeoHookeanAdditiveSplit mat{.density = 1.0, .K = K, .G = G};
-    solid_mechanics::NeoHookeanAdditiveSplit::State state{};
+  constexpr int                                   dim = 3;
+  double                                          G   = 1.0;
+  double                                          K   = 2.0;
+  solid_mechanics::NeoHookeanAdditiveSplit        mat{.density = 1.0, .K = K, .G = G};
+  solid_mechanics::NeoHookeanAdditiveSplit::State state{};
 
-    // clang-format off
+  // clang-format off
     // random rotation matrix
     tensor<double, dim, dim> Q{{{ 0.85293210845696,  0.40557741669729, -0.32865449552427},
                                 {-0.51876824611259,  0.72872528356249, -0.44703351990878},
@@ -51,39 +51,38 @@ TEST(NeoHookeanSplit, materialFrameIndifference)
     tensor<double, dim, dim> H{{{0.33749426589249, 0.19423845458191, 0.30783257318134},
                                 {0.0901473654803 , 0.6104025179124 , 0.45897891871615},
                                 {0.68930932313059, 0.19832140905316, 0.90197331346206}}};
-    // clang-format on
+  // clang-format on
 
-    auto P = mat(state, H);
-    auto H_star = dot(Q, H + Identity<dim>()) - Identity<dim>();
-    auto P_star = mat(state, H_star);
-    auto error = P_star - dot(Q, P);
-    EXPECT_LT(norm(error), 1e-12);
+  auto P      = mat(state, H);
+  auto H_star = dot(Q, H + Identity<dim>()) - Identity<dim>();
+  auto P_star = mat(state, H_star);
+  auto error  = P_star - dot(Q, P);
+  EXPECT_LT(norm(error), 1e-12);
 };
 
 TEST(NeoHookeanSplit, deviatoricPartIsCorrectlySplit)
 {
-    // When the bulk modulus is zero, the Cauchy stress should be strictly symmetric
-    
-    constexpr int dim = 3;
-    double G = 1.0;
-    double K = 0.0;
-    solid_mechanics::NeoHookeanAdditiveSplit mat{.density = 1.0, .K = K, .G = G};
-    solid_mechanics::NeoHookeanAdditiveSplit::State state{};
+  // When the bulk modulus is zero, the Cauchy stress should be strictly symmetric
 
-    // clang-format off
+  constexpr int                                   dim = 3;
+  double                                          G   = 1.0;
+  double                                          K   = 0.0;
+  solid_mechanics::NeoHookeanAdditiveSplit        mat{.density = 1.0, .K = K, .G = G};
+  solid_mechanics::NeoHookeanAdditiveSplit::State state{};
+
+  // clang-format off
     tensor<double, dim, dim> H{{{0.33749426589249, 0.19423845458191, 0.30783257318134},
                                 {0.0901473654803 , 0.6104025179124 , 0.45897891871615},
                                 {0.68930932313059, 0.19832140905316, 0.90197331346206}}};
-    // clang-format on
+  // clang-format on
 
-    auto P = mat(state, H);
-    auto F = H + Identity<dim>();
-    auto T = dot(P, transpose(F))/det(F); // Cauchy stress
-    EXPECT_LT(std::abs(tr(T)), 1e-12);
+  auto P = mat(state, H);
+  auto F = H + Identity<dim>();
+  auto T = dot(P, transpose(F)) / det(F);  // Cauchy stress
+  EXPECT_LT(std::abs(tr(T)), 1e-12);
 };
 
-
-} //namespace serac
+}  // namespace serac
 
 int main(int argc, char* argv[])
 {

--- a/src/serac/physics/materials/tests/neohookean_additive_split.cpp
+++ b/src/serac/physics/materials/tests/neohookean_additive_split.cpp
@@ -62,7 +62,7 @@ TEST(NeoHookeanSplit, materialFrameIndifference)
 
 TEST(NeoHookeanSplit, deviatoricPartIsCorrectlySplit)
 {
-  // When the bulk modulus is zero, the Cauchy stress should be strictly symmetric
+  // When the bulk modulus is zero, the Cauchy stress should be strictly deviatoric
 
   constexpr int                                   dim = 3;
   double                                          G   = 1.0;


### PR DESCRIPTION
Implement the other family of neo-Hookean material models, in which the strain energy is additively separable into a deviatoric part and a volumetric part.