### PR TITLE
Change displacement and velocity setters to use serac tensors

### DIFF
--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -831,10 +831,10 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
    *
    *   returns: u, the displacement at X.
    */
-  template <typename Callable>
-  void setDisplacement(Callable applied_displacement)
+  template <typename AppliedDisplacementFunction>
+  void setDisplacement(AppliedDisplacementFunction applied_displacement)
   {
-    displacement_.setFromField(applied_displacement);
+    displacement_.setFromFieldFunction(applied_displacement);
   }
 
   /// @overload
@@ -852,10 +852,10 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
    *
    *   returns: v, the velocity at X.
    */
-  template <typename Callable>
-  void setVelocity(Callable applied_velocity)
+  template <typename AppliedVelocityFunction>
+  void setVelocity(AppliedVelocityFunction applied_velocity)
   {
-    velocity_.setFromField(applied_velocity);
+    velocity_.setFromFieldFunction(applied_velocity);
   }
 
   /// @overload

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -834,7 +834,7 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
   template <typename Callable>
   void setDisplacement(Callable applied_displacement)
   {
-    displacement_.setFromField<dim>(applied_displacement);
+    displacement_.setFromField(applied_displacement);
   }
 
   /// @overload
@@ -855,7 +855,7 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
   template <typename Callable>
   void setVelocity(Callable applied_velocity)
   {
-    velocity_.setFromField<dim>(applied_velocity);
+    velocity_.setFromField(applied_velocity);
   }
 
   /// @overload

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -834,14 +834,7 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
   template <typename Callable>
   void setDisplacement(Callable applied_displacement)
   {
-    auto evaluate_mfem = [applied_displacement](const mfem::Vector& X_mfem, mfem::Vector& u_mfem) {
-      auto X = make_tensor<dim>([&X_mfem](int i) { return X_mfem[i]; });
-      auto u = applied_displacement(X);
-      for (int i = 0; i < dim; i++) u_mfem(i) = u[i];
-    };
-
-    mfem::VectorFunctionCoefficient disp_coef(dim, evaluate_mfem);
-    displacement_.project(disp_coef);
+    displacement_.setFromField<dim>(applied_displacement);
   }
 
   /// @overload
@@ -862,14 +855,7 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
   template <typename Callable>
   void setVelocity(Callable applied_velocity)
   {
-    auto evaluate_mfem = [applied_velocity](const mfem::Vector& X_mfem, mfem::Vector& v_mfem) {
-      auto X = make_tensor<dim>([&X_mfem](int i) { return X_mfem[i]; });
-      auto v = applied_velocity(X);
-      for (int i = 0; i < dim; i++) v_mfem(i) = v[i];
-    };
-
-    mfem::VectorFunctionCoefficient vel_coef(dim, evaluate_mfem);
-    velocity_.project(vel_coef);
+    velocity_.setFromField<dim>(applied_velocity);
   }
 
   /// @overload

--- a/src/serac/physics/solid_mechanics.hpp
+++ b/src/serac/physics/solid_mechanics.hpp
@@ -825,10 +825,10 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
    * @param applied_displacement The displacement field as a callable,
    *   which must have the signature:
    *   tensor<double, dim> applied_displacement(tensor<double, dim> X)
-   *   
+   *
    *   args:
    *   X: coordinates of the material point in the reference configuration
-   * 
+   *
    *   returns: u, the displacement at X.
    */
   template <typename Callable>
@@ -853,10 +853,10 @@ class SolidMechanics<order, dim, Parameters<parameter_space...>, std::integer_se
    * @param applied_velocity The velocity field as a callable,
    *   which must have the signature:
    *   tensor<double, dim> applied_velocity(tensor<double, dim> X)
-   *   
+   *
    *   args:
    *   X: coordinates of the material point in the reference configuration
-   * 
+   *
    *   returns: v, the velocity at X.
    */
   template <typename Callable>

--- a/src/serac/physics/state/CMakeLists.txt
+++ b/src/serac/physics/state/CMakeLists.txt
@@ -32,3 +32,7 @@ install(TARGETS              serac_state
         EXPORT               serac-targets
         DESTINATION          lib
         )
+
+if(SERAC_ENABLE_TESTS)
+    add_subdirectory(tests)
+endif()

--- a/src/serac/physics/state/finite_element_state.hpp
+++ b/src/serac/physics/state/finite_element_state.hpp
@@ -76,7 +76,7 @@ template <typename T>
 using first_argument = decltype(first_argument_helper(std::declval<T>()));
 
 /**
- * @brief Evaluate a function of a \ref tensor with an mfem Vector object
+ * @brief Evaluate a function of a tensor with an mfem Vector object
  */
 template <typename Callable>
 auto evaluateTensorFunctionOnMfemVector(const mfem::Vector& X_mfem, Callable&& f)

--- a/src/serac/physics/state/finite_element_state.hpp
+++ b/src/serac/physics/state/finite_element_state.hpp
@@ -277,9 +277,9 @@ class FiniteElementState : public FiniteElementVector {
    * In other words, this sets the dofs by direct evaluation of the analytical
    * field at the nodal points.
    *
-   * @tparam dim Number of components of this FiniteElementState
-   * @param field An analytical field function that should have the signature:
-   *   tensor<double, field_dim> field(tensor<double, spatial_dim> X)
+   * @tparam FieldFunction A callable type
+   * @param field_function A function that should have the signature:
+   *   tensor<double, field_dim> field_function(tensor<double, spatial_dim> X)
    *
    *   template params:
    *     spatial_dim: number of components in the mesh coordinates
@@ -290,11 +290,11 @@ class FiniteElementState : public FiniteElementVector {
    *
    *   returns: the value of the field at X.
    *
-   *   If the field is scalar-valued, then alternatively the signature may be
-   *   double field(tensor<double, spatial_dim> X)
+   *   If the field is scalar-valued, then alternatively the signature may be:
+   *   double field_function(tensor<double, spatial_dim> X)
    */
-  template <typename Callable>
-  void setFromField(Callable&& field)
+  template <typename FieldFunction>
+  void setFromFieldFunction(FieldFunction&& field)
   {
     auto evaluate_mfem = [&field](const mfem::Vector& X_mfem, mfem::Vector& u_mfem) {
       auto u = detail::evaluateTensorFunctionOnMfemVector(X_mfem, field);

--- a/src/serac/physics/state/finite_element_state.hpp
+++ b/src/serac/physics/state/finite_element_state.hpp
@@ -278,13 +278,20 @@ class FiniteElementState : public FiniteElementVector {
    * field at the nodal points.
    *
    * @tparam dim Number of components of this FiniteElementState
-   * @param field An analytical field function with the signature:
-   *   tensor<double, dim> field(tensor<double, dim> X)
+   * @param field An analytical field function that should have the signature:
+   *   tensor<double, field_dim> field(tensor<double, spatial_dim> X)
+   *
+   *   template params:
+   *     spatial_dim: number of components in the mesh coordinates
+   *     field_dim: number of components of the FiniteElementState field
    *
    *   args:
-   *   X: coordinates of the material point
+   *     X: coordinates of the material point
    *
    *   returns: the value of the field at X.
+   *
+   *   If the field is scalar-valued, then alternatively the signature may be
+   *   double field(tensor<double, spatial_dim> X)
    */
   template <typename Callable>
   void setFromField(Callable&& field)

--- a/src/serac/physics/state/finite_element_state.hpp
+++ b/src/serac/physics/state/finite_element_state.hpp
@@ -294,10 +294,10 @@ class FiniteElementState : public FiniteElementVector {
    *   double field_function(tensor<double, spatial_dim> X)
    */
   template <typename FieldFunction>
-  void setFromFieldFunction(FieldFunction&& field)
+  void setFromFieldFunction(FieldFunction&& field_function)
   {
-    auto evaluate_mfem = [&field](const mfem::Vector& X_mfem, mfem::Vector& u_mfem) {
-      auto u = detail::evaluateTensorFunctionOnMfemVector(X_mfem, field);
+    auto evaluate_mfem = [&field_function](const mfem::Vector& X_mfem, mfem::Vector& u_mfem) {
+      auto u = detail::evaluateTensorFunctionOnMfemVector(X_mfem, field_function);
       detail::setMfemVectorFromTensorOrDouble(u_mfem, u);
     };
 

--- a/src/serac/physics/state/finite_element_state.hpp
+++ b/src/serac/physics/state/finite_element_state.hpp
@@ -26,7 +26,7 @@
 namespace serac {
 
 namespace detail {
-/** 
+/**
  * @brief Helper function to copy a tensor into an mfem Vector
  */
 template <int dim>
@@ -48,30 +48,32 @@ inline void setMfemVectorFromTensorOrDouble(mfem::Vector& v_mfem, double v)
 /**
  * @brief Helper for extracting type of first argument of a free function
  */
-template<typename Ret, typename Arg, typename... Rest>
-Arg first_argument_helper(Ret(*) (Arg, Rest...));
+template <typename Ret, typename Arg, typename... Rest>
+Arg first_argument_helper(Ret (*)(Arg, Rest...));
 
 /**
  * @brief Helper for extracting type of first argument of a class method
  */
-template<typename Ret, typename F, typename Arg, typename... Rest>
-Arg first_argument_helper(Ret(F::*) (Arg, Rest...));
+template <typename Ret, typename F, typename Arg, typename... Rest>
+Arg first_argument_helper(Ret (F::*)(Arg, Rest...));
 
 /**
  * @brief Helper for extracting type of first argument of a const class method
  */
-template<typename Ret, typename F, typename Arg, typename... Rest>
-Arg first_argument_helper(Ret(F::*) (Arg, Rest...) const);
+template <typename Ret, typename F, typename Arg, typename... Rest>
+Arg first_argument_helper(Ret (F::*)(Arg, Rest...) const);
 
 /**
  * Extract type of first argument of a class method
  */
-template <typename F>decltype(first_argument_helper(&F::operator())) first_argument_helper(F);
+template <typename F>
+decltype(first_argument_helper(&F::operator())) first_argument_helper(F);
 
 /**
  * Extract type of first argument of a free callable
  */
-template <typename T>using first_argument = decltype(first_argument_helper(std::declval<T>()));
+template <typename T>
+using first_argument = decltype(first_argument_helper(std::declval<T>()));
 
 /**
  * @brief Evaluate a function of a \ref tensor with an mfem Vector object
@@ -79,14 +81,14 @@ template <typename T>using first_argument = decltype(first_argument_helper(std::
 template <typename Callable>
 auto evaluateTensorFunctionOnMfemVector(const mfem::Vector& X_mfem, Callable&& f)
 {
-    first_argument<Callable> X;
-    SLIC_ERROR_IF(X_mfem.Size() != size(X), "Size of tensor in callable does not match spatial dimension of MFEM Vector.");
-    for (int i = 0; i < X_mfem.Size(); i++) X[i] = X_mfem[i];
-    return f(X);
+  first_argument<Callable> X;
+  SLIC_ERROR_IF(X_mfem.Size() != size(X),
+                "Size of tensor in callable does not match spatial dimension of MFEM Vector.");
+  for (int i = 0; i < X_mfem.Size(); i++) X[i] = X_mfem[i];
+  return f(X);
 }
 
-} // namespace detail
-
+}  // namespace detail
 
 /**
  * @brief convenience function for querying the type stored in a GeneralCoefficient
@@ -271,17 +273,17 @@ class FiniteElementState : public FiniteElementVector {
 
   /**
    * @brief Set state as interpolant of an analytical function
-   * 
+   *
    * In other words, this sets the dofs by direct evaluation of the analytical
    * field at the nodal points.
-   * 
+   *
    * @tparam dim Number of components of this FiniteElementState
    * @param field An analytical field function with the signature:
    *   tensor<double, dim> field(tensor<double, dim> X)
-   *   
+   *
    *   args:
    *   X: coordinates of the material point
-   * 
+   *
    *   returns: the value of the field at X.
    */
   template <typename Callable>

--- a/src/serac/physics/state/tests/CMakeLists.txt
+++ b/src/serac/physics/state/tests/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
+# other Serac Project Developers. See the top-level LICENSE file for
+# details.
+#
+# SPDX-License-Identifier: (BSD-3-Clause)
+
+set(state_test_depends serac_mesh serac_state gtest)
+
+set(state_test_sources
+    test_finite_element_state.cpp)
+
+serac_add_tests(SOURCES    ${state_test_sources}
+                DEPENDS_ON ${state_test_depends})

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -12,6 +12,7 @@
 
 #include "axom/slic/core/SimpleLogger.hpp"
 #include <gtest/gtest.h>
+#include "mfem.hpp"
 
 #include "serac/infrastructure/initialize.hpp"
 #include "serac/infrastructure/terminator.hpp"
@@ -20,7 +21,51 @@
 
 namespace serac {
 
-TEST(FiniteElementState, SetFromFieldFunction)
+
+
+// class FiniteElementTest : public testing::Test {
+//  protected:
+
+//     FiniteElementTest() : spatial_dim_(3) {}
+
+//     void SetUp override {
+//         constexpr int p = 2;
+//         constexpr int spatial_dim = 3;
+//         int serial_refinement = 0;
+//         int parallel_refinement = 0;
+
+//         std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
+//         auto mesh_ptr = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+//         mesh_ = std::move(mesh_ptr);
+//     }
+
+//     void foo(const FiniteElementState& state) const
+//     {
+//         for (int node = 0; node < state.space().GetNDofs(); node++) {
+//         tensor<double, spatial_dim> Xn;
+//         for (int i = 0; i < spatial_dim; i++) {
+//             int dof_index = mfem::Ordering::Map<serac::ordering>(
+//                 nodal_coords.FESpace()->GetNDofs(), nodal_coords.FESpace()->GetVDim(), node, i);
+//             Xn[i] = nodal_coords(dof_index);
+//         }
+//         EXPECT_DOUBLE_EQ(scalar_field(Xn), scalar_state(node));
+//     }
+//     }
+
+//     const int spatial_dim_;
+//     std::unique_ptr<mfem::ParMesh> mesh_;
+// };
+
+// TEST_F(FiniteElementTest, SetFromScalarFieldFunction)
+// {
+//     FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
+//     double c = 2.0;
+//     auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c*X[0]; };
+//     scalar_state.setFromField(scalar_field);
+
+// }
+
+TEST(FiniteElementState, SetScalarStateFromFieldFunction)
 {
     constexpr int p = 1;
     constexpr int spatial_dim = 3;
@@ -32,6 +77,7 @@ TEST(FiniteElementState, SetFromFieldFunction)
     auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
 
     FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
+    // check that captures work
     double c = 2.0;
     auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c*X[0]; };
     scalar_state.setFromField(scalar_field);
@@ -49,11 +95,57 @@ TEST(FiniteElementState, SetFromFieldFunction)
         }
         EXPECT_DOUBLE_EQ(scalar_field(Xn), scalar_state(node));
     }
+}
 
-    // constexpr int vdim = 3;
-    // auto vector_state = serac::StateManager::newState(H1<p, vdim>{}, "vector_field", mesh_tag);
-    // auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
-    // vector_state.setFromField(vector_field);
+TEST(FiniteElementState, SetVectorStateFromFieldFunction)
+{
+    constexpr int p = 2;
+    constexpr int spatial_dim = 3;
+    int serial_refinement = 0;
+    int parallel_refinement = 0;
+
+    // Construct mesh
+    std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
+    auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+    ASSERT_EQ(spatial_dim, mesh->SpaceDimension()) << "Test configured incorrectly. The variable spatial_dim must match the spatial dimension of the mesh.";
+
+    // Choose vector dimension for state field that is different from spatial dimension
+    // to test the field indexing more thoroughly.
+    constexpr int vdim = 2;
+    FiniteElementState state(*mesh, H1<p, vdim>{}, "vector_field");
+
+    // set the field with an arbitrarily chosen field function
+    auto vector_field = [](tensor<double, spatial_dim> X) { return tensor<double, vdim>{norm(X), 1.0/(1.0 + norm(X))}; };
+    state.setFromField(vector_field);
+    
+    // Get the nodal positions for the state in a grid function
+    auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
+    mfem::ParGridFunction nodal_coords_gf(coords_fe_space.get());
+    mesh->GetNodes(nodal_coords_gf);
+
+    // we need the state values and the nodal coordinates in the same kind of container,
+    // so we will get the grid function view of the state
+    mfem::ParGridFunction& state_gf = state.gridFunction();
+
+
+    for (int node = 0; node < state_gf.FESpace()->GetNDofs(); node++) {
+
+        // Fill a tensor with the coordinates of the node
+        tensor<double, spatial_dim> Xn;
+        for (int i = 0; i < spatial_dim; i++) {
+            int dof_index = nodal_coords_gf.FESpace()->DofToVDof(node, i);
+            Xn[i] = nodal_coords_gf(dof_index);
+        }
+        
+        // apply the field function to the node coords
+        auto v = vector_field(Xn);
+
+        // check that value set in the state matches the field function
+        for (int j = 0; j < vdim; j++) {
+            int dof_index = state_gf.FESpace()->DofToVDof(node, j);
+            EXPECT_DOUBLE_EQ(v[j], state_gf(dof_index));
+        }
+    }
 }
 
 } // namespace serac

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -23,58 +23,25 @@ namespace serac {
 
 
 
-// class FiniteElementTest : public testing::Test {
-//  protected:
+class TestFiniteElementState : public testing::Test {
+ protected:
+    void SetUp() override
+    {
+        int serial_refinement = 0;
+        int parallel_refinement = 0;
 
-//     FiniteElementTest() : spatial_dim_(3) {}
+        std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
+        mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+        ASSERT_EQ(spatial_dim, mesh->SpaceDimension()) << "Test configured incorrectly. The variable spatial_dim must match the spatial dimension of the mesh.";
+    }
 
-//     void SetUp override {
-//         constexpr int p = 2;
-//         constexpr int spatial_dim = 3;
-//         int serial_refinement = 0;
-//         int parallel_refinement = 0;
+    static constexpr int spatial_dim{3};
+    std::unique_ptr<mfem::ParMesh> mesh;
+};
 
-//         std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
-//         auto mesh_ptr = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
-//         mesh_ = std::move(mesh_ptr);
-//     }
-
-//     void foo(const FiniteElementState& state) const
-//     {
-//         for (int node = 0; node < state.space().GetNDofs(); node++) {
-//         tensor<double, spatial_dim> Xn;
-//         for (int i = 0; i < spatial_dim; i++) {
-//             int dof_index = mfem::Ordering::Map<serac::ordering>(
-//                 nodal_coords.FESpace()->GetNDofs(), nodal_coords.FESpace()->GetVDim(), node, i);
-//             Xn[i] = nodal_coords(dof_index);
-//         }
-//         EXPECT_DOUBLE_EQ(scalar_field(Xn), scalar_state(node));
-//     }
-//     }
-
-//     const int spatial_dim_;
-//     std::unique_ptr<mfem::ParMesh> mesh_;
-// };
-
-// TEST_F(FiniteElementTest, SetFromScalarFieldFunction)
-// {
-//     FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
-//     double c = 2.0;
-//     auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c*X[0]; };
-//     scalar_state.setFromField(scalar_field);
-
-// }
-
-TEST(FiniteElementState, SetScalarStateFromFieldFunction)
+TEST_F(TestFiniteElementState, SetScalarStateFromFieldFunction)
 {
     constexpr int p = 1;
-    constexpr int spatial_dim = 3;
-    int serial_refinement = 0;
-    int parallel_refinement = 0;
-
-    // Construct the appropriate dimension mesh and give it to the data store
-    std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
-    auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
 
     FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
     // check that captures work
@@ -97,17 +64,9 @@ TEST(FiniteElementState, SetScalarStateFromFieldFunction)
     }
 }
 
-TEST(FiniteElementState, SetVectorStateFromFieldFunction)
+TEST_F(TestFiniteElementState, SetVectorStateFromFieldFunction)
 {
     constexpr int p = 2;
-    constexpr int spatial_dim = 3;
-    int serial_refinement = 0;
-    int parallel_refinement = 0;
-
-    // Construct mesh
-    std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
-    auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
-    ASSERT_EQ(spatial_dim, mesh->SpaceDimension()) << "Test configured incorrectly. The variable spatial_dim must match the spatial dimension of the mesh.";
 
     // Choose vector dimension for state field that is different from spatial dimension
     // to test the field indexing more thoroughly.
@@ -148,17 +107,9 @@ TEST(FiniteElementState, SetVectorStateFromFieldFunction)
     }
 }
 
-TEST(FiniteElementState, ErrorsIfFieldFunctionDimensionMismatchedToState)
+TEST_F(TestFiniteElementState, ErrorsIfFieldFunctionDimensionMismatchedToState)
 {
     constexpr int p = 2;
-    constexpr int spatial_dim = 3;
-    int serial_refinement = 0;
-    int parallel_refinement = 0;
-
-    // Construct mesh
-    std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
-    auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
-    ASSERT_EQ(spatial_dim, mesh->SpaceDimension()) << "Test configured incorrectly. The variable spatial_dim must match the spatial dimension of the mesh.";
 
     // Choose vector dimension for state field that is different from spatial dimension
     constexpr int vdim = 2;

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file test_finite_element_staet.cpp
+ */
+
+#include "serac/physics/state/finite_element_state.hpp"
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include <gtest/gtest.h>
+
+#include "serac/infrastructure/initialize.hpp"
+#include "serac/infrastructure/terminator.hpp"
+#include "serac/mesh/mesh_utils.hpp"
+#include "serac/numerics/functional/tensor.hpp"
+
+namespace serac {
+
+TEST(FiniteElementState, Set)
+{
+    constexpr int p = 1;
+    constexpr int spatial_dim = 3;
+    int serial_refinement = 0;
+    int parallel_refinement = 0;
+
+    // Construct the appropriate dimension mesh and give it to the data store
+    std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
+    auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+
+    FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
+    double c = 2.0;
+    auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c*X[0]; };
+    scalar_state.setFromField(scalar_field);
+
+    // constexpr int vdim = 3;
+    // auto vector_state = serac::StateManager::newState(H1<p, vdim>{}, "vector_field", mesh_tag);
+    // auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
+    // vector_state.setFromField(vector_field);
+}
+
+} // namespace serac
+
+int main(int argc, char* argv[])
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    serac::initialize(argc, argv);
+    int result = RUN_ALL_TESTS();
+    serac::exitGracefully(result);
+}

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -54,11 +54,14 @@ TEST_F(TestFiniteElementState, SetScalarStateFromFieldFunction)
   mesh->GetNodes(nodal_coords_gf);
 
   for (int node = 0; node < scalar_state.space().GetNDofs(); node++) {
+    // Fill a tensor with the coordinates of the node
     tensor<double, spatial_dim> Xn;
     for (int i = 0; i < spatial_dim; i++) {
       int dof_index = nodal_coords_gf.FESpace()->DofToVDof(node, i);
       Xn[i] = nodal_coords_gf(dof_index);
     }
+
+    // check that value set in the state matches the field function
     EXPECT_DOUBLE_EQ(scalar_field(Xn), scalar_state(node));
   }
 }

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -123,7 +123,8 @@ TEST_F(TestFiniteElementState, DISABLED_ErrorsIfFieldFunctionDimensionMismatched
   // Should return tensor of size vdim!
   auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
 
-  EXPECT_DEATH(state.setFromFieldFunction(vector_field), "Cannot copy tensor into an MFEM Vector with incompatible size.");
+  EXPECT_DEATH(state.setFromFieldFunction(vector_field),
+               "Cannot copy tensor into an MFEM Vector with incompatible size.");
 }
 
 }  // namespace serac

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -40,15 +40,17 @@ class TestFiniteElementState : public testing::Test {
 
 TEST_F(TestFiniteElementState, SetScalarStateFromFieldFunction)
 {
+  // make a scalar-valued state
   constexpr int p = 1;
-
   FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
-  // check that lambda captures work
+
+  // Set state with field function.
+  // Check that lambda captures work with this.
   double c = 2.0;
   auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c * X[0]; };
   scalar_state.setFromField(scalar_field);
 
-  // Get the nodal positions for the state in a grid function
+  // Get the nodal positions corresponding to state dofs in a grid function
   auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
   mfem::ParGridFunction nodal_coords_gf(coords_fe_space.get());
   mesh->GetNodes(nodal_coords_gf);
@@ -61,7 +63,7 @@ TEST_F(TestFiniteElementState, SetScalarStateFromFieldFunction)
       Xn[i] = nodal_coords_gf(dof_index);
     }
 
-    // check that value set in the state matches the field function
+    // check that value set in the state for this node matches the field function
     EXPECT_DOUBLE_EQ(scalar_field(Xn), scalar_state(node));
   }
 }

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -48,7 +48,7 @@ TEST_F(TestFiniteElementState, SetScalarStateFromFieldFunction)
   // Check that lambda captures work with this.
   double c = 2.0;
   auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c * X[0]; };
-  scalar_state.setFromField(scalar_field);
+  scalar_state.setFromFieldFunction(scalar_field);
 
   // Get the nodal positions corresponding to state dofs in a grid function
   auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
@@ -81,7 +81,7 @@ TEST_F(TestFiniteElementState, SetVectorStateFromFieldFunction)
   auto vector_field = [](tensor<double, spatial_dim> X) {
     return tensor<double, vdim>{norm(X), 1.0 / (1.0 + norm(X))};
   };
-  state.setFromField(vector_field);
+  state.setFromFieldFunction(vector_field);
 
   // Get the nodal positions for the state in a grid function
   auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
@@ -123,7 +123,7 @@ TEST_F(TestFiniteElementState, DISABLED_ErrorsIfFieldFunctionDimensionMismatched
   // Should return tensor of size vdim!
   auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
 
-  EXPECT_DEATH(state.setFromField(vector_field), "Cannot copy tensor into an MFEM Vector with incompatible size.");
+  EXPECT_DEATH(state.setFromFieldFunction(vector_field), "Cannot copy tensor into an MFEM Vector with incompatible size.");
 }
 
 }  // namespace serac

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -111,7 +111,7 @@ TEST_F(TestFiniteElementState, SetVectorStateFromFieldFunction)
   }
 }
 
-TEST_F(TestFiniteElementState, ErrorsIfFieldFunctionDimensionMismatchedToState)
+TEST_F(TestFiniteElementState, DISABLED_ErrorsIfFieldFunctionDimensionMismatchedToState)
 {
   constexpr int p = 2;
 

--- a/src/serac/physics/state/tests/test_finite_element_state.cpp
+++ b/src/serac/physics/state/tests/test_finite_element_state.cpp
@@ -21,113 +21,112 @@
 
 namespace serac {
 
-
-
 class TestFiniteElementState : public testing::Test {
  protected:
-    void SetUp() override
-    {
-        int serial_refinement = 0;
-        int parallel_refinement = 0;
+  void SetUp() override
+  {
+    int serial_refinement = 0;
+    int parallel_refinement = 0;
 
-        std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
-        mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
-        ASSERT_EQ(spatial_dim, mesh->SpaceDimension()) << "Test configured incorrectly. The variable spatial_dim must match the spatial dimension of the mesh.";
-    }
+    std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
+    mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
+    ASSERT_EQ(spatial_dim, mesh->SpaceDimension())
+        << "Test configured incorrectly. The variable spatial_dim must match the spatial dimension of the mesh.";
+  }
 
-    static constexpr int spatial_dim{3};
-    std::unique_ptr<mfem::ParMesh> mesh;
+  static constexpr int spatial_dim{3};
+  std::unique_ptr<mfem::ParMesh> mesh;
 };
 
 TEST_F(TestFiniteElementState, SetScalarStateFromFieldFunction)
 {
-    constexpr int p = 1;
+  constexpr int p = 1;
 
-    FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
-    // check that captures work
-    double c = 2.0;
-    auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c*X[0]; };
-    scalar_state.setFromField(scalar_field);
+  FiniteElementState scalar_state(*mesh, H1<p>{}, "scalar_field");
+  // check that lambda captures work
+  double c = 2.0;
+  auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c * X[0]; };
+  scalar_state.setFromField(scalar_field);
 
-    // Get the nodal positions for the state in a grid function
-    auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
-    mfem::ParGridFunction nodal_coords_gf(coords_fe_space.get());
-    mesh->GetNodes(nodal_coords_gf);
+  // Get the nodal positions for the state in a grid function
+  auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
+  mfem::ParGridFunction nodal_coords_gf(coords_fe_space.get());
+  mesh->GetNodes(nodal_coords_gf);
 
-    for (int node = 0; node < scalar_state.space().GetNDofs(); node++) {
-        tensor<double, spatial_dim> Xn;
-        for (int i = 0; i < spatial_dim; i++) {
-            int dof_index = nodal_coords_gf.FESpace()->DofToVDof(node, i);
-            Xn[i] = nodal_coords_gf(dof_index);
-        }
-        EXPECT_DOUBLE_EQ(scalar_field(Xn), scalar_state(node));
+  for (int node = 0; node < scalar_state.space().GetNDofs(); node++) {
+    tensor<double, spatial_dim> Xn;
+    for (int i = 0; i < spatial_dim; i++) {
+      int dof_index = nodal_coords_gf.FESpace()->DofToVDof(node, i);
+      Xn[i] = nodal_coords_gf(dof_index);
     }
+    EXPECT_DOUBLE_EQ(scalar_field(Xn), scalar_state(node));
+  }
 }
 
 TEST_F(TestFiniteElementState, SetVectorStateFromFieldFunction)
 {
-    constexpr int p = 2;
+  constexpr int p = 2;
 
-    // Choose vector dimension for state field that is different from spatial dimension
-    // to test the field indexing more thoroughly.
-    constexpr int vdim = 2;
-    FiniteElementState state(*mesh, H1<p, vdim>{}, "vector_field");
+  // Choose vector dimension for state field that is different from spatial dimension
+  // to test the field indexing more thoroughly.
+  constexpr int vdim = 2;
+  FiniteElementState state(*mesh, H1<p, vdim>{}, "vector_field");
 
-    // set the field with an arbitrarily chosen field function
-    auto vector_field = [](tensor<double, spatial_dim> X) { return tensor<double, vdim>{norm(X), 1.0/(1.0 + norm(X))}; };
-    state.setFromField(vector_field);
-    
-    // Get the nodal positions for the state in a grid function
-    auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
-    mfem::ParGridFunction nodal_coords_gf(coords_fe_space.get());
-    mesh->GetNodes(nodal_coords_gf);
+  // set the field with an arbitrarily chosen field function
+  auto vector_field = [](tensor<double, spatial_dim> X) {
+    return tensor<double, vdim>{norm(X), 1.0 / (1.0 + norm(X))};
+  };
+  state.setFromField(vector_field);
 
-    // we need the state values and the nodal coordinates in the same kind of container,
-    // so we will get the grid function view of the state
-    mfem::ParGridFunction& state_gf = state.gridFunction();
+  // Get the nodal positions for the state in a grid function
+  auto [coords_fe_space, coords_fe_coll] = serac::generateParFiniteElementSpace<H1<p, spatial_dim>>(mesh.get());
+  mfem::ParGridFunction nodal_coords_gf(coords_fe_space.get());
+  mesh->GetNodes(nodal_coords_gf);
 
+  // we need the state values and the nodal coordinates in the same kind of container,
+  // so we will get the grid function view of the state
+  mfem::ParGridFunction& state_gf = state.gridFunction();
 
-    for (int node = 0; node < state_gf.FESpace()->GetNDofs(); node++) {
-
-        // Fill a tensor with the coordinates of the node
-        tensor<double, spatial_dim> Xn;
-        for (int i = 0; i < spatial_dim; i++) {
-            int dof_index = nodal_coords_gf.FESpace()->DofToVDof(node, i);
-            Xn[i] = nodal_coords_gf(dof_index);
-        }
-        
-        // apply the field function to the node coords
-        auto v = vector_field(Xn);
-
-        // check that value set in the state matches the field function
-        for (int j = 0; j < vdim; j++) {
-            int dof_index = state_gf.FESpace()->DofToVDof(node, j);
-            EXPECT_DOUBLE_EQ(v[j], state_gf(dof_index));
-        }
+  for (int node = 0; node < state_gf.FESpace()->GetNDofs(); node++) {
+    // Fill a tensor with the coordinates of the node
+    tensor<double, spatial_dim> Xn;
+    for (int i = 0; i < spatial_dim; i++) {
+      int dof_index = nodal_coords_gf.FESpace()->DofToVDof(node, i);
+      Xn[i] = nodal_coords_gf(dof_index);
     }
+
+    // apply the field function to the node coords
+    auto v = vector_field(Xn);
+
+    // check that value set in the state matches the field function
+    for (int j = 0; j < vdim; j++) {
+      int dof_index = state_gf.FESpace()->DofToVDof(node, j);
+      EXPECT_DOUBLE_EQ(v[j], state_gf(dof_index));
+    }
+  }
 }
 
 TEST_F(TestFiniteElementState, ErrorsIfFieldFunctionDimensionMismatchedToState)
 {
-    constexpr int p = 2;
+  constexpr int p = 2;
 
-    // Choose vector dimension for state field that is different from spatial dimension
-    constexpr int vdim = 2;
-    FiniteElementState state(*mesh, H1<p, vdim>{}, "vector_field");
+  // Choose vector dimension for state field that is different from spatial dimension
+  constexpr int vdim = 2;
+  FiniteElementState state(*mesh, H1<p, vdim>{}, "vector_field");
 
-    // Set the field with a field function with the wrong vector dimension.
-    // Should return tensor of size vdim!
-    auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
+  // Set the field with a field function with the wrong vector dimension.
+  // Should return tensor of size vdim!
+  auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
 
-    EXPECT_DEATH(state.setFromField(vector_field), "Cannot copy tensor into an MFEM Vector with incompatible size.");
+  EXPECT_DEATH(state.setFromField(vector_field), "Cannot copy tensor into an MFEM Vector with incompatible size.");
 }
 
-} // namespace serac
+}  // namespace serac
 
 int main(int argc, char* argv[])
 {
-    ::testing::InitGoogleTest(&argc, argv);
-    serac::initialize(argc, argv);
-    int result = RUN_ALL_TESTS();
-    serac::exitGracefully(result);
+  ::testing::InitGoogleTest(&argc, argv);
+  serac::initialize(argc, argv);
+  int result = RUN_ALL_TESTS();
+  serac::exitGracefully(result);
 }

--- a/src/serac/physics/tests/beam_bending.cpp
+++ b/src/serac/physics/tests/beam_bending.cpp
@@ -76,9 +76,6 @@ TEST(BeamBending, TwoDimensional)
   Domain support = Domain::ofBoundaryElements(pmesh, by_attr<dim>(1));
   solid_solver.setFixedBCs(support);
 
-  // initial displacement
-  solid_solver.setDisplacement([](const mfem::Vector&, mfem::Vector& bc_vec) { bc_vec = 0.0; });
-
   Domain top_face = Domain::ofBoundaryElements(
       pmesh, [](std::vector<vec2> vertices, int /*attr*/) { return (average(vertices)[1] > 0.99); });
 

--- a/src/serac/physics/tests/fit_test.cpp
+++ b/src/serac/physics/tests/fit_test.cpp
@@ -83,9 +83,6 @@ void stress_extrapolation_test()
   auto   down        = [up](tensor<double, dim> X, double time) { return -up(X, time); };
   solid_solver.setDisplacementBCs(down, bottom_hole);
 
-  auto zero_displacement = [](const mfem::Vector&, mfem::Vector& u) -> void { u = 0.0; };
-  solid_solver.setDisplacement(zero_displacement);
-
   // Finalize the data structures
   solid_solver.completeSetup();
 

--- a/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
+++ b/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
@@ -124,9 +124,9 @@ TEST(LiquidCrystalElastomer, Bertoldi)
   auto support = Domain::ofBoundaryElements(pmesh, by_attr<dim>(2));
   solid_solver.setFixedBCs(support);
 
-  double iniDispVal       = 5.0e-6;
-  auto   ini_displacement = [iniDispVal](const mfem::Vector&, mfem::Vector& u) -> void { u = iniDispVal; };
-  solid_solver.setDisplacement(ini_displacement);
+  constexpr double iniDispVal = 5.0e-6;
+  auto initial_displacement = [lx](vec3 X) { return vec3{0.0, (X[0]/lx)*iniDispVal, 0.0}; };
+  solid_solver.setDisplacement(initial_displacement);
 
   // Finalize the data structures
   solid_solver.completeSetup();

--- a/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
+++ b/src/serac/physics/tests/lce_Bertoldi_lattice.cpp
@@ -125,7 +125,7 @@ TEST(LiquidCrystalElastomer, Bertoldi)
   solid_solver.setFixedBCs(support);
 
   constexpr double iniDispVal = 5.0e-6;
-  auto initial_displacement = [lx](vec3 X) { return vec3{0.0, (X[0]/lx)*iniDispVal, 0.0}; };
+  auto initial_displacement = [lx](vec3 X) { return vec3{0.0, (X[0] / lx) * iniDispVal, 0.0}; };
   solid_solver.setDisplacement(initial_displacement);
 
   // Finalize the data structures

--- a/src/serac/physics/tests/lce_Brighenti_tensile.cpp
+++ b/src/serac/physics/tests/lce_Brighenti_tensile.cpp
@@ -135,15 +135,10 @@ TEST(LiquidCrystalElastomer, Brighenti)
   solid_solver.setFixedBCs(ymin_face, Component::Y);
   solid_solver.setFixedBCs(zmin_face, Component::Z);
 
-  // set initila displacement different than zero to help solver
-  auto ini_displacement = [](const mfem::Vector&, mfem::Vector& u) -> void { u = 1.0e-5; };
-
   double iniLoadVal = 1.0e0;
   double maxLoadVal = 4 * 1.3e0 / lx / lz;
   double loadVal    = iniLoadVal + 0.0 * maxLoadVal;
   solid_solver.setTraction([&loadVal](auto, auto n, auto) { return loadVal * n; }, ymax_face);
-
-  solid_solver.setDisplacement(ini_displacement);
 
   // Finalize the data structures
   solid_solver.completeSetup();

--- a/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
+++ b/src/serac/physics/tests/parameterized_thermomechanics_example.cpp
@@ -134,10 +134,6 @@ TEST(Thermomechanics, ParameterizedMaterial)
   simulation.setFixedBCs(y_equals_0, Component::Y);
   simulation.setFixedBCs(z_equals_0, Component::Z);
 
-  // set up initial conditions
-  auto zero_vector = [](const mfem::Vector&, mfem::Vector& u) -> void { u = 0.0; };
-  simulation.setDisplacement(zero_vector);
-
   // Finalize the data structures
   simulation.completeSetup();
 

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -270,7 +270,8 @@ TEST(FiniteElementState, Set)
   paraview_dc->SetCompression(true);
 
   auto scalar_state = serac::StateManager::newState(H1<p>{}, "scalar_field", mesh_tag);
-  auto scalar_field = [](tensor<double, spatial_dim> X) -> double { return X[0]; };
+  double c = 2.0;
+  auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c*X[0]; };
   scalar_state.setFromField(scalar_field);
   paraview_dc->RegisterField(scalar_state.name(), &scalar_state.gridFunction());
 

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -196,7 +196,6 @@ void functional_parameterized_solid_test(double expected_disp_norm)
   Domain essential_boundary = Domain::ofBoundaryElements(pmesh, by_attr<dim>(1));
 
   solid_solver.setFixedBCs(essential_boundary);
-  solid_solver.setDisplacement([](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; });
 
   tensor<double, dim> constant_force;
 

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -242,52 +242,6 @@ TEST(SolidMechanics, 2DQuadParameterizedStatic) { functional_parameterized_solid
 
 TEST(SolidMechanics, 3DQuadStaticJ2) { functional_solid_test_static_J2(); }
 
-TEST(FiniteElementState, Set)
-{
-  constexpr int p                   = 1;
-  constexpr int spatial_dim = 3;
-  int           serial_refinement   = 0;
-  int           parallel_refinement = 0;
-
-  // Create DataStore
-  axom::sidre::DataStore datastore;
-  serac::StateManager::initialize(datastore, "test_FiniteElementState");
-
-  // Construct the appropriate dimension mesh and give it to the data store
-  std::string filename = SERAC_REPO_DIR "/data/meshes/beam-hex.mesh";
-
-  auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), serial_refinement, parallel_refinement);
-
-  std::string mesh_tag{"mesh"};
-
-  auto& pmesh = serac::StateManager::setMesh(std::move(mesh), mesh_tag);
-
-  auto paraview_dc = std::make_unique<mfem::ParaViewDataCollection>("pv", &pmesh);
-
-  paraview_dc->SetLevelsOfDetail(p);
-  paraview_dc->SetHighOrderOutput(true);
-  paraview_dc->SetDataFormat(mfem::VTKFormat::BINARY);
-  paraview_dc->SetCompression(true);
-
-  auto scalar_state = serac::StateManager::newState(H1<p>{}, "scalar_field", mesh_tag);
-  double c = 2.0;
-  auto scalar_field = [c](tensor<double, spatial_dim> X) -> double { return c*X[0]; };
-  scalar_state.setFromField(scalar_field);
-  paraview_dc->RegisterField(scalar_state.name(), &scalar_state.gridFunction());
-
-  constexpr int vdim = 3;
-  auto vector_state = serac::StateManager::newState(H1<p, vdim>{}, "vector_field", mesh_tag);
-  auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
-  vector_state.setFromField(vector_field);
-  paraview_dc->RegisterField(vector_state.name(), &vector_state.gridFunction());
-
-  paraview_dc->SetCycle(0);
-  paraview_dc->SetTime(0.0);
-  paraview_dc->SetPrefixPath("test_state");
-
-  paraview_dc->Save();
-}
-
 }  // namespace serac
 
 int main(int argc, char* argv[])

--- a/src/serac/physics/tests/solid.cpp
+++ b/src/serac/physics/tests/solid.cpp
@@ -271,14 +271,14 @@ TEST(FiniteElementState, Set)
 
   auto scalar_state = serac::StateManager::newState(H1<p>{}, "scalar_field", mesh_tag);
   auto scalar_field = [](tensor<double, spatial_dim> X) -> double { return X[0]; };
-  scalar_state.setFromField<spatial_dim>(scalar_field);
+  scalar_state.setFromField(scalar_field);
   paraview_dc->RegisterField(scalar_state.name(), &scalar_state.gridFunction());
 
-  // constexpr int vdim = 3;
-  // auto vector_state = serac::StateManager::newState(H1<p, vdim>{}, "vector_field", mesh_tag);
-  // auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
-  // vector_state.setFromField<vdim, spatial_dim>(vector_field);
-  // paraview_dc->RegisterField(vector_state.name(), &vector_state.gridFunction());
+  constexpr int vdim = 3;
+  auto vector_state = serac::StateManager::newState(H1<p, vdim>{}, "vector_field", mesh_tag);
+  auto vector_field = [](tensor<double, spatial_dim> X) { return X; };
+  vector_state.setFromField(vector_field);
+  paraview_dc->RegisterField(vector_state.name(), &vector_state.gridFunction());
 
   paraview_dc->SetCycle(0);
   paraview_dc->SetTime(0.0);

--- a/src/serac/physics/tests/solid_dynamics_patch.cpp
+++ b/src/serac/physics/tests/solid_dynamics_patch.cpp
@@ -111,10 +111,7 @@ class AffineSolution {
     for (int i = 0; i < dim; ++i) u[i] = u_tensor[i];
   }
 
-  tensor<double, dim> velocity(tensor<double, dim> X, double /* t */) const
-  {
-    return dot(disp_grad_rate, X);
-  }
+  tensor<double, dim> velocity(tensor<double, dim> X, double /* t */) const { return dot(disp_grad_rate, X); }
 
   /**
    * @brief Apply forcing that should produce this exact displacement
@@ -193,10 +190,7 @@ class ConstantAccelerationSolution {
     for (int i = 0; i < dim; ++i) u[i] = u_tensor[i];
   }
 
-  tensor<double, dim> velocity(tensor<double, dim>, double t) const
-  {
-    return t*acceleration;
-  }
+  tensor<double, dim> velocity(tensor<double, dim>, double t) const { return t * acceleration; }
 
   /**
    * @brief Apply forcing that should produce this exact displacement

--- a/src/serac/physics/tests/solid_dynamics_patch.cpp
+++ b/src/serac/physics/tests/solid_dynamics_patch.cpp
@@ -74,8 +74,8 @@ std::set<int> essentialBoundaryAttributes(PatchBoundaryCondition bc)
 
 // clang-format off
 constexpr tensor<double, 3, 3> A_3d{{{0.110791568544027, 0.230421268325901, 0.15167673653354},
-                                 {0.198344644470483, 0.060514559793513, 0.084137393813728},
-                                 {0.011544253485023, 0.060942846497753, 0.186383473579596}}};
+                                     {0.198344644470483, 0.060514559793513, 0.084137393813728},
+                                     {0.011544253485023, 0.060942846497753, 0.186383473579596}}};
 
 constexpr tensor<double, 3> b_3d{{0.765645367640828, 0.992487355850465, 0.162199373722092}};
 // clang-format on
@@ -93,7 +93,7 @@ public:
         initial_displacement(make_tensor<dim>([](int i) { return b_3d[i]; })){};
 
   /// exact solution for displacement field
-  tensor<double, dim> eval(tensor<double, dim> X, double t) const
+  tensor<double, dim> displacement(tensor<double, dim> X, double t) const
   {
     return t * dot(disp_grad_rate, X) + initial_displacement;
   }
@@ -107,15 +107,13 @@ public:
   void operator()(const mfem::Vector& X, double t, mfem::Vector& u) const
   {
     auto X_tensor = make_tensor<dim>([&X](int i) { return X[i]; });
-    auto u_tensor = this->eval(X_tensor, t);
+    auto u_tensor = this->displacement(X_tensor, t);
     for (int i = 0; i < dim; ++i) u[i] = u_tensor[i];
   }
 
-  void velocity(const mfem::Vector& X, double /* t */, mfem::Vector& v) const
+  tensor<double, dim> velocity(tensor<double, dim> X, double /* t */) const
   {
-    auto X_tensor = make_tensor<dim>([&X](int i) { return X[i]; });
-    auto v_tensor = disp_grad_rate * X_tensor;
-    for (int i = 0; i < dim; ++i) v[i] = v_tensor[i];
+    return dot(disp_grad_rate, X);
   }
 
   /**
@@ -141,7 +139,7 @@ public:
                   Domain /* whole_domain */) const
   {
     // essential BCs
-    auto ebc_func = [*this](tensor<double, dim> X, double t) { return this->eval(X, t); };
+    auto ebc_func = [*this](tensor<double, dim> X, double t) { return this->displacement(X, t); };
     solid.setDisplacementBCs(ebc_func, essential_boundary);
 
     // It's tempting to restrict the traction to the appropriate sub-boundary by defining
@@ -180,7 +178,7 @@ class ConstantAccelerationSolution {
 public:
   ConstantAccelerationSolution() : acceleration(make_tensor<dim>([](int i) { return a_3d[i]; })){};
 
-  tensor<double, dim> eval(tensor<double, dim>, double t) const { return 0.5 * t * t * acceleration; };
+  tensor<double, dim> displacement(tensor<double, dim>, double t) const { return 0.5 * t * t * acceleration; };
 
   /**
    * @brief MFEM-style coefficient function corresponding to this solution
@@ -191,14 +189,13 @@ public:
   void operator()(const mfem::Vector& X, double t, mfem::Vector& u) const
   {
     tensor<double, dim> X_tensor{make_tensor<dim>([&X](int i) { return X[i]; })};
-    tensor<double, dim> u_tensor = eval(X_tensor, t);
+    tensor<double, dim> u_tensor = displacement(X_tensor, t);
     for (int i = 0; i < dim; ++i) u[i] = u_tensor[i];
   }
 
-  void velocity(const mfem::Vector& /* X */, double t, mfem::Vector& v) const
+  tensor<double, dim> velocity(tensor<double, dim>, double t) const
   {
-    auto v_tensor = acceleration * t;
-    for (int i = 0; i < dim; ++i) v[i] = v_tensor[i];
+    return t*acceleration;
   }
 
   /**
@@ -224,7 +221,7 @@ public:
                   Domain whole_domain) const
   {
     // essential BCs
-    auto ebc_func = [*this](tensor<double, dim> X, double t) { return this->eval(X, t); };
+    auto ebc_func = [*this](tensor<double, dim> X, double t) { return this->displacement(X, t); };
     solid.setDisplacementBCs(ebc_func, essential_boundary);
 
     // no natural BCs
@@ -311,9 +308,8 @@ double solution_error(solution_type exact_solution, PatchBoundaryCondition bc)
   solid.setMaterial(mat, whole_domain);
 
   // initial conditions
-  solid.setVelocity([exact_solution](const mfem::Vector& x, mfem::Vector& v) { exact_solution.velocity(x, 0.0, v); });
-
-  solid.setDisplacement([exact_solution](const mfem::Vector& x, mfem::Vector& u) { exact_solution(x, 0.0, u); });
+  solid.setVelocity([&exact_solution](tensor<double, dim> X) { return exact_solution.velocity(X, 0.0); });
+  solid.setDisplacement([&exact_solution](tensor<double, dim> X) { return exact_solution.displacement(X, 0.0); });
 
   // forcing terms
   Domain essential_boundary = Domain::ofBoundaryElements(pmesh, by_attr<dim>(essentialBoundaryAttributes<dim>(bc)));

--- a/src/serac/physics/tests/solid_finite_diff.cpp
+++ b/src/serac/physics/tests/solid_finite_diff.cpp
@@ -77,9 +77,6 @@ TEST(SolidMechanics, FiniteDifferenceParameter)
   Domain                                        whole_mesh = EntireDomain(pmesh);
   solid_solver.setMaterial(DependsOn<0, 1>{}, mat, whole_mesh);
 
-  // Define the function for the initial displacement and boundary condition
-  auto bc = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
-
   // Define a boundary attribute set and specify initial / boundary conditions
   Domain essential_boundary = Domain::ofBoundaryElements(pmesh, by_attr<dim>(1));
   solid_solver.setFixedBCs(essential_boundary);
@@ -128,10 +125,11 @@ TEST(SolidMechanics, FiniteDifferenceParameter)
   // to check if computed qoi sensitivity is consistent
   // with finite difference on the displacement
   double eps = 1.0e-5;
+  FiniteElementState zero_state(pmesh, H1<p, dim>{}, "zero");
   for (int i = 0; i < user_defined_bulk_modulus.gridFunction().Size(); ++i) {
     // Perturb the bulk modulus
     user_defined_bulk_modulus(i) = bulk_modulus_value + eps;
-    solid_solver.setDisplacement(bc);
+    solid_solver.setDisplacement(zero_state);
 
     solid_solver.setParameter(0, user_defined_bulk_modulus);
 
@@ -140,7 +138,7 @@ TEST(SolidMechanics, FiniteDifferenceParameter)
 
     user_defined_bulk_modulus(i) = bulk_modulus_value - eps;
 
-    solid_solver.setDisplacement(bc);
+    solid_solver.setDisplacement(zero_state);
 
     solid_solver.setParameter(0, user_defined_bulk_modulus);
     solid_solver.advanceTimestep(1.0);
@@ -230,12 +228,8 @@ void finite_difference_shape_test(LoadingType load)
   shape_displacement = shape_displacement_value;
   solid_solver.setShapeDisplacement(shape_displacement);
 
-  // Define the function for the initial displacement and boundary condition
-  auto mfem_vector_zero = [](const mfem::Vector&, mfem::Vector& bc_vec) -> void { bc_vec = 0.0; };
-
   // Set the initial displacement and boundary condition
   solid_solver.setFixedBCs(essential_boundary);
-  solid_solver.setDisplacement(mfem_vector_zero);
 
   Domain top_face = Domain::ofBoundaryElements(pmesh, [](std::vector<vec2> vertices, int /*attr*/) {
     return average(vertices)[1] > 0.99;  // select faces by y-coordinate

--- a/src/serac/physics/tests/solid_periodic.cpp
+++ b/src/serac/physics/tests/solid_periodic.cpp
@@ -86,7 +86,7 @@ void periodic_test(mfem::Element::Type element_type)
   solid_solver.setFixedBCs(support);
 
   constexpr double iniDispVal = 5.0e-6;
-  auto initial_displacement = [](tensor<double, dim>){ return make_tensor<dim>([](int) { return iniDispVal; }); };
+  auto initial_displacement = [](tensor<double, dim>) { return make_tensor<dim>([](int) { return iniDispVal; }); };
   solid_solver.setDisplacement(initial_displacement);
 
   tensor<double, dim> constant_force{};

--- a/src/serac/physics/tests/solid_periodic.cpp
+++ b/src/serac/physics/tests/solid_periodic.cpp
@@ -85,9 +85,9 @@ void periodic_test(mfem::Element::Type element_type)
   Domain support = Domain::ofBoundaryElements(pmesh, by_attr<dim>(2));
   solid_solver.setFixedBCs(support);
 
-  double iniDispVal       = 5.0e-6;
-  auto   ini_displacement = [iniDispVal](const mfem::Vector&, mfem::Vector& u) -> void { u = iniDispVal; };
-  solid_solver.setDisplacement(ini_displacement);
+  constexpr double iniDispVal = 5.0e-6;
+  auto initial_displacement = [](tensor<double, dim>){ return make_tensor<dim>([](int) { return iniDispVal; }); };
+  solid_solver.setDisplacement(initial_displacement);
 
   tensor<double, dim> constant_force{};
   constant_force[1] = 1.0e-2;

--- a/src/serac/physics/tests/solid_robin_condition.cpp
+++ b/src/serac/physics/tests/solid_robin_condition.cpp
@@ -89,9 +89,6 @@ void functional_solid_test_robin_condition()
       },
       support);
 
-  auto zero_displacement = [](const mfem::Vector&, mfem::Vector& u) -> void { u = 0.0; };
-  solid_solver.setDisplacement(zero_displacement);
-
   // Finalize the data structures
   solid_solver.completeSetup();
 

--- a/src/serac/physics/tests/solid_shape.cpp
+++ b/src/serac/physics/tests/solid_shape.cpp
@@ -118,7 +118,8 @@ void shape_test()
     solid_solver.setDisplacementBCs(applied_displacement, ess_bdr);
 
     // For consistency of the problem, this value should match the one in the BCs
-    solid_solver.setDisplacement([applied_displacement](tensor<double, dim> X) { return applied_displacement(X, 0.0); });
+    solid_solver.setDisplacement(
+        [applied_displacement](tensor<double, dim> X) { return applied_displacement(X, 0.0); });
 
     solid_solver.setShapeDisplacement(user_defined_shape_displacement);
 
@@ -168,7 +169,8 @@ void shape_test()
 
     // Set the initial displacement and boundary condition
     solid_solver_no_shape.setDisplacementBCs(applied_displacement_pure, ess_bdr);
-    solid_solver_no_shape.setDisplacement([applied_displacement_pure](tensor<double, dim> X) { return applied_displacement_pure(X, 0.0); });
+    solid_solver_no_shape.setDisplacement(
+        [applied_displacement_pure](tensor<double, dim> X) { return applied_displacement_pure(X, 0.0); });
 
     Domain whole_mesh = EntireDomain(StateManager::mesh(new_mesh_tag));
 

--- a/src/serac/physics/tests/solid_shape.cpp
+++ b/src/serac/physics/tests/solid_shape.cpp
@@ -74,18 +74,6 @@ void shape_test()
 
   double shape_factor = 2.0;
 
-  // Define the function for the initial displacement and boundary condition
-  auto bc = [](const mfem::Vector& x, mfem::Vector& bc_vec) -> void {
-    bc_vec[0] = 0.0;
-    bc_vec[1] = x[0] * 0.1;
-  };
-
-  // Define the function for the initial displacement and boundary condition
-  auto bc_pure = [shape_factor](const mfem::Vector& x, mfem::Vector& bc_vec) -> void {
-    bc_vec[0] = 0.0;
-    bc_vec[1] = (x[0] * 0.1) / (shape_factor + 1.0);
-  };
-
   auto applied_displacement = [](tensor<double, dim> x, double) {
     tensor<double, dim> u{};
     u[1] = x[0] * 0.1;
@@ -130,9 +118,7 @@ void shape_test()
     solid_solver.setDisplacementBCs(applied_displacement, ess_bdr);
 
     // For consistency of the problem, this value should match the one in the BCs
-    // TODO(Brandon): When the setDisplacement is updated to take a serac::tensor valued callable,
-    // pass the same functor here as is used for the BCs.
-    solid_solver.setDisplacement(bc);
+    solid_solver.setDisplacement([applied_displacement](tensor<double, dim> X) { return applied_displacement(X, 0.0); });
 
     solid_solver.setShapeDisplacement(user_defined_shape_displacement);
 
@@ -182,7 +168,7 @@ void shape_test()
 
     // Set the initial displacement and boundary condition
     solid_solver_no_shape.setDisplacementBCs(applied_displacement_pure, ess_bdr);
-    solid_solver_no_shape.setDisplacement(bc_pure);
+    solid_solver_no_shape.setDisplacement([applied_displacement_pure](tensor<double, dim> X) { return applied_displacement_pure(X, 0.0); });
 
     Domain whole_mesh = EntireDomain(StateManager::mesh(new_mesh_tag));
 

--- a/src/serac/physics/tests/thermal_mechanics.cpp
+++ b/src/serac/physics/tests/thermal_mechanics.cpp
@@ -87,12 +87,8 @@ void functional_test_static_3D(double expected_norm)
   thermal_solid_solver.setTemperatureBCs(ess_bdr, one);
   thermal_solid_solver.setTemperature(one);
 
-  // Define the function for the disolacement boundary condition
-  auto zeroVector = [](const mfem::Vector&, mfem::Vector& u) { u = 0.0; };
-
-  // Set the initial displcament and boundary condition
+  // Set the boundary condition
   thermal_solid_solver.setFixedBCs(displacement_essential_boundary);
-  thermal_solid_solver.setDisplacement(zeroVector);
 
   // Finalize the data structures
   thermal_solid_solver.completeSetup();
@@ -175,12 +171,8 @@ void functional_test_shrinking_3D(double expected_norm)
   thermal_solid_solver.setTemperatureBCs(temp_bdr, one);
   thermal_solid_solver.setTemperature(initial_temperature_field);
 
-  // Define the function for the displacement boundary condition
-  auto zeroVector = [](const mfem::Vector&, mfem::Vector& u) { u = 0.0; };
-
   // Set the initial displacement and boundary condition
   thermal_solid_solver.setFixedBCs(constraint_bdr);
-  thermal_solid_solver.setDisplacement(zeroVector);
 
   // Finalize the data structures
   thermal_solid_solver.completeSetup();

--- a/src/serac/physics/thermomechanics.hpp
+++ b/src/serac/physics/thermomechanics.hpp
@@ -475,7 +475,8 @@ public:
    *
    * @param displacement The function describing the displacement field
    */
-  void setDisplacement(std::function<void(const mfem::Vector& x, mfem::Vector& u)> displacement)
+  template <typename Callable>
+  void setDisplacement(Callable displacement)
   {
     solid_.setDisplacement(displacement);
   }


### PR DESCRIPTION
Make the interface consistent with that used for boundary conditions, using callables that take and return `tensor` objects instead of `mfem::Vector`s.

- Setting a `FiniteElementState` from a field function $$f(X)$$ is a general capability, so I moved this code out of the `SolidMechanics` class and into the `FiniteElementState` class.
- I wrote unit tests for this new capability. It turns out there were no unit tests in the `serac/physics/state/` directory, so I had to add build files for this.

