### PR TITLE
Resolve some undefined behavior reported by -fsanitize=undefined

### DIFF
--- a/src/serac/numerics/functional/quadrature_data.cpp
+++ b/src/serac/numerics/functional/quadrature_data.cpp
@@ -15,9 +15,9 @@
 namespace serac {
 
 /// a single instance of a QuadratureData container of `Nothing`s, since they are all interchangeable
-std::shared_ptr<QuadratureData<Nothing> > NoQData;
+std::shared_ptr<QuadratureData<Nothing>> NoQData = ::std::make_shared<QuadratureData<Nothing>>();
 
 /// a single instance of a QuadratureData container of `Empty`s, since they are all interchangeable
-std::shared_ptr<QuadratureData<Empty> > EmptyQData;
+std::shared_ptr<QuadratureData<Empty>> EmptyQData = ::std::make_shared<QuadratureData<Empty>>();
 
 }  // namespace serac

--- a/src/serac/numerics/functional/tests/functional_basic_dg.cpp
+++ b/src/serac/numerics/functional/tests/functional_basic_dg.cpp
@@ -95,7 +95,9 @@ void L2_qoi_test(std::string meshfile)
   auto fec = mfem::L2_FECollection(p, dim, mfem::BasisType::GaussLobatto);
   mfem::ParFiniteElementSpace fespace(mesh.get(), &fec, dim, serac::ordering);
 
-  mfem::HypreParVector U = *fespace.NewTrueDofVector();
+  ::std::unique_ptr<mfem::HypreParVector> trueDof(fespace.NewTrueDofVector());
+  mfem::HypreParVector U = *trueDof;
+
   int seed = 2;
   U.Randomize(seed);
 

--- a/src/serac/numerics/functional/tests/functional_qoi.cpp
+++ b/src/serac/numerics/functional/tests/functional_qoi.cpp
@@ -199,6 +199,10 @@ void qoi_test(mfem::ParMesh& mesh, H1<p> trial, Dimension<dim>, WhichTest which)
   mfem::FunctionCoefficient x_squared([](mfem::Vector x) { return x[0] * x[0]; });
   U_gf.ProjectCoefficient(x_squared);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);

--- a/src/serac/numerics/functional/tests/functional_qoi.cpp
+++ b/src/serac/numerics/functional/tests/functional_qoi.cpp
@@ -211,6 +211,10 @@ void qoi_test(mfem::ParMesh& mesh, H1<p> trial, Dimension<dim>, WhichTest which)
   mfem::FunctionCoefficient x_coord([](mfem::Vector x) { return x[0]; });
   V_gf.ProjectCoefficient(x_coord);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   ::std::unique_ptr<mfem::HypreParVector> tmp2(fespace->NewTrueDofVector());
   mfem::HypreParVector V = *tmp2;
   V_gf.GetTrueDofs(V);
@@ -310,9 +314,11 @@ void qoi_test(mfem::ParMesh& mesh, H1<p1> trial1, H1<p2> trial2, Dimension<dim>)
   mfem::ParGridFunction U2_gf(fespace2.get());
   U2_gf.ProjectCoefficient(y);
 
-  std::unique_ptr<mfem::HypreParVector> tmp;
-
-  tmp.reset(fespace1->NewTrueDofVector());
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
+  std::unique_ptr<mfem::HypreParVector> tmp(fespace1->NewTrueDofVector());
   mfem::HypreParVector U1 = *tmp;
   U1_gf.GetTrueDofs(U1);
 
@@ -361,6 +367,10 @@ TEST(QoI, DependsOnVectorValuedInput)
   });
   U_gf.ProjectCoefficient(x_squared);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);
@@ -390,6 +400,10 @@ TEST(QoI, AddAreaIntegral)
   mfem::FunctionCoefficient x_squared([](mfem::Vector x) { return x[0] * x[0]; });
   U_gf.ProjectCoefficient(x_squared);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);
@@ -418,6 +432,10 @@ TEST(QoI, AddVolumeIntegral)
   mfem::FunctionCoefficient x_squared([](mfem::Vector x) { return x[0] * x[0]; });
   U_gf.ProjectCoefficient(x_squared);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);
@@ -444,9 +462,17 @@ TEST(QoI, UsingL2)
 
   auto [fespace_1, fec1] = serac::generateParFiniteElementSpace<trial_space_1>(&mesh);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   std::unique_ptr<mfem::HypreParVector> U0(fespace_0->NewTrueDofVector());
   U0->Randomize(0);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   std::unique_ptr<mfem::HypreParVector> U1(fespace_1->NewTrueDofVector());
   U1->Randomize(1);
 
@@ -501,9 +527,17 @@ TEST(QoI, ShapeAndParameter)
 
   serac_volume.AddDomainIntegral(serac::Dimension<dim>{}, serac::DependsOn<>{}, TrivialIntegrator{}, whole_mesh);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   std::unique_ptr<mfem::HypreParVector> shape_displacement(shape_fe_space->NewTrueDofVector());
   *shape_displacement = 1.0;
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   std::unique_ptr<mfem::HypreParVector> parameter(parameter_fe_space->NewTrueDofVector());
   *parameter = 0.1;
 
@@ -565,9 +599,17 @@ TEST(QoI, ShapeAndParameterBoundary)
   serac_area.AddBoundaryIntegral(serac::Dimension<dim - 1>{}, serac::DependsOn<>{}, TrivialIntegrator{},
                                  whole_boundary);
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   std::unique_ptr<mfem::HypreParVector> shape_displacement(shape_fe_space->NewTrueDofVector());
   *shape_displacement = 1.0;
 
+  // NewTrueDofVector returns a raw pointer allocated using new and gives
+  // ownership of the pointer to the caller. Here we wrap the return value
+  // in a std::unique_ptr to discharge our ownership responsibility to
+  // delete it when we're done with it.
   std::unique_ptr<mfem::HypreParVector> parameter(parameter_fe_space->NewTrueDofVector());
   *parameter = 5.0;
 

--- a/src/serac/numerics/functional/tests/functional_qoi.cpp
+++ b/src/serac/numerics/functional/tests/functional_qoi.cpp
@@ -199,7 +199,7 @@ void qoi_test(mfem::ParMesh& mesh, H1<p> trial, Dimension<dim>, WhichTest which)
   mfem::FunctionCoefficient x_squared([](mfem::Vector x) { return x[0] * x[0]; });
   U_gf.ProjectCoefficient(x_squared);
 
-  mfem::HypreParVector* tmp = fespace->NewTrueDofVector();
+  ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);
 
@@ -207,7 +207,7 @@ void qoi_test(mfem::ParMesh& mesh, H1<p> trial, Dimension<dim>, WhichTest which)
   mfem::FunctionCoefficient x_coord([](mfem::Vector x) { return x[0]; });
   V_gf.ProjectCoefficient(x_coord);
 
-  mfem::HypreParVector* tmp2 = fespace->NewTrueDofVector();
+  ::std::unique_ptr<mfem::HypreParVector> tmp2(fespace->NewTrueDofVector());
   mfem::HypreParVector V = *tmp2;
   V_gf.GetTrueDofs(V);
 
@@ -285,8 +285,6 @@ void qoi_test(mfem::ParMesh& mesh, H1<p> trial, Dimension<dim>, WhichTest which)
 
     } break;
   }
-
-  delete tmp;
 }
 
 template <int p1, int p2, int dim>
@@ -359,7 +357,7 @@ TEST(QoI, DependsOnVectorValuedInput)
   });
   U_gf.ProjectCoefficient(x_squared);
 
-  mfem::HypreParVector* tmp = fespace->NewTrueDofVector();
+  ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);
 
@@ -371,8 +369,6 @@ TEST(QoI, DependsOnVectorValuedInput)
   double exact_answer = 141.3333333333333;
   double relative_error = (f(t, U) - exact_answer) / exact_answer;
   EXPECT_NEAR(0.0, relative_error, 1.0e-10);
-
-  delete tmp;
 }
 
 TEST(QoI, AddAreaIntegral)
@@ -390,7 +386,7 @@ TEST(QoI, AddAreaIntegral)
   mfem::FunctionCoefficient x_squared([](mfem::Vector x) { return x[0] * x[0]; });
   U_gf.ProjectCoefficient(x_squared);
 
-  mfem::HypreParVector* tmp = fespace->NewTrueDofVector();
+  ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);
 
@@ -400,8 +396,6 @@ TEST(QoI, AddAreaIntegral)
   measure.AddAreaIntegral(DependsOn<>{}, TrivialIntegrator{}, whole_mesh);
   double relative_error = (measure(t, U) - measure_mfem(mesh)) / measure(t, U);
   EXPECT_NEAR(0.0, relative_error, 1.0e-10);
-
-  delete tmp;
 }
 
 TEST(QoI, AddVolumeIntegral)
@@ -420,7 +414,7 @@ TEST(QoI, AddVolumeIntegral)
   mfem::FunctionCoefficient x_squared([](mfem::Vector x) { return x[0] * x[0]; });
   U_gf.ProjectCoefficient(x_squared);
 
-  mfem::HypreParVector* tmp = fespace->NewTrueDofVector();
+  ::std::unique_ptr<mfem::HypreParVector> tmp(fespace->NewTrueDofVector());
   mfem::HypreParVector U = *tmp;
   U_gf.GetTrueDofs(U);
 
@@ -430,8 +424,6 @@ TEST(QoI, AddVolumeIntegral)
   measure.AddVolumeIntegral(DependsOn<>{}, TrivialIntegrator{}, whole_mesh);
   double relative_error = (measure(t, U) - measure_mfem(mesh)) / measure(t, U);
   EXPECT_NEAR(0.0, relative_error, 1.0e-10);
-
-  delete tmp;
 }
 
 TEST(QoI, UsingL2)


### PR DESCRIPTION
Compiling serac with `-fsanitize=undefined` and running tests produced numerous instances of error messages about calling methods on a `nullptr`.  For example,
```sh
$ ./functional_shape_derivatives 
[INFO] Opening mesh file: '/home/generic/serac/data/meshes/patch2D_tris_and_quads.mesh' 
[INFO] Opening mesh file: '/home/generic/serac/data/meshes/patch3D_tets_and_hexes.mesh' 
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from ShapeDerivative
[ RUN      ] ShapeDerivative.2DLinear
/usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/shared_ptr_base.h:1350:9: runtime error: reference binding to null pointer of type 'element_type' (aka 'serac::QuadratureData<Nothing>')
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /usr/bin/../lib/gcc/x86_64-redhat-linux/13/../../../../include/c++/13/bits/shared_ptr_base.h:1350:9 in 
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/quadrature_data.hpp:153:31: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing> *'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/quadrature_data.hpp:153:31 in 
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
[       OK ] ShapeDerivative.2DLinear (19 ms)
[ RUN      ] ShapeDerivative.2DQuadratic
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
[       OK ] ShapeDerivative.2DQuadratic (29 ms)
[ RUN      ] ShapeDerivative.3DLinear
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
[       OK ] ShapeDerivative.3DLinear (392 ms)
[ RUN      ] ShapeDerivative.3DQuadratic
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
/home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88: runtime error: member call on null pointer of type 'serac::QuadratureData<Nothing>'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/generic/serac/src/serac/infrastructure/../../serac/numerics/functional/domain_integral_kernels.hpp:374:88 in 
[       OK ] ShapeDerivative.3DQuadratic (933 ms)
[----------] 4 tests from ShapeDerivative (1379 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (1383 ms total)
[  PASSED  ] 4 tests.
$
```

@tupek2, I think this resolves the issue I reported to you.