### PR TITLE
Move git sha header to better location

### DIFF
--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -9,7 +9,7 @@
 # a full rebuild.
 serac_configure_file(
   git_sha.hpp.in
-  ${PROJECT_BINARY_DIR}/include/serac/infrastructure/git_sha.hpp
+  ${CMAKE_BINARY_DIR}/include/serac/git_sha.hpp
  )
 
 set(infrastructure_headers
@@ -17,7 +17,7 @@ set(infrastructure_headers
     accelerator.hpp
     cli.hpp
     debug_print.hpp
-    ${PROJECT_BINARY_DIR}/include/serac/infrastructure/git_sha.hpp
+    ${CMAKE_BINARY_DIR}/include/serac/git_sha.hpp
     initialize.hpp
     input.hpp
     logger.hpp

--- a/src/serac/infrastructure/about.cpp
+++ b/src/serac/infrastructure/about.cpp
@@ -44,7 +44,7 @@
 #include "tribol/config.hpp"
 #endif
 
-#include "serac/infrastructure/git_sha.hpp"
+#include "serac/git_sha.hpp"
 #include "serac/infrastructure/initialize.hpp"
 #include "serac/infrastructure/logger.hpp"
 


### PR DESCRIPTION
I've been testing a serac-only lido build and noticed something weird about the git sha header... in serac, `git_sha.hpp` is being configured into `${PROJECT_BINARY_DIR}/include/serac/infrastructure`, but in smith (which is what lido has been testing against) configures it in an entirely different location: `${CMAKE_BINARY_DIR}/include/serac/infrastructure`.

Smith shouldn't need to configure this file in the first place, so it has been removed in the associated Smith MR.

I've updated Serac and Smith so that this header is being configured to a consistent location: `${CMAKE_BINARY_DIR}/include/serac`