### PR TITLE
Fix vjp dual types

### DIFF
--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -241,8 +241,8 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
     SLIC_ERROR_IF(vs.size() != 1, "FunctionalResidual nonlinear systems only supports 1 output residual");
 
     dt_ = dt;
-    auto vecJacs = vectorJacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time,
-                                           vs[0], fields);
+    auto vecJacs =
+        vectorJacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, vs[0], fields);
 
     for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
       if (vjp_sensitivities[input_col] != nullptr) {

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -233,20 +233,20 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
   }
 
   /// @overload
-  void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vs,
+  void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& v_fields,
            const std::vector<DualFieldPtr>& vjp_sensitivities) const override
   {
     SLIC_ERROR_IF(vjp_sensitivities.size() != fields.size(),
                   "Invalid number of field sensitivities relative to the number of fields");
-    SLIC_ERROR_IF(vs.size() != 1, "FunctionalResidual nonlinear systems only supports 1 output residual");
+    SLIC_ERROR_IF(v_fields.size() != 1, "FunctionalResidual nonlinear systems only supports 1 output residual");
 
     dt_ = dt;
-    auto vecJacs =
-        vectorJacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time, vs[0], fields);
+    auto vecJacs = vectorJacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time,
+                                           v_fields[0], fields);
 
     for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
       if (vjp_sensitivities[input_col] != nullptr) {
-        auto vecJac = serac::get<DERIVATIVE>(vecJacs[input_col](time, vs[0], fields));
+        auto vecJac = serac::get<DERIVATIVE>(vecJacs[input_col](time, v_fields[0], fields));
         auto vecJacMfemVector = assemble(vecJac);
         *vjp_sensitivities[input_col] += *vecJacMfemVector;
       }

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -233,22 +233,22 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
   }
 
   /// @overload
-  void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<DualFieldPtr>& v_reactions,
-           const std::vector<FieldPtr>& vjp_fields) const override
+  void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vs,
+           const std::vector<DualFieldPtr>& vjp_sensitivities) const override
   {
-    SLIC_ERROR_IF(vjp_fields.size() != fields.size(),
+    SLIC_ERROR_IF(vjp_sensitivities.size() != fields.size(),
                   "Invalid number of field sensitivities relative to the number of fields");
-    SLIC_ERROR_IF(v_reactions.size() != 1, "FunctionalResidual nonlinear systems only supports 1 output residual");
+    SLIC_ERROR_IF(vs.size() != 1, "FunctionalResidual nonlinear systems only supports 1 output residual");
 
     dt_ = dt;
     auto vecJacs = vectorJacobianFunctions(std::make_integer_sequence<int, sizeof...(input_indices) + 1>{}, time,
-                                           v_reactions[0], fields);
+                                           vs[0], fields);
 
     for (size_t input_col = 0; input_col < fields.size(); ++input_col) {
-      if (vjp_fields[input_col] != nullptr) {
-        auto vecJac = serac::get<DERIVATIVE>(vecJacs[input_col](time, v_reactions[0], fields));
+      if (vjp_sensitivities[input_col] != nullptr) {
+        auto vecJac = serac::get<DERIVATIVE>(vecJacs[input_col](time, vs[0], fields));
         auto vecJacMfemVector = assemble(vecJac);
-        *vjp_fields[input_col] += *vecJacMfemVector;
+        *vjp_sensitivities[input_col] += *vecJacMfemVector;
       }
     }
   }
@@ -279,12 +279,12 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
 
   /// @brief Utility to get array of jvp functions, one for each input field in fs
   template <int... i>
-  auto vectorJacobianFunctions(std::integer_sequence<int, i...>, double time, DualFieldPtr v,
+  auto vectorJacobianFunctions(std::integer_sequence<int, i...>, double time, FieldPtr v,
                                const std::vector<FieldPtr>& fs) const
   {
     using GradFuncType = std::function<decltype((*v_residual_)(DifferentiateWRT<1>{}, time, *v, *fs[i]...))(
-        double, DualFieldPtr, const std::vector<FieldPtr>&)>;
-    return std::array<GradFuncType, sizeof...(i)>{[=](double _time, DualFieldPtr _v, const std::vector<FieldPtr>& _fs) {
+        double, FieldPtr, const std::vector<FieldPtr>&)>;
+    return std::array<GradFuncType, sizeof...(i)>{[=](double _time, FieldPtr _v, const std::vector<FieldPtr>& _fs) {
       std::vector<mfem::Vector*> _vfs{_v};
       _vfs.insert(_vfs.end(), _fs.begin() + 1, _fs.end());
       constexpr bool is_shape_disp = i == 0;

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -89,8 +89,8 @@ class Residual {
    * @param vReactions left hand side 'v' fields
    * @param vjpFields output jvps, 1 per input field: vResiduals[i] * d{r}_i / d{fields}_j
    */
-  virtual void vjp(double time, double dt, const std::vector<FieldPtr>& fields,
-                   const std::vector<FieldPtr>& vReactions, const std::vector<DualFieldPtr>& vjpFields) const = 0;
+  virtual void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vReactions,
+                   const std::vector<DualFieldPtr>& vjpFields) const = 0;
 
   /// @brief name
   std::string name() const { return name_; }

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -90,7 +90,7 @@ class Residual {
    * @param vjpFields output jvps, 1 per input field: vResiduals[i] * d{r}_i / d{fields}_j
    */
   virtual void vjp(double time, double dt, const std::vector<FieldPtr>& fields,
-                   const std::vector<DualFieldPtr>& vReactions, const std::vector<FieldPtr>& vjpFields) const = 0;
+                   const std::vector<FieldPtr>& vReactions, const std::vector<DualFieldPtr>& vjpFields) const = 0;
 
   /// @brief name
   std::string name() const { return name_; }

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -74,23 +74,23 @@ class Residual {
    * @param time time
    * @param dt time step
    * @param fields vector of serac::FiniteElementState* as arguments to the residual
-   * @param vFields right hand side 'v' fields
-   * @param jvpReactions output vjps, 1 per row of a block system: d{r}_i / d{fields}_j * fieldsV[j]
+   * @param v_fields right hand side 'v' fields
+   * @param jvp_reactions output vjps, 1 per row of a block system: d{r}_i / d{fields}_j * fieldsV[j]
    * nullptr fieldsV are assumed to be all zero to avoid extra calculations
    */
-  virtual void jvp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vFields,
-                   const std::vector<DualFieldPtr>& jvpReactions) const = 0;
+  virtual void jvp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& v_fields,
+                   const std::vector<DualFieldPtr>& jvp_reactions) const = 0;
 
   /**
    * @brief Vector-Jacobian product, will += into existing values in vjpFields
    * @param time time
    * @param dt time step
    * @param fields vector of serac::FiniteElementState* as arguments to the residual
-   * @param vReactions left hand side 'v' fields
-   * @param vjpFields output jvps, 1 per input field: vResiduals[i] * d{r}_i / d{fields}_j
+   * @param v_fields left hand side 'v' fields
+   * @param vjp_sensitivities output jvps, 1 per input field: v_fields[i] * d{r}_i / d{fields}_j
    */
-  virtual void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& vReactions,
-                   const std::vector<DualFieldPtr>& vjpFields) const = 0;
+  virtual void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& v_fields,
+                   const std::vector<DualFieldPtr>& vjp_sensitivities) const = 0;
 
   /// @brief name
   std::string name() const { return name_; }

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -89,8 +89,12 @@ struct ResidualFixture : public testing::Test {
     states = {disp, velo};
     params = {shape_disp, density};
 
-    dual_states = states;
-    dual_params = params;
+    for (auto s : states) {
+      dual_states.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
+    }
+    for (auto p : params) {
+      dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
+    }
 
     v_rhs_states = states;
     v_rhs_params = params;
@@ -166,8 +170,8 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementState> states;
   std::vector<serac::FiniteElementState> params;
 
-  std::vector<serac::FiniteElementState> dual_states;
-  std::vector<serac::FiniteElementState> dual_params;
+  std::vector<serac::FiniteElementDual> dual_states;
+  std::vector<serac::FiniteElementDual> dual_params;
 
   std::vector<serac::FiniteElementState> v_rhs_states;
   std::vector<serac::FiniteElementState> v_rhs_params;
@@ -190,17 +194,17 @@ TEST_F(ResidualFixture, VjpConsistency)
   };
 
   // test vjp
-  serac::FiniteElementDual v(res_vector.space(), "v");
+  serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
   auto all_jvps = getPointers(dual_states, dual_params);
 
-  std::vector<serac::FiniteElementState> all_Jvps;
+  std::vector<serac::FiniteElementDual> all_Jvps;
   for (auto& jvp : all_jvps) {
     all_Jvps.push_back(*jvp);
   }
 
   for (size_t i = 0; i < all_states.size(); ++i) {
-    serac::FiniteElementState& vjp = all_Jvps[i];
+    serac::FiniteElementDual& vjp = all_Jvps[i];
     auto J = residual->jacobian(time, dt, all_states, jacobian_weights(i));
     J->AddMultTranspose(v, vjp);
   }

--- a/src/serac/physics/tests/test_heat_residual.cpp
+++ b/src/serac/physics/tests/test_heat_residual.cpp
@@ -96,8 +96,12 @@ struct ResidualFixture : public testing::Test {
     states = {shape_disp, temperature, temp_rate};
     params = {conductivity_offset};
 
-    dual_states = states;
-    dual_params = params;
+    for (auto s : states) {
+      dual_states.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
+    }
+    for (auto p : params) {
+      dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
+    }
 
     v_rhs_states = states;
     v_rhs_params = params;
@@ -146,8 +150,8 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementState> states;
   std::vector<serac::FiniteElementState> params;
 
-  std::vector<serac::FiniteElementState> dual_states;
-  std::vector<serac::FiniteElementState> dual_params;
+  std::vector<serac::FiniteElementDual> dual_states;
+  std::vector<serac::FiniteElementDual> dual_params;
 
   std::vector<serac::FiniteElementState> v_rhs_states;
   std::vector<serac::FiniteElementState> v_rhs_params;
@@ -168,7 +172,7 @@ TEST_F(ResidualFixture, VjpConsistency)
   };
 
   // test vjp
-  serac::FiniteElementDual v(res_vector.space(), "v");
+  serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
   auto all_vjps = getPointers(dual_states, dual_params);
 

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -131,8 +131,12 @@ struct ResidualFixture : public testing::Test {
     states = {shape_disp, disp, velo, accel};
     params = {density};
 
-    dual_states = states;
-    dual_params = params;
+    for (auto s : states) {
+      dual_states.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
+    }
+    for (auto p : params) {
+      dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
+    }
 
     v_rhs_states = states;
     v_rhs_params = params;
@@ -200,8 +204,8 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementState> states;
   std::vector<serac::FiniteElementState> params;
 
-  std::vector<serac::FiniteElementState> dual_states;
-  std::vector<serac::FiniteElementState> dual_params;
+  std::vector<serac::FiniteElementDual> dual_states;
+  std::vector<serac::FiniteElementDual> dual_params;
 
   std::vector<serac::FiniteElementState> v_rhs_states;
   std::vector<serac::FiniteElementState> v_rhs_params;
@@ -223,7 +227,7 @@ TEST_F(ResidualFixture, VjpConsistency)
   };
 
   // test vjp
-  serac::FiniteElementDual v(res_vector.space(), "v");
+  serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
   auto all_vjps = getPointers(dual_states, dual_params);
 


### PR DESCRIPTION
The types where backward for the vjp.  The 'v', should be a ParGridFunction as its interpolated.  All derivatives are linear forms (FiniteElementDual).  This cleans up a few things in smith implementations, avoids copies, etc.