### PR TITLE
spack v1.0 support: `%foo +bar` -> `+bar %foo`

### DIFF
--- a/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
@@ -78,9 +78,9 @@ spack:
     mvapich2:
       buildable: false
       externals:
-      - spec: mvapich2@2.3.7%clang@14.0.6~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.7~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple %clang@14.0.6
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-clang-14.0.6
-      - spec: mvapich2@2.3.7%gcc@10.3.1~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.7~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple %gcc@10.3.1
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
 
     netlib-lapack:

--- a/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
@@ -68,7 +68,7 @@ spack:
     mvapich2:
       buildable: false
       externals:
-      - spec: mvapich2@2.3.7%gcc@10.3.1~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple
+      - spec: mvapich2@2.3.7~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple %gcc@10.3.1
         prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
 
     netlib-lapack:


### PR DESCRIPTION
Spack v1.0 will parse `pkg %gcc +foo` as "pkg with direct dependency gcc
with variant foo enabled" instead of "pkg with variant foo enabled and compiler
gcc". Reorder as `pkg +foo %gcc` to be compatible with Spack v0.x and
v1.0.
