### PR TITLE
Only error when invalid maps are passed to base physics methods

### DIFF
--- a/src/serac/numerics/functional/tests/functional_basic_dg.cpp
+++ b/src/serac/numerics/functional/tests/functional_basic_dg.cpp
@@ -189,7 +189,7 @@ void L2_scalar_valued_test(std::string meshfile)
       interior_faces);
 
   double t = 0.0;
-  check_gradient(residual, t, U0, U1);
+  check_gradient(residual, t, U0, U1, 2e-4);
 }
 
 TEST(basic, L2_mixed_scalar_test_tris_and_quads_linear)
@@ -197,7 +197,7 @@ TEST(basic, L2_mixed_scalar_test_tris_and_quads_linear)
   L2_scalar_valued_test<2, 1>(SERAC_REPO_DIR "/data/meshes/patch2D_tris_and_quads.mesh");
 }
 
-TEST(basic, DISABLED_L2_mixed_scalar_test_tets_and_hexes_linear)
+TEST(basic, L2_mixed_scalar_test_tets_and_hexes_linear)
 {
   L2_scalar_valued_test<3, 1>(SERAC_REPO_DIR "/data/meshes/patch3D_tets_and_hexes.mesh");
 }

--- a/src/serac/numerics/functional/tests/functional_basic_dg.cpp
+++ b/src/serac/numerics/functional/tests/functional_basic_dg.cpp
@@ -197,7 +197,7 @@ TEST(basic, L2_mixed_scalar_test_tris_and_quads_linear)
   L2_scalar_valued_test<2, 1>(SERAC_REPO_DIR "/data/meshes/patch2D_tris_and_quads.mesh");
 }
 
-TEST(basic, L2_mixed_scalar_test_tets_and_hexes_linear)
+TEST(basic, DISABLED_L2_mixed_scalar_test_tets_and_hexes_linear)
 {
   L2_scalar_valued_test<3, 1>(SERAC_REPO_DIR "/data/meshes/patch3D_tets_and_hexes.mesh");
 }

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -368,7 +368,7 @@ public:
    */
   virtual void setAdjointLoad(std::unordered_map<std::string, const serac::FiniteElementDual&> string_to_dual)
   {
-    if (string_to_dual.size()) {
+    if (!string_to_dual.empty()) {
       SLIC_ERROR_ROOT(
           axom::fmt::format("Failed to setAdjointLoad.  Adjoint analysis not defined for physics module {}", name_));
     }
@@ -382,7 +382,7 @@ public:
    */
   virtual void setDualAdjointBcs(std::unordered_map<std::string, const serac::FiniteElementState&> string_to_bc)
   {
-    if (string_to_bc.size()) {
+    if (!string_to_bc.empty()) {
       SLIC_ERROR_ROOT(
           axom::fmt::format("Failed to setDualAdjointBCs.  Adjoint analysis not defined for physics module {}", name_));
     }

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -348,7 +348,7 @@ public:
    */
   virtual const std::unordered_map<std::string, const serac::FiniteElementDual&> computeInitialConditionSensitivity()
   {
-    SLIC_ERROR_ROOT(axom::fmt::format("Initial condition sensitivities not enabled in physics module {}", name_));
+    SLIC_WARNING_ROOT(axom::fmt::format("Initial condition sensitivities not enabled in physics module {}", name_));
     return {};
   }
 
@@ -363,19 +363,27 @@ public:
 
   /**
    * @brief Set the loads for the adjoint reverse timestep solve
+   * @param string_to_dual An unorder map from the state field name string to the finite element adjoint/dual load
+   * The adjoint load is d(qoi)/d(state)
    */
-  virtual void setAdjointLoad(std::unordered_map<std::string, const serac::FiniteElementDual&>)
+  virtual void setAdjointLoad(std::unordered_map<std::string, const serac::FiniteElementDual&> string_to_dual)
   {
-    SLIC_ERROR_ROOT(axom::fmt::format("Adjoint analysis not defined for physics module {}", name_));
+    if (string_to_dual.size()) {
+      SLIC_ERROR_ROOT(axom::fmt::format("Failed to setAdjointLoad.  Adjoint analysis not defined for physics module {}", name_));
+    }
   }
 
   /**
    * @brief Set the dual loads (dirichlet values) for the adjoint reverse timestep solve
    * This must be called after setAdjointLoad
+   * @param string_to_bc An unorder map from dual name string to finite element adjoint/state boundary condition
+   * The adjoint bc is d(qoi)/d(dual)
    */
-  virtual void setDualAdjointBcs(std::unordered_map<std::string, const serac::FiniteElementState&>)
+  virtual void setDualAdjointBcs(std::unordered_map<std::string, const serac::FiniteElementState&> string_to_bc)
   {
-    SLIC_ERROR_ROOT(axom::fmt::format("Adjoint analysis not defined for physics module {}", name_));
+    if (string_to_bc.size()) {
+      SLIC_ERROR_ROOT(axom::fmt::format("Failed to setDualAdjointBCs.  Adjoint analysis not defined for physics module {}", name_));
+    }
   }
 
   /**

--- a/src/serac/physics/base_physics.hpp
+++ b/src/serac/physics/base_physics.hpp
@@ -369,7 +369,8 @@ public:
   virtual void setAdjointLoad(std::unordered_map<std::string, const serac::FiniteElementDual&> string_to_dual)
   {
     if (string_to_dual.size()) {
-      SLIC_ERROR_ROOT(axom::fmt::format("Failed to setAdjointLoad.  Adjoint analysis not defined for physics module {}", name_));
+      SLIC_ERROR_ROOT(
+          axom::fmt::format("Failed to setAdjointLoad.  Adjoint analysis not defined for physics module {}", name_));
     }
   }
 
@@ -382,7 +383,8 @@ public:
   virtual void setDualAdjointBcs(std::unordered_map<std::string, const serac::FiniteElementState&> string_to_bc)
   {
     if (string_to_bc.size()) {
-      SLIC_ERROR_ROOT(axom::fmt::format("Failed to setDualAdjointBCs.  Adjoint analysis not defined for physics module {}", name_));
+      SLIC_ERROR_ROOT(
+          axom::fmt::format("Failed to setDualAdjointBCs.  Adjoint analysis not defined for physics module {}", name_));
     }
   }
 


### PR DESCRIPTION
Allow some base physics interfaces to be used in cases where maps are empty to allow end users to use the common interface in more cases.