### PR TITLE
Bugfix: call `refineAndDistribute` in `physics_benchmark_solid_nonlinear_solve`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ stages:
   - comparison
 
 # Run src build each push
+# NOTE: When you add a new workflow, remember to add it to this `if` statement!
 .src_workflow:
   stage: src
   rules:

--- a/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
+++ b/src/serac/physics/benchmarks/physics_benchmark_solid_nonlinear_solve.cpp
@@ -229,7 +229,7 @@ void functional_solid_test_euler(NonlinSolve nonlinSolve, Prec prec)
 
   std::string meshTag = "mesh";
   mfem::Mesh mesh = mfem::Mesh::MakeCartesian3D(Nx, Ny, Nz, mfem::Element::HEXAHEDRON, Lx, Ly, Lz);
-  auto pmesh = std::make_unique<mfem::ParMesh>(MPI_COMM_WORLD, mesh);
+  auto pmesh = mesh::refineAndDistribute(std::move(mesh), 0, 0, MPI_COMM_WORLD);
   mfem::ParMesh* meshPtr = &serac::StateManager::setMesh(std::move(pmesh), meshTag);
 
   // solid mechanics
@@ -310,7 +310,7 @@ void functional_solid_test_nonlinear_buckle(NonlinSolve nonlinSolve, Prec prec, 
 
   std::string meshTag = "mesh";
   mfem::Mesh mesh = mfem::Mesh::MakeCartesian3D(Nx, Ny, Nz, mfem::Element::HEXAHEDRON, Lx, Ly, Lz);
-  auto pmesh = std::make_unique<mfem::ParMesh>(MPI_COMM_WORLD, mesh);
+  auto pmesh = mesh::refineAndDistribute(std::move(mesh), 0, 0, MPI_COMM_WORLD);
   mfem::ParMesh* meshPtr = &serac::StateManager::setMesh(std::move(pmesh), meshTag);
 
   // solid mechanics


### PR DESCRIPTION
fixes the following error:

```
80: Test command: /usr/bin/srun "-n" "4" "/usr/WS2/meemee/.jacamar-ci/builds/DDKVZ6_e/000/gitlab/smith/serac/_serac_build_and_test_2025_04_19_00_04_24/build-ruby-toss_4_x86_64_ib-clang@14.0.6/benchmarks/physics_benchmark_solid_nonlinear_solve"
80: Test timeout computed to be: 4800
80: [0] Logger activated: 'serac_parallel_logger'
80: [SIGNAL]: Received signal 11 (Segmentation fault), exiting
80: [SIGNAL]: Received signal 11 (Segmentation fault), exiting
80: [SIGNAL]: Received signal 11 (Segmentation fault), exiting
80: [0][ERROR (/usr/WS2/meemee/.jacamar-ci/builds/DDKVZ6_e/000/gitlab/smith/serac/src/serac/physics/state/state_manager.cpp:286)]
80: The mesh must have a grid function for the nodes defined. Call the EnsureNodes() method on your mesh before setting it with the state manager.
80: ** StackTrace of 7 frames **
80: Frame 1: axom::slic::logErrorMessage(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, int)
80: Frame 2: serac::checkMesh(mfem::ParMesh const&, bool)
80: Frame 3: serac::StateManager::setMesh(std::unique_ptr<mfem::ParMesh, std::default_delete<mfem::ParMesh> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)
80: Frame 4: functional_solid_test_nonlinear_buckle(NonlinSolve, Prec, ProblemSize)
80: Frame 5: main
80: Frame 6: __libc_start_main
80: Frame 7: _start
80: =====
```

https://lc.llnl.gov/gitlab/smith/serac/-/jobs/2569921#L1487