### PR TITLE
Tupek/residual redesign

### DIFF
--- a/src/serac/infrastructure/variant.hpp
+++ b/src/serac/infrastructure/variant.hpp
@@ -37,8 +37,8 @@ struct variant_storage {
    */
   int index_ = 0;
   union {
-    T0 t0_;
-    T1 t1_;
+    T0 t0_;  ///< first type
+    T1 t1_;  ///< second type
   };
 
   /**

--- a/src/serac/physics/CMakeLists.txt
+++ b/src/serac/physics/CMakeLists.txt
@@ -32,6 +32,7 @@ set(physics_headers
     thermomechanics_input.hpp
     thermomechanics_monolithic.hpp
     residual.hpp
+    functional_residual.hpp
     solid_residual.hpp
     )
 

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -33,7 +33,6 @@ template <int spatial_dim, typename ShapeSpace, typename OutputSpace, typename..
 class FunctionalResidual<spatial_dim, ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
                          std::integer_sequence<int, input_indices...>> : public Residual {
  public:
-
   using SpacesT = std::vector<const mfem::ParFiniteElementSpace*>;  ///< typedef
 
   /**
@@ -54,7 +53,7 @@ class FunctionalResidual<spatial_dim, ShapeSpace, OutputSpace, Parameters<InputS
 
     SLIC_ERROR_ROOT_IF(
         sizeof...(InputSpaces) != input_mfem_spaces.size(),
-        axom::fmt::format("{} parameter spaces given in the template argument but {} parameter names were supplied.",
+        axom::fmt::format("{} parameter spaces given in the template argument but {} input mfem spaces were supplied.",
                           sizeof...(InputSpaces), input_mfem_spaces.size()));
 
     if constexpr (sizeof...(InputSpaces) > 0) {
@@ -252,5 +251,16 @@ class FunctionalResidual<spatial_dim, ShapeSpace, OutputSpace, Parameters<InputS
   /// @brief functional residual evaluator, shape aware
   std::unique_ptr<ShapeAwareFunctional<ShapeSpace, OutputSpace(InputSpaces...)>> residual_;
 };
+
+/// @brief Helper function to construct vector of spaces from an existing vector of FiniteElementState.
+/// @param states vector of FiniteElementState
+inline std::vector<const mfem::ParFiniteElementSpace*> getSpaces(const std::vector<serac::FiniteElementState>& states)
+{
+  std::vector<const mfem::ParFiniteElementSpace*> spaces;
+  for (auto& f : states) {
+    spaces.push_back(&f.space());
+  }
+  return spaces;
+}
 
 }  // namespace serac

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -87,7 +87,8 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   template <int... active_parameters, typename BodyIntegralType>
   void addBodyIntegral(DependsOn<active_parameters...>, std::string domain_name, BodyIntegralType body_integral)
   {
-    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral, mesh_->domain(domain_name));
+    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral,
+                                 mesh_->domain(domain_name));
   }
 
   /// @overload

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -5,9 +5,10 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /**
- * @file solid_residual.hpp
+ * @file functional_residual.hpp
  *
- * @brief Implement the residual interface for solid mechanics physics
+ * @brief Implements the residual interface using serac::ShapeAwareFunctional.
+ * Allows for generic specification of body and boundary integrals
  */
 
 #pragma once
@@ -36,7 +37,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   static constexpr int dim = OutputSpace::components;
 
   /**
-   * @brief Construct a new SolidResidual object
+   * @brief Construct a new FunctionalResidual object
    *
    * @param physics_name A name for the physics module instance
    * @param mesh The serac mesh
@@ -70,7 +71,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    * @tparam BodyIntegralType The type of the body integral
    * // DependsOn<active_parameters...> can be indices into fields which the body integral may depend on
-   * @param domain_name The name of the registered domain over which the body force is applied. If nothing is supplied
+   * @param body_name The name of the registered domain over which the body force is applied. If nothing is supplied
    * the entire domain is
    * @param body_integral A function describing the body force applied
    * used.
@@ -86,17 +87,17 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    */
   template <int... active_parameters, typename BodyIntegralType>
-  void addBodyIntegral(DependsOn<active_parameters...>, std::string domain_name, BodyIntegralType body_integral)
+  void addBodyIntegral(DependsOn<active_parameters...>, std::string body_name, BodyIntegralType body_integral)
   {
     residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral,
-                                 mesh_->domain(domain_name));
+                                 mesh_->domain(body_name));
   }
 
   /// @overload
   template <typename BodyForceType>
-  void addBodyIntegral(std::string domain_name, BodyForceType body_integral)
+  void addBodyIntegral(std::string body_name, BodyForceType body_integral)
   {
-    addBodyIntegral(DependsOn<>{}, domain_name, body_integral);
+    addBodyIntegral(DependsOn<>{}, body_name, body_integral);
   }
 
   /**
@@ -104,7 +105,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    * @tparam NeumannType The type of the traction load
    * * // DependsOn<active_parameters...> can be indices into fields which the body integral may depend on
-   * @param domain_name The name of the registered domain over which the traction is applied. If nothing is supplied the
+   * @param boundary_name The name of the registered domain over which the traction is applied. If nothing is supplied the
    * entire boundary is
    * @param surface_function A function describing the traction applied to a boundary
    * used.
@@ -122,7 +123,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    */
   template <int... active_parameters, typename NeumannType>
-  void addBoundaryIntegral(DependsOn<active_parameters...>, std::string domain_name, NeumannType surface_function)
+  void addBoundaryIntegral(DependsOn<active_parameters...>, std::string boundary_name, NeumannType surface_function)
   {
     residual_->AddBoundaryIntegral(
         Dimension<dim - 1>{}, DependsOn<active_parameters...>{},
@@ -130,14 +131,14 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
           auto n = cross(get<DERIVATIVE>(X));
           return surface_function(t, get<VALUE>(X), normalize(n), params...);
         },
-        mesh_->domain(domain_name));
+        mesh_->domain(boundary_name));
   }
 
   /// @overload
   template <typename NeumannType>
-  void addBoundaryIntegral(std::string domain_name, NeumannType surface_function)
+  void addBoundaryIntegral(std::string boundary_name, NeumannType surface_function)
   {
-    addBoundaryIntegral(DependsOn<>{}, domain_name, surface_function);
+    addBoundaryIntegral(DependsOn<>{}, boundary_name, surface_function);
   }
 
   /// @overload

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -1,0 +1,261 @@
+// Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file solid_residual.hpp
+ *
+ * @brief Implement the residual interface for solid mechanics physics
+ */
+
+#pragma once
+
+#include "serac/physics/residual.hpp"
+#include "serac/physics/mesh.hpp"
+#include "serac/physics/state/state_manager.hpp"
+
+namespace serac {
+
+template <typename ShapeSpace, typename OutputSpace, typename parameters = Parameters<>,
+          typename parameter_indices = std::make_integer_sequence<int, parameters::n>>
+class FunctionalResidual;
+
+/**
+ * @brief The nonlinear residual class
+ *
+ * This uses Functional to compute the solid mechanics residuals and tangent
+ * stiffness matrices.
+ *
+ * @tparam dim The spatial dimension of the mesh
+ */
+template <typename ShapeSpace, typename OutputSpace, typename... parameter_space, int... parameter_indices>
+class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>, std::integer_sequence<int, parameter_indices...>>
+    : public Residual {
+ public:
+
+  static constexpr int dim = OutputSpace::components;
+
+  /**
+   * @brief Construct a new SolidResidual object
+   *
+   * @param physics_name A name for the physics module instance
+   * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
+   * @param shape_disp_space Shape displacement space
+   * @param test_space Test space
+   * @param argument_states Vector of finite element states which are arguments to the residual
+   */
+  FunctionalResidual(std::string physics_name, std::string mesh_tag,
+                     const mfem::ParFiniteElementSpace& shape_disp_space, const mfem::ParFiniteElementSpace& test_space,
+                     std::vector<const FiniteElementState*> argument_states)
+      : Residual(physics_name), mesh_tag_(mesh_tag), mesh_(StateManager::mesh(mesh_tag_))
+  {
+    std::array<const mfem::ParFiniteElementSpace*, sizeof...(parameter_space)> trial_spaces;
+
+    SLIC_ERROR_ROOT_IF(
+        sizeof...(parameter_space) != argument_states.size(),
+        axom::fmt::format("{} parameter spaces given in the template argument but {} parameter names were supplied.",
+                          sizeof...(parameter_space), argument_states.size()));
+
+    if constexpr (sizeof...(parameter_space) > 0) {
+      for_constexpr<sizeof...(parameter_space)>([&](auto i) { trial_spaces[i] = &argument_states[i]->space(); });
+    }
+
+    residual_ = std::make_unique<ShapeAwareFunctional<ShapeSpace, OutputSpace(parameter_space...)>>(
+        &shape_disp_space, &test_space, trial_spaces);
+  }
+
+
+  /**
+   * @brief Add a body integral contribution to the residual
+   *
+   * @tparam BodyForceType The type of the body force load
+   * @param body_integral A function describing the body force applied
+   * @param optional_domain The domain over which the body force is applied. If nothing is supplied the entire domain is
+   * used.
+   * @pre body_integral must be a object that can be called with the following arguments:
+   *    1. `double t` the time
+   *    2. `tensor<T,dim> x` the spatial coordinates for the quadrature point
+   *    3. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative),
+   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument.
+   * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
+   *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
+   * 3>`)
+   *
+   */
+  template <int... active_parameters, typename BodyIntegralType>
+  void addBodyIntegral(DependsOn<active_parameters...>, BodyIntegralType body_integral,
+                       const std::optional<Domain>& optional_domain = std::nullopt)
+  {
+    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
+    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{},
+                                 body_integral, domain);
+  }
+
+  /// @overload
+  template <typename BodyForceType>
+  void addBodyIntegral(BodyForceType body_integral, const std::optional<Domain>& optional_domain = std::nullopt)
+  {
+    addBodyIntegral(DependsOn<>{}, body_integral, optional_domain);
+  }
+
+  /**
+   * @brief Set the Neumann boundary condition
+   *
+   * @tparam NeumannType The type of the traction load
+   * @param surface_function A function describing the traction applied to a boundary
+   * @param optional_domain The domain over which the traction is applied. If nothing is supplied the entire boundary is
+   * used.
+   * @pre NeumannType must be a object that can be called with the following arguments:
+   *    1. `double t` the time
+   *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
+   *    3. `tensor<T,dim> n` the outward-facing unit normal for the quadrature point
+   *    4. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative),
+   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument.
+   *
+   * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
+   *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
+   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
+   * 3>`)
+   *
+   * @note This method must be called prior to completeSetup()
+   */
+  template <int... active_parameters, typename NeumannType>
+  void addSurfaceIntegral(DependsOn<active_parameters...>, NeumannType surface_function,
+                         const std::optional<Domain>& optional_domain = std::nullopt)
+  {
+    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_);
+
+    residual_->AddBoundaryIntegral(
+        Dimension<dim - 1>{}, DependsOn<active_parameters...>{},
+        [surface_function](double t, auto X, auto... params) {
+          auto n = cross(get<DERIVATIVE>(X));
+          return surface_function(t, get<VALUE>(X), normalize(n), params...);
+        },
+        domain);
+  }
+
+  /// @overload
+  template <typename NeumannType>
+  void addSurfaceIntegral(NeumannType surface_function, const std::optional<Domain>& optional_domain = std::nullopt)
+  {
+    addSurfaceIntegral(DependsOn<>{}, surface_function, optional_domain);
+  }
+
+  /// @overload
+  mfem::Vector residual(double time, const std::vector<FieldPtr>& fields, int block_row = 0) const override
+  {
+    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
+    //auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
+    auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
+    return ret;
+  }
+
+  /// @overload
+  std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, const std::vector<FieldPtr>& fields,
+                                                 const std::vector<double>& jacobian_weights,
+                                                 int block_row = 0) const override
+  {
+    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
+
+    std::unique_ptr<mfem::HypreParMatrix> J;
+
+    auto addToJ = [&J](double factor, std::unique_ptr<mfem::HypreParMatrix> jac_contrib) {
+      if (J) {
+        SLIC_ERROR_IF(J->N() != jac_contrib->N(),
+                      "Multiple nonzero jacobian weights are being used on inconsistently sized input arguments.");
+        SLIC_ERROR_IF(J->M() != jac_contrib->M(),
+                      "Multiple nonzero jacobian weights are being used on inconsistently sized input arguments.");
+        J->Add(factor, *jac_contrib);
+      } else {
+        J.reset(jac_contrib.release());
+        if (factor != 1.0) (*J) *= factor;
+      }
+    };
+
+    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + 1>{}, time, fields);
+
+    for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
+      if (jacobian_weights[input_col] != 0.0) {
+        auto K = serac::get<DERIVATIVE>(jacs[input_col](time, fields));
+        addToJ(jacobian_weights[input_col], assemble(K));
+      }
+    }
+
+    return J;
+  }
+
+  /// @overload
+  void jvp([[maybe_unused]] double time, [[maybe_unused]] const std::vector<FieldPtr>& fields,
+           [[maybe_unused]] const std::vector<FieldPtr>& vFields,
+           [[maybe_unused]] std::vector<DualFieldPtr>& jvpReactions) const override
+  {
+    SLIC_ERROR_IF(vFields.size() != fields.size(),
+                  "Invalid number of field sensitivities relative to the number of fields");
+    SLIC_ERROR_IF(jvpReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
+
+    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + 1>{}, time, fields);
+
+    *jvpReactions[0] = 0.0;
+
+    for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
+      if (vFields[input_col] != nullptr) {
+        auto K = serac::get<DERIVATIVE>(jacs[input_col](time, fields));
+        K.AddMult(*vFields[input_col], *jvpReactions[0]);
+      }
+    }
+    return;
+  }
+
+  /// @overload
+  void vjp([[maybe_unused]] double time, [[maybe_unused]] const std::vector<FieldPtr>& fields,
+           [[maybe_unused]] const std::vector<DualFieldPtr>& vReactions,
+           [[maybe_unused]] std::vector<FieldPtr>& vjpFields) const override
+  {
+    SLIC_ERROR_IF(vjpFields.size() != fields.size(),
+                  "Invalid number of field sensitivities relative to the number of fields");
+    SLIC_ERROR_IF(vReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
+
+    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + 1>{}, time, fields);
+
+    for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
+      auto K = serac::get<DERIVATIVE>(jacs[input_col](time, fields));
+      std::unique_ptr<mfem::HypreParMatrix> J = assemble(K);
+      J->AddMultTranspose(*vReactions[0], *vjpFields[input_col]);
+    }
+
+    return;
+  }
+
+ private:
+  /// @brief Utility to evaluate residual using all fields in vector
+  template <int... i>
+  auto evaluateResidual(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
+  {
+    return (*residual_)(time, *fs[i]...);
+  };
+
+  /// @brief Utility to get array of jacobian functions, one for each input field in fs
+  template <int... i>
+  auto jacobianFunctions(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
+  {
+    using JacFuncType = std::function<decltype((*residual_)(DifferentiateWRT<1>{}, time, *fs[i]...))(
+        double, const std::vector<FieldPtr>&)>;
+    return std::array<JacFuncType, sizeof...(i)>{[=](double _time, const std::vector<FieldPtr>& _fs) {
+      return (*residual_)(DifferentiateWRT<i>{}, _time, *_fs[i]...);
+    }...};
+  };
+
+  /// @brief string tag for the mesh
+  std::string mesh_tag_;
+
+  /// @brief primary mesh
+  mfem::ParMesh& mesh_;
+
+  /// @brief functional residual evaluator, shape aware
+  std::unique_ptr<ShapeAwareFunctional<ShapeSpace, OutputSpace(parameter_space...)>> residual_;
+};
+
+}  // namespace serac

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -18,8 +18,8 @@
 
 namespace serac {
 
-template <typename ShapeSpace, typename OutputSpace, typename parameters = Parameters<>,
-          typename parameter_indices = std::make_integer_sequence<int, parameters::n>>
+template <typename ShapeSpace, typename OutputSpace, typename inputs = Parameters<>,
+          typename input_indices = std::make_integer_sequence<int, inputs::n>>
 class FunctionalResidual;
 
 /**
@@ -29,9 +29,9 @@ class FunctionalResidual;
  * stiffness matrices.
  *
  */
-template <typename ShapeSpace, typename OutputSpace, typename... parameter_space, int... parameter_indices>
-class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>,
-                         std::integer_sequence<int, parameter_indices...>> : public Residual {
+template <typename ShapeSpace, typename OutputSpace, typename... InputSpaces, int... input_indices>
+class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
+                         std::integer_sequence<int, input_indices...>> : public Residual {
  public:
   /// @brief extract residual dimension from the output space
   static constexpr int dim = OutputSpace::components;
@@ -51,18 +51,18 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
                      std::vector<const mfem::ParFiniteElementSpace*> input_mfem_spaces)
       : Residual(physics_name), mesh_(mesh)
   {
-    std::array<const mfem::ParFiniteElementSpace*, sizeof...(parameter_space)> trial_spaces;
+    std::array<const mfem::ParFiniteElementSpace*, sizeof...(InputSpaces)> trial_spaces;
 
     SLIC_ERROR_ROOT_IF(
-        sizeof...(parameter_space) != input_mfem_spaces.size(),
+        sizeof...(InputSpaces) != input_mfem_spaces.size(),
         axom::fmt::format("{} parameter spaces given in the template argument but {} parameter names were supplied.",
-                          sizeof...(parameter_space), input_mfem_spaces.size()));
+                          sizeof...(InputSpaces), input_mfem_spaces.size()));
 
-    if constexpr (sizeof...(parameter_space) > 0) {
-      for_constexpr<sizeof...(parameter_space)>([&](auto i) { trial_spaces[i] = input_mfem_spaces[i]; });
+    if constexpr (sizeof...(InputSpaces) > 0) {
+      for_constexpr<sizeof...(InputSpaces)>([&](auto i) { trial_spaces[i] = input_mfem_spaces[i]; });
     }
 
-    residual_ = std::make_unique<ShapeAwareFunctional<ShapeSpace, OutputSpace(parameter_space...)>>(
+    residual_ = std::make_unique<ShapeAwareFunctional<ShapeSpace, OutputSpace(InputSpaces...)>>(
         &shape_disp_space, &output_mfem_space, trial_spaces);
   }
 
@@ -142,19 +142,22 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   }
 
   /// @overload
-  mfem::Vector residual(double time, const std::vector<FieldPtr>& fields, int block_row = 0) const override
+  mfem::Vector residual(double time, double dt, const std::vector<FieldPtr>& fields, int block_row = 0) const override
   {
     SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
-    auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
+    dt_ = dt;
+    auto ret = (*residual_)(time, *fields[0], *fields[input_indices + 1]...);
     return ret;
   }
 
   /// @overload
-  std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, const std::vector<FieldPtr>& fields,
+  std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, double dt, const std::vector<FieldPtr>& fields,
                                                  const std::vector<double>& jacobian_weights,
                                                  int block_row = 0) const override
   {
     SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
+
+    dt_ = dt;
 
     std::unique_ptr<mfem::HypreParMatrix> J;
 
@@ -171,7 +174,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
       }
     };
 
-    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + 1>{}, time, fields);
+    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, fields);
 
     for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
       if (jacobian_weights[input_col] != 0.0) {
@@ -184,15 +187,15 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   }
 
   /// @overload
-  void jvp([[maybe_unused]] double time, [[maybe_unused]] const std::vector<FieldPtr>& fields,
-           [[maybe_unused]] const std::vector<FieldPtr>& vFields,
-           [[maybe_unused]] std::vector<DualFieldPtr>& jvpReactions) const override
+  void jvp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vFields,
+           std::vector<DualFieldPtr>& jvpReactions) const override
   {
     SLIC_ERROR_IF(vFields.size() != fields.size(),
                   "Invalid number of field sensitivities relative to the number of fields");
     SLIC_ERROR_IF(jvpReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
 
-    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + 1>{}, time, fields);
+    dt_ = dt;
+    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, fields);
 
     *jvpReactions[0] = 0.0;
 
@@ -206,15 +209,15 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   }
 
   /// @overload
-  void vjp([[maybe_unused]] double time, [[maybe_unused]] const std::vector<FieldPtr>& fields,
-           [[maybe_unused]] const std::vector<DualFieldPtr>& vReactions,
-           [[maybe_unused]] std::vector<FieldPtr>& vjpFields) const override
+  void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<DualFieldPtr>& vReactions,
+           std::vector<FieldPtr>& vjpFields) const override
   {
     SLIC_ERROR_IF(vjpFields.size() != fields.size(),
                   "Invalid number of field sensitivities relative to the number of fields");
     SLIC_ERROR_IF(vReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
 
-    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + 1>{}, time, fields);
+    dt_ = dt;
+    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, fields);
 
     for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
       auto K = serac::get<DERIVATIVE>(jacs[input_col](time, fields));
@@ -244,11 +247,14 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
     }...};
   };
 
+  /// @brief timestep, this needs to be held here and modified for rate dependent applications
+  mutable double dt_ = std::numeric_limits<double>::max();
+
   /// @brief primary mesh
   std::shared_ptr<Mesh> mesh_;
 
   /// @brief functional residual evaluator, shape aware
-  std::unique_ptr<ShapeAwareFunctional<ShapeSpace, OutputSpace(parameter_space...)>> residual_;
+  std::unique_ptr<ShapeAwareFunctional<ShapeSpace, OutputSpace(InputSpaces...)>> residual_;
 };
 
 }  // namespace serac

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -42,27 +42,27 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    * @param physics_name A name for the physics module instance
    * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
    * @param shape_disp_space Shape displacement space
-   * @param test_space Test space
-   * @param argument_states Vector of finite element states which are arguments to the residual
+   * @param output_mfem_space Test space
+   * @param input_mfem_spaces Vector of finite element states which are arguments to the residual
    */
   FunctionalResidual(std::string physics_name, std::string mesh_tag,
-                     const mfem::ParFiniteElementSpace& shape_disp_space, const mfem::ParFiniteElementSpace& test_space,
-                     std::vector<const FiniteElementState*> argument_states)
+                     const mfem::ParFiniteElementSpace& shape_disp_space, const mfem::ParFiniteElementSpace& output_mfem_space,
+                     std::vector<const mfem::ParFiniteElementSpace*> input_mfem_spaces)
       : Residual(physics_name), mesh_tag_(mesh_tag), mesh_(StateManager::mesh(mesh_tag_))
   {
     std::array<const mfem::ParFiniteElementSpace*, sizeof...(parameter_space)> trial_spaces;
 
     SLIC_ERROR_ROOT_IF(
-        sizeof...(parameter_space) != argument_states.size(),
+        sizeof...(parameter_space) != input_mfem_spaces.size(),
         axom::fmt::format("{} parameter spaces given in the template argument but {} parameter names were supplied.",
-                          sizeof...(parameter_space), argument_states.size()));
+                          sizeof...(parameter_space), input_mfem_spaces.size()));
 
     if constexpr (sizeof...(parameter_space) > 0) {
-      for_constexpr<sizeof...(parameter_space)>([&](auto i) { trial_spaces[i] = &argument_states[i]->space(); });
+      for_constexpr<sizeof...(parameter_space)>([&](auto i) { trial_spaces[i] = input_mfem_spaces[i]; });
     }
 
     residual_ = std::make_unique<ShapeAwareFunctional<ShapeSpace, OutputSpace(parameter_space...)>>(
-        &shape_disp_space, &test_space, trial_spaces);
+        &shape_disp_space, &output_mfem_space, trial_spaces);
   }
 
   /**
@@ -226,7 +226,8 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
     return;
   }
 
- private:
+ protected:
+
   /// @brief Utility to evaluate residual using all fields in vector
   template <int... i>
   auto evaluateResidual(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -14,7 +14,6 @@
 
 #include "serac/physics/residual.hpp"
 #include "serac/physics/mesh.hpp"
-#include "serac/physics/state/state_manager.hpp"
 
 namespace serac {
 
@@ -69,9 +68,10 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   /**
    * @brief Add a body integral contribution to the residual
    *
-   * @tparam BodyForceType The type of the body force load
+   * @tparam BodyIntegralType The type of the body integral
+   * // DependsOn<active_parameters...> can be indices into fields which the body integral may depend on
+   * @param domain The domain over which the body force is applied. If nothing is supplied the entire domain is
    * @param body_integral A function describing the body force applied
-   * @param optional_domain The domain over which the body force is applied. If nothing is supplied the entire domain is
    * used.
    * @pre body_integral must be a object that can be called with the following arguments:
    *    1. `double t` the time
@@ -85,26 +85,39 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    */
   template <int... active_parameters, typename BodyIntegralType>
-  void addBodyIntegral(DependsOn<active_parameters...>, BodyIntegralType body_integral,
-                       const std::optional<Domain>& optional_domain = std::nullopt)
+  void addBodyIntegral(DependsOn<active_parameters...>, Domain& domain, BodyIntegralType body_integral)
   {
-    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_->mfemParMesh());
     residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral, domain);
   }
 
   /// @overload
-  template <typename BodyForceType>
-  void addBodyIntegral(BodyForceType body_integral, const std::optional<Domain>& optional_domain = std::nullopt)
+  template <int... active_parameters, typename BodyIntegralType>
+  void addBodyIntegral(DependsOn<active_parameters...> depends, BodyIntegralType body_integral)
   {
-    addBodyIntegral(DependsOn<>{}, body_integral, optional_domain);
+    addBodyIntegral(depends, mesh_->entireDomain(), body_integral);
+  }
+
+  /// @overload
+  template <typename BodyForceType>
+  void addBodyIntegral(Domain& domain, BodyForceType body_integral)
+  {
+    addBodyIntegral(DependsOn<>{}, domain, body_integral);
+  }
+
+  /// @overload
+  template <typename BodyForceType>
+  void addBodyIntegral(BodyForceType body_integral)
+  {
+    addBodyIntegral(mesh_->entireDomain(), body_integral);
   }
 
   /**
    * @brief Set the Neumann boundary condition
    *
    * @tparam NeumannType The type of the traction load
+   * * // DependsOn<active_parameters...> can be indices into fields which the body integral may depend on
+   * @param domain The domain over which the traction is applied. If nothing is supplied the entire boundary is
    * @param surface_function A function describing the traction applied to a boundary
-   * @param optional_domain The domain over which the traction is applied. If nothing is supplied the entire boundary is
    * used.
    * @pre NeumannType must be a object that can be called with the following arguments:
    *    1. `double t` the time
@@ -118,14 +131,10 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
    * 3>`)
    *
-   * @note This method must be called prior to completeSetup()
    */
   template <int... active_parameters, typename NeumannType>
-  void addSurfaceIntegral(DependsOn<active_parameters...>, NeumannType surface_function,
-                          const std::optional<Domain>& optional_domain = std::nullopt)
+  void addSurfaceIntegral(DependsOn<active_parameters...>, Domain& domain, NeumannType surface_function)
   {
-    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_->mfemParMesh());
-
     residual_->AddBoundaryIntegral(
         Dimension<dim - 1>{}, DependsOn<active_parameters...>{},
         [surface_function](double t, auto X, auto... params) {
@@ -136,17 +145,30 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   }
 
   /// @overload
-  template <typename NeumannType>
-  void addSurfaceIntegral(NeumannType surface_function, const std::optional<Domain>& optional_domain = std::nullopt)
+  template <int... active_parameters, typename NeumannType>
+  void addSurfaceIntegral(DependsOn<active_parameters...> depends, NeumannType surface_function)
   {
-    addSurfaceIntegral(DependsOn<>{}, surface_function, optional_domain);
+    addSurfaceIntegral(depends, mesh_->entireDomain(), surface_function);
+  }
+
+  /// @overload
+  template <typename NeumannType>
+  void addSurfaceIntegral(Domain& domain, NeumannType surface_function)
+  {
+    addSurfaceIntegral(DependsOn<>{}, domain, surface_function);
+  }
+
+  /// @overload
+  template <typename NeumannType>
+  void addSurfaceIntegral(NeumannType surface_function)
+  {
+    addSurfaceIntegral(DependsOn<>{}, surface_function);
   }
 
   /// @overload
   mfem::Vector residual(double time, const std::vector<FieldPtr>& fields, int block_row = 0) const override
   {
     SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
-    // auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
     auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
     return ret;
   }

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -85,30 +85,16 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    */
   template <int... active_parameters, typename BodyIntegralType>
-  void addBodyIntegral(DependsOn<active_parameters...>, Domain& domain, BodyIntegralType body_integral)
+  void addBodyIntegral(DependsOn<active_parameters...>, std::string domain_name, BodyIntegralType body_integral)
   {
-    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral, domain);
-  }
-
-  /// @overload
-  template <int... active_parameters, typename BodyIntegralType>
-  void addBodyIntegral(DependsOn<active_parameters...> depends, BodyIntegralType body_integral)
-  {
-    addBodyIntegral(depends, mesh_->entireDomain(), body_integral);
+    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral, mesh_->domain(domain_name));
   }
 
   /// @overload
   template <typename BodyForceType>
-  void addBodyIntegral(Domain& domain, BodyForceType body_integral)
+  void addBodyIntegral(std::string domain_name, BodyForceType body_integral)
   {
-    addBodyIntegral(DependsOn<>{}, domain, body_integral);
-  }
-
-  /// @overload
-  template <typename BodyForceType>
-  void addBodyIntegral(BodyForceType body_integral)
-  {
-    addBodyIntegral(mesh_->entireDomain(), body_integral);
+    addBodyIntegral(DependsOn<>{}, domain_name, body_integral);
   }
 
   /**
@@ -133,7 +119,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    */
   template <int... active_parameters, typename NeumannType>
-  void addSurfaceIntegral(DependsOn<active_parameters...>, Domain& domain, NeumannType surface_function)
+  void addBoundaryIntegral(DependsOn<active_parameters...>, std::string domain_name, NeumannType surface_function)
   {
     residual_->AddBoundaryIntegral(
         Dimension<dim - 1>{}, DependsOn<active_parameters...>{},
@@ -141,28 +127,14 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
           auto n = cross(get<DERIVATIVE>(X));
           return surface_function(t, get<VALUE>(X), normalize(n), params...);
         },
-        domain);
-  }
-
-  /// @overload
-  template <int... active_parameters, typename NeumannType>
-  void addSurfaceIntegral(DependsOn<active_parameters...> depends, NeumannType surface_function)
-  {
-    addSurfaceIntegral(depends, mesh_->entireDomain(), surface_function);
+        mesh_->domain(domain_name));
   }
 
   /// @overload
   template <typename NeumannType>
-  void addSurfaceIntegral(Domain& domain, NeumannType surface_function)
+  void addBoundaryIntegral(std::string domain_name, NeumannType surface_function)
   {
-    addSurfaceIntegral(DependsOn<>{}, domain, surface_function);
-  }
-
-  /// @overload
-  template <typename NeumannType>
-  void addSurfaceIntegral(NeumannType surface_function)
-  {
-    addSurfaceIntegral(DependsOn<>{}, surface_function);
+    addBoundaryIntegral(DependsOn<>{}, domain_name, surface_function);
   }
 
   /// @overload

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -70,7 +70,8 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    * @tparam BodyIntegralType The type of the body integral
    * // DependsOn<active_parameters...> can be indices into fields which the body integral may depend on
-   * @param domain The domain over which the body force is applied. If nothing is supplied the entire domain is
+   * @param domain_name The name of the registered domain over which the body force is applied. If nothing is supplied
+   * the entire domain is
    * @param body_integral A function describing the body force applied
    * used.
    * @pre body_integral must be a object that can be called with the following arguments:
@@ -103,7 +104,8 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    * @tparam NeumannType The type of the traction load
    * * // DependsOn<active_parameters...> can be indices into fields which the body integral may depend on
-   * @param domain The domain over which the traction is applied. If nothing is supplied the entire boundary is
+   * @param domain_name The name of the registered domain over which the traction is applied. If nothing is supplied the
+   * entire boundary is
    * @param surface_function A function describing the traction applied to a boundary
    * used.
    * @pre NeumannType must be a object that can be called with the following arguments:

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -36,7 +36,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   /// @brief extract residual dimension from the output space
   static constexpr int dim = OutputSpace::components;
 
-  using SpacesT = std::vector<const mfem::ParFiniteElementSpace*>;
+  using SpacesT = std::vector<const mfem::ParFiniteElementSpace*>;  ///< typedef
 
   /**
    * @brief Construct a new FunctionalResidual object
@@ -49,8 +49,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
    */
   FunctionalResidual(std::string physics_name, std::shared_ptr<Mesh> mesh,
                      const mfem::ParFiniteElementSpace& shape_disp_space,
-                     const mfem::ParFiniteElementSpace& output_mfem_space,
-                     SpacesT input_mfem_spaces)
+                     const mfem::ParFiniteElementSpace& output_mfem_space, SpacesT input_mfem_spaces)
       : Residual(physics_name), mesh_(mesh)
   {
     std::array<const mfem::ParFiniteElementSpace*, sizeof...(InputSpaces)> trial_spaces;

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -18,23 +18,21 @@
 
 namespace serac {
 
-template <typename ShapeSpace, typename OutputSpace, typename inputs = Parameters<>,
+template <int spatial_dim, typename ShapeSpace, typename OutputSpace, typename inputs = Parameters<>,
           typename input_indices = std::make_integer_sequence<int, inputs::n>>
 class FunctionalResidual;
 
 /**
  * @brief The nonlinear residual class
  *
- * This uses Functional to compute the solid mechanics residuals and tangent
- * stiffness matrices.
+ * This uses Functional to compute fairly arbitrary residuals and tangent
+ * stiffness matrices based on body and boundary integrals.
  *
  */
-template <typename ShapeSpace, typename OutputSpace, typename... InputSpaces, int... input_indices>
-class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
+template <int spatial_dim, typename ShapeSpace, typename OutputSpace, typename... InputSpaces, int... input_indices>
+class FunctionalResidual<spatial_dim, ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
                          std::integer_sequence<int, input_indices...>> : public Residual {
  public:
-  /// @brief extract residual dimension from the output space
-  static constexpr int dim = OutputSpace::components;
 
   using SpacesT = std::vector<const mfem::ParFiniteElementSpace*>;  ///< typedef
 
@@ -90,7 +88,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   template <int... active_parameters, typename BodyIntegralType>
   void addBodyIntegral(DependsOn<active_parameters...>, std::string body_name, BodyIntegralType body_integral)
   {
-    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral,
+    residual_->AddDomainIntegral(Dimension<spatial_dim>{}, DependsOn<active_parameters...>{}, body_integral,
                                  mesh_->domain(body_name));
   }
 
@@ -127,7 +125,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   void addBoundaryIntegral(DependsOn<active_parameters...>, std::string boundary_name, NeumannType surface_function)
   {
     residual_->AddBoundaryIntegral(
-        Dimension<dim - 1>{}, DependsOn<active_parameters...>{},
+        Dimension<spatial_dim - 1>{}, DependsOn<active_parameters...>{},
         [surface_function](double t, auto X, auto... params) {
           auto n = cross(get<DERIVATIVE>(X));
           return surface_function(t, get<VALUE>(X), normalize(n), params...);
@@ -145,7 +143,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   /// @overload
   mfem::Vector residual(double time, double dt, const std::vector<FieldPtr>& fields, int block_row = 0) const override
   {
-    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
+    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for FunctionalResidual");
     dt_ = dt;
     auto ret = (*residual_)(time, *fields[0], *fields[input_indices + 1]...);
     return ret;
@@ -156,7 +154,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
                                                  const std::vector<double>& jacobian_weights,
                                                  int block_row = 0) const override
   {
-    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
+    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for FunctionalResidual");
 
     dt_ = dt;
 
@@ -177,7 +175,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
 
     auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, fields);
 
-    for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
+    for (size_t input_col = 0; input_col < jacobian_weights.size(); ++input_col) {
       if (jacobian_weights[input_col] != 0.0) {
         auto K = serac::get<DERIVATIVE>(jacs[input_col](time, fields));
         addToJ(jacobian_weights[input_col], assemble(K));
@@ -193,7 +191,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   {
     SLIC_ERROR_IF(vFields.size() != fields.size(),
                   "Invalid number of field sensitivities relative to the number of fields");
-    SLIC_ERROR_IF(jvpReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
+    SLIC_ERROR_IF(jvpReactions.size() != 1, "FunctionalResidual nonlinear systems only supports 1 output residual");
 
     dt_ = dt;
     auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, fields);
@@ -214,7 +212,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   {
     SLIC_ERROR_IF(vjpFields.size() != fields.size(),
                   "Invalid number of field sensitivities relative to the number of fields");
-    SLIC_ERROR_IF(vReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
+    SLIC_ERROR_IF(vReactions.size() != 1, "FunctionalResidual nonlinear systems only supports 1 output residual");
 
     dt_ = dt;
     auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, fields);

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -42,7 +42,7 @@ class FunctionalResidual<spatial_dim, ShapeSpace, OutputSpace, Parameters<InputS
    * @param mesh The serac mesh
    * @param shape_disp_space Shape displacement space
    * @param output_mfem_space Test space
-   * @param input_mfem_spaces Vector of finite element states which are arguments to the residual
+   * @param input_mfem_spaces Vector of finite element spaces which are arguments to the residual
    */
   FunctionalResidual(std::string physics_name, std::shared_ptr<Mesh> mesh,
                      const mfem::ParFiniteElementSpace& shape_disp_space,

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -224,13 +224,6 @@ class FunctionalResidual<spatial_dim, ShapeSpace, OutputSpace, Parameters<InputS
   }
 
  protected:
-  /// @brief Utility to evaluate residual using all fields in vector
-  template <int... i>
-  auto evaluateResidual(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
-  {
-    return (*residual_)(time, *fs[i]...);
-  };
-
   /// @brief Utility to get array of jacobian functions, one for each input field in fs
   template <int... i>
   auto jacobianFunctions(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -40,15 +40,16 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    * @brief Construct a new SolidResidual object
    *
    * @param physics_name A name for the physics module instance
-   * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
+   * @param mesh The serac mesh
    * @param shape_disp_space Shape displacement space
    * @param output_mfem_space Test space
    * @param input_mfem_spaces Vector of finite element states which are arguments to the residual
    */
-  FunctionalResidual(std::string physics_name, std::string mesh_tag,
-                     const mfem::ParFiniteElementSpace& shape_disp_space, const mfem::ParFiniteElementSpace& output_mfem_space,
+  FunctionalResidual(std::string physics_name, std::shared_ptr<Mesh> mesh,
+                     const mfem::ParFiniteElementSpace& shape_disp_space,
+                     const mfem::ParFiniteElementSpace& output_mfem_space,
                      std::vector<const mfem::ParFiniteElementSpace*> input_mfem_spaces)
-      : Residual(physics_name), mesh_tag_(mesh_tag), mesh_(StateManager::mesh(mesh_tag_))
+      : Residual(physics_name), mesh_(mesh)
   {
     std::array<const mfem::ParFiniteElementSpace*, sizeof...(parameter_space)> trial_spaces;
 
@@ -87,7 +88,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   void addBodyIntegral(DependsOn<active_parameters...>, BodyIntegralType body_integral,
                        const std::optional<Domain>& optional_domain = std::nullopt)
   {
-    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
+    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_->mfemParMesh());
     residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral, domain);
   }
 
@@ -123,7 +124,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   void addSurfaceIntegral(DependsOn<active_parameters...>, NeumannType surface_function,
                           const std::optional<Domain>& optional_domain = std::nullopt)
   {
-    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_);
+    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_->mfemParMesh());
 
     residual_->AddBoundaryIntegral(
         Dimension<dim - 1>{}, DependsOn<active_parameters...>{},
@@ -227,7 +228,6 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   }
 
  protected:
-
   /// @brief Utility to evaluate residual using all fields in vector
   template <int... i>
   auto evaluateResidual(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
@@ -246,11 +246,8 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
     }...};
   };
 
-  /// @brief string tag for the mesh
-  std::string mesh_tag_;
-
   /// @brief primary mesh
-  mfem::ParMesh& mesh_;
+  std::shared_ptr<Mesh> mesh_;
 
   /// @brief functional residual evaluator, shape aware
   std::unique_ptr<ShapeAwareFunctional<ShapeSpace, OutputSpace(parameter_space...)>> residual_;

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -105,8 +105,8 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    *
    * @tparam NeumannType The type of the traction load
    * * // DependsOn<active_parameters...> can be indices into fields which the body integral may depend on
-   * @param boundary_name The name of the registered domain over which the traction is applied. If nothing is supplied the
-   * entire boundary is
+   * @param boundary_name The name of the registered domain over which the traction is applied. If nothing is supplied
+   * the entire boundary is
    * @param surface_function A function describing the traction applied to a boundary
    * used.
    * @pre NeumannType must be a object that can be called with the following arguments:

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -28,13 +28,12 @@ class FunctionalResidual;
  * This uses Functional to compute the solid mechanics residuals and tangent
  * stiffness matrices.
  *
- * @tparam dim The spatial dimension of the mesh
  */
 template <typename ShapeSpace, typename OutputSpace, typename... parameter_space, int... parameter_indices>
-class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>, std::integer_sequence<int, parameter_indices...>>
-    : public Residual {
+class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>,
+                         std::integer_sequence<int, parameter_indices...>> : public Residual {
  public:
-
+  /// @brief extract residual dimension from the output space
   static constexpr int dim = OutputSpace::components;
 
   /**
@@ -66,7 +65,6 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
         &shape_disp_space, &test_space, trial_spaces);
   }
 
-
   /**
    * @brief Add a body integral contribution to the residual
    *
@@ -90,8 +88,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
                        const std::optional<Domain>& optional_domain = std::nullopt)
   {
     Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
-    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{},
-                                 body_integral, domain);
+    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<active_parameters...>{}, body_integral, domain);
   }
 
   /// @overload
@@ -124,7 +121,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
    */
   template <int... active_parameters, typename NeumannType>
   void addSurfaceIntegral(DependsOn<active_parameters...>, NeumannType surface_function,
-                         const std::optional<Domain>& optional_domain = std::nullopt)
+                          const std::optional<Domain>& optional_domain = std::nullopt)
   {
     Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_);
 
@@ -148,7 +145,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<parameter_space...>
   mfem::Vector residual(double time, const std::vector<FieldPtr>& fields, int block_row = 0) const override
   {
     SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
-    //auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
+    // auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
     auto ret = (*residual_)(time, *fields[0], *fields[parameter_indices + 1]...);
     return ret;
   }

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -36,6 +36,8 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   /// @brief extract residual dimension from the output space
   static constexpr int dim = OutputSpace::components;
 
+  using SpacesT = std::vector<const mfem::ParFiniteElementSpace*>;
+
   /**
    * @brief Construct a new FunctionalResidual object
    *
@@ -48,7 +50,7 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
   FunctionalResidual(std::string physics_name, std::shared_ptr<Mesh> mesh,
                      const mfem::ParFiniteElementSpace& shape_disp_space,
                      const mfem::ParFiniteElementSpace& output_mfem_space,
-                     std::vector<const mfem::ParFiniteElementSpace*> input_mfem_spaces)
+                     SpacesT input_mfem_spaces)
       : Residual(physics_name), mesh_(mesh)
   {
     std::array<const mfem::ParFiniteElementSpace*, sizeof...(InputSpaces)> trial_spaces;
@@ -205,7 +207,6 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
         K.AddMult(*vFields[input_col], *jvpReactions[0]);
       }
     }
-    return;
   }
 
   /// @overload
@@ -224,8 +225,6 @@ class FunctionalResidual<ShapeSpace, OutputSpace, Parameters<InputSpaces...>,
       std::unique_ptr<mfem::HypreParMatrix> J = assemble(K);
       J->AddMultTranspose(*vReactions[0], *vjpFields[input_col]);
     }
-
-    return;
   }
 
  protected:

--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -128,48 +128,6 @@ struct NeoHookean {
   double G;        ///< shear modulus
 };
 
-/**
- * @brief Neo-Hookean material model
- *
- */
-struct NeoHookeanWithFieldDensity {
-  using State = Empty;  ///< this material has no internal variables
-
-  /**
-   * @brief stress calculation for a NeoHookean material model
-   *
-   * When applied to 2D displacement gradients, the stress is computed in plane strain,
-   * returning only the in-plane components.
-   * @return The first Piola stress
-   */
-  template <typename T, int dim, typename Density>
-  SERAC_HOST_DEVICE auto pkStress(State& /* state */, const tensor<T, dim, dim>& du_dX, const Density&) const
-  {
-    using std::log1p;
-    constexpr auto I = Identity<dim>();
-    auto lambda = K - (2.0 / 3.0) * G;
-    auto B_minus_I = dot(du_dX, transpose(du_dX)) + transpose(du_dX) + du_dX;
-
-    auto logJ = log1p(detApIm1(du_dX));
-    // Kirchoff stress, in form that avoids cancellation error when F is near I
-    auto TK = lambda * logJ * I + G * B_minus_I;
-
-    // Pull back to Piola
-    auto F = du_dX + I;
-    return dot(TK, inv(transpose(F)));
-  }
-
-  /// @brief interpolates density field
-  template <typename Density>
-  SERAC_HOST_DEVICE auto density(const Density& density) const
-  {
-    return get<VALUE>(density);
-  }
-
-  double K;  ///< bulk modulus
-  double G;  ///< shear modulus
-};
-
 /// Neo-Hookean material version with additive split of deviatoric and volumetric behavior
 struct NeoHookeanAdditiveSplit {
   using State = Empty;  ///< this material has no internal variables
@@ -519,6 +477,54 @@ struct ConstantTraction {
   {
     return traction_;
   }
+};
+
+/**
+ * @brief Neo-Hookean material model
+ * This struct differs in style relative to the older materials as it needs to evaluate both stress
+ * and density.  As a result, we want to clearly name these functions.
+ * This is likely going to be a new design going forward, at the moment it works with the
+ * solid_residual_class.
+ *
+ */
+struct NeoHookeanWithFieldDensity {
+  using State = Empty;  ///< this material has no internal variables
+
+  /**
+   * @brief stress calculation for a NeoHookean material model
+   * @tparam T type of float or dual in tensor
+   * @tparam dim Dimensionality of space
+   * @param du_dX displacement gradient with respect to the reference configuration
+   * When applied to 2D displacement gradients, the stress is computed in plane strain,
+   * returning only the in-plane components.
+   * @return The first Piola stress
+   */
+  template <typename T, int dim, typename Density>
+  SERAC_HOST_DEVICE auto pkStress(State& /* state */, const tensor<T, dim, dim>& du_dX, const Density&) const
+  {
+    using std::log1p;
+    constexpr auto I = Identity<dim>();
+    auto lambda = K - (2.0 / 3.0) * G;
+    auto B_minus_I = dot(du_dX, transpose(du_dX)) + transpose(du_dX) + du_dX;
+
+    auto logJ = log1p(detApIm1(du_dX));
+    // Kirchoff stress, in form that avoids cancellation error when F is near I
+    auto TK = lambda * logJ * I + G * B_minus_I;
+
+    // Pull back to Piola
+    auto F = du_dX + I;
+    return dot(TK, inv(transpose(F)));
+  }
+
+  /// @brief interpolates density field
+  template <typename Density>
+  SERAC_HOST_DEVICE auto density(const Density& density) const
+  {
+    return get<VALUE>(density);
+  }
+
+  double K;  ///< bulk modulus
+  double G;  ///< shear modulus
 };
 
 }  // namespace serac::solid_mechanics

--- a/src/serac/physics/materials/solid_material.hpp
+++ b/src/serac/physics/materials/solid_material.hpp
@@ -484,7 +484,7 @@ struct ConstantTraction {
  * This struct differs in style relative to the older materials as it needs to evaluate both stress
  * and density.  As a result, we want to clearly name these functions.
  * This is likely going to be a new design going forward, at the moment it works with the
- * solid_residual_class.
+ * SolidResidual class.
  *
  */
 struct NeoHookeanWithFieldDensity {

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -34,9 +34,15 @@ Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_s
 
 MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }
 
-void Mesh::createDomains() { domains_.insert({entireDomainName(), serac::EntireDomain(*mfem_mesh_)}); }
+void Mesh::createDomains() 
+{ 
+  domains_.insert({entireBodyName(), serac::EntireDomain(*mfem_mesh_)});
+  domains_.insert({entireBoundaryName(), serac::EntireBoundary(*mfem_mesh_)});
+}
 
-serac::Domain& Mesh::entireDomain() const { return domain(entireDomainName()); }
+serac::Domain& Mesh::entireBody() const { return domain(entireBodyName()); }
+
+serac::Domain& Mesh::entireBoundary() const { return domain(entireBoundaryName()); }
 
 serac::Domain& Mesh::domain(const std::string& domain_name) const
 {

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -14,13 +14,13 @@ namespace serac {
 Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int refine_parallel) : mesh_tag(meshtag)
 {
   auto meshtmp = serac::mesh::refineAndDistribute(std::move(mesh), refine_serial, refine_parallel);
-  mfem_mesh = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag);
+  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag);
   createDomains();
 }
 
 Mesh::Mesh(mfem::ParMesh& mesh, const std::string& meshtag) : mesh_tag(meshtag)
 {
-  mfem_mesh = &mesh;
+  mfem_mesh_ = &mesh;
   createDomains();
 }
 
@@ -28,13 +28,13 @@ Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_s
     : mesh_tag(meshtag)
 {
   auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel);
-  mfem_mesh = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag);
+  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag);
   createDomains();
 }
 
-MPI_Comm Mesh::getComm() const { return mfem_mesh->GetComm(); }
+MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }
 
-void Mesh::createDomains() { domains_.insert({"entire_mesh", serac::EntireDomain(*mfem_mesh)}); }
+void Mesh::createDomains() { domains_.insert({"entire_mesh", serac::EntireDomain(*mfem_mesh_)}); }
 
 serac::Domain& Mesh::entireDomain() const { return domain("entire_mesh"); }
 
@@ -50,7 +50,7 @@ serac::Domain& Mesh::addDomainOfBoundaryElements(const std::string& domain_name,
 {
   SLIC_ERROR_IF(domains_.find(domain_name) != domains_.end(),
                 axom::fmt::format("A domain named {0} already exists in mesh with tag {1}", domain_name, mesh_tag));
-  domains_.emplace(domain_name, Domain::ofBoundaryElements(*mfem_mesh, func));
+  domains_.emplace(domain_name, Domain::ofBoundaryElements(*mfem_mesh_, func));
   return domain(domain_name);
 }
 
@@ -59,7 +59,7 @@ serac::Domain& Mesh::addDomainOfBoundaryElements(const std::string& domain_name,
 {
   SLIC_ERROR_IF(domains_.find(domain_name) != domains_.end(),
                 axom::fmt::format("A domain named {0} already exists in mesh with tag {1}", domain_name, mesh_tag));
-  domains_.emplace(domain_name, Domain::ofBoundaryElements(*mfem_mesh, func));
+  domains_.emplace(domain_name, Domain::ofBoundaryElements(*mfem_mesh_, func));
   return domain(domain_name);
 }
 

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -11,24 +11,24 @@
 
 namespace serac {
 
-Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int refine_parallel) : mesh_tag(meshtag)
+Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int refine_parallel) : mesh_tag_(meshtag)
 {
   auto meshtmp = serac::mesh::refineAndDistribute(std::move(mesh), refine_serial, refine_parallel);
-  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag);
+  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
   createDomains();
 }
 
-Mesh::Mesh(mfem::ParMesh& mesh, const std::string& meshtag) : mesh_tag(meshtag)
+Mesh::Mesh(mfem::ParMesh& mesh, const std::string& meshtag) : mesh_tag_(meshtag)
 {
   mfem_mesh_ = &mesh;
   createDomains();
 }
 
 Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_serial, int refine_parallel)
-    : mesh_tag(meshtag)
+    : mesh_tag_(meshtag)
 {
   auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel);
-  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag);
+  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
   createDomains();
 }
 
@@ -41,7 +41,7 @@ serac::Domain& Mesh::entireDomain() const { return domain(entireDomainName()); }
 serac::Domain& Mesh::domain(const std::string& domain_name) const
 {
   SLIC_ERROR_IF(domains_.find(domain_name) == domains_.end(),
-                axom::fmt::format("Could not find domain named {0} in mesh with tag {1}", domain_name, mesh_tag));
+                axom::fmt::format("Could not find domain named {0} in mesh with tag {1}", domain_name, mesh_tag_));
   return domains_.at(domain_name);
 }
 
@@ -49,7 +49,7 @@ serac::Domain& Mesh::addDomainOfBoundaryElements(const std::string& domain_name,
                                                  std::function<bool(std::vector<vec2>, int)> func)
 {
   SLIC_ERROR_IF(domains_.find(domain_name) != domains_.end(),
-                axom::fmt::format("A domain named {0} already exists in mesh with tag {1}", domain_name, mesh_tag));
+                axom::fmt::format("A domain named {0} already exists in mesh with tag {1}", domain_name, mesh_tag_));
   domains_.emplace(domain_name, Domain::ofBoundaryElements(*mfem_mesh_, func));
   return domain(domain_name);
 }
@@ -58,7 +58,7 @@ serac::Domain& Mesh::addDomainOfBoundaryElements(const std::string& domain_name,
                                                  std::function<bool(std::vector<vec3>, int)> func)
 {
   SLIC_ERROR_IF(domains_.find(domain_name) != domains_.end(),
-                axom::fmt::format("A domain named {0} already exists in mesh with tag {1}", domain_name, mesh_tag));
+                axom::fmt::format("A domain named {0} already exists in mesh with tag {1}", domain_name, mesh_tag_));
   domains_.emplace(domain_name, Domain::ofBoundaryElements(*mfem_mesh_, func));
   return domain(domain_name);
 }

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -34,8 +34,8 @@ Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_s
 
 MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }
 
-void Mesh::createDomains() 
-{ 
+void Mesh::createDomains()
+{
   domains_.insert({entireBodyName(), serac::EntireDomain(*mfem_mesh_)});
   domains_.insert({entireBoundaryName(), serac::EntireBoundary(*mfem_mesh_)});
 }

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -34,9 +34,9 @@ Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_s
 
 MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }
 
-void Mesh::createDomains() { domains_.insert({"entire_mesh", serac::EntireDomain(*mfem_mesh_)}); }
+void Mesh::createDomains() { domains_.insert({entireDomainName(), serac::EntireDomain(*mfem_mesh_)}); }
 
-serac::Domain& Mesh::entireDomain() const { return domain("entire_mesh"); }
+serac::Domain& Mesh::entireDomain() const { return domain(entireDomainName()); }
 
 serac::Domain& Mesh::domain(const std::string& domain_name) const
 {

--- a/src/serac/physics/mesh.hpp
+++ b/src/serac/physics/mesh.hpp
@@ -53,11 +53,17 @@ class Mesh {
   /// @brief Returns parallel communicator
   MPI_Comm getComm() const;
 
-  /// @brief  Returns string, name used to access the entire domain
-  std::string entireDomainName() const { return "entire_mesh"; }
+  /// @brief  Returns string, name used to access the entire domain body
+  static std::string entireBodyName() { return "entire_body"; }
 
   /// @brief Returns domain corresponding to the entire mesh
-  serac::Domain& entireDomain() const;
+  serac::Domain& entireBody() const;
+
+  /// @brief  Returns string, name used to access the entire boundary
+  static std::string entireBoundaryName() { return "entire_boundary"; }
+
+  /// @brief Returns domain boundary corresponding to the entire mesh
+  serac::Domain& entireBoundary() const;
 
   /// @brief Returns registered domain with specified name
   serac::Domain& domain(const std::string& domain_name) const;

--- a/src/serac/physics/mesh.hpp
+++ b/src/serac/physics/mesh.hpp
@@ -45,7 +45,7 @@ class Mesh {
   Mesh(const std::string& meshfile, const std::string& meshtag, int serial_refine = 0, int parallel_refine = 0);
 
   /// @brief Returns string tag for mesh
-  const std::string& tag() const { return mesh_tag; }
+  const std::string& tag() const { return mesh_tag_; }
 
   /// @brief Returns parallel mfem mesh, ignores const for mfem interfaces
   mfem::ParMesh& mfemParMesh() const { return *mfem_mesh_; }
@@ -80,7 +80,7 @@ class Mesh {
   void createDomains();
 
   /// @brief String identifying mesh in the state manager
-  std::string mesh_tag;
+  std::string mesh_tag_;
 
   /// @brief Parallel mfem mesh
   mfem::ParMesh* mfem_mesh_;

--- a/src/serac/physics/mesh.hpp
+++ b/src/serac/physics/mesh.hpp
@@ -48,7 +48,7 @@ class Mesh {
   const std::string& tag() const { return mesh_tag; }
 
   /// @brief Returns parallel mfem mesh, ignores const for mfem interfaces
-  mfem::ParMesh& mfemParMesh() const { return *mfem_mesh; }
+  mfem::ParMesh& mfemParMesh() const { return *mfem_mesh_; }
 
   /// @brief Returns parallel communicator
   MPI_Comm getComm() const;
@@ -76,13 +76,13 @@ class Mesh {
   /// names/blocks/attributes from the mesh and create default domains
   void createDomains();
 
-  /// @brief
+  /// @brief String identifying mesh in the state manager
   std::string mesh_tag;
 
-  /// @brief
-  mfem::ParMesh* mfem_mesh;
+  /// @brief Parallel mfem mesh
+  mfem::ParMesh* mfem_mesh_;
 
-  /// @brief
+  /// @brief Map from registered domain name to the domain instance
   mutable std::map<std::string, serac::Domain> domains_;
 };
 

--- a/src/serac/physics/mesh.hpp
+++ b/src/serac/physics/mesh.hpp
@@ -53,6 +53,9 @@ class Mesh {
   /// @brief Returns parallel communicator
   MPI_Comm getComm() const;
 
+  /// @brief  Returns string, name used to access the entire domain
+  std::string entireDomainName() const { return "entire_mesh"; }
+
   /// @brief Returns domain corresponding to the entire mesh
   serac::Domain& entireDomain() const;
 

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -23,7 +23,9 @@ class FiniteElementDual;
 /// @brief Abstract residual class
 class Residual {
  public:
-  /// @brief base constructor takes the name of the physics
+  /** @brief base constructor takes the name of the physics
+   * @param name provide a name corresponding to the physics
+   */
   Residual(std::string name) : name_(name) {}
 
   /// @brief destructor

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -40,15 +40,18 @@ class Residual {
   /** @brief Virtual interface for computing residual from a vector of serac::FiniteElementState*
    *
    * @param time time
+   * @param dt time step
    * @param fields vector of serac::FiniteElementState* as arguments to the residual
    * @param block_row integer which specifies which row of a block system to get the residual for, defaults to 0
    * @return mfem::Vector
    */
-  virtual mfem::Vector residual(double time, const std::vector<FieldPtr>& fields, int block_row = 0) const = 0;
+  virtual mfem::Vector residual(double time, double dt, const std::vector<FieldPtr>& fields,
+                                int block_row = 0) const = 0;
 
   /** @brief Derivative of the residual with respect to specified field arguments: sum_j d{r}_i/d{fields}_j *
    * argument_tangents[j], i is row, j are input fields (columns)
    * @param time time
+   * @param dt time step
    * @param fields vector of serac::FiniteElementState* as arguments to the residual
    * @param argument_tangents specifies the weighting of the residual derivative with respect to each field
    * @param block_row specifies which block row of the residual to compute the jacobian for
@@ -56,30 +59,32 @@ class Residual {
    * @return std::unique_ptr<mfem::HypreParMatrix> returns sum_j d{r}_i/d{fields}_j * argument_tangents[j], where
    * {fields}_j is the jth field, {r}_i is the ith residual block row
    */
-  virtual std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, const std::vector<FieldPtr>& fields,
+  virtual std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, double dt, const std::vector<FieldPtr>& fields,
                                                          const std::vector<double>& argument_tangents,
                                                          int block_row = 0) const = 0;
 
   /**
    * @brief Jacobian-vector product, will overwrite any existing values in jvpReactions
    * @param time time
+   * @param dt time step
    * @param fields vector of serac::FiniteElementState* as arguments to the residual
    * @param vFields right hand side 'v' fields
    * @param jvpReactions output vjps, 1 per row of a block system: d{r}_i / d{fields}_j * fieldsV[j]
    * nullptr fieldsV are assumed to be all zero to avoid extra calculations
    */
-  virtual void jvp(double time, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vFields,
+  virtual void jvp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vFields,
                    std::vector<DualFieldPtr>& jvpReactions) const = 0;
 
   /**
    * @brief Vector-Jacobian product, will += into existing values in vjpFields
    * @param time time
+   * @param dt time step
    * @param fields vector of serac::FiniteElementState* as arguments to the residual
    * @param vReactions left hand side 'v' fields
    * @param vjpFields output jvps, 1 per input field: vResiduals[i] * d{r}_i / d{fields}_j
    */
-  virtual void vjp(double time, const std::vector<FieldPtr>& fields, const std::vector<DualFieldPtr>& vReactions,
-                   std::vector<FieldPtr>& vjpFields) const = 0;
+  virtual void vjp(double time, double dt, const std::vector<FieldPtr>& fields,
+                   const std::vector<DualFieldPtr>& vReactions, std::vector<FieldPtr>& vjpFields) const = 0;
 
   /// @brief name
   std::string name() const { return name_; }

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -200,7 +200,7 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
    * @brief Functor representing a body force integrand.  A functor is necessary instead
    * of an extended, generic lambda for compatibility with NVCC.
    */
-  template <typename BodyForceType>
+  template <typename VolumeIntegralType>
   struct BodyForceIntegrand {
     /// @brief Body force model
     BodyForceType body_force_;
@@ -250,7 +250,7 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
    *
    * @note This method must be called prior to completeSetup()
    */
-  template <int... active_parameters, typename BodyForceType>
+  template <int... active_parameters, typename VolumeIntegralType>
   void addBodyForce(DependsOn<active_parameters...>, BodyForceType body_force,
                     const std::optional<Domain>& optional_domain = std::nullopt)
   {

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -172,11 +172,8 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
    * @note This pressure is applied in the deformed (current) configuration if GeometricNonlinearities are on.
    */
   template <int... active_parameters, typename PressureType>
-  void addPressure(DependsOn<active_parameters...>, PressureType pressure_function,
-                   const std::optional<Domain>& optional_domain = std::nullopt)
+  void addPressure(DependsOn<active_parameters...>, std::string boundary_name, PressureType pressure_function)
   {
-    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(BaseResidualT::mesh_);
-
     BaseResidualT::residual_->AddBoundaryIntegral(
         Dimension<dim - 1>{}, DependsOn<0, active_parameters + NUM_STATE_VARS...>{},
         [pressure_function](double t, auto X, auto displacement, auto... params) {
@@ -201,14 +198,14 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
           // We always query the pressure function in the undeformed configuration
           return pressure_function(t, get<VALUE>(X), params...) * (n / norm(cross(get<DERIVATIVE>(X))));
         },
-        domain);
+        BaseResidualT::mesh_->domain(boundary_name));
   }
 
   /// @overload
   template <typename PressureType>
-  void addPressure(PressureType pressure_function, const std::optional<Domain>& optional_domain = std::nullopt)
+  void addPressure(std::string boundary_name, PressureType pressure_function)
   {
-    addPressure(DependsOn<>{}, pressure_function, optional_domain);
+    addPressure(DependsOn<>{}, boundary_name, pressure_function);
   }
 
  protected:

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -35,9 +35,8 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
                                 Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, InputSpaces...>> {
  public:
   /// @brief typedef for underlying functional type with templates
-  using BaseResidualT =
-      FunctionalResidual<H1<order, dim>, H1<order, dim>,
-                         Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, InputSpaces...>>;
+  using BaseResidualT = FunctionalResidual<H1<order, dim>, H1<order, dim>,
+                                           Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, InputSpaces...>>;
 
   /// @brief a container holding quadrature point data of the specified type
   /// @tparam T the type of data to store at each quadrature point

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -155,8 +155,8 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
    * @tparam active_parameters the indices for active non-state params (i.e., indexing starts just after disp, velo, or
    * accel)
    * @tparam PressureType The type of the pressure load
+   * @param boundary_name string, name of boundary domain
    * @param pressure_function A function describing the pressure applied to a boundary
-   * @param optional_domain The domain over which the pressure is applied. If nothing is supplied the entire boundary is
    * used.
    * @pre PressureType must be a object that can be called with the following arguments:
    *    1. `double t` the time (note: time will be handled differently in the future)

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -68,8 +68,8 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
    *
    * @tparam MaterialType The solid material type
    * @tparam StateType the type that contains the internal variables for MaterialType
+   * @param body_name string name for a registered body Domain on the mesh
    * @param material A material that provides a function to evaluate stress
-   * @param domain Domain for material to be integrated over
    * @pre material must be a object that can be called with the following arguments:
    *    1. `MaterialType::State & state` an mutable reference to the internal variables for this quadrature point
    *    2. `tensor<T,dim,dim> du_dx` the displacement gradient at this quadrature point
@@ -112,8 +112,8 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
    *
    * @tparam MaterialType The solid material type
    * @tparam StateType the type that contains the internal variables for MaterialType
+   * @param body_name string name for a registered domain on the mesh
    * @param material A material that provides a function to evaluate stress
-   * @param domain Domain for material to be integrated over
    * @pre material must be a object that can be called with the following arguments:
    *    1. `MaterialType::State & state` an mutable reference to the internal variables for this quadrature point
    *    2. `tensor<T,dim,dim> du_dx` the displacement gradient at this quadrature point

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -13,13 +13,13 @@
 #pragma once
 
 #include "serac/physics/residual.hpp"
+#include "serac/physics/functional_residual.hpp"
 #include "serac/physics/mesh.hpp"
 #include "serac/physics/state/state_manager.hpp"
 
 namespace serac {
 
-template <int order, int dim, typename parameters = Parameters<>,
-          typename parameter_indices = std::make_integer_sequence<int, parameters::n>>
+template <int order, int dim, typename parameters = Parameters<>>
 class SolidResidual;
 
 /**
@@ -31,18 +31,29 @@ class SolidResidual;
  * @tparam order The order of the discretization of the displacement and velocity fields
  * @tparam dim The spatial dimension of the mesh
  */
-template <int order, int dim, typename... parameter_space, int... parameter_indices>
-class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_sequence<int, parameter_indices...>>
-    : public Residual {
+template <int order, int dim, typename... parameter_space>
+class SolidResidual<order, dim, Parameters<parameter_space...>>
+    : public FunctionalResidual< H1<order,dim>, H1<order,dim>, Parameters< H1<order,dim>, H1<order,dim>, H1<order,dim>, parameter_space...> > {
  public:
-  static constexpr auto NUM_STATE_VARS = 3;                                  ///< displacement, velocity, acceleration
-  static constexpr auto NUM_PRE_PARAMS = 1;                                  ///< shape_displacement
-  static constexpr auto NUM_FIELD_OFFSET = NUM_STATE_VARS + NUM_PRE_PARAMS;  ///< sum of num states and num params
+
+  using BaseResidualT = FunctionalResidual< H1<order,dim>, H1<order,dim>, Parameters< H1<order,dim>, H1<order,dim>, H1<order,dim>, parameter_space...> >;
 
   /// @brief a container holding quadrature point data of the specified type
   /// @tparam T the type of data to store at each quadrature point
   template <typename T>
   using qdata_type = std::shared_ptr<QuadratureData<T>>;
+
+  static constexpr int NUM_STATE_VARS = 3;
+
+  std::vector<const mfem::ParFiniteElementSpace*> constructAllSpaces(const mfem::ParFiniteElementSpace& state_space, 
+                                                                     const std::vector<const mfem::ParFiniteElementSpace*>& spaces)
+  {
+    std::vector<const mfem::ParFiniteElementSpace*> all_spaces{&state_space, &state_space, &state_space};
+    for (auto& s : spaces) {
+      all_spaces.push_back(s);
+    }
+    return all_spaces;
+  }
 
   /**
    * @brief Construct a new SolidResidual object
@@ -52,62 +63,12 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
    * @param shape_disp_space Shape displacement space
    * @param test_space Test space
    * @param parameter_fe_spaces Vector of parameters spaces
-   * @param parameter_names Vector of parameter names, must match size of parameter_fe_spaces
    */
   SolidResidual(std::string physics_name, std::string mesh_tag, const mfem::ParFiniteElementSpace& shape_disp_space,
                 const mfem::ParFiniteElementSpace& test_space,
-                std::vector<const mfem::ParFiniteElementSpace*> parameter_fe_spaces = {},
-                std::vector<std::string> parameter_names = {})
-      : Residual(physics_name), mesh_tag_(mesh_tag), mesh_(StateManager::mesh(mesh_tag_))
+                std::vector<const mfem::ParFiniteElementSpace*> parameter_fe_spaces = {})
+      : BaseResidualT(physics_name, mesh_tag, shape_disp_space, test_space, constructAllSpaces(test_space, parameter_fe_spaces))
   {
-    std::array<const mfem::ParFiniteElementSpace*, NUM_STATE_VARS + sizeof...(parameter_space)> trial_spaces;
-    trial_spaces[0] = &test_space;
-    trial_spaces[1] = &test_space;
-    trial_spaces[2] = &test_space;
-
-    SLIC_ERROR_ROOT_IF(
-        sizeof...(parameter_space) != parameter_names.size(),
-        axom::fmt::format("{} parameter spaces given in the template argument but {} parameter names were supplied.",
-                          sizeof...(parameter_space), parameter_names.size()));
-
-    if constexpr (sizeof...(parameter_space) > 0) {
-      for_constexpr<sizeof...(parameter_space)>(
-          [&](auto i) { trial_spaces[i + NUM_STATE_VARS] = parameter_fe_spaces[i]; });
-    }
-
-    residual_ = std::make_unique<ShapeAwareFunctional<shape_trial, test(trial, trial, trial, parameter_space...)>>(
-        &shape_disp_space, &test_space, trial_spaces);
-  }
-
-  /**
-   * @brief register a custom boundary integral calculation as part of the residual
-   *
-   * @tparam active_parameters a list of indices, describing which parameters to pass to the q-function
-   * @param qfunction a callable that returns the traction on a boundary surface
-   * @param optional_domain The domain over which the boundary integral is evaluated. If nothing is supplied the entire
-   * boundary is used.
-   * ~~~ {.cpp}
-   *
-   *  solid_mechanics.addCustomBoundaryIntegral(DependsOn<>{}, [](double t, auto position, auto displacement, auto
-   * acceleration, auto shape){ auto [X, dX_dxi] = position;
-   *
-   *     auto [u, du_dxi] = displacement;
-   *     auto f           = u * 3.0 (X[0] < 0.01);
-   *     return f;  // define a displacement-proportional traction at a given support
-   *  });
-   *
-   * ~~~
-   *
-   * @note This method must be called prior to completeSetup()
-   */
-  template <int... active_parameters, typename callable>
-  void addCustomBoundaryIntegral(DependsOn<active_parameters...>, callable qfunction,
-                                 const std::optional<Domain>& optional_domain = std::nullopt)
-  {
-    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_);
-
-    residual_->AddBoundaryIntegral(Dimension<dim - 1>{}, DependsOn<0, 1, 2, active_parameters + NUM_FIELD_OFFSET...>{},
-                                   qfunction, domain);
   }
 
   /**
@@ -133,7 +94,6 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
    * @pre MaterialType must have a public method `density` which can take FiniteElementState parameter inputs
    * @pre MaterialType must have a public method 'pkStress' which returns the first Piola-Kirchhoff stress
    *
-   * @note This method must be called prior to completeSetup()
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
   void setMaterial(DependsOn<active_parameters...>, const MaterialType& material, Domain& domain,
@@ -142,8 +102,8 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
     MaterialStressFunctor<MaterialType> material_functor(material);
-    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<0, 2, active_parameters + NUM_STATE_VARS...>{},
-                                 std::move(material_functor), domain, qdata);
+    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<0, 2, active_parameters + NUM_STATE_VARS...>{},
+                                                std::move(material_functor), domain, qdata);
   }
 
   /// @overload
@@ -176,7 +136,6 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
    * @pre MaterialType must have a public method `density` which can take FiniteElementState parameter inputs
    * @pre MaterialType must have a public method 'pkStress' which returns the first Piola-Kirchhoff stress
    *
-   * @note This method must be called prior to completeSetup()
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
   void setRateMaterial(DependsOn<active_parameters...>, const MaterialType& material, Domain& domain,
@@ -185,7 +144,7 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
     RateMaterialStressFunctor<MaterialType> material_functor(material);
-    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<0, 1, 2, active_parameters + NUM_STATE_VARS...>{},
+    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<0, 1, 2, active_parameters + NUM_STATE_VARS...>{},
                                  std::move(material_functor), domain, qdata);
   }
 
@@ -197,130 +156,16 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
   }
 
   /**
-   * @brief Functor representing a body force integrand.  A functor is necessary instead
-   * of an extended, generic lambda for compatibility with NVCC.
-   */
-  template <typename VolumeIntegralType>
-  struct BodyForceIntegrand {
-    /// @brief Body force model
-    BodyForceType body_force_;
-    /// @brief Constructor for the functor
-    BodyForceIntegrand(BodyForceType body_force) : body_force_(body_force) {}
-
-    /**
-     * @brief Body force call
-     *
-     * @tparam T temperature
-     * @tparam Position Spatial position type
-     * @tparam Displacement displacement
-     * @tparam Velocity displacement
-     * @tparam Acceleration acceleration
-     * @tparam Params variadic parameters for call
-     * @param[in] t temperature
-     * @param[in] position position
-     * @param[in] params parameter pack
-     * @return The calculated material response (tuple of volumetric heat capacity and thermal flux) for a linear
-     * isotropic material
-     */
-    template <typename T, typename Position, typename Displacement, typename Velocity, typename Acceleration,
-              typename... Params>
-    auto SERAC_HOST_DEVICE operator()(T t, Position position, Displacement, Velocity, Acceleration,
-                                      Params... params) const
-    {
-      return serac::tuple{-1.0 * body_force_(get<VALUE>(position), t, params...), zero{}};
-    }
-  };
-
-  /**
-   * @brief Set the body forcefunction
-   *
-   * @tparam BodyForceType The type of the body force load
-   * @param body_force A function describing the body force applied
-   * @param optional_domain The domain over which the body force is applied. If nothing is supplied the entire domain is
-   * used.
-   * @pre body_force must be a object that can be called with the following arguments:
-   *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
-   *    2. `double t` the time (note: time will be handled differently in the future)
-   *    3. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative),
-   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument.
-   * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
-   *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
-   * 3>`)
-   *
-   * @note This method must be called prior to completeSetup()
-   */
-  template <int... active_parameters, typename VolumeIntegralType>
-  void addBodyForce(DependsOn<active_parameters...>, BodyForceType body_force,
-                    const std::optional<Domain>& optional_domain = std::nullopt)
-  {
-    Domain domain = (optional_domain) ? *optional_domain : EntireDomain(mesh_);
-    residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<0, 1, 2, active_parameters + NUM_STATE_VARS...>{},
-                                 BodyForceIntegrand<BodyForceType>(body_force), domain);
-  }
-
-  /// @overload
-  template <typename BodyForceType>
-  void addBodyForce(BodyForceType body_force, const std::optional<Domain>& optional_domain = std::nullopt)
-  {
-    addBodyForce(DependsOn<>{}, body_force, optional_domain);
-  }
-
-  /**
-   * @brief Set the traction boundary condition
-   *
-   * @tparam TractionType The type of the traction load
-   * @param traction_function A function describing the traction applied to a boundary
-   * @param optional_domain The domain over which the traction is applied. If nothing is supplied the entire boundary is
-   * used.
-   * @pre TractionType must be a object that can be called with the following arguments:
-   *    1. `tensor<T,dim> x` the spatial coordinates for the quadrature point
-   *    2. `tensor<T,dim> n` the outward-facing unit normal for the quadrature point
-   *    3. `double t` the time (note: time will be handled differently in the future)
-   *    4. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative),
-   *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument.
-   *
-   * @note The actual types of these arguments passed will be `double`, `tensor<double, ... >` or tuples thereof
-   *    when doing direct evaluation. When differentiating with respect to one of the inputs, its stored
-   *    values will change to `dual` numbers rather than `double`. (e.g. `tensor<double,3>` becomes `tensor<dual<...>,
-   * 3>`)
-   *
-   * @note This traction is applied in the reference (undeformed) configuration.
-   *
-   * @note This method must be called prior to completeSetup()
-   */
-  template <int... active_parameters, typename TractionType>
-  void setTraction(DependsOn<active_parameters...>, TractionType traction_function,
-                   const std::optional<Domain>& optional_domain = std::nullopt)
-  {
-    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_);
-
-    residual_->AddBoundaryIntegral(
-        Dimension<dim - 1>{}, DependsOn<0, active_parameters + NUM_FIELD_OFFSET...>{},
-        [traction_function](double t, auto X, auto /* displacement */, auto... params) {
-          auto n = cross(get<DERIVATIVE>(X));
-          return -1.0 * traction_function(get<VALUE>(X), normalize(n), t, params...);
-        },
-        domain);
-  }
-
-  /// @overload
-  template <typename TractionType>
-  void setTraction(TractionType traction_function, const std::optional<Domain>& optional_domain = std::nullopt)
-  {
-    setTraction(DependsOn<>{}, traction_function, optional_domain);
-  }
-
-  /**
    * @brief Set the pressure boundary condition
    *
+   * @tparam active_parameters the indices for active non-state params (i.e., indexing starts just after disp, velo, or accel)
    * @tparam PressureType The type of the pressure load
    * @param pressure_function A function describing the pressure applied to a boundary
    * @param optional_domain The domain over which the pressure is applied. If nothing is supplied the entire boundary is
    * used.
    * @pre PressureType must be a object that can be called with the following arguments:
-   *    1. `tensor<T,dim> x` the reference configuration spatial coordinates for the quadrature point
-   *    2. `double t` the time (note: time will be handled differently in the future)
+   *    1. `double t` the time (note: time will be handled differently in the future)
+   *    2. `tensor<T,dim> x` the reference configuration spatial coordinates for the quadrature point
    *    3. `tuple{value, derivative}`, a variadic list of tuples (each with a values and derivative),
    *            one tuple for each of the trial spaces specified in the `DependsOn<...>` argument.
    *
@@ -330,17 +175,15 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
    * 3>`)
    *
    * @note This pressure is applied in the deformed (current) configuration if GeometricNonlinearities are on.
-   *
-   * @note This method must be called prior to completeSetup()
    */
   template <int... active_parameters, typename PressureType>
-  void setPressure(DependsOn<active_parameters...>, PressureType pressure_function,
+  void addPressure(DependsOn<active_parameters...>, PressureType pressure_function,
                    const std::optional<Domain>& optional_domain = std::nullopt)
   {
-    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(mesh_);
+    Domain domain = (optional_domain) ? *optional_domain : EntireBoundary(BaseResidualT::mesh_);
 
-    residual_->AddBoundaryIntegral(
-        Dimension<dim - 1>{}, DependsOn<0, active_parameters + NUM_FIELD_OFFSET...>{},
+    BaseResidualT::residual_->AddBoundaryIntegral(
+        Dimension<dim - 1>{}, DependsOn<0, active_parameters + NUM_STATE_VARS...>{},
         [pressure_function](double t, auto X, auto displacement, auto... params) {
           // Calculate the position and normal in the shape perturbed deformed configuration
           auto x = X + 0.0 * displacement;
@@ -361,132 +204,19 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
           // = pressure * (normal_new / norm(normal_old)) * w_old
 
           // We always query the pressure function in the undeformed configuration
-          return pressure_function(get<VALUE>(X), t, params...) * (n / norm(cross(get<DERIVATIVE>(X))));
+          return pressure_function(t, get<VALUE>(X), params...) * (n / norm(cross(get<DERIVATIVE>(X))));
         },
         domain);
   }
 
   /// @overload
   template <typename PressureType>
-  void setPressure(PressureType pressure_function, const std::optional<Domain>& optional_domain = std::nullopt)
+  void addPressure(PressureType pressure_function, const std::optional<Domain>& optional_domain = std::nullopt)
   {
-    setPressure(DependsOn<>{}, pressure_function, optional_domain);
-  }
-
-  /// @overload
-  mfem::Vector residual(double time, const std::vector<FieldPtr>& fields, int block_row = 0) const override
-  {
-    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
-    auto& disp = *fields[0];
-    auto& velo = *fields[1];
-    auto& acceleration = *fields[2];
-    auto& shape_disp = *fields[3];
-    return (*residual_)(time, shape_disp, disp, velo, acceleration, *fields[parameter_indices + NUM_FIELD_OFFSET]...);
-  }
-
-  /// @overload
-  std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, const std::vector<FieldPtr>& fields,
-                                                 const std::vector<double>& jacobian_weights,
-                                                 int block_row = 0) const override
-  {
-    SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for SolidResidual");
-
-    std::unique_ptr<mfem::HypreParMatrix> J;
-
-    auto addToJ = [&J](double factor, std::unique_ptr<mfem::HypreParMatrix> jac_contrib) {
-      if (J) {
-        SLIC_ERROR_IF(J->N() != jac_contrib->N(),
-                      "Multiple nonzero jacobian weights are being used on inconsistently sized input arguments.");
-        SLIC_ERROR_IF(J->M() != jac_contrib->M(),
-                      "Multiple nonzero jacobian weights are being used on inconsistently sized input arguments.");
-        J->Add(factor, *jac_contrib);
-      } else {
-        J.reset(jac_contrib.release());
-        if (factor != 1.0) (*J) *= factor;
-      }
-    };
-
-    auto fields_in_residual_order = reorder_fields(fields);
-    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + NUM_FIELD_OFFSET>{},
-                                  time, fields_in_residual_order);
-
-    for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
-      if (jacobian_weights[input_col] != 0.0) {
-        auto K = serac::get<DERIVATIVE>(jacs[residual_index(input_col)](time, fields_in_residual_order));
-        addToJ(jacobian_weights[input_col], assemble(K));
-      }
-    }
-
-    return J;
-  }
-
-  /// @overload
-  void jvp([[maybe_unused]] double time, [[maybe_unused]] const std::vector<FieldPtr>& fields,
-           [[maybe_unused]] const std::vector<FieldPtr>& vFields,
-           [[maybe_unused]] std::vector<DualFieldPtr>& jvpReactions) const override
-  {
-    SLIC_ERROR_IF(vFields.size() != fields.size(),
-                  "Invalid number of field sensitivities relative to the number of fields");
-    SLIC_ERROR_IF(jvpReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
-
-    auto fields_in_residual_order = reorder_fields(fields);
-    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + NUM_FIELD_OFFSET>{},
-                                  time, fields_in_residual_order);
-
-    *jvpReactions[0] = 0.0;
-    serac::FiniteElementDual tmp = *jvpReactions[0];
-
-    for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
-      if (vFields[input_col] != nullptr) {
-        auto K = serac::get<DERIVATIVE>(jacs[residual_index(input_col)](time, fields_in_residual_order));
-        tmp = 0.0;
-        K.Mult(*vFields[input_col], tmp);
-        *jvpReactions[0] += tmp;
-      }
-    }
-    return;
-  }
-
-  /// @overload
-  void vjp([[maybe_unused]] double time, [[maybe_unused]] const std::vector<FieldPtr>& fields,
-           [[maybe_unused]] const std::vector<DualFieldPtr>& vReactions,
-           [[maybe_unused]] std::vector<FieldPtr>& vjpFields) const override
-  {
-    SLIC_ERROR_IF(vjpFields.size() != fields.size(),
-                  "Invalid number of field sensitivities relative to the number of fields");
-    SLIC_ERROR_IF(vReactions.size() != 1, "Solid mechanics nonlinear system only supports 1 output residual");
-
-    auto fields_in_residual_order = reorder_fields(fields);
-    auto jacs = jacobianFunctions(std::make_integer_sequence<int, sizeof...(parameter_indices) + NUM_FIELD_OFFSET>{},
-                                  time, fields_in_residual_order);
-
-    for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
-      auto K = serac::get<DERIVATIVE>(jacs[residual_index(input_col)](time, fields_in_residual_order));
-      std::unique_ptr<mfem::HypreParMatrix> J = assemble(K);
-      J->MultTranspose(1.0, *vReactions[0], 1.0, *vjpFields[input_col]);
-    }
-
-    return;
+    addPressure(DependsOn<>{}, pressure_function, optional_domain);
   }
 
  private:
-  /// @brief Utility to evaluate residual using all fields in vector
-  template <int... i>
-  auto evaluateResidual(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
-  {
-    return (*residual_)(time, *fs[i]...);
-  };
-
-  /// @brief Utility to get array of jacobian functions, one for each input field in fs
-  template <int... i>
-  auto jacobianFunctions(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
-  {
-    using JacFuncType = std::function<decltype((*residual_)(DifferentiateWRT<1>{}, time, *fs[i]...))(
-        double, const std::vector<FieldPtr>&)>;
-    return std::array<JacFuncType, sizeof...(i)>{[=](double _time, const std::vector<FieldPtr>& _fs) {
-      return (*residual_)(DifferentiateWRT<i>{}, _time, *_fs[i]...);
-    }...};
-  };
 
   /**
    * @brief Functor representing a material stress.  A functor is used here instead of an
@@ -571,39 +301,6 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
     }
   };
 
-  /// convert between the input argument order and the argument order expected by the residual call
-  /// here we go from u, v, a, shape_u to shape_u, u, v, a
-  static constexpr std::array<size_t, 4> input_to_residual_index_map{1, 2, 3, 0};
-
-  /// @brief reorder fields from input into residual order
-  std::vector<FieldPtr> reorder_fields(const std::vector<FieldPtr>& fields) const
-  {
-    std::vector<FieldPtr> residual_fields = fields;
-    for (size_t input_col = 0; input_col < input_to_residual_index_map.size(); ++input_col) {
-      size_t res_index = input_to_residual_index_map[input_col];
-      residual_fields[res_index] = fields[input_col];
-    }
-    return residual_fields;
-  }
-
-  /// @brief convert from input ordering to ordering expected by shapeAwareFunctional
-  constexpr size_t residual_index(size_t input_index) const
-  {
-    return input_index < input_to_residual_index_map.size() ? input_to_residual_index_map[input_index] : input_index;
-  }
-
-  using trial = H1<order, dim>;        /// typedef
-  using test = H1<order, dim>;         /// typedef
-  using shape_trial = H1<order, dim>;  /// typedef
-
-  /// @brief string tag for the mesh
-  std::string mesh_tag_;
-
-  /// @brief primary mesh
-  mfem::ParMesh& mesh_;
-
-  /// @brief functional
-  std::unique_ptr<ShapeAwareFunctional<shape_trial, test(trial, trial, trial, parameter_space...)>> residual_;
 };
 
 /**
@@ -612,18 +309,17 @@ class SolidResidual<order, dim, Parameters<parameter_space...>, std::integer_seq
 template <int order, int dim, typename... parameter_space>
 auto create_solid_residual(const std::string& physics_name, const serac::Mesh& mesh,
                            const std::vector<serac::FiniteElementState*>& states,
-                           const std::vector<serac::FiniteElementState*>& params,
-                           const std::vector<std::string>& parameter_names)
+                           const std::vector<serac::FiniteElementState*>& params)
 {
   std::vector<const mfem::ParFiniteElementSpace*> parameter_fe_spaces;
   if constexpr (sizeof...(parameter_space) > 0) {
-    for_constexpr<sizeof...(parameter_space)>([&](auto) { parameter_fe_spaces.push_back(&params.back()->space()); });
+    for_constexpr<sizeof...(parameter_space)>([&](auto i) { parameter_fe_spaces.push_back(&params[i+1]->space()); });
   }
 
   using ResidualT = SolidResidual<order, dim, Parameters<parameter_space...>>;
 
-  return std::make_shared<ResidualT>(physics_name, mesh.tag(), states[3]->space(), states[0]->space(),
-                                     parameter_fe_spaces, parameter_names);
+  return std::make_shared<ResidualT>(physics_name, mesh.tag(), params[0]->space(), states[0]->space(),
+                                     parameter_fe_spaces);
 }
 
 }  // namespace serac

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -31,11 +31,11 @@ class SolidResidual;
  */
 template <int order, int dim, typename... InputSpaces>
 class SolidResidual<order, dim, Parameters<InputSpaces...>>
-    : public FunctionalResidual<H1<order, dim>, H1<order, dim>,
+    : public FunctionalResidual<dim, H1<order, dim>, H1<order, dim>,
                                 Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, InputSpaces...>> {
  public:
   /// @brief typedef for underlying functional type with templates
-  using BaseResidualT = FunctionalResidual<H1<order, dim>, H1<order, dim>,
+  using BaseResidualT = FunctionalResidual<dim, H1<order, dim>, H1<order, dim>,
                                            Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, InputSpaces...>>;
 
   /// @brief a container holding quadrature point data of the specified type
@@ -309,23 +309,5 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
     }
   };
 };
-
-/**
- * @brief Utility function for creating a shared_ptr<SolidResidual<>>
- */
-template <int order, int dim, typename... InputSpaces>
-auto create_solid_residual(const std::string& physics_name, std::shared_ptr<serac::Mesh> mesh,
-                           const std::vector<serac::FiniteElementState*>& states,
-                           const std::vector<serac::FiniteElementState*>& params)
-{
-  std::vector<const mfem::ParFiniteElementSpace*> parameter_fe_spaces;
-  if constexpr (sizeof...(InputSpaces) > 0) {
-    for_constexpr<sizeof...(InputSpaces)>([&](auto i) { parameter_fe_spaces.push_back(&params[i + 1]->space()); });
-  }
-
-  using ResidualT = SolidResidual<order, dim, Parameters<InputSpaces...>>;
-
-  return std::make_shared<ResidualT>(physics_name, mesh, params[0]->space(), states[0]->space(), parameter_fe_spaces);
-}
 
 }  // namespace serac

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -17,7 +17,7 @@
 
 namespace serac {
 
-template <int order, int dim, typename parameters = Parameters<>>
+template <int order, int dim, typename InputSpaces = Parameters<>>
 class SolidResidual;
 
 /**
@@ -29,15 +29,15 @@ class SolidResidual;
  * @tparam order The order of the discretization of the displacement and velocity fields
  * @tparam dim The spatial dimension of the mesh
  */
-template <int order, int dim, typename... parameter_space>
-class SolidResidual<order, dim, Parameters<parameter_space...>>
+template <int order, int dim, typename... InputSpaces>
+class SolidResidual<order, dim, Parameters<InputSpaces...>>
     : public FunctionalResidual<H1<order, dim>, H1<order, dim>,
-                                Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, parameter_space...>> {
+                                Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, InputSpaces...>> {
  public:
   /// @brief typedef for underlying functional type with templates
   using BaseResidualT =
       FunctionalResidual<H1<order, dim>, H1<order, dim>,
-                         Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, parameter_space...>>;
+                         Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, InputSpaces...>>;
 
   /// @brief a container holding quadrature point data of the specified type
   /// @tparam T the type of data to store at each quadrature point
@@ -317,17 +317,17 @@ class SolidResidual<order, dim, Parameters<parameter_space...>>
 /**
  * @brief Utility function for creating a shared_ptr<SolidResidual<>>
  */
-template <int order, int dim, typename... parameter_space>
+template <int order, int dim, typename... InputSpaces>
 auto create_solid_residual(const std::string& physics_name, std::shared_ptr<serac::Mesh> mesh,
                            const std::vector<serac::FiniteElementState*>& states,
                            const std::vector<serac::FiniteElementState*>& params)
 {
   std::vector<const mfem::ParFiniteElementSpace*> parameter_fe_spaces;
-  if constexpr (sizeof...(parameter_space) > 0) {
-    for_constexpr<sizeof...(parameter_space)>([&](auto i) { parameter_fe_spaces.push_back(&params[i + 1]->space()); });
+  if constexpr (sizeof...(InputSpaces) > 0) {
+    for_constexpr<sizeof...(InputSpaces)>([&](auto i) { parameter_fe_spaces.push_back(&params[i + 1]->space()); });
   }
 
-  using ResidualT = SolidResidual<order, dim, Parameters<parameter_space...>>;
+  using ResidualT = SolidResidual<order, dim, Parameters<InputSpaces...>>;
 
   return std::make_shared<ResidualT>(physics_name, mesh, params[0]->space(), states[0]->space(), parameter_fe_spaces);
 }

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -88,22 +88,23 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
    *
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
-  void setMaterial(DependsOn<active_parameters...>, const MaterialType& material, Domain& domain,
+  void setMaterial(DependsOn<active_parameters...>, std::string body_name, const MaterialType& material,
                    qdata_type<StateType> qdata = EmptyQData)
   {
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
     MaterialStressFunctor<MaterialType> material_functor(material);
-    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{},
-                                                DependsOn<0, 2, active_parameters + NUM_STATE_VARS...>{},
-                                                std::move(material_functor), domain, qdata);
+    BaseResidualT::residual_->AddDomainIntegral(
+        Dimension<dim>{}, DependsOn<0, 2, active_parameters + NUM_STATE_VARS...>{}, std::move(material_functor),
+        BaseResidualT::mesh_->domain(body_name), qdata);
   }
 
   /// @overload
   template <typename MaterialType, typename StateType = Empty>
-  void setMaterial(const MaterialType& material, std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
+  void setMaterial(std::string body_name, const MaterialType& material,
+                   std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
-    setMaterial(DependsOn<>{}, material, qdata);
+    setMaterial(DependsOn<>{}, body_name, material, qdata);
   }
 
   /**
@@ -131,22 +132,23 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
    *
    */
   template <int... active_parameters, typename MaterialType, typename StateType = Empty>
-  void setRateMaterial(DependsOn<active_parameters...>, const MaterialType& material, Domain& domain,
+  void setRateMaterial(DependsOn<active_parameters...>, std::string body_name, const MaterialType& material,
                        qdata_type<StateType> qdata = EmptyQData)
   {
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
-    RateMaterialStressFunctor<MaterialType> material_functor(material);
-    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{},
-                                                DependsOn<0, 1, 2, active_parameters + NUM_STATE_VARS...>{},
-                                                std::move(material_functor), domain, qdata);
+    RateMaterialStressFunctor<MaterialType> material_functor(material, &this->dt_);
+    BaseResidualT::residual_->AddDomainIntegral(
+        Dimension<dim>{}, DependsOn<0, 1, 2, active_parameters + NUM_STATE_VARS...>{}, std::move(material_functor),
+        BaseResidualT::mesh_->domain(body_name), qdata);
   }
 
   /// @overload
   template <typename MaterialType, typename StateType = Empty>
-  void setRateMaterial(const MaterialType& material, std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
+  void setRateMaterial(std::string body_name, const MaterialType& material,
+                       std::shared_ptr<QuadratureData<StateType>> qdata = EmptyQData)
   {
-    setRateMaterial(DependsOn<>{}, material, qdata);
+    setRateMaterial(DependsOn<>{}, body_name, material, qdata);
   }
 
   /**
@@ -271,10 +273,13 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
   template <typename Material>
   struct RateMaterialStressFunctor {
     /// Constructor for the functor
-    RateMaterialStressFunctor(Material material) : material_(material) {}
+    RateMaterialStressFunctor(Material material, const double* dt) : material_(material), dt_(dt) {}
 
     /// Material model
     Material material_;
+
+    /// Time step
+    const double* dt_;
 
     /**
      * @brief Material stress response call
@@ -285,7 +290,6 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
      * @tparam Velocity velocity
      * @tparam Acceleration acceleration
      * @tparam Params variadic parameters for call
-     * @param[in] dt time step
      * @param[in] state state
      * @param[in] displacement displacement
      * @param[in] velocity velocity
@@ -296,14 +300,14 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
      */
     template <typename X, typename State, typename Displacement, typename Velocity, typename Acceleration,
               typename... Params>
-    auto SERAC_HOST_DEVICE operator()(double dt, X, State& state, Displacement displacement, Velocity velocity,
+    auto SERAC_HOST_DEVICE operator()(double /*t*/, X, State& state, Displacement displacement, Velocity velocity,
                                       Acceleration acceleration, Params... params) const
     {
       auto du_dX = get<DERIVATIVE>(displacement);
       auto dv_dX = get<DERIVATIVE>(velocity);
       auto d2u_dt2 = get<VALUE>(acceleration);
 
-      auto stress = material_.pkStress(dt, state, du_dX, dv_dX, params...);
+      auto stress = material_.pkStress(*dt_, state, du_dX, dv_dX, params...);
 
       return serac::tuple{material_.density(params...) * d2u_dt2, stress};
     }

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -12,9 +12,7 @@
 
 #pragma once
 
-#include "serac/physics/residual.hpp"
 #include "serac/physics/functional_residual.hpp"
-#include "serac/physics/mesh.hpp"
 #include "serac/physics/state/state_manager.hpp"
 
 namespace serac {
@@ -33,41 +31,36 @@ class SolidResidual;
  */
 template <int order, int dim, typename... parameter_space>
 class SolidResidual<order, dim, Parameters<parameter_space...>>
-    : public FunctionalResidual< H1<order,dim>, H1<order,dim>, Parameters< H1<order,dim>, H1<order,dim>, H1<order,dim>, parameter_space...> > {
+    : public FunctionalResidual<H1<order, dim>, H1<order, dim>,
+                                Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, parameter_space...>> {
  public:
-
-  using BaseResidualT = FunctionalResidual< H1<order,dim>, H1<order,dim>, Parameters< H1<order,dim>, H1<order,dim>, H1<order,dim>, parameter_space...> >;
+  /// @brief typedef for underlying functional type with templates
+  using BaseResidualT =
+      FunctionalResidual<H1<order, dim>, H1<order, dim>,
+                         Parameters<H1<order, dim>, H1<order, dim>, H1<order, dim>, parameter_space...>>;
 
   /// @brief a container holding quadrature point data of the specified type
   /// @tparam T the type of data to store at each quadrature point
   template <typename T>
   using qdata_type = std::shared_ptr<QuadratureData<T>>;
 
+  /// @brief disp, velo, accel
   static constexpr int NUM_STATE_VARS = 3;
-
-  std::vector<const mfem::ParFiniteElementSpace*> constructAllSpaces(const mfem::ParFiniteElementSpace& state_space, 
-                                                                     const std::vector<const mfem::ParFiniteElementSpace*>& spaces)
-  {
-    std::vector<const mfem::ParFiniteElementSpace*> all_spaces{&state_space, &state_space, &state_space};
-    for (auto& s : spaces) {
-      all_spaces.push_back(s);
-    }
-    return all_spaces;
-  }
 
   /**
    * @brief Construct a new SolidResidual object
    *
    * @param physics_name A name for the physics module instance
-   * @param mesh_tag The tag for the mesh in the StateManager to construct the physics module on
+   * @param mesh The serac Mesh
    * @param shape_disp_space Shape displacement space
    * @param test_space Test space
    * @param parameter_fe_spaces Vector of parameters spaces
    */
-  SolidResidual(std::string physics_name, std::string mesh_tag, const mfem::ParFiniteElementSpace& shape_disp_space,
-                const mfem::ParFiniteElementSpace& test_space,
+  SolidResidual(std::string physics_name, std::shared_ptr<Mesh> mesh,
+                const mfem::ParFiniteElementSpace& shape_disp_space, const mfem::ParFiniteElementSpace& test_space,
                 std::vector<const mfem::ParFiniteElementSpace*> parameter_fe_spaces = {})
-      : BaseResidualT(physics_name, mesh_tag, shape_disp_space, test_space, constructAllSpaces(test_space, parameter_fe_spaces))
+      : BaseResidualT(physics_name, mesh, shape_disp_space, test_space,
+                      constructAllSpaces(test_space, parameter_fe_spaces))
   {
   }
 
@@ -102,7 +95,8 @@ class SolidResidual<order, dim, Parameters<parameter_space...>>
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
     MaterialStressFunctor<MaterialType> material_functor(material);
-    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<0, 2, active_parameters + NUM_STATE_VARS...>{},
+    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{},
+                                                DependsOn<0, 2, active_parameters + NUM_STATE_VARS...>{},
                                                 std::move(material_functor), domain, qdata);
   }
 
@@ -144,8 +138,9 @@ class SolidResidual<order, dim, Parameters<parameter_space...>>
     static_assert(std::is_same_v<StateType, Empty> || std::is_same_v<StateType, typename MaterialType::State>,
                   "invalid quadrature data provided in setMaterial()");
     RateMaterialStressFunctor<MaterialType> material_functor(material);
-    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{}, DependsOn<0, 1, 2, active_parameters + NUM_STATE_VARS...>{},
-                                 std::move(material_functor), domain, qdata);
+    BaseResidualT::residual_->AddDomainIntegral(Dimension<dim>{},
+                                                DependsOn<0, 1, 2, active_parameters + NUM_STATE_VARS...>{},
+                                                std::move(material_functor), domain, qdata);
   }
 
   /// @overload
@@ -158,7 +153,8 @@ class SolidResidual<order, dim, Parameters<parameter_space...>>
   /**
    * @brief Set the pressure boundary condition
    *
-   * @tparam active_parameters the indices for active non-state params (i.e., indexing starts just after disp, velo, or accel)
+   * @tparam active_parameters the indices for active non-state params (i.e., indexing starts just after disp, velo, or
+   * accel)
    * @tparam PressureType The type of the pressure load
    * @param pressure_function A function describing the pressure applied to a boundary
    * @param optional_domain The domain over which the pressure is applied. If nothing is supplied the entire boundary is
@@ -216,7 +212,21 @@ class SolidResidual<order, dim, Parameters<parameter_space...>>
     addPressure(DependsOn<>{}, pressure_function, optional_domain);
   }
 
- private:
+ protected:
+  /// @brief For use in the constructor, combined the correct number of state spaces (disp,velo,accel) with the vector
+  /// of parameters
+  /// @param state_space H1<order,dim> displacement space
+  /// @param spaces parameter spaces
+  /// @return
+  std::vector<const mfem::ParFiniteElementSpace*> constructAllSpaces(
+      const mfem::ParFiniteElementSpace& state_space, const std::vector<const mfem::ParFiniteElementSpace*>& spaces)
+  {
+    std::vector<const mfem::ParFiniteElementSpace*> all_spaces{&state_space, &state_space, &state_space};
+    for (auto& s : spaces) {
+      all_spaces.push_back(s);
+    }
+    return all_spaces;
+  }
 
   /**
    * @brief Functor representing a material stress.  A functor is used here instead of an
@@ -279,8 +289,10 @@ class SolidResidual<order, dim, Parameters<parameter_space...>>
      * @tparam Velocity velocity
      * @tparam Acceleration acceleration
      * @tparam Params variadic parameters for call
+     * @param[in] dt time step
      * @param[in] state state
      * @param[in] displacement displacement
+     * @param[in] velocity velocity
      * @param[in] acceleration acceleration
      * @param[in] params parameter pack
      * @return The calculated material response (tuple of volumetric heat capacity and thermal flux) for a linear
@@ -300,26 +312,24 @@ class SolidResidual<order, dim, Parameters<parameter_space...>>
       return serac::tuple{material_.density(params...) * d2u_dt2, stress};
     }
   };
-
 };
 
 /**
  * @brief Utility function for creating a shared_ptr<SolidResidual<>>
  */
 template <int order, int dim, typename... parameter_space>
-auto create_solid_residual(const std::string& physics_name, const serac::Mesh& mesh,
+auto create_solid_residual(const std::string& physics_name, std::shared_ptr<serac::Mesh> mesh,
                            const std::vector<serac::FiniteElementState*>& states,
                            const std::vector<serac::FiniteElementState*>& params)
 {
   std::vector<const mfem::ParFiniteElementSpace*> parameter_fe_spaces;
   if constexpr (sizeof...(parameter_space) > 0) {
-    for_constexpr<sizeof...(parameter_space)>([&](auto i) { parameter_fe_spaces.push_back(&params[i+1]->space()); });
+    for_constexpr<sizeof...(parameter_space)>([&](auto i) { parameter_fe_spaces.push_back(&params[i + 1]->space()); });
   }
 
   using ResidualT = SolidResidual<order, dim, Parameters<parameter_space...>>;
 
-  return std::make_shared<ResidualT>(physics_name, mesh.tag(), params[0]->space(), states[0]->space(),
-                                     parameter_fe_spaces);
+  return std::make_shared<ResidualT>(physics_name, mesh, params[0]->space(), states[0]->space(), parameter_fe_spaces);
 }
 
 }  // namespace serac

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2024, Lawrence Livermore National Security, LLC and
+// Copyright (c) 2019-2025, Lawrence Livermore National Security, LLC and
 // other Serac Project Developers. See the top-level LICENSE file for
 // details.
 //
@@ -7,7 +7,8 @@
 /**
  * @file solid_residual.hpp
  *
- * @brief Implement the residual interface for solid mechanics physics
+ * @brief Implements the residual interface for solid mechanics physics.
+ * Derives from functional_residual.
  */
 
 #pragma once

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -13,7 +13,6 @@
 #pragma once
 
 #include "serac/physics/functional_residual.hpp"
-#include "serac/physics/state/state_manager.hpp"
 
 namespace serac {
 

--- a/src/serac/physics/tests/CMakeLists.txt
+++ b/src/serac/physics/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ set(physics_serial_test_sources
     finite_element_vector_set_over_domain.cpp
     solid_multi_material.cpp
     test_solid_residual.cpp
+    test_functional_residual.cpp
     thermomech_finite_diff.cpp
     thermomech_statics_patch.cpp
     )

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -6,35 +6,27 @@
 
 #include <gtest/gtest.h>
 #include "mfem.hpp"
-#include "serac/infrastructure/application_manager.hpp"
+#include "serac/infrastructure/initialize.hpp"
+#include "serac/infrastructure/terminator.hpp"
 #include "serac/mesh/mesh_utils.hpp"
-#include "serac/physics/materials/solid_material.hpp"
 #include "serac/physics/mesh.hpp"
 #include "serac/physics/common.hpp"
 
-#include "serac/physics/solid_residual.hpp"
+#include "serac/physics/functional_residual.hpp"
 
 auto element_shape = mfem::Element::QUADRILATERAL;
 
 template <typename T>
-auto getPointers(std::vector<T>& values)
-{
-  std::vector<T*> pointers;
-  for (auto& t : values) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
 auto getPointers(std::vector<T>& states, std::vector<T>& params)
 {
-  std::vector<T*> pointers;
+  assert(params.size()>0);
+
+  std::vector<T*> pointers{&params[0]};
   for (auto& t : states) {
     pointers.push_back(&t);
   }
-  for (auto& t : params) {
-    pointers.push_back(&t);
+  for (size_t n=1; n < params.size(); ++n) {
+    pointers.push_back(&params[n]);
   }
   return pointers;
 }
@@ -68,7 +60,15 @@ struct ResidualFixture : public testing::Test {
   using VectorSpace = serac::H1<disp_order, dim>;
   using DensitySpace = serac::L2<disp_order - 1>;
 
-  using SolidMaterial = serac::solid_mechanics::NeoHookeanWithFieldDensity;
+  enum STATE {
+    DISP,
+    VELO
+  };
+
+  enum PAR {
+    SHAPE,
+    DENSITY
+  };
 
   void SetUp()
   {
@@ -82,13 +82,12 @@ struct ResidualFixture : public testing::Test {
 
     serac::FiniteElementState disp = serac::StateManager::newState(VectorSpace{}, "displacement", mesh->tag());
     serac::FiniteElementState velo = serac::StateManager::newState(VectorSpace{}, "velocity", mesh->tag());
-    serac::FiniteElementState accel = serac::StateManager::newState(VectorSpace{}, "acceleration", mesh->tag());
     serac::FiniteElementState shape_disp =
         serac::StateManager::newState(VectorSpace{}, "shape_displacement", mesh->tag());
     serac::FiniteElementState density = serac::StateManager::newState(DensitySpace{}, "density", mesh->tag());
 
-    states = {disp, velo, accel, shape_disp};
-    params = {density};
+    states = {disp, velo};
+    params = {shape_disp, density};
 
     dual_states = states;
     dual_params = params;
@@ -96,26 +95,26 @@ struct ResidualFixture : public testing::Test {
     v_rhs_states = states;
     v_rhs_params = params;
 
-    std::vector<std::string> param_names{"density"};
-    std::string physics_name = "solid";
+    std::string physics_name = "fake_physics";
 
-    auto solid_mechanics_residual = serac::create_solid_residual<disp_order, dim, DensitySpace>(
-        physics_name, *mesh, getPointers(states), getPointers(params), param_names);
+    using TrialSpace = VectorSpace;
+    using ShapeSpace = VectorSpace;
 
-    // setup material model
+    using ResidualT =
+        serac::FunctionalResidual<ShapeSpace, TrialSpace, serac::Parameters<VectorSpace, VectorSpace, DensitySpace>>;
 
-    SolidMaterial mat;
-    mat.K = 1.0;
-    mat.G = 0.5;
-    solid_mechanics_residual->setMaterial(serac::DependsOn<0>{}, mat, mesh->entireDomain());
+    auto f_residual = std::make_shared<ResidualT>(physics_name, mesh->tag(), params[PAR::SHAPE].space(), states[STATE::DISP].space(),
+                                                  std::vector<const serac::FiniteElementState*>{&states[STATE::DISP], &states[STATE::DISP], &params[PAR::DENSITY]});
 
     // apply some traction boundary conditions
 
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    solid_mechanics_residual->setTraction([](auto /*x*/, auto n, auto /*t*/) { return -1.0 * n; },
-                                          mesh->domain(surface_name));
+    f_residual->addSurfaceIntegral([](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; }, mesh->domain(surface_name));
+    f_residual->addBodyIntegral(serac::DependsOn<0>{}, [](double /*t*/, auto /*x*/, auto u) {
+      return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
+    }, mesh->entireDomain());
 
     // initialize fields for testing
 
@@ -126,21 +125,26 @@ struct ResidualFixture : public testing::Test {
       pseudoRand(p);
     }
 
-    dual_states[0] = 1.0;  // used to test that vjp acts via +=
+    dual_states[0] = 1.0;
+    dual_states[1] = 2.0;
+    dual_params[0] = 1.0;
+    dual_params[1] = 2.0;
 
     states[0].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = 0.1 * x;
       return u;
     });
 
-    states[2].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[1].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = -0.01 * x;
       return u;
     });
-    params[0] = 1.2;
+
+    params[0] = 0.0;
+    params[1] = 1.2;
 
     // residual is abstract Residual class to ensure usage only through BasePhysics interface
-    residual = solid_mechanics_residual;
+    residual = f_residual;
   }
 
   std::string velo_name = "solid_velocity";
@@ -166,6 +170,7 @@ TEST_F(ResidualFixture, VjpConsistency)
   auto all_states = getPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[0].space(), "residual");
+
   res_vector = residual->residual(time, all_states);
   ASSERT_NE(0.0, res_vector.Norml2());
 
@@ -180,15 +185,20 @@ TEST_F(ResidualFixture, VjpConsistency)
   pseudoRand(v);
   auto all_jvps = getPointers(dual_states, dual_params);
 
+  std::vector<serac::FiniteElementState> all_Jvps;
+  for (auto& jvp : all_jvps) {
+    all_Jvps.push_back(*jvp);
+  }
+
+  for (size_t i = 0; i < all_states.size(); ++i) {
+    serac::FiniteElementState& vjp = all_Jvps[i];
+    auto J = residual->jacobian(time, all_states, jacobian_weights(i));
+    J->AddMultTranspose(v, vjp);
+  }
   residual->vjp(time, all_states, getPointers(v), all_jvps);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
-    serac::FiniteElementState vjp = *all_states[i];
-    vjp = 0.0;
-    auto J = residual->jacobian(time, all_states, jacobian_weights(i));
-    J->MultTranspose(v, vjp);
-    if (i == 0) vjp += 1.0;  // make sure jvp uses +=
-    EXPECT_NEAR(vjp.Norml2(), all_jvps[i]->Norml2(), 1e-12);
+    EXPECT_NEAR(all_Jvps[i].Norml2(), all_jvps[i]->Norml2(), 1e-12);
   }
 }
 
@@ -254,6 +264,10 @@ TEST_F(ResidualFixture, JvpConsistency)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-  serac::ApplicationManager applicationManager(argc, argv);
-  return RUN_ALL_TESTS();
+
+  serac::initialize(argc, argv);
+  int result = RUN_ALL_TESTS();
+  serac::exitGracefully(result);
+
+  return result;
 }

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -6,8 +6,7 @@
 
 #include <gtest/gtest.h>
 #include "mfem.hpp"
-#include "serac/infrastructure/initialize.hpp"
-#include "serac/infrastructure/terminator.hpp"
+#include "serac/infrastructure/application_manager.hpp"
 #include "serac/mesh/mesh_utils.hpp"
 #include "serac/physics/mesh.hpp"
 #include "serac/physics/state/state_manager.hpp"
@@ -272,10 +271,6 @@ TEST_F(ResidualFixture, JvpConsistency)
 int main(int argc, char* argv[])
 {
   ::testing::InitGoogleTest(&argc, argv);
-
-  serac::initialize(argc, argv);
-  int result = RUN_ALL_TESTS();
-  serac::exitGracefully(result);
-
-  return result;
+  serac::ApplicationManager applicationManager(argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -19,13 +19,13 @@ auto element_shape = mfem::Element::QUADRILATERAL;
 template <typename T>
 auto getPointers(std::vector<T>& states, std::vector<T>& params)
 {
-  assert(params.size()>0);
+  assert(params.size() > 0);
 
   std::vector<T*> pointers{&params[0]};
   for (auto& t : states) {
     pointers.push_back(&t);
   }
-  for (size_t n=1; n < params.size(); ++n) {
+  for (size_t n = 1; n < params.size(); ++n) {
     pointers.push_back(&params[n]);
   }
   return pointers;
@@ -60,12 +60,14 @@ struct ResidualFixture : public testing::Test {
   using VectorSpace = serac::H1<disp_order, dim>;
   using DensitySpace = serac::L2<disp_order - 1>;
 
-  enum STATE {
+  enum STATE
+  {
     DISP,
     VELO
   };
 
-  enum PAR {
+  enum PAR
+  {
     SHAPE,
     DENSITY
   };
@@ -103,18 +105,24 @@ struct ResidualFixture : public testing::Test {
     using ResidualT =
         serac::FunctionalResidual<ShapeSpace, TrialSpace, serac::Parameters<VectorSpace, VectorSpace, DensitySpace>>;
 
-    auto f_residual = std::make_shared<ResidualT>(physics_name, mesh->tag(), params[PAR::SHAPE].space(), states[STATE::DISP].space(),
-                                                  std::vector<const serac::FiniteElementState*>{&states[STATE::DISP], &states[STATE::DISP], &params[PAR::DENSITY]});
+    auto f_residual =
+        std::make_shared<ResidualT>(physics_name, mesh->tag(), params[PAR::SHAPE].space(), states[STATE::DISP].space(),
+                                    std::vector<const serac::FiniteElementState*>{
+                                        &states[STATE::DISP], &states[STATE::DISP], &params[PAR::DENSITY]});
 
     // apply some traction boundary conditions
 
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    f_residual->addSurfaceIntegral([](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; }, mesh->domain(surface_name));
-    f_residual->addBodyIntegral(serac::DependsOn<0>{}, [](double /*t*/, auto /*x*/, auto u) {
-      return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
-    }, mesh->entireDomain());
+    f_residual->addSurfaceIntegral([](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; },
+                                   mesh->domain(surface_name));
+    f_residual->addBodyIntegral(
+        serac::DependsOn<0>{},
+        [](double /*t*/, auto /*x*/, auto u) {
+          return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
+        },
+        mesh->entireDomain());
 
     // initialize fields for testing
 

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -20,7 +20,6 @@ template <typename T>
 auto getPointers(std::vector<T>& states, std::vector<T>& params)
 {
   assert(params.size() > 0);
-
   std::vector<T*> pointers{&params[0]};
   for (auto& t : states) {
     pointers.push_back(&t);
@@ -107,8 +106,8 @@ struct ResidualFixture : public testing::Test {
 
     auto f_residual =
         std::make_shared<ResidualT>(physics_name, mesh->tag(), params[PAR::SHAPE].space(), states[STATE::DISP].space(),
-                                    std::vector<const serac::FiniteElementState*>{
-                                        &states[STATE::DISP], &states[STATE::DISP], &params[PAR::DENSITY]});
+                                    std::vector<const mfem::ParFiniteElementSpace*>{
+                                        &states[STATE::DISP].space(), &states[STATE::DISP].space(), &params[PAR::DENSITY].space()});
 
     // apply some traction boundary conditions
 

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -100,8 +100,8 @@ struct ResidualFixture : public testing::Test {
     using TrialSpace = VectorSpace;
     using ShapeSpace = VectorSpace;
 
-    using ResidualT =
-        serac::FunctionalResidual<ShapeSpace, TrialSpace, serac::Parameters<VectorSpace, VectorSpace, DensitySpace>>;
+    using ResidualT = serac::FunctionalResidual<dim, ShapeSpace, TrialSpace,
+                                                serac::Parameters<VectorSpace, VectorSpace, DensitySpace>>;
 
     std::vector<const mfem::ParFiniteElementSpace*> inputs{&states[STATE::DISP].space(), &states[STATE::DISP].space(),
                                                            &params[PAR::DENSITY].space()};

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -154,6 +154,9 @@ struct ResidualFixture : public testing::Test {
     residual = f_residual;
   }
 
+  const double time = 0.0;
+  const double dt = 1.0;
+
   std::string velo_name = "solid_velocity";
 
   axom::sidre::DataStore datastore;
@@ -173,12 +176,11 @@ struct ResidualFixture : public testing::Test {
 TEST_F(ResidualFixture, VjpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  double time = 0.0;
   auto all_states = getPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[0].space(), "residual");
 
-  res_vector = residual->residual(time, all_states);
+  res_vector = residual->residual(time, dt, all_states);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobian_weights = [&](size_t i) {
@@ -199,10 +201,10 @@ TEST_F(ResidualFixture, VjpConsistency)
 
   for (size_t i = 0; i < all_states.size(); ++i) {
     serac::FiniteElementState& vjp = all_Jvps[i];
-    auto J = residual->jacobian(time, all_states, jacobian_weights(i));
+    auto J = residual->jacobian(time, dt, all_states, jacobian_weights(i));
     J->AddMultTranspose(v, vjp);
   }
-  residual->vjp(time, all_states, getPointers(v), all_jvps);
+  residual->vjp(time, dt, all_states, getPointers(v), all_jvps);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
     EXPECT_NEAR(all_Jvps[i].Norml2(), all_jvps[i]->Norml2(), 1e-12);
@@ -212,11 +214,10 @@ TEST_F(ResidualFixture, VjpConsistency)
 TEST_F(ResidualFixture, JvpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  double time = 0.0;
   auto all_states = getPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[0].space(), "residual");
-  res_vector = residual->residual(time, all_states);
+  res_vector = residual->residual(time, dt, all_states);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobianWeights = [&](size_t i) {
@@ -243,9 +244,9 @@ TEST_F(ResidualFixture, JvpConsistency)
   auto all_v_rhs_states = getPointers(v_rhs_states, v_rhs_params);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
-    auto J = residual->jacobian(time, all_states, jacobianWeights(i));
+    auto J = residual->jacobian(time, dt, all_states, jacobianWeights(i));
     J->Mult(*all_v_rhs_states[i], jvp_slow);
-    residual->jvp(time, all_states, selectStates(i), jvps);
+    residual->jvp(time, dt, all_states, selectStates(i), jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 
@@ -258,12 +259,12 @@ TEST_F(ResidualFixture, JvpConsistency)
     double acceleration_factor = 0.2;
     std::vector<double> jacobian_weights = {1.0, 0.0, acceleration_factor, 0.0, 0.0};
 
-    auto J = residual->jacobian(time, all_states, jacobian_weights);
+    auto J = residual->jacobian(time, dt, all_states, jacobian_weights);
     J->Mult(*all_v_rhs_states[0], jvp_slow);
 
     *all_v_rhs_states[2] = *all_v_rhs_states[0];
     *all_v_rhs_states[2] *= acceleration_factor;
-    residual->jvp(time, all_states, all_v_rhs_states, jvps);
+    residual->jvp(time, dt, all_states, all_v_rhs_states, jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 }

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -78,7 +78,7 @@ struct ResidualFixture : public testing::Test {
 
     double length = 0.5;
     double width = 2.0;
-    mesh = std::make_unique<serac::Mesh>(mfem::Mesh::MakeCartesian2D(6, 20, element_shape, true, length, width),
+    mesh = std::make_shared<serac::Mesh>(mfem::Mesh::MakeCartesian2D(6, 20, element_shape, true, length, width),
                                          "this_mesh_name", 0, 0);
 
     serac::FiniteElementState disp = serac::StateManager::newState(VectorSpace{}, "displacement", mesh->tag());
@@ -104,10 +104,11 @@ struct ResidualFixture : public testing::Test {
     using ResidualT =
         serac::FunctionalResidual<ShapeSpace, TrialSpace, serac::Parameters<VectorSpace, VectorSpace, DensitySpace>>;
 
-    auto f_residual =
-        std::make_shared<ResidualT>(physics_name, mesh->tag(), params[PAR::SHAPE].space(), states[STATE::DISP].space(),
-                                    std::vector<const mfem::ParFiniteElementSpace*>{
-                                        &states[STATE::DISP].space(), &states[STATE::DISP].space(), &params[PAR::DENSITY].space()});
+    std::vector<const mfem::ParFiniteElementSpace*> inputs{&states[STATE::DISP].space(), &states[STATE::DISP].space(),
+                                                           &params[PAR::DENSITY].space()};
+
+    auto f_residual = std::make_shared<ResidualT>(physics_name, mesh, params[PAR::SHAPE].space(),
+                                                  states[STATE::DISP].space(), inputs);
 
     // apply some traction boundary conditions
 
@@ -157,7 +158,7 @@ struct ResidualFixture : public testing::Test {
   std::string velo_name = "solid_velocity";
 
   axom::sidre::DataStore datastore;
-  std::unique_ptr<serac::Mesh> mesh;
+  std::shared_ptr<serac::Mesh> mesh;
   std::shared_ptr<serac::Residual> residual;
 
   std::vector<serac::FiniteElementState> states;

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -115,8 +115,7 @@ struct ResidualFixture : public testing::Test {
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    f_residual->addBoundaryIntegral(surface_name,
-                                   [](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
+    f_residual->addBoundaryIntegral(surface_name, [](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
     f_residual->addBodyIntegral(serac::DependsOn<0>{}, mesh->entireDomainName(), [](double /*t*/, auto /*x*/, auto u) {
       return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
     });

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -10,7 +10,7 @@
 #include "serac/infrastructure/terminator.hpp"
 #include "serac/mesh/mesh_utils.hpp"
 #include "serac/physics/mesh.hpp"
-#include "serac/physics/common.hpp"
+#include "serac/physics/state/state_manager.hpp"
 
 #include "serac/physics/functional_residual.hpp"
 
@@ -115,14 +115,15 @@ struct ResidualFixture : public testing::Test {
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    f_residual->addSurfaceIntegral([](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; },
-                                   mesh->domain(surface_name));
-    f_residual->addBodyIntegral(
-        serac::DependsOn<0>{},
-        [](double /*t*/, auto /*x*/, auto u) {
-          return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
-        },
-        mesh->entireDomain());
+    f_residual->addSurfaceIntegral(mesh->domain(surface_name),
+                                   [](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
+    f_residual->addBodyIntegral(serac::DependsOn<0>{}, mesh->entireDomain(), [](double /*t*/, auto /*x*/, auto u) {
+      return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
+    });
+
+    f_residual->addBodyIntegral([](double /*t*/, auto x) {
+      return serac::tuple{0.5 * serac::get<serac::VALUE>(x), 0.0 * serac::get<serac::DERIVATIVE>(x)};
+    });
 
     // initialize fields for testing
 

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -115,13 +115,13 @@ struct ResidualFixture : public testing::Test {
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    f_residual->addSurfaceIntegral(mesh->domain(surface_name),
+    f_residual->addBoundaryIntegral(surface_name,
                                    [](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
-    f_residual->addBodyIntegral(serac::DependsOn<0>{}, mesh->entireDomain(), [](double /*t*/, auto /*x*/, auto u) {
+    f_residual->addBodyIntegral(serac::DependsOn<0>{}, mesh->entireDomainName(), [](double /*t*/, auto /*x*/, auto u) {
       return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
     });
 
-    f_residual->addBodyIntegral([](double /*t*/, auto x) {
+    f_residual->addBodyIntegral(mesh->entireDomainName(), [](double /*t*/, auto x) {
       return serac::tuple{0.5 * serac::get<serac::VALUE>(x), 0.0 * serac::get<serac::DERIVATIVE>(x)};
     });
 

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -115,11 +115,11 @@ struct ResidualFixture : public testing::Test {
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
     f_residual->addBoundaryIntegral(surface_name, [](double /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
-    f_residual->addBodyIntegral(serac::DependsOn<0>{}, mesh->entireDomainName(), [](double /*t*/, auto /*x*/, auto u) {
+    f_residual->addBodyIntegral(serac::DependsOn<0>{}, mesh->entireBodyName(), [](double /*t*/, auto /*x*/, auto u) {
       return serac::tuple{serac::get<serac::VALUE>(u), 0.0 * serac::get<serac::DERIVATIVE>(u)};
     });
 
-    f_residual->addBodyIntegral(mesh->entireDomainName(), [](double /*t*/, auto x) {
+    f_residual->addBodyIntegral(mesh->entireBodyName(), [](double /*t*/, auto x) {
       return serac::tuple{0.5 * serac::get<serac::VALUE>(x), 0.0 * serac::get<serac::DERIVATIVE>(x)};
     });
 

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -114,8 +114,7 @@ struct ResidualFixture : public testing::Test {
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    solid_mechanics_residual->addBoundaryIntegral(surface_name,
-                                                  [](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
+    solid_mechanics_residual->addBoundaryIntegral(surface_name, [](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
 
     // initialize fields for testing
 

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -108,11 +108,9 @@ struct ResidualFixture : public testing::Test {
     mat.G = 0.5;
     solid_mechanics_residual->setMaterial(serac::DependsOn<0>{}, mat, mesh->entireDomain());
 
-    // apply some traction boundary conditions
-
+    // apply traction boundary conditions
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
-
     solid_mechanics_residual->addBoundaryIntegral(surface_name, [](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
 
     // initialize fields for testing

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -78,7 +78,7 @@ struct ResidualFixture : public testing::Test {
 
     double length = 0.5;
     double width = 2.0;
-    mesh = std::make_unique<serac::Mesh>(mfem::Mesh::MakeCartesian2D(6, 20, element_shape, true, length, width),
+    mesh = std::make_shared<serac::Mesh>(mfem::Mesh::MakeCartesian2D(6, 20, element_shape, true, length, width),
                                          "this_mesh_name", 0, 0);
 
     serac::FiniteElementState disp = serac::StateManager::newState(VectorSpace{}, "displacement", mesh->tag());
@@ -100,7 +100,7 @@ struct ResidualFixture : public testing::Test {
     std::string physics_name = "solid";
 
     auto solid_mechanics_residual = serac::create_solid_residual<disp_order, dim, DensitySpace>(
-        physics_name, *mesh, getPointers(states), getPointers(params));
+        physics_name, mesh, getPointers(states), getPointers(params));
 
     // setup material model
 
@@ -150,7 +150,7 @@ struct ResidualFixture : public testing::Test {
   std::string velo_name = "solid_velocity";
 
   axom::sidre::DataStore datastore;
-  std::unique_ptr<serac::Mesh> mesh;
+  std::shared_ptr<serac::Mesh> mesh;
   std::shared_ptr<serac::Residual> residual;
 
   std::vector<serac::FiniteElementState> states;

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -29,6 +29,9 @@ template <typename T>
 auto getPointers(std::vector<T>& states, std::vector<T>& params)
 {
   assert(params.size() > 0);
+  // At the moment, every FunctionalResidual expects the shape displacement to go first.
+  // so we have to do some slight reordering of the arguments.
+  // Here shape displacement is expected to be the first parameter.
   std::vector<T*> pointers{&params[0]};
   for (auto& t : states) {
     pointers.push_back(&t);

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -112,7 +112,7 @@ struct ResidualFixture : public testing::Test {
     SolidMaterial mat;
     mat.K = 1.0;
     mat.G = 0.5;
-    solid_mechanics_residual->setMaterial(serac::DependsOn<0>{}, mat, mesh->entireBody());
+    solid_mechanics_residual->setMaterial(serac::DependsOn<0>{}, mesh->entireBodyName(), mat);
 
     // apply traction boundary conditions
     std::string surface_name = "side";
@@ -186,17 +186,17 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementDual v(res_vector.space(), "v");
   pseudoRand(v);
-  auto all_jvps = getPointers(dual_states, dual_params);
+  auto all_vjps = getPointers(dual_states, dual_params);
 
-  residual->vjp(time, dt, all_states, getPointers(v), all_jvps);
+  residual->vjp(time, dt, all_states, getPointers(v), all_vjps);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
     serac::FiniteElementState vjp = *all_states[i];
     vjp = 0.0;
     auto J = residual->jacobian(time, dt, all_states, jacobian_weights(i));
     J->MultTranspose(v, vjp);
-    if (i == 0) vjp += 1.0;  // make sure jvp uses +=
-    EXPECT_NEAR(vjp.Norml2(), all_jvps[i]->Norml2(), 1e-12);
+    if (i == 0) vjp += 1.0;  // make sure vjp uses +=
+    EXPECT_NEAR(vjp.Norml2(), all_vjps[i]->Norml2(), 1e-12);
   }
 }
 

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -114,8 +114,8 @@ struct ResidualFixture : public testing::Test {
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    solid_mechanics_residual->addSurfaceIntegral(mesh->domain(surface_name),
-                                                 [](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
+    solid_mechanics_residual->addBoundaryIntegral(surface_name,
+                                                  [](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
 
     // initialize fields for testing
 

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -11,7 +11,6 @@
 #include "serac/physics/materials/solid_material.hpp"
 #include "serac/physics/mesh.hpp"
 #include "serac/physics/state/state_manager.hpp"
-
 #include "serac/physics/solid_residual.hpp"
 
 auto element_shape = mfem::Element::QUADRILATERAL;

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -109,7 +109,7 @@ struct ResidualFixture : public testing::Test {
     SolidMaterial mat;
     mat.K = 1.0;
     mat.G = 0.5;
-    solid_mechanics_residual->setMaterial(serac::DependsOn<0>{}, mat, mesh->entireDomain());
+    solid_mechanics_residual->setMaterial(serac::DependsOn<0>{}, mat, mesh->entireBody());
 
     // apply traction boundary conditions
     std::string surface_name = "side";

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -29,15 +29,12 @@ template <typename T>
 auto getPointers(std::vector<T>& states, std::vector<T>& params)
 {
   assert(params.size() > 0);
-  // At the moment, every FunctionalResidual expects the shape displacement to go first.
-  // so we have to do some slight reordering of the arguments.
-  // Here shape displacement is expected to be the first parameter.
-  std::vector<T*> pointers{&params[0]};
+  std::vector<T*> pointers;
   for (auto& t : states) {
     pointers.push_back(&t);
   }
-  for (size_t n = 1; n < params.size(); ++n) {
-    pointers.push_back(&params[n]);
+  for (auto& t : params) {
+    pointers.push_back(&t);
   }
   return pointers;
 }
@@ -73,6 +70,14 @@ struct ResidualFixture : public testing::Test {
 
   using SolidMaterial = serac::solid_mechanics::NeoHookeanWithFieldDensity;
 
+  enum StateOrder
+  {
+    SHAPE,
+    DISP,
+    VELO,
+    ACCEL
+  };
+
   void SetUp()
   {
     MPI_Barrier(MPI_COMM_WORLD);
@@ -90,8 +95,8 @@ struct ResidualFixture : public testing::Test {
         serac::StateManager::newState(VectorSpace{}, "shape_displacement", mesh->tag());
     serac::FiniteElementState density = serac::StateManager::newState(DensitySpace{}, "density", mesh->tag());
 
-    states = {disp, velo, accel};
-    params = {shape_disp, density};
+    states = {shape_disp, disp, velo, accel};
+    params = {density};
 
     dual_states = states;
     dual_params = params;
@@ -101,11 +106,9 @@ struct ResidualFixture : public testing::Test {
 
     std::string physics_name = "solid";
 
-    auto solid_mechanics_residual = serac::create_solid_residual<disp_order, dim, DensitySpace>(
-        physics_name, mesh, getPointers(states), getPointers(params));
-
-    // setup material model
-
+    using SolidResidualT = serac::SolidResidual<disp_order, dim, serac::Parameters<DensitySpace>>;
+    auto solid_mechanics_residual = std::make_shared<SolidResidualT>(physics_name, mesh, states[SHAPE].space(),
+                                                                     states[DISP].space(), getSpaces(params));
     SolidMaterial mat;
     mat.K = 1.0;
     mat.G = 0.5;
@@ -125,22 +128,22 @@ struct ResidualFixture : public testing::Test {
       pseudoRand(p);
     }
 
-    dual_params[0] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
+    dual_states[0] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
 
-    states[0].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[DISP].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = 0.1 * x;
       return u;
     });
-    states[1].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[VELO].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = -0.1 * x;
       return u;
     });
-    states[2].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[ACCEL].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = -0.01 * x;
       return u;
     });
-    params[0] = 0.0;
-    params[1] = 1.2;
+    states[SHAPE] = 0.0;
+    params[0] = 1.2;
 
     // residual is abstract Residual class to ensure usage only through BasePhysics interface
     residual = solid_mechanics_residual;
@@ -170,7 +173,7 @@ TEST_F(ResidualFixture, VjpConsistency)
   // initialize the displacement and acceleration to a non-trivial field
   auto all_states = getPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[0].space(), "residual");
+  serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
   res_vector = residual->residual(time, dt, all_states);
   ASSERT_NE(0.0, res_vector.Norml2());
 
@@ -202,7 +205,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   // initialize the displacement and acceleration to a non-trivial field
   auto all_states = getPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[0].space(), "residual");
+  serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
   res_vector = residual->residual(time, dt, all_states);
   ASSERT_NE(0.0, res_vector.Norml2());
 
@@ -222,8 +225,8 @@ TEST_F(ResidualFixture, JvpConsistency)
     return pts;
   };
 
-  serac::FiniteElementDual jvp_slow(states[0].space(), "jvp_slow");
-  serac::FiniteElementDual jvp(states[0].space(), "jvp");
+  serac::FiniteElementDual jvp_slow(states[DISP].space(), "jvp_slow");
+  serac::FiniteElementDual jvp(states[DISP].space(), "jvp");
   jvp = 4.0;  // set to some value to test jvp resets these values
   std::vector<serac::FiniteElementDual*> jvps = getPointers(jvp);
 
@@ -238,18 +241,19 @@ TEST_F(ResidualFixture, JvpConsistency)
 
   // test jacobians in weighted combinations
   {
-    all_v_rhs_states[1] = nullptr;
-    all_v_rhs_states[3] = nullptr;
+    all_v_rhs_states[SHAPE] = nullptr;
+    all_v_rhs_states[VELO] = nullptr;
     all_v_rhs_states[4] = nullptr;
 
     double acceleration_factor = 0.2;
-    std::vector<double> jacobian_weights = {1.0, 0.0, acceleration_factor, 0.0, 0.0};
+    std::vector<double> jacobian_weights = {0.0, 1.0, 0.0, acceleration_factor, 0.0};
 
     auto J = residual->jacobian(time, dt, all_states, jacobian_weights);
-    J->Mult(*all_v_rhs_states[0], jvp_slow);
+    J->Mult(*all_v_rhs_states[DISP], jvp_slow);
 
-    *all_v_rhs_states[2] = *all_v_rhs_states[0];
-    *all_v_rhs_states[2] *= acceleration_factor;
+    *all_v_rhs_states[ACCEL] = *all_v_rhs_states[DISP];
+    *all_v_rhs_states[ACCEL] *= acceleration_factor;
+
     residual->jvp(time, dt, all_states, all_v_rhs_states, jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -29,12 +29,13 @@ auto getPointers(std::vector<T>& values)
 template <typename T>
 auto getPointers(std::vector<T>& states, std::vector<T>& params)
 {
-  std::vector<T*> pointers;
+  assert(params.size() > 0);
+  std::vector<T*> pointers{&params[0]};
   for (auto& t : states) {
     pointers.push_back(&t);
   }
-  for (auto& t : params) {
-    pointers.push_back(&t);
+  for (size_t n = 1; n < params.size(); ++n) {
+    pointers.push_back(&params[n]);
   }
   return pointers;
 }
@@ -87,8 +88,8 @@ struct ResidualFixture : public testing::Test {
         serac::StateManager::newState(VectorSpace{}, "shape_displacement", mesh->tag());
     serac::FiniteElementState density = serac::StateManager::newState(DensitySpace{}, "density", mesh->tag());
 
-    states = {disp, velo, accel, shape_disp};
-    params = {density};
+    states = {disp, velo, accel};
+    params = {shape_disp, density};
 
     dual_states = states;
     dual_params = params;
@@ -96,11 +97,10 @@ struct ResidualFixture : public testing::Test {
     v_rhs_states = states;
     v_rhs_params = params;
 
-    std::vector<std::string> param_names{"density"};
     std::string physics_name = "solid";
 
     auto solid_mechanics_residual = serac::create_solid_residual<disp_order, dim, DensitySpace>(
-        physics_name, *mesh, getPointers(states), getPointers(params), param_names);
+        physics_name, *mesh, getPointers(states), getPointers(params));
 
     // setup material model
 
@@ -114,8 +114,8 @@ struct ResidualFixture : public testing::Test {
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    solid_mechanics_residual->setTraction([](auto /*x*/, auto n, auto /*t*/) { return -1.0 * n; },
-                                          mesh->domain(surface_name));
+    solid_mechanics_residual->addSurfaceIntegral([](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; },
+                                                 mesh->domain(surface_name));
 
     // initialize fields for testing
 
@@ -126,18 +126,22 @@ struct ResidualFixture : public testing::Test {
       pseudoRand(p);
     }
 
-    dual_states[0] = 1.0;  // used to test that vjp acts via +=
+    dual_params[0] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
 
     states[0].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = 0.1 * x;
       return u;
     });
-
+    states[1].setFromFieldFunction([](serac::tensor<double, dim> x) {
+      auto u = -0.1 * x;
+      return u;
+    });
     states[2].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = -0.01 * x;
       return u;
     });
-    params[0] = 1.2;
+    params[0] = 0.0;
+    params[1] = 1.2;
 
     // residual is abstract Residual class to ensure usage only through BasePhysics interface
     residual = solid_mechanics_residual;

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -10,7 +10,7 @@
 #include "serac/mesh/mesh_utils.hpp"
 #include "serac/physics/materials/solid_material.hpp"
 #include "serac/physics/mesh.hpp"
-#include "serac/physics/common.hpp"
+#include "serac/physics/state/state_manager.hpp"
 
 #include "serac/physics/solid_residual.hpp"
 
@@ -114,8 +114,8 @@ struct ResidualFixture : public testing::Test {
     std::string surface_name = "side";
     mesh->addDomainOfBoundaryElements(surface_name, serac::by_attr<dim>(1));
 
-    solid_mechanics_residual->addSurfaceIntegral([](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; },
-                                                 mesh->domain(surface_name));
+    solid_mechanics_residual->addSurfaceIntegral(mesh->domain(surface_name),
+                                                 [](auto /*t*/, auto /*x*/, auto n) { return 1.0 * n; });
 
     // initialize fields for testing
 

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -143,6 +143,9 @@ struct ResidualFixture : public testing::Test {
     residual = solid_mechanics_residual;
   }
 
+  const double time = 0.0;
+  const double dt = 1.0;
+
   std::string velo_name = "solid_velocity";
 
   axom::sidre::DataStore datastore;
@@ -162,11 +165,10 @@ struct ResidualFixture : public testing::Test {
 TEST_F(ResidualFixture, VjpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  double time = 0.0;
   auto all_states = getPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[0].space(), "residual");
-  res_vector = residual->residual(time, all_states);
+  res_vector = residual->residual(time, dt, all_states);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobian_weights = [&](size_t i) {
@@ -180,12 +182,12 @@ TEST_F(ResidualFixture, VjpConsistency)
   pseudoRand(v);
   auto all_jvps = getPointers(dual_states, dual_params);
 
-  residual->vjp(time, all_states, getPointers(v), all_jvps);
+  residual->vjp(time, dt, all_states, getPointers(v), all_jvps);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
     serac::FiniteElementState vjp = *all_states[i];
     vjp = 0.0;
-    auto J = residual->jacobian(time, all_states, jacobian_weights(i));
+    auto J = residual->jacobian(time, dt, all_states, jacobian_weights(i));
     J->MultTranspose(v, vjp);
     if (i == 0) vjp += 1.0;  // make sure jvp uses +=
     EXPECT_NEAR(vjp.Norml2(), all_jvps[i]->Norml2(), 1e-12);
@@ -195,11 +197,10 @@ TEST_F(ResidualFixture, VjpConsistency)
 TEST_F(ResidualFixture, JvpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  double time = 0.0;
   auto all_states = getPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[0].space(), "residual");
-  res_vector = residual->residual(time, all_states);
+  res_vector = residual->residual(time, dt, all_states);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobianWeights = [&](size_t i) {
@@ -226,9 +227,9 @@ TEST_F(ResidualFixture, JvpConsistency)
   auto all_v_rhs_states = getPointers(v_rhs_states, v_rhs_params);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
-    auto J = residual->jacobian(time, all_states, jacobianWeights(i));
+    auto J = residual->jacobian(time, dt, all_states, jacobianWeights(i));
     J->Mult(*all_v_rhs_states[i], jvp_slow);
-    residual->jvp(time, all_states, selectStates(i), jvps);
+    residual->jvp(time, dt, all_states, selectStates(i), jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 
@@ -241,12 +242,12 @@ TEST_F(ResidualFixture, JvpConsistency)
     double acceleration_factor = 0.2;
     std::vector<double> jacobian_weights = {1.0, 0.0, acceleration_factor, 0.0, 0.0};
 
-    auto J = residual->jacobian(time, all_states, jacobian_weights);
+    auto J = residual->jacobian(time, dt, all_states, jacobian_weights);
     J->Mult(*all_v_rhs_states[0], jvp_slow);
 
     *all_v_rhs_states[2] = *all_v_rhs_states[0];
     *all_v_rhs_states[2] *= acceleration_factor;
-    residual->jvp(time, all_states, all_v_rhs_states, jvps);
+    residual->jvp(time, dt, all_states, all_v_rhs_states, jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 }


### PR DESCRIPTION
This completes some of the follow ons from the previous review (naming, _, etc.), but also extends and simplifies the use by including a serac::FunctionalResidual, which will eliminate a TON of duplication in the downstream smith new physics.  Also, now SolidResidual derives from FunctionalResidual.