### PR TITLE
Fix Smith symlink issues

### DIFF
--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -691,7 +691,7 @@ def on_rz():
 
 
 def get_script_dir():
-    return os.path.dirname(os.path.abspath(__file__))
+    return os.path.dirname(os.path.abspath(sys.argv[0]))
 
 
 _project_name = ""

--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -691,6 +691,8 @@ def on_rz():
 
 
 def get_script_dir():
+    # NOTE: sys.argv[0] is based-on the script that is calling get_script_dir (e.g. build_tpls.py). This is to properly
+    # handle the case where this `scripts/llnl` directory is being symlinked by Smith. 
     return os.path.dirname(os.path.abspath(sys.argv[0]))
 
 


### PR DESCRIPTION
This PR fixes an issue in Smith (...that I thought I fixed already but I guess not). This PR doesn't affect Serac.

In Smith, we have a symlink that points to the `scripts/llnl` directory. This is nice because then we don't have to repeat ourselves, but has been causing problems when attempting to differentiate Smith from Serac.

When working on enabling benchmarks CI in Smith, I noticed that `__file__` was relative to the script `scripts/llnl/common_build_functions.py` in *Serac*. This was causing `get_project_name` was returning `serac` when it should be `smith`, for example.

LivChat introduced me to `sys.argv[0]` as opposed to `__file__`. A major difference is that `sys.argv[0]` will return the path to the symlink (rather than the actual file it points to) if a symlink is being used, which is exactly what we need in Smith. 