### PR TITLE
Smith fix: serac config header use PROJECT_BINARY_DIR

### DIFF
--- a/cmake/SeracConfigHeader.cmake
+++ b/cmake/SeracConfigHeader.cmake
@@ -67,10 +67,10 @@ serac_convert_to_native_escaped_file_path(${CMAKE_BINARY_DIR}   SERAC_BINARY_DIR
 #------------------------------------------------------------------------------
 serac_configure_file(
     ${PROJECT_SOURCE_DIR}/src/serac/serac_config.hpp.in
-    ${CMAKE_BINARY_DIR}/include/serac/serac_config.hpp
+    ${PROJECT_BINARY_DIR}/include/serac/serac_config.hpp
 )
 
-install(FILES ${CMAKE_BINARY_DIR}/include/serac/serac_config.hpp DESTINATION include/serac)
+install(FILES ${PROJECT_BINARY_DIR}/include/serac/serac_config.hpp DESTINATION include/serac)
 
 #------------------------------------------------------------------------------
 # Generate serac-config.cmake for importing serac into other CMake packages


### PR DESCRIPTION
A followup on https://github.com/LLNL/serac/pull/1304