### PR TITLE
Fix small bug in benchmarks ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -105,7 +105,7 @@ stages:
     # Builds src, runs benchmarks, and stores Caliper files in shared location
     - echo -e "section_start:$(date +%s):benchmarks_build\r\e[0K
       Benchmarks Build ${CI_PROJECT_NAME}"
-    - mkdir ${SPOT_DIR}
+    - mkdir -p ${SPOT_DIR}
     - ${ALLOC_COMMAND} python3 scripts/llnl/run_benchmarks.py --spot-dir ${SPOT_DIR}
     - echo -e "section_end:$(date +%s):benchmarks_build\r\e[0K"
   artifacts:


### PR DESCRIPTION
Fixes an error I noticed from last weekend's CI pipeline https://lc.llnl.gov/gitlab/smith/serac/-/jobs/2418287#L137

The `mkdir` is important for the Hatchet comparison CI pipeline, but it was causing a problem in the weekly benchmarks ci.