### PR TITLE
Remove deprecation warning. 

### DIFF
--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -507,9 +507,8 @@ public:
    *
    * @note This method must be called prior to completeSetup()
    */
-  void
-  setDisplacementBCs(std::function<bool(const mfem::Vector&)>           is_node_constrained,
-                     std::function<double(const mfem::Vector&, double)> disp, int component)
+  void setDisplacementBCs(std::function<bool(const mfem::Vector&)>           is_node_constrained,
+                          std::function<double(const mfem::Vector&, double)> disp, int component)
   {
     // Get the nodal positions for the displacement vector in grid function form
     mfem::ParGridFunction coordinates(

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -537,7 +537,6 @@ public:
     bcs_.addEssential(ldof_list, component_disp_bdr_coef_, displacement_.space(), component);
   }
 
-
   /// @overload
   const FiniteElementState& state(const std::string& state_name) const override
   {

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -507,9 +507,6 @@ public:
    *
    * @note This method must be called prior to completeSetup()
    */
-  //clang-format off
-  [[deprecated("Please use the boundary condition methods that take Domain objects. This method will be removed.")]]
-  //clang-format on
   void
   setDisplacementBCs(std::function<bool(const mfem::Vector&)>           is_node_constrained,
                      std::function<double(const mfem::Vector&, double)> disp, int component)

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -537,6 +537,7 @@ public:
     bcs_.addEssential(ldof_list, component_disp_bdr_coef_, displacement_.space(), component);
   }
 
+
   /// @overload
   const FiniteElementState& state(const std::string& state_name) const override
   {


### PR DESCRIPTION
 Its warnings to errors, so this is essentially disabling the capability.  Unfortunately, we do now have a replacement for it yet, nor a design planned to replace it, as far as I'm aware.  We could consider making it more consistent with the new BC interface, e.g. taking Components an using tensor, instead of mfem::Vector.