### PR TITLE
Separate Smith and Serac shared SPOT locations

### DIFF
--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -680,7 +680,7 @@ def get_shared_libs_dir():
 
 
 def get_shared_spot_dir():
-    return pjoin(get_shared_base_dir(), "califiles")
+    return pjoin(get_shared_base_dir(), "califiles", get_project_name())
 
 
 def get_uberenv_path():

--- a/src/docs/sphinx/dev_guide/profiling.rst
+++ b/src/docs/sphinx/dev_guide/profiling.rst
@@ -139,7 +139,7 @@ files:
 Serac benchmarks are run weekly to track changes over time. The following are steps to visualize this data in a meaningful
 way:
 
-- Go to https://lc.llnl.gov/spot2/?sf=/usr/WS2/smithdev/califiles
+- Go to https://lc.llnl.gov/spot2/?sf=/usr/WS2/smithdev/califiles/serac
 - Click the check mark button on the top right to view additional data categories
 - Ensure ``mpi.world.size``, ``executable``, ``cluster``, and ``compilers`` are enabled
 - Find the pie and bar charts associated with those categories


### PR DESCRIPTION
Alliteration unintentional. Splits Caliper files by project name (smith or serac), meaning files are now in the following location: `/usr/WS2/smithdev/califiles/serac`.

I already moved all the current caliper files into this new location. Let me know if you can access them:

[https://lc.llnl.gov/spot2/?sf=/usr/WS2/smithdev/califiles/serac](https://lc.llnl.gov/spot2/?sf=/usr/WS2/smithdev/califiles/serac)