### PR TITLE
Fix incorrect include dir (lido fix)

### DIFF
--- a/src/serac/infrastructure/CMakeLists.txt
+++ b/src/serac/infrastructure/CMakeLists.txt
@@ -58,7 +58,7 @@ set_source_files_properties(input.cpp PROPERTIES LANGUAGE CXX)
 
 target_include_directories(serac_infrastructure PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/include>
     $<INSTALL_INTERFACE:include>
     )
 


### PR DESCRIPTION
https://github.com/LLNL/serac/pull/1303 has been closed since turns out the issue was one of the target includes pointing at Serac's include directory was using CMAKE_BINARY_DIR instead of PROJECT_BINARY_DIR.

This PR fixes an issue seen in downstream projects where the serac intrastructure target was missing include dirs.

```
/usr/workspace/meemee/lido-2.0/repo/smith/serac/src/serac/infrastructure/about.cpp:47:10: fatal error: 'serac/infrastructure/git_sha.hpp' file not found
#include "serac/infrastructure/git_sha.hpp"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```