### PR TITLE
Prevent maybe-uninitialized error on GCC Release builds

### DIFF
--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -628,7 +628,7 @@ class TrustRegion : public mfem::NewtonSolver {
     num_subspace_solves = 0;
     num_jacobian_assembles = 0;
 
-    real_t norm, norm_goal, prev_norm;
+    real_t norm, norm_goal, prev_norm = 0.0;
     norm = initial_norm = computeResidual(X, r);
     norm_goal = std::max(rel_tol * initial_norm, abs_tol);
     if (print_options.first_and_last && !print_options.iterations) {

--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -85,7 +85,7 @@ class NewtonSolver : public mfem::NewtonSolver {
 
     using real_t = mfem::real_t;
 
-    real_t norm, norm_goal, prev_norm;
+    real_t norm, norm_goal, prev_norm = 0;
     norm = initial_norm = evaluateNorm(x, r);
 
     if (print_options.first_and_last && !print_options.iterations) {


### PR DESCRIPTION
I noticed this benchmark was failing: https://lc.llnl.gov/gitlab/smith/serac/-/jobs/2618056#L272

Seems like on GCC Release builds, there is a warning that others do not catch.