### PR TITLE
lido fix: newer hypre requires init call

### DIFF
--- a/scripts/spack/configs/blueos_3_ppc64le_ib_p9/spack.yaml
+++ b/scripts/spack/configs/blueos_3_ppc64le_ib_p9/spack.yaml
@@ -243,6 +243,8 @@ spack:
       require: "@0.9.2~shared~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     petsc:

--- a/scripts/spack/configs/docker/ubuntu22/spack.yaml
+++ b/scripts/spack/configs/docker/ubuntu22/spack.yaml
@@ -197,6 +197,8 @@ spack:
       require: "@0.9.2~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     petsc:

--- a/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib/spack.yaml
@@ -307,6 +307,8 @@ spack:
       require: "@0.9.2~shared~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     raja:

--- a/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
+++ b/scripts/spack/configs/toss_4_x86_64_ib_cray/spack.yaml
@@ -335,6 +335,8 @@ spack:
       require: "@0.9.2~shared~test~examples~utilities"
     hdf5:
       variants: ~shared~mpi
+    hypre:
+      require: "@2.26.0"
     mfem:
       require: "@4.7.0.2"
     raja:

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -111,7 +111,7 @@ class Serac(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("netcdf-c@4.7.4")
 
-    depends_on("hypre~superlu-dist+mpi")
+    depends_on("hypre@2.26.0:~superlu-dist+mpi")
 
     depends_on("petsc", when="+petsc")
     depends_on("petsc+strumpack", when="+petsc+strumpack")

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -111,7 +111,7 @@ class Serac(CachedCMakePackage, CudaPackage, ROCmPackage):
 
     depends_on("netcdf-c@4.7.4")
 
-    depends_on("hypre@2.26.0~superlu-dist+mpi")
+    depends_on("hypre~superlu-dist+mpi")
 
     depends_on("petsc", when="+petsc")
     depends_on("petsc+strumpack", when="+petsc+strumpack")

--- a/src/serac/physics/tests/beam_bending.cpp
+++ b/src/serac/physics/tests/beam_bending.cpp
@@ -100,6 +100,8 @@ int main(int argc, char* argv[])
 
   axom::slic::SimpleLogger logger;
 
+  mfem::Hypre::Init();
+
   int result = RUN_ALL_TESTS();
   MPI_Finalize();
 

--- a/src/serac/physics/tests/solid_dynamics_patch.cpp
+++ b/src/serac/physics/tests/solid_dynamics_patch.cpp
@@ -580,6 +580,8 @@ int main(int argc, char* argv[])
 
   axom::slic::SimpleLogger logger;
 
+  mfem::Hypre::Init();
+
   int result = RUN_ALL_TESTS();
   MPI_Finalize();
 

--- a/src/serac/physics/tests/solid_periodic.cpp
+++ b/src/serac/physics/tests/solid_periodic.cpp
@@ -121,6 +121,8 @@ int main(int argc, char* argv[])
 
   axom::slic::SimpleLogger logger;
 
+  mfem::Hypre::Init();
+
   int result = RUN_ALL_TESTS();
   MPI_Finalize();
 

--- a/src/serac/physics/tests/solid_robin_condition.cpp
+++ b/src/serac/physics/tests/solid_robin_condition.cpp
@@ -113,6 +113,8 @@ int main(int argc, char* argv[])
 
   axom::slic::SimpleLogger logger;
 
+  mfem::Hypre::Init();
+
   int result = RUN_ALL_TESTS();
   MPI_Finalize();
 

--- a/src/serac/physics/tests/solid_statics_patch.cpp
+++ b/src/serac/physics/tests/solid_statics_patch.cpp
@@ -553,6 +553,8 @@ int main(int argc, char* argv[])
 
   axom::slic::SimpleLogger logger;
 
+  mfem::Hypre::Init();
+
   int result = RUN_ALL_TESTS();
   MPI_Finalize();
 

--- a/src/serac/physics/tests/thermal_mechanics.cpp
+++ b/src/serac/physics/tests/thermal_mechanics.cpp
@@ -356,6 +356,8 @@ int main(int argc, char* argv[])
 
   axom::slic::SimpleLogger logger;
 
+  mfem::Hypre::Init();
+
   int result = RUN_ALL_TESTS();
   MPI_Finalize();
 


### PR DESCRIPTION
In lido codevelop builds, we test Smith and Serac's tests. When lido updated to hypre 2.32.0, some of the tests broke due to hypre now requiring an init call. In the future it might be better to make these tests call serac's init function, but this MR quickly resolves the issues that were occuring in lido.

Some of the history from my previous lido fix MR is in this one, but it doesn't include all of the commits required, so both should be merged. Preferably this one should merge last.