### PR TITLE
Re-enable mfem_petsc_smoketests by linking with `CUDA::cublasLt`

### DIFF
--- a/cmake/thirdparty/SetupSeracThirdParty.cmake
+++ b/cmake/thirdparty/SetupSeracThirdParty.cmake
@@ -41,7 +41,10 @@ if (NOT SERAC_THIRD_PARTY_LIBRARIES_FOUND)
     # Create global variable to toggle between GPU targets
     #------------------------------------------------------------------------------
     if(SERAC_ENABLE_CUDA)
-        set(serac_device_depends blt::cuda CACHE STRING "" FORCE)
+        # CUDAToolkit required to find cublasLt library
+        # Can be removed once this BLT PR is merged https://github.com/LLNL/blt/pull/585 (?)
+        find_package(CUDAToolkit REQUIRED)
+        set(serac_device_depends blt::cuda CUDA::cublasLt CACHE STRING "" FORCE)
     elseif(SERAC_ENABLE_HIP)
         set(serac_device_depends blt::hip CACHE STRING "" FORCE)
     else()

--- a/src/tests/mfem_petsc_smoketest.cpp
+++ b/src/tests/mfem_petsc_smoketest.cpp
@@ -407,20 +407,19 @@ int ex1_main(int argc, char *argv[])
 TEST(MfemPetscSmoketest, MfemPetscEx1)
 {
   ::testing::internal::CaptureStdout();
-  // https://github.com/LLNL/serac/issues/1361
-  // #ifdef SERAC_USE_CUDA
-  //   const char* fake_argv[] = {"ex1",
-  //                              "-m",
-  //                              SERAC_REPO_DIR "/mfem/data/star.mesh",
-  //                              "--usepetsc",
-  //                              "--device",
-  //                              "cuda",
-  //                              "--petscopts",
-  //                              SERAC_REPO_DIR "/src/tests/rc_mfem_petsc_smoketest_gpu"};
-  // #else
+#ifdef SERAC_USE_CUDA
+  const char* fake_argv[] = {"ex1",
+                             "-m",
+                             SERAC_REPO_DIR "/mfem/data/star.mesh",
+                             "--usepetsc",
+                             "--device",
+                             "cuda",
+                             "--petscopts",
+                             SERAC_REPO_DIR "/src/tests/rc_mfem_petsc_smoketest_gpu"};
+#else
   const char* fake_argv[] = {"ex1",        "-m",          SERAC_REPO_DIR "/mfem/data/amr-quad.mesh",
                              "--usepetsc", "--petscopts", SERAC_REPO_DIR "/src/tests/rc_mfem_petsc_smoketest"};
-  // #endif
+#endif
   int fake_argc = sizeof(fake_argv) / sizeof(fake_argv[0]);
   ex1_main(fake_argc, const_cast<char**>(fake_argv));
   std::string output = ::testing::internal::GetCapturedStdout();

--- a/src/tests/mfem_slepc_smoketest.cpp
+++ b/src/tests/mfem_slepc_smoketest.cpp
@@ -462,12 +462,11 @@ int ex11_main(int argc, char *argv[])
 TEST(MfemSlepcSmoketest, MfemPetscEx11)
 {
   ::testing::internal::CaptureStdout();
-  // https://github.com/LLNL/serac/issues/1361
-  // #ifdef SERAC_USE_CUDA
-  //   const char* fake_argv[] = {"ex11",       "-m",          SERAC_REPO_DIR "/mfem/data/star.mesh",
-  //                              "--useslepc", "--slepcopts", SERAC_REPO_DIR "/src/tests/rc_mfem_slepc_smoketest_gpu",
-  //                              "--device",   "cuda",        "--no-visualization"};
-  // #else
+#ifdef SERAC_USE_CUDA
+  const char* fake_argv[] = {"ex11",       "-m",          SERAC_REPO_DIR "/mfem/data/star.mesh",
+                             "--useslepc", "--slepcopts", SERAC_REPO_DIR "/src/tests/rc_mfem_slepc_smoketest_gpu",
+                             "--device",   "cuda",        "--no-visualization"};
+#else
   const char* fake_argv[] = {"ex11",
                              "-m",
                              SERAC_REPO_DIR "/mfem/data/star.mesh",
@@ -475,7 +474,7 @@ TEST(MfemSlepcSmoketest, MfemPetscEx11)
                              "--slepcopts",
                              SERAC_REPO_DIR "/src/tests/rc_mfem_slepc_smoketest",
                              "--no-visualization"};
-  // #endif
+#endif
   int fake_argc = sizeof(fake_argv) / sizeof(fake_argv[0]);
   ex11_main(fake_argc, const_cast<char**>(fake_argv));
   std::string output = ::testing::internal::GetCapturedStdout();


### PR DESCRIPTION
Fixes #1361

Not sure why all the sudden `CUDA::cublasLt` became missing. But I realized the issue was probably related to `find_package(CUDA)` (what blt uses right now) vs `find_package(CUDA_Toolkit)`.