### PR TITLE
fix initialization bug in `mpi::out`

### DIFF
--- a/src/serac/infrastructure/mpi_fstream.hpp
+++ b/src/serac/infrastructure/mpi_fstream.hpp
@@ -7,7 +7,6 @@ namespace mpi {
 
 /// a tool for writing processor-specific log files
 struct ofstream : public std::ofstream {
-
   /// open an output file for this processor (don't call directly)
   void initialize();
 
@@ -16,13 +15,10 @@ struct ofstream : public std::ofstream {
   friend ofstream& operator<<(ofstream&, T);
 
   /// default ctor
-  ofstream() {
-    initialized = false;
-  }
+  ofstream() { initialized = false; }
 
   /// whether or not the fstream is in use or not
-  bool initialized; 
-
+  bool initialized;
 };
 
 /// analogous to operator<< used with e.g. std::cout
@@ -38,7 +34,7 @@ ofstream& operator<<(ofstream& out, T op)
 extern ofstream out;
 
 /// open an output file for this processor (don't call directly)
-inline void ofstream::initialize() 
+inline void ofstream::initialize()
 {
   int rank, size;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);

--- a/src/serac/infrastructure/mpi_fstream.hpp
+++ b/src/serac/infrastructure/mpi_fstream.hpp
@@ -7,30 +7,42 @@ namespace mpi {
 
 /// a tool for writing processor-specific log files
 struct ofstream : public std::ofstream {
+
   /// open an output file for this processor (don't call directly)
-  void initialize()
-  {
-    int rank, size;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &size);
-    open("mpi_output_" + std::to_string(rank) + "_" + std::to_string(size) + ".txt");
-  }
+  void initialize();
 
   /// @note don't call this before MPI_Init()
   template <typename T>
   friend ofstream& operator<<(ofstream&, T);
+
+  ofstream() {
+    initialized = false;
+  }
+
+  bool initialized;
+
 };
 
 /// analogous to operator<< used with e.g. std::cout
 template <typename T>
 ofstream& operator<<(ofstream& out, T op)
 {
-  if (!out) out.initialize();
+  if (!out.initialized) out.initialize();
   static_cast<std::ofstream&>(out) << op;
   return out;
 }
 
 /// the processor-specific output stream
 extern ofstream out;
+
+/// open an output file for this processor (don't call directly)
+inline void ofstream::initialize() 
+{
+  int rank, size;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  open("mpi_output_" + std::to_string(rank) + "_" + std::to_string(size) + ".txt", std::ios::out);
+  initialized = true;
+}
 
 }  // namespace mpi

--- a/src/serac/infrastructure/mpi_fstream.hpp
+++ b/src/serac/infrastructure/mpi_fstream.hpp
@@ -15,11 +15,13 @@ struct ofstream : public std::ofstream {
   template <typename T>
   friend ofstream& operator<<(ofstream&, T);
 
+  /// default ctor
   ofstream() {
     initialized = false;
   }
 
-  bool initialized;
+  /// whether or not the fstream is in use or not
+  bool initialized; 
 
 };
 


### PR DESCRIPTION
The previous implementation of the debugging tool `mpi::out` relied on `fstream`'s implicit conversion to bool to detect if the file was already open, but this seems to not work reliably. As a result, when writing to `mpi::out`, the first thing the user asked to write would often be discarded. 

This PR handles the initialization process more explicitly in a way that seems to address the issue above.