### PR TITLE
Increase "no optional solvers" CI Job Allocation time to prevent CI failures

### DIFF
--- a/.gitlab/build_toss4.yml
+++ b/.gitlab/build_toss4.yml
@@ -84,7 +84,7 @@ toss4-gcc_10_3_1-src-no-optional-solvers:
     HOST_CONFIG: "ruby-toss_4_x86_64_ib-${COMPILER}.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -USUNDIALS_DIR -UPETSC_DIR"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "20"
+    ALLOC_TIME: "30"
     ALLOC_DEADLINE: "60"
   extends: .src_build_on_toss4
 


### PR DESCRIPTION
My CI jobs have been failing because this CI job's allocation time is only 20 minutes, where all the others are 30.