### PR TITLE
Move hypre version to config yaml (for lido)

### DIFF
--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/spack.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/spack.yaml
@@ -243,6 +243,8 @@ spack:
       require: "@0.9.2~shared~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     petsc:

--- a/scripts/spack/configs/docker/ubuntu22/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu22/spack.yaml
@@ -197,6 +197,8 @@ spack:
       require: "@0.9.2~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     petsc:

--- a/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
@@ -307,6 +307,8 @@ spack:
       require: "@0.9.2~shared~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     raja:

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -335,6 +335,8 @@ spack:
       require: "@0.9.2~shared~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     raja:

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -111,7 +111,7 @@ class Serac(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("netcdf-c@4.7.4")
 
-    depends_on("hypre@2.26.0~superlu-dist+mpi")
+    depends_on("hypre~superlu-dist+mpi")
 
     depends_on("petsc", when="+petsc")
     depends_on("petsc+strumpack", when="+petsc+strumpack")


### PR DESCRIPTION
This moves the hypre version locking to the config yaml. This allows lido to use a different version of hypre than Serac. Eventually, Serac/ Smith may be interested in moving to a newer hypre version as well.