### PR TITLE
Tupek/residual const and sign correctness

### DIFF
--- a/src/serac/physics/CMakeLists.txt
+++ b/src/serac/physics/CMakeLists.txt
@@ -22,6 +22,7 @@ set(physics_headers
     base_physics.hpp
     mesh.hpp
     common.hpp
+    field_types.hpp
     fit.hpp
     heat_transfer.hpp
     heat_transfer_input.hpp

--- a/src/serac/physics/field_types.hpp
+++ b/src/serac/physics/field_types.hpp
@@ -32,7 +32,7 @@ using ConstDualFieldPtr = FiniteElementDual const*;
 /// @brief Get a vector of FieldPtr or DualFieldPtr from a vector of shared_pointers to FiniteElementState or
 /// FiniteElementDual
 template <typename T>
-auto getFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+auto getFieldPointers(const std::vector<std::shared_ptr<T>>& states, const std::vector<std::shared_ptr<T>>& params)
 {
   static_assert(std::is_same_v<T, FiniteElementState> || std::is_same_v<T, FiniteElementDual>,
                 "Type must be either FiniteElementState or FiniteElementDual");
@@ -50,6 +50,8 @@ auto getFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::
 template <typename T>
 auto getFieldPointers(std::vector<T>& states, std::vector<T>& params)
 {
+  static_assert(std::is_same_v<T, FiniteElementState> || std::is_same_v<T, FiniteElementDual>,
+                "Type must be either FiniteElementState or FiniteElementDual");
   std::vector<T*> pointers;
   for (auto& t : states) {
     pointers.push_back(&t);
@@ -64,14 +66,18 @@ auto getFieldPointers(std::vector<T>& states, std::vector<T>& params)
 template <typename T>
 auto getFieldPointers(T& state)
 {
+  static_assert(std::is_same_v<T, FiniteElementState> || std::is_same_v<T, FiniteElementDual>,
+                "Type must be either FiniteElementState or FiniteElementDual");
   return std::vector<T*>{&state};
 }
 
 /// @brief Get a vector of ConstFieldPtr or ConstDualFieldPtr from a vector of shared_pointers to FiniteElementState or
 /// FiniteElementDual
 template <typename T>
-auto getConstFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+auto getConstFieldPointers(const std::vector<std::shared_ptr<T>>& states, const std::vector<std::shared_ptr<T>>& params)
 {
+  static_assert(std::is_same_v<T, FiniteElementState> || std::is_same_v<T, FiniteElementDual>,
+                "Type must be either FiniteElementState or FiniteElementDual");
   std::vector<T const*> pointers;
   for (auto& t : states) {
     pointers.push_back(t.get());
@@ -86,6 +92,8 @@ auto getConstFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<
 template <typename T>
 auto getConstFieldPointers(const std::vector<T>& states, const std::vector<T>& params = {})
 {
+  static_assert(std::is_same_v<T, FiniteElementState> || std::is_same_v<T, FiniteElementDual>,
+                "Type must be either FiniteElementState or FiniteElementDual");
   std::vector<T const*> pointers;
   for (auto& t : states) {
     pointers.push_back(&t);
@@ -100,6 +108,8 @@ auto getConstFieldPointers(const std::vector<T>& states, const std::vector<T>& p
 template <typename T>
 auto getConstFieldPointers(const T& state)
 {
+  static_assert(std::is_same_v<T, FiniteElementState> || std::is_same_v<T, FiniteElementDual>,
+                "Type must be either FiniteElementState or FiniteElementDual");
   return std::vector<T const*>{&state};
 }
 

--- a/src/serac/physics/field_types.hpp
+++ b/src/serac/physics/field_types.hpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: (BSD-3-Clause)
 
 /**
- * @file residual_types.hpp
+ * @file field_types.hpp
  *
  * @brief Defines common types and helper functions for using the residual and scalar_objective classes
  */
@@ -29,9 +29,13 @@ using ConstFieldPtr = FiniteElementState const*;
 /// @brief using
 using ConstDualFieldPtr = FiniteElementDual const*;
 
+/// @brief Get a vector of FieldPtr or DualFieldPtr from a vector of shared_pointers to FiniteElementState or
+/// FiniteElementDual
 template <typename T>
 auto getFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
 {
+  static_assert(std::is_same_v<T, FiniteElementState> || std::is_same_v<T, FiniteElementDual>,
+                "Type must be either FiniteElementState or FiniteElementDual");
   std::vector<T*> pointers;
   for (auto& t : states) {
     pointers.push_back(t.get());
@@ -42,6 +46,7 @@ auto getFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::
   return pointers;
 }
 
+/// @brief Get a vector of FieldPtr or DualFieldPtr from a vector of FiniteElementState or FiniteElementDual
 template <typename T>
 auto getFieldPointers(std::vector<T>& states, std::vector<T>& params)
 {
@@ -55,12 +60,15 @@ auto getFieldPointers(std::vector<T>& states, std::vector<T>& params)
   return pointers;
 }
 
+/// @brief Get a vector of FieldPtr or DualFieldPtr from a single FiniteElementState or FiniteElementDual
 template <typename T>
 auto getFieldPointers(T& state)
 {
   return std::vector<T*>{&state};
 }
 
+/// @brief Get a vector of ConstFieldPtr or ConstDualFieldPtr from a vector of shared_pointers to FiniteElementState or
+/// FiniteElementDual
 template <typename T>
 auto getConstFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
 {
@@ -74,6 +82,7 @@ auto getConstFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<
   return pointers;
 }
 
+/// @brief Get a vector of ConstFieldPtr or ConstDualFieldPtr from a vector of FiniteElementState or FiniteElementDual
 template <typename T>
 auto getConstFieldPointers(const std::vector<T>& states, const std::vector<T>& params = {})
 {
@@ -87,6 +96,7 @@ auto getConstFieldPointers(const std::vector<T>& states, const std::vector<T>& p
   return pointers;
 }
 
+/// @brief Get a vector of ConstFieldPtr or ConstDualFieldPtr from a single FiniteElementState or FiniteElementDual
 template <typename T>
 auto getConstFieldPointers(const T& state)
 {

--- a/src/serac/physics/field_types.hpp
+++ b/src/serac/physics/field_types.hpp
@@ -29,8 +29,8 @@ using ConstFieldPtr = FiniteElementState const*;
 /// @brief using
 using ConstDualFieldPtr = FiniteElementDual const*;
 
-  template <typename T>
-auto residualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+template <typename T>
+auto getFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
 {
   std::vector<T*> pointers;
   for (auto& t : states) {
@@ -43,7 +43,7 @@ auto residualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::
 }
 
 template <typename T>
-auto residualPointers(std::vector<T>& states, std::vector<T>& params)
+auto getFieldPointers(std::vector<T>& states, std::vector<T>& params)
 {
   std::vector<T*> pointers;
   for (auto& t : states) {
@@ -56,13 +56,13 @@ auto residualPointers(std::vector<T>& states, std::vector<T>& params)
 }
 
 template <typename T>
-auto residualPointers(T& state)
+auto getFieldPointers(T& state)
 {
   return std::vector<T*>{&state};
 }
 
 template <typename T>
-auto constResidualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+auto getConstFieldPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
 {
   std::vector<T const*> pointers;
   for (auto& t : states) {
@@ -75,7 +75,7 @@ auto constResidualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<
 }
 
 template <typename T>
-auto constResidualPointers(const std::vector<T>& states, const std::vector<T>& params = {})
+auto getConstFieldPointers(const std::vector<T>& states, const std::vector<T>& params = {})
 {
   std::vector<T const*> pointers;
   for (auto& t : states) {
@@ -88,9 +88,9 @@ auto constResidualPointers(const std::vector<T>& states, const std::vector<T>& p
 }
 
 template <typename T>
-auto constResidualPointers(const T& state)
+auto getConstFieldPointers(const T& state)
 {
   return std::vector<T const*>{&state};
 }
 
-}
+}  // namespace serac

--- a/src/serac/physics/field_types.hpp
+++ b/src/serac/physics/field_types.hpp
@@ -1,0 +1,96 @@
+// Copyright Lawrence Livermore National Security, LLC and
+// other Serac Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file residual_types.hpp
+ *
+ * @brief Defines common types and helper functions for using the residual and scalar_objective classes
+ */
+
+#pragma once
+
+#include "serac/physics/state/finite_element_state.hpp"
+#include "serac/physics/state/finite_element_dual.hpp"
+
+namespace serac {
+
+/// @brief using
+using FieldPtr = FiniteElementState*;
+
+/// @brief using
+using DualFieldPtr = FiniteElementDual*;
+
+/// @brief using
+using ConstFieldPtr = FiniteElementState const*;
+
+/// @brief using
+using ConstDualFieldPtr = FiniteElementDual const*;
+
+  template <typename T>
+auto residualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+{
+  std::vector<T*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(t.get());
+  }
+  for (auto& t : params) {
+    pointers.push_back(t.get());
+  }
+  return pointers;
+}
+
+template <typename T>
+auto residualPointers(std::vector<T>& states, std::vector<T>& params)
+{
+  std::vector<T*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(&t);
+  }
+  for (auto& t : params) {
+    pointers.push_back(&t);
+  }
+  return pointers;
+}
+
+template <typename T>
+auto residualPointers(T& state)
+{
+  return std::vector<T*>{&state};
+}
+
+template <typename T>
+auto constResidualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+{
+  std::vector<T const*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(t.get());
+  }
+  for (auto& t : params) {
+    pointers.push_back(t.get());
+  }
+  return pointers;
+}
+
+template <typename T>
+auto constResidualPointers(const std::vector<T>& states, const std::vector<T>& params = {})
+{
+  std::vector<T const*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(&t);
+  }
+  for (auto& t : params) {
+    pointers.push_back(&t);
+  }
+  return pointers;
+}
+
+template <typename T>
+auto constResidualPointers(const T& state)
+{
+  return std::vector<T const*>{&state};
+}
+
+}

--- a/src/serac/physics/functional_objective.hpp
+++ b/src/serac/physics/functional_objective.hpp
@@ -58,9 +58,6 @@ class FunctionalObjective<spatial_dim, ShapeDispSpace, Parameters<InputSpaces...
         std::make_unique<ShapeAwareFunctional<ShapeDispSpace, double(InputSpaces...)>>(&shape_disp_space, mfem_spaces);
   }
 
-  /// @brief using
-  using FieldPtr = FiniteElementState*;
-
   /**
    * @brief register a custom domain integral calculation as part of the residual
    *
@@ -77,14 +74,14 @@ class FunctionalObjective<spatial_dim, ShapeDispSpace, Parameters<InputSpaces...
   }
 
   /// @overload
-  virtual double evaluate(double time, double dt, const std::vector<FieldPtr>& fields) const override
+  virtual double evaluate(double time, double dt, const std::vector<ConstFieldPtr>& fields) const override
   {
     dt_ = dt;
     return evaluateObjective(std::make_integer_sequence<int, sizeof...(parameter_indices) + 1>{}, time, fields);
   }
 
   /// @overload
-  virtual mfem::Vector gradient(double time, double dt, const std::vector<FieldPtr>& fields,
+  virtual mfem::Vector gradient(double time, double dt, const std::vector<ConstFieldPtr>& fields,
                                 int direction) const override
   {
     dt_ = dt;
@@ -96,18 +93,18 @@ class FunctionalObjective<spatial_dim, ShapeDispSpace, Parameters<InputSpaces...
  private:
   /// @brief Utility to evaluate residual using all fields in vector
   template <int... i>
-  auto evaluateObjective(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
+  auto evaluateObjective(std::integer_sequence<int, i...>, double time, const std::vector<ConstFieldPtr>& fs) const
   {
     return (*objective_)(time, *fs[i]...);
   };
 
   /// @brief Utility to get array of jacobian functions, one for each input field in fs
   template <int... i>
-  auto gradientEvaluators(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
+  auto gradientEvaluators(std::integer_sequence<int, i...>, double time, const std::vector<ConstFieldPtr>& fs) const
   {
     using JacFuncType = std::function<decltype((*objective_)(DifferentiateWRT<1>{}, time, *fs[i]...))(
-        double, const std::vector<FieldPtr>&)>;
-    return std::array<JacFuncType, sizeof...(i)>{[=](double _time, const std::vector<FieldPtr>& _fs) {
+        double, const std::vector<ConstFieldPtr>&)>;
+    return std::array<JacFuncType, sizeof...(i)>{[=](double _time, const std::vector<ConstFieldPtr>& _fs) {
       return (*objective_)(DifferentiateWRT<i>{}, _time, *_fs[i]...);
     }...};
   };

--- a/src/serac/physics/functional_residual.hpp
+++ b/src/serac/physics/functional_residual.hpp
@@ -167,7 +167,8 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
   }
 
   /// @overload
-  mfem::Vector residual(double time, double dt, const std::vector<FieldPtr>& fields, int block_row = 0) const override
+  mfem::Vector residual(double time, double dt, const std::vector<ConstFieldPtr>& fields,
+                        int block_row = 0) const override
   {
     SLIC_ERROR_IF(block_row != 0, "Invalid block row and column requested in fieldJacobian for FunctionalResidual");
     dt_ = dt;
@@ -176,7 +177,7 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
   }
 
   /// @overload
-  std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, double dt, const std::vector<FieldPtr>& fields,
+  std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, double dt, const std::vector<ConstFieldPtr>& fields,
                                                  const std::vector<double>& jacobian_weights,
                                                  int block_row = 0) const override
   {
@@ -212,7 +213,7 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
   }
 
   /// @overload
-  void jvp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& v_fields,
+  void jvp(double time, double dt, const std::vector<ConstFieldPtr>& fields, const std::vector<ConstFieldPtr>& v_fields,
            const std::vector<DualFieldPtr>& jvp_reactions) const override
   {
     SLIC_ERROR_IF(v_fields.size() != fields.size(),
@@ -233,7 +234,7 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
   }
 
   /// @overload
-  void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& v_fields,
+  void vjp(double time, double dt, const std::vector<ConstFieldPtr>& fields, const std::vector<ConstFieldPtr>& v_fields,
            const std::vector<DualFieldPtr>& vjp_sensitivities) const override
   {
     SLIC_ERROR_IF(vjp_sensitivities.size() != fields.size(),
@@ -268,29 +269,30 @@ class FunctionalResidual<spatial_dim, ShapeDispSpace, OutputSpace, Parameters<In
  protected:
   /// @brief Utility to get array of jacobian functions, one for each input field in fs
   template <int... i>
-  auto jacobianFunctions(std::integer_sequence<int, i...>, double time, const std::vector<FieldPtr>& fs) const
+  auto jacobianFunctions(std::integer_sequence<int, i...>, double time, const std::vector<ConstFieldPtr>& fs) const
   {
     using JacFuncType = std::function<decltype((*residual_)(DifferentiateWRT<1>{}, time, *fs[i]...))(
-        double, const std::vector<FieldPtr>&)>;
-    return std::array<JacFuncType, sizeof...(i)>{[=](double _time, const std::vector<FieldPtr>& _fs) {
+        double, const std::vector<ConstFieldPtr>&)>;
+    return std::array<JacFuncType, sizeof...(i)>{[=](double _time, const std::vector<ConstFieldPtr>& _fs) {
       return (*residual_)(DifferentiateWRT<i>{}, _time, *_fs[i]...);
     }...};
   };
 
   /// @brief Utility to get array of jvp functions, one for each input field in fs
   template <int... i>
-  auto vectorJacobianFunctions(std::integer_sequence<int, i...>, double time, FieldPtr v,
-                               const std::vector<FieldPtr>& fs) const
+  auto vectorJacobianFunctions(std::integer_sequence<int, i...>, double time, ConstFieldPtr v,
+                               const std::vector<ConstFieldPtr>& fs) const
   {
     using GradFuncType = std::function<decltype((*v_residual_)(DifferentiateWRT<1>{}, time, *v, *fs[i]...))(
-        double, FieldPtr, const std::vector<FieldPtr>&)>;
-    return std::array<GradFuncType, sizeof...(i)>{[=](double _time, FieldPtr _v, const std::vector<FieldPtr>& _fs) {
-      std::vector<mfem::Vector*> _vfs{_v};
-      _vfs.insert(_vfs.end(), _fs.begin() + 1, _fs.end());
-      constexpr bool is_shape_disp = i == 0;
-      constexpr int diff_index = is_shape_disp ? 0 : i + 1;
-      return (*v_residual_)(DifferentiateWRT<diff_index>{}, _time, *_fs[0], *_vfs[i]...);
-    }...};
+        double, ConstFieldPtr, const std::vector<ConstFieldPtr>&)>;
+    return std::array<GradFuncType, sizeof...(i)>{
+        [=](double _time, ConstFieldPtr _v, const std::vector<ConstFieldPtr>& _fs) {
+          std::vector<mfem::Vector const*> _vfs{_v};
+          _vfs.insert(_vfs.end(), _fs.begin() + 1, _fs.end());
+          constexpr bool is_shape_disp = i == 0;
+          constexpr int diff_index = is_shape_disp ? 0 : i + 1;
+          return (*v_residual_)(DifferentiateWRT<diff_index>{}, _time, *_fs[0], *_vfs[i]...);
+        }...};
   };
 
   /// @brief timestep, this needs to be held here and modified for rate dependent applications

--- a/src/serac/physics/heat_transfer_residual.hpp
+++ b/src/serac/physics/heat_transfer_residual.hpp
@@ -172,7 +172,7 @@ class HeatTransferResidual<order, dim, Parameters<InputSpaces...>>
 
       auto [heat_capacity, heat_flux] = material_(x, u, du_dX, params...);
 
-      return serac::tuple{heat_capacity * du_dt, -1.0 * heat_flux};
+      return serac::tuple{-heat_capacity * du_dt, heat_flux};
     }
   };
 };

--- a/src/serac/physics/heat_transfer_residual.hpp
+++ b/src/serac/physics/heat_transfer_residual.hpp
@@ -45,6 +45,13 @@ class HeatTransferResidual<order, dim, Parameters<InputSpaces...>>
   /// @brief temperature, temperature rate
   static constexpr int NUM_STATE_VARS = 2;
 
+  enum STATE
+  {
+    SHAPE_DISPLACEMENT,
+    TEMPERATURE,
+    TEMPERATURE_RATE
+  };
+
   /**
    * @brief Construct a new HeatTransferResidual object
    *

--- a/src/serac/physics/heat_transfer_residual.hpp
+++ b/src/serac/physics/heat_transfer_residual.hpp
@@ -45,11 +45,13 @@ class HeatTransferResidual<order, dim, Parameters<InputSpaces...>>
   /// @brief temperature, temperature rate
   static constexpr int NUM_STATE_VARS = 2;
 
+  /// @brief enumeration of the required heat transfer states
   enum STATE
   {
     SHAPE_DISPLACEMENT,
     TEMPERATURE,
-    TEMPERATURE_RATE
+    TEMPERATURE_RATE,
+    NUM_STATES
   };
 
   /**

--- a/src/serac/physics/materials/thermal_material.hpp
+++ b/src/serac/physics/materials/thermal_material.hpp
@@ -51,7 +51,7 @@ struct LinearIsotropicConductor {
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */,
                                     const T3& temperature_gradient) const
   {
-    return serac::tuple{(-density_) * specific_heat_capacity_, conductivity_ * temperature_gradient};
+    return serac::tuple{density_ * specific_heat_capacity_, -1.0 * conductivity_ * temperature_gradient};
   }
 
  private:

--- a/src/serac/physics/materials/thermal_material.hpp
+++ b/src/serac/physics/materials/thermal_material.hpp
@@ -51,7 +51,7 @@ struct LinearIsotropicConductor {
   SERAC_HOST_DEVICE auto operator()(const T1& /* x */, const T2& /* temperature */,
                                     const T3& temperature_gradient) const
   {
-    return serac::tuple{density_ * specific_heat_capacity_, -1.0 * conductivity_ * temperature_gradient};
+    return serac::tuple{(-density_) * specific_heat_capacity_, conductivity_ * temperature_gradient};
   }
 
  private:

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -11,6 +11,14 @@
 
 namespace serac {
 
+Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_serial, int refine_parallel)
+    : mesh_tag_(meshtag)
+{
+  auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel);
+  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
+  createDomains();
+}
+
 Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int refine_parallel) : mesh_tag_(meshtag)
 {
   auto meshtmp = serac::mesh::refineAndDistribute(std::move(mesh), refine_serial, refine_parallel);
@@ -21,14 +29,8 @@ Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int
 Mesh::Mesh(mfem::ParMesh& mesh, const std::string& meshtag) : mesh_tag_(meshtag)
 {
   mfem_mesh_ = &mesh;
-  createDomains();
-}
-
-Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_serial, int refine_parallel)
-    : mesh_tag_(meshtag)
-{
-  auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel);
-  mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
+  mfem_mesh_->EnsureNodes();
+  mfem_mesh_->ExchangeFaceNbrData();
   createDomains();
 }
 

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -12,6 +12,18 @@
 
 #pragma once
 
+// reverse residual sign
+// enums on residuals for state?
+// shared_ptr for field inputs
+// proper const correctness
+// shape_disp on mesh
+
+// action of the mass...
+// force, residual, inertial terms
+// lumped-mass residual, acceleration needs to be 0
+
+// C(u) u_dot + K(u) u = 0
+
 #include <vector>
 #include <string>
 #include "serac/physics/common.hpp"
@@ -43,6 +55,12 @@ class Residual {
   /// @brief using
   using DualFieldPtr = FiniteElementDual*;
 
+  /// @brief using
+  using ConstFieldPtr = FiniteElementState const*;
+
+  /// @brief using
+  using ConstDualFieldPtr = FiniteElementDual const*;
+
   /** @brief Virtual interface for computing residual from a vector of serac::FiniteElementState*
    *
    * @param time time
@@ -51,7 +69,7 @@ class Residual {
    * @param block_row integer which specifies which row of a block system to get the residual for, defaults to 0
    * @return mfem::Vector
    */
-  virtual mfem::Vector residual(double time, double dt, const std::vector<FieldPtr>& fields,
+  virtual mfem::Vector residual(double time, double dt, const std::vector<ConstFieldPtr>& fields,
                                 int block_row = 0) const = 0;
 
   /** @brief Derivative of the residual with respect to specified field arguments: sum_j d{r}_i/d{fields}_j *
@@ -65,7 +83,8 @@ class Residual {
    * @return std::unique_ptr<mfem::HypreParMatrix> returns sum_j d{r}_i/d{fields}_j * argument_tangents[j], where
    * {fields}_j is the jth field, {r}_i is the ith residual block row
    */
-  virtual std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, double dt, const std::vector<FieldPtr>& fields,
+  virtual std::unique_ptr<mfem::HypreParMatrix> jacobian(double time, double dt,
+                                                         const std::vector<ConstFieldPtr>& fields,
                                                          const std::vector<double>& argument_tangents,
                                                          int block_row = 0) const = 0;
 
@@ -78,7 +97,8 @@ class Residual {
    * @param jvp_reactions output vjps, 1 per row of a block system: d{r}_i / d{fields}_j * fieldsV[j]
    * nullptr fieldsV are assumed to be all zero to avoid extra calculations
    */
-  virtual void jvp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& v_fields,
+  virtual void jvp(double time, double dt, const std::vector<ConstFieldPtr>& fields,
+                   const std::vector<ConstFieldPtr>& v_fields,
                    const std::vector<DualFieldPtr>& jvp_reactions) const = 0;
 
   /**
@@ -89,7 +109,8 @@ class Residual {
    * @param v_fields left hand side 'v' fields
    * @param vjp_sensitivities output jvps, 1 per input field: v_fields[i] * d{r}_i / d{fields}_j
    */
-  virtual void vjp(double time, double dt, const std::vector<FieldPtr>& fields, const std::vector<FieldPtr>& v_fields,
+  virtual void vjp(double time, double dt, const std::vector<ConstFieldPtr>& fields,
+                   const std::vector<ConstFieldPtr>& v_fields,
                    const std::vector<DualFieldPtr>& vjp_sensitivities) const = 0;
 
   /// @brief name
@@ -99,5 +120,69 @@ class Residual {
   /// name
   std::string name_;
 };
+
+template <typename T>
+auto residualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+{
+  std::vector<T*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(t.get());
+  }
+  for (auto& t : params) {
+    pointers.push_back(t.get());
+  }
+  return pointers;
+}
+
+template <typename T>
+auto residualPointers(std::vector<T>& states, std::vector<T>& params)
+{
+  std::vector<T*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(&t);
+  }
+  for (auto& t : params) {
+    pointers.push_back(&t);
+  }
+  return pointers;
+}
+
+template <typename T>
+auto residualPointers(T& state)
+{
+  return std::vector<T*>{&state};
+}
+
+template <typename T>
+auto constResidualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
+{
+  std::vector<T const*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(t.get());
+  }
+  for (auto& t : params) {
+    pointers.push_back(t.get());
+  }
+  return pointers;
+}
+
+template <typename T>
+auto constResidualPointers(const std::vector<T>& states, const std::vector<T>& params = {})
+{
+  std::vector<T const*> pointers;
+  for (auto& t : states) {
+    pointers.push_back(&t);
+  }
+  for (auto& t : params) {
+    pointers.push_back(&t);
+  }
+  return pointers;
+}
+
+template <typename T>
+auto constResidualPointers(const T& state)
+{
+  return std::vector<T const*>{&state};
+}
 
 }  // namespace serac

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -12,10 +12,6 @@
 
 #pragma once
 
-// reverse residual sign
-// shared_ptr for field inputs
-// shape_disp on mesh
-
 #include <vector>
 #include <string>
 #include "serac/physics/common.hpp"

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <string>
 #include "serac/physics/common.hpp"
+#include "serac/physics/field_types.hpp"
 
 namespace mfem {
 class Vector;
@@ -48,18 +49,6 @@ class Residual {
 
   /// @brief destructor
   virtual ~Residual() {}
-
-  /// @brief using
-  using FieldPtr = FiniteElementState*;
-
-  /// @brief using
-  using DualFieldPtr = FiniteElementDual*;
-
-  /// @brief using
-  using ConstFieldPtr = FiniteElementState const*;
-
-  /// @brief using
-  using ConstDualFieldPtr = FiniteElementDual const*;
 
   /** @brief Virtual interface for computing residual from a vector of serac::FiniteElementState*
    *
@@ -120,69 +109,5 @@ class Residual {
   /// name
   std::string name_;
 };
-
-template <typename T>
-auto residualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
-{
-  std::vector<T*> pointers;
-  for (auto& t : states) {
-    pointers.push_back(t.get());
-  }
-  for (auto& t : params) {
-    pointers.push_back(t.get());
-  }
-  return pointers;
-}
-
-template <typename T>
-auto residualPointers(std::vector<T>& states, std::vector<T>& params)
-{
-  std::vector<T*> pointers;
-  for (auto& t : states) {
-    pointers.push_back(&t);
-  }
-  for (auto& t : params) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto residualPointers(T& state)
-{
-  return std::vector<T*>{&state};
-}
-
-template <typename T>
-auto constResidualPointers(std::vector<std::shared_ptr<T>>& states, std::vector<std::shared_ptr<T>>& params)
-{
-  std::vector<T const*> pointers;
-  for (auto& t : states) {
-    pointers.push_back(t.get());
-  }
-  for (auto& t : params) {
-    pointers.push_back(t.get());
-  }
-  return pointers;
-}
-
-template <typename T>
-auto constResidualPointers(const std::vector<T>& states, const std::vector<T>& params = {})
-{
-  std::vector<T const*> pointers;
-  for (auto& t : states) {
-    pointers.push_back(&t);
-  }
-  for (auto& t : params) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto constResidualPointers(const T& state)
-{
-  return std::vector<T const*>{&state};
-}
 
 }  // namespace serac

--- a/src/serac/physics/residual.hpp
+++ b/src/serac/physics/residual.hpp
@@ -13,16 +13,8 @@
 #pragma once
 
 // reverse residual sign
-// enums on residuals for state?
 // shared_ptr for field inputs
-// proper const correctness
 // shape_disp on mesh
-
-// action of the mass...
-// force, residual, inertial terms
-// lumped-mass residual, acceleration needs to be 0
-
-// C(u) u_dot + K(u) u = 0
 
 #include <vector>
 #include <string>

--- a/src/serac/physics/scalar_objective.hpp
+++ b/src/serac/physics/scalar_objective.hpp
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include "serac/physics/common.hpp"
+#include "serac/physics/field_types.hpp"
 
 namespace mfem {
 class Vector;
@@ -32,9 +33,6 @@ class ScalarObjective {
   /// @brief destructor
   virtual ~ScalarObjective() {}
 
-  /// @brief using
-  using FieldPtr = FiniteElementState*;
-
   /** @brief Virtual interface for computing the scale value for the objective/constrant, given a vector of
    * serac::FiniteElementState*
    *
@@ -43,7 +41,7 @@ class ScalarObjective {
    * @param fields vector of serac::FiniteElementState* as arguments to the residual
    * @return double which is the scalar objective value
    */
-  virtual double evaluate(double time, double dt, const std::vector<FieldPtr>& fields) const = 0;
+  virtual double evaluate(double time, double dt, const std::vector<ConstFieldPtr>& fields) const = 0;
 
   /** @brief Virtual interface for computing objective gradient from a vector of serac::FiniteElementState*
    *
@@ -53,7 +51,7 @@ class ScalarObjective {
    * @param direction index for which field to take the gradient with respect to
    * @return mfem::Vector
    */
-  virtual mfem::Vector gradient(double time, double dt, const std::vector<FieldPtr>& fields, int direction) const = 0;
+  virtual mfem::Vector gradient(double time, double dt, const std::vector<ConstFieldPtr>& fields, int direction) const = 0;
 
   /// @brief name
   std::string name() const { return name_; }

--- a/src/serac/physics/scalar_objective.hpp
+++ b/src/serac/physics/scalar_objective.hpp
@@ -51,7 +51,8 @@ class ScalarObjective {
    * @param direction index for which field to take the gradient with respect to
    * @return mfem::Vector
    */
-  virtual mfem::Vector gradient(double time, double dt, const std::vector<ConstFieldPtr>& fields, int direction) const = 0;
+  virtual mfem::Vector gradient(double time, double dt, const std::vector<ConstFieldPtr>& fields,
+                                int direction) const = 0;
 
   /// @brief name
   std::string name() const { return name_; }

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -46,6 +46,7 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
   /// @brief disp, velo, accel
   static constexpr int NUM_STATE_VARS = 3;
 
+  /// @brief enumeration of the required states
   enum STATE
   {
     SHAPE_DISPLACEMENT,
@@ -221,7 +222,7 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
           // = pressure * (normal_new / norm(normal_old)) * w_old
 
           // We always query the pressure function in the undeformed configuration
-          return pressure_function(t, get<VALUE>(X), params...) * (n / norm(cross(get<DERIVATIVE>(X))));
+          return -pressure_function(t, get<VALUE>(X), params...) * (n / norm(cross(get<DERIVATIVE>(X))));
         },
         BaseResidualT::mesh_->domain(boundary_name));
 
@@ -231,7 +232,7 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
           auto x = X + displacement;
           auto n = cross(get<DERIVATIVE>(x));
           auto pressure = pressure_function(t, get<VALUE>(X), params...) * (n / norm(cross(get<DERIVATIVE>(X))));
-          return inner(get<VALUE>(V), pressure);
+          return inner(get<VALUE>(V), -pressure);
         },
         BaseResidualT::mesh_->domain(boundary_name));
   }
@@ -342,7 +343,7 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
 
       auto stress = material_.pkStress(*dt_, state, du_dX, dv_dX, params...);
 
-      return serac::tuple{material_.density(params...) * d2u_dt2, stress};
+      return serac::tuple{-material_.density(params...) * d2u_dt2, -stress};
     }
   };
 };
@@ -374,17 +375,6 @@ auto create_solid_residual(const std::string& physics_name, std::shared_ptr<sera
 
   return std::make_shared<ResidualT>(physics_name, mesh, states[SHAPE]->space(), states[DISP]->space(),
                                      parameter_fe_spaces);
-}
-
-namespace solid_states {
-
-enum SOLID_STATES
-{
-  DISPLACEMENT,
-  VELOCITY,
-  ACCEL,
-};
-
 }
 
 }  // namespace serac

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -46,7 +46,7 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
   /// @brief disp, velo, accel
   static constexpr int NUM_STATE_VARS = 3;
 
-  static enum SOLID_STATE { SHAPE_DISPLACEMENT, DISPLACEMENT, VELOCITY, ACCELERATION };
+  enum STATES { SHAPE_DISPLACEMENT, DISPLACEMENT, VELOCITY, ACCELERATION, NUM_STATES };
 
   /**
    * @brief Construct a new SolidResidual object

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -46,6 +46,8 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
   /// @brief disp, velo, accel
   static constexpr int NUM_STATE_VARS = 3;
 
+  static enum SOLID_STATE { SHAPE_DISPLACEMENT, DISPLACEMENT, VELOCITY, ACCELERATION };
+
   /**
    * @brief Construct a new SolidResidual object
    *
@@ -365,6 +367,17 @@ auto create_solid_residual(const std::string& physics_name, std::shared_ptr<sera
 
   return std::make_shared<ResidualT>(physics_name, mesh, states[SHAPE]->space(), states[DISP]->space(),
                                      parameter_fe_spaces);
+}
+
+namespace solid_states {
+
+enum SOLID_STATES
+{
+  DISPLACEMENT,
+  VELOCITY,
+  ACCEL,
+};
+
 }
 
 }  // namespace serac

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -232,7 +232,7 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
           auto x = X + displacement;
           auto n = cross(get<DERIVATIVE>(x));
           auto pressure = pressure_function(t, get<VALUE>(X), params...) * (n / norm(cross(get<DERIVATIVE>(X))));
-          return inner(get<VALUE>(V), -pressure);
+          return -inner(get<VALUE>(V), pressure);
         },
         BaseResidualT::mesh_->domain(boundary_name));
   }
@@ -296,7 +296,7 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
 
       auto stress = material_.pkStress(state, du_dX, params...);
 
-      return serac::tuple{material_.density(params...) * d2u_dt2, stress};
+      return serac::tuple{-material_.density(params...) * d2u_dt2, -stress};
     }
   };
 

--- a/src/serac/physics/solid_residual.hpp
+++ b/src/serac/physics/solid_residual.hpp
@@ -46,7 +46,14 @@ class SolidResidual<order, dim, Parameters<InputSpaces...>>
   /// @brief disp, velo, accel
   static constexpr int NUM_STATE_VARS = 3;
 
-  enum STATES { SHAPE_DISPLACEMENT, DISPLACEMENT, VELOCITY, ACCELERATION, NUM_STATES };
+  enum STATE
+  {
+    SHAPE_DISPLACEMENT,
+    DISPLACEMENT,
+    VELOCITY,
+    ACCELERATION,
+    NUM_STATES
+  };
 
   /**
    * @brief Construct a new SolidResidual object

--- a/src/serac/physics/tests/physics_test_utils.hpp
+++ b/src/serac/physics/tests/physics_test_utils.hpp
@@ -23,4 +23,3 @@ void pseudoRand(serac::FiniteElementVector& dual)
     dual(i) = -1.2 + 2.02 * (double(i) / sz);
   }
 }
-

--- a/src/serac/physics/tests/physics_test_utils.hpp
+++ b/src/serac/physics/tests/physics_test_utils.hpp
@@ -16,36 +16,7 @@
 #include "serac/physics/state/finite_element_dual.hpp"
 #include "serac/physics/state/finite_element_state.hpp"
 
-template <typename T>
-auto getPointers(std::vector<T>& values)
-{
-  std::vector<T*> pointers;
-  for (auto& t : values) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto getPointers(std::vector<T>& states, std::vector<T>& params)
-{
-  std::vector<T*> pointers;
-  for (auto& t : states) {
-    pointers.push_back(&t);
-  }
-  for (auto& t : params) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto getPointers(T& v)
-{
-  return std::vector<T*>{&v};
-}
-
-void pseudoRand(serac::FiniteElementState& dual)
+void pseudoRand(serac::FiniteElementVector& dual)
 {
   int sz = dual.Size();
   for (int i = 0; i < sz; ++i) {
@@ -53,10 +24,3 @@ void pseudoRand(serac::FiniteElementState& dual)
   }
 }
 
-void pseudoRand(serac::FiniteElementDual& dual)
-{
-  int sz = dual.Size();
-  for (int i = 0; i < sz; ++i) {
-    dual(i) = -1.2 + 2.02 * (double(i) / sz);
-  }
-}

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -15,35 +15,7 @@
 
 auto element_shape = mfem::Element::QUADRILATERAL;
 
-template <typename T>
-auto getPointers(std::vector<T>& states, std::vector<T>& params)
-{
-  assert(params.size() > 0);
-  std::vector<T*> pointers{&params[0]};
-  for (auto& t : states) {
-    pointers.push_back(&t);
-  }
-  for (size_t n = 1; n < params.size(); ++n) {
-    pointers.push_back(&params[n]);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto getPointers(T& v)
-{
-  return std::vector<T*>{&v};
-}
-
-void pseudoRand(serac::FiniteElementState& dual)
-{
-  int sz = dual.Size();
-  for (int i = 0; i < sz; ++i) {
-    dual(i) = -1.2 + 2.02 * (double(i) / sz);
-  }
-}
-
-void pseudoRand(serac::FiniteElementDual& dual)
+void pseudoRand(serac::FiniteElementVector& dual)
 {
   int sz = dual.Size();
   for (int i = 0; i < sz; ++i) {
@@ -60,13 +32,13 @@ struct ResidualFixture : public testing::Test {
 
   enum STATE
   {
+    SHAPE_DISP,
     DISP,
     VELO
   };
 
   enum PAR
   {
-    SHAPE_DISP,
     DENSITY
   };
 
@@ -86,8 +58,8 @@ struct ResidualFixture : public testing::Test {
         serac::StateManager::newState(VectorSpace{}, "shape_displacement", mesh->tag());
     serac::FiniteElementState density = serac::StateManager::newState(DensitySpace{}, "density", mesh->tag());
 
-    states = {disp, velo};
-    params = {shape_disp, density};
+    states = {shape_disp, disp, velo};
+    params = {density};
 
     for (auto s : states) {
       dual_states.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
@@ -96,8 +68,8 @@ struct ResidualFixture : public testing::Test {
       dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
     }
 
-    v_rhs_states = states;
-    v_rhs_params = params;
+    tangent_states = states;
+    tangent_params = params;
 
     std::string physics_name = "fake_physics";
 
@@ -107,10 +79,10 @@ struct ResidualFixture : public testing::Test {
     using ResidualT = serac::FunctionalResidual<dim, ShapeSpace, TrialSpace,
                                                 serac::Parameters<VectorSpace, VectorSpace, DensitySpace>>;
 
-    std::vector<const mfem::ParFiniteElementSpace*> inputs{&states[STATE::DISP].space(), &states[STATE::DISP].space(),
+    std::vector<const mfem::ParFiniteElementSpace*> inputs{&states[STATE::DISP].space(), &states[STATE::VELO].space(),
                                                            &params[PAR::DENSITY].space()};
 
-    auto f_residual = std::make_shared<ResidualT>(physics_name, mesh, params[PAR::SHAPE_DISP].space(),
+    auto f_residual = std::make_shared<ResidualT>(physics_name, mesh, states[STATE::SHAPE_DISP].space(),
                                                   states[STATE::DISP].space(), inputs);
 
     // apply some traction boundary conditions
@@ -129,30 +101,30 @@ struct ResidualFixture : public testing::Test {
 
     // initialize fields for testing
 
-    for (auto& s : v_rhs_states) {
+    for (auto& s : tangent_states) {
       pseudoRand(s);
     }
-    for (auto& p : v_rhs_params) {
+    for (auto& p : tangent_params) {
       pseudoRand(p);
     }
 
-    dual_states[0] = 1.0;
-    dual_states[1] = 2.0;
-    dual_params[0] = 1.0;
-    dual_params[1] = 2.0;
+    dual_states[SHAPE_DISP] = 4.0;
+    dual_states[DISP] = 1.0;
+    dual_states[VELO] = 2.0;
+    dual_params[DENSITY] = 3.0;
 
-    states[0].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[DISP].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = 0.1 * x;
       return u;
     });
 
-    states[1].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[VELO].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = -0.01 * x;
       return u;
     });
 
-    params[0] = 0.0;
-    params[1] = 1.2;
+    states[SHAPE_DISP] = 0.0;
+    params[DENSITY] = 1.2;
 
     // residual is abstract Residual class to ensure usage only through BasePhysics interface
     residual = f_residual;
@@ -173,22 +145,22 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementDual> dual_states;
   std::vector<serac::FiniteElementDual> dual_params;
 
-  std::vector<serac::FiniteElementState> v_rhs_states;
-  std::vector<serac::FiniteElementState> v_rhs_params;
+  std::vector<serac::FiniteElementState> tangent_states;
+  std::vector<serac::FiniteElementState> tangent_params;
 };
 
 TEST_F(ResidualFixture, VjpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto all_states = getPointers(states, params);
+  auto input_fields = constResidualPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[0].space(), "residual");
+  serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
 
-  res_vector = residual->residual(time, dt, all_states);
+  res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobian_weights = [&](size_t i) {
-    std::vector<double> tangents(all_states.size());
+    std::vector<double> tangents(input_fields.size());
     tangents[i] = 1.0;
     return tangents;
   };
@@ -196,21 +168,21 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
-  auto all_jvps = getPointers(dual_states, dual_params);
+  auto all_jvps = residualPointers(dual_states, dual_params);
 
   std::vector<serac::FiniteElementDual> all_Jvps;
   for (auto& jvp : all_jvps) {
     all_Jvps.push_back(*jvp);
   }
 
-  for (size_t i = 0; i < all_states.size(); ++i) {
+  for (size_t i = 0; i < input_fields.size(); ++i) {
     serac::FiniteElementDual& vjp = all_Jvps[i];
-    auto J = residual->jacobian(time, dt, all_states, jacobian_weights(i));
+    auto J = residual->jacobian(time, dt, input_fields, jacobian_weights(i));
     J->AddMultTranspose(v, vjp);
   }
-  residual->vjp(time, dt, all_states, getPointers(v), all_jvps);
+  residual->vjp(time, dt, input_fields, constResidualPointers(v), all_jvps);
 
-  for (size_t i = 0; i < all_states.size(); ++i) {
+  for (size_t i = 0; i < input_fields.size(); ++i) {
     EXPECT_NEAR(all_Jvps[i].Norml2(), all_jvps[i]->Norml2(), 1e-12) << " " << all_Jvps[i].name() << std::endl;
   }
 }
@@ -218,20 +190,20 @@ TEST_F(ResidualFixture, VjpConsistency)
 TEST_F(ResidualFixture, JvpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto all_states = getPointers(states, params);
+  auto input_fields = constResidualPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[0].space(), "residual");
-  res_vector = residual->residual(time, dt, all_states);
+  res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobianWeights = [&](size_t i) {
-    std::vector<double> tangents(all_states.size());
+    std::vector<double> tangents(input_fields.size());
     tangents[i] = 1.0;
     return tangents;
   };
 
   auto selectStates = [&](size_t i) {
-    auto pts = getPointers(v_rhs_states, v_rhs_params);
+    auto pts = constResidualPointers(tangent_states, tangent_params);
     for (size_t j = 0; j < pts.size(); ++j) {
       if (i != j) {
         pts[j] = nullptr;
@@ -243,32 +215,31 @@ TEST_F(ResidualFixture, JvpConsistency)
   serac::FiniteElementDual jvp_slow(states[0].space(), "jvp_slow");
   serac::FiniteElementDual jvp(states[0].space(), "jvp");
   jvp = 4.0;  // set to some value to test jvp resets these values
-  std::vector<serac::FiniteElementDual*> jvps = getPointers(jvp);
+  auto jvps = residualPointers(jvp);
 
-  auto all_v_rhs_states = getPointers(v_rhs_states, v_rhs_params);
+  auto all_tangent_fields = constResidualPointers(tangent_states, tangent_params);
 
-  for (size_t i = 0; i < all_states.size(); ++i) {
-    auto J = residual->jacobian(time, dt, all_states, jacobianWeights(i));
-    J->Mult(*all_v_rhs_states[i], jvp_slow);
-    residual->jvp(time, dt, all_states, selectStates(i), jvps);
+  for (size_t i = 0; i < input_fields.size(); ++i) {
+    auto J = residual->jacobian(time, dt, input_fields, jacobianWeights(i));
+    J->Mult(*all_tangent_fields[i], jvp_slow);
+    residual->jvp(time, dt, input_fields, selectStates(i), jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 
   // test jacobians in weighted combinations
   {
-    all_v_rhs_states[1] = nullptr;
-    all_v_rhs_states[3] = nullptr;
-    all_v_rhs_states[4] = nullptr;
+    all_tangent_fields[SHAPE_DISP] = nullptr;
+    all_tangent_fields[3] = nullptr;
 
-    double acceleration_factor = 0.2;
-    std::vector<double> jacobian_weights = {1.0, 0.0, acceleration_factor, 0.0, 0.0};
+    double velo_factor = 0.2;
+    std::vector<double> jacobian_weights = {0.0, 1.0, velo_factor, 0.0};
 
-    auto J = residual->jacobian(time, dt, all_states, jacobian_weights);
-    J->Mult(*all_v_rhs_states[0], jvp_slow);
+    auto J = residual->jacobian(time, dt, input_fields, jacobian_weights);
+    J->Mult(*all_tangent_fields[DISP], jvp_slow);
 
-    *all_v_rhs_states[2] = *all_v_rhs_states[0];
-    *all_v_rhs_states[2] *= acceleration_factor;
-    residual->jvp(time, dt, all_states, all_v_rhs_states, jvps);
+    tangent_states[VELO] = tangent_states[0];
+    tangent_states[VELO] *= velo_factor;
+    residual->jvp(time, dt, input_fields, all_tangent_fields, jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 }

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -145,7 +145,7 @@ struct ResidualFixture : public testing::Test {
 TEST_F(ResidualFixture, VjpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto input_fields = constResidualPointers(states, params);
+  auto input_fields = getConstFieldPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
 
@@ -161,7 +161,7 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
-  auto field_vjps = residualPointers(state_duals, state_params);
+  auto field_vjps = getFieldPointers(state_duals, state_params);
 
   std::vector<serac::FiniteElementDual> field_vjps_slow;
   for (auto& vjp : field_vjps) {
@@ -173,17 +173,18 @@ TEST_F(ResidualFixture, VjpConsistency)
     auto J = residual->jacobian(time, dt, input_fields, jacobian_weights(i));
     J->AddMultTranspose(v, vjp);
   }
-  residual->vjp(time, dt, input_fields, constResidualPointers(v), field_vjps);
+  residual->vjp(time, dt, input_fields, getConstFieldPointers(v), field_vjps);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
-    EXPECT_NEAR(field_vjps_slow[i].Norml2(), field_vjps[i]->Norml2(), 1e-12) << " " << field_vjps_slow[i].name() << std::endl;
+    EXPECT_NEAR(field_vjps_slow[i].Norml2(), field_vjps[i]->Norml2(), 1e-12)
+        << " " << field_vjps_slow[i].name() << std::endl;
   }
 }
 
 TEST_F(ResidualFixture, JvpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto input_fields = constResidualPointers(states, params);
+  auto input_fields = getConstFieldPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
   res_vector = residual->residual(time, dt, input_fields);
@@ -196,7 +197,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   };
 
   auto selectStates = [&](size_t i) {
-    auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+    auto field_tangents = getConstFieldPointers(state_tangents, param_tangents);
     for (size_t j = 0; j < field_tangents.size(); ++j) {
       if (i != j) {
         field_tangents[j] = nullptr;
@@ -208,9 +209,9 @@ TEST_F(ResidualFixture, JvpConsistency)
   serac::FiniteElementDual jvp_slow(states[DISP].space(), "jvp_slow");
   serac::FiniteElementDual jvp(states[DISP].space(), "jvp");
   jvp = 4.0;  // set to some value to test jvp resets these values
-  auto jvps = residualPointers(jvp);
+  auto jvps = getFieldPointers(jvp);
 
-  auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+  auto field_tangents = getConstFieldPointers(state_tangents, param_tangents);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
     auto J = residual->jacobian(time, dt, input_fields, jacobianWeights(i));

--- a/src/serac/physics/tests/test_functional_residual.cpp
+++ b/src/serac/physics/tests/test_functional_residual.cpp
@@ -11,17 +11,10 @@
 #include "serac/physics/mesh.hpp"
 #include "serac/physics/state/state_manager.hpp"
 
+#include "serac/physics/tests/physics_test_utils.hpp"
 #include "serac/physics/functional_residual.hpp"
 
 auto element_shape = mfem::Element::QUADRILATERAL;
-
-void pseudoRand(serac::FiniteElementVector& dual)
-{
-  int sz = dual.Size();
-  for (int i = 0; i < sz; ++i) {
-    dual(i) = -1.2 + 2.02 * (double(i) / sz);
-  }
-}
 
 struct ResidualFixture : public testing::Test {
   static constexpr int dim = 2;
@@ -62,14 +55,14 @@ struct ResidualFixture : public testing::Test {
     params = {density};
 
     for (auto s : states) {
-      dual_states.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
+      state_duals.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
     }
     for (auto p : params) {
-      dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
+      state_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
     }
 
-    tangent_states = states;
-    tangent_params = params;
+    state_tangents = states;
+    param_tangents = params;
 
     std::string physics_name = "fake_physics";
 
@@ -101,17 +94,17 @@ struct ResidualFixture : public testing::Test {
 
     // initialize fields for testing
 
-    for (auto& s : tangent_states) {
+    for (auto& s : state_tangents) {
       pseudoRand(s);
     }
-    for (auto& p : tangent_params) {
+    for (auto& p : param_tangents) {
       pseudoRand(p);
     }
 
-    dual_states[SHAPE_DISP] = 4.0;
-    dual_states[DISP] = 1.0;
-    dual_states[VELO] = 2.0;
-    dual_params[DENSITY] = 3.0;
+    state_duals[SHAPE_DISP] = 4.0;
+    state_duals[DISP] = 1.0;
+    state_duals[VELO] = 2.0;
+    state_params[DENSITY] = 3.0;
 
     states[DISP].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = 0.1 * x;
@@ -142,11 +135,11 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementState> states;
   std::vector<serac::FiniteElementState> params;
 
-  std::vector<serac::FiniteElementDual> dual_states;
-  std::vector<serac::FiniteElementDual> dual_params;
+  std::vector<serac::FiniteElementDual> state_duals;
+  std::vector<serac::FiniteElementDual> state_params;
 
-  std::vector<serac::FiniteElementState> tangent_states;
-  std::vector<serac::FiniteElementState> tangent_params;
+  std::vector<serac::FiniteElementState> state_tangents;
+  std::vector<serac::FiniteElementState> param_tangents;
 };
 
 TEST_F(ResidualFixture, VjpConsistency)
@@ -168,22 +161,22 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
-  auto all_jvps = residualPointers(dual_states, dual_params);
+  auto field_vjps = residualPointers(state_duals, state_params);
 
-  std::vector<serac::FiniteElementDual> all_Jvps;
-  for (auto& jvp : all_jvps) {
-    all_Jvps.push_back(*jvp);
+  std::vector<serac::FiniteElementDual> field_vjps_slow;
+  for (auto& vjp : field_vjps) {
+    field_vjps_slow.push_back(*vjp);
   }
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
-    serac::FiniteElementDual& vjp = all_Jvps[i];
+    serac::FiniteElementDual& vjp = field_vjps_slow[i];
     auto J = residual->jacobian(time, dt, input_fields, jacobian_weights(i));
     J->AddMultTranspose(v, vjp);
   }
-  residual->vjp(time, dt, input_fields, constResidualPointers(v), all_jvps);
+  residual->vjp(time, dt, input_fields, constResidualPointers(v), field_vjps);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
-    EXPECT_NEAR(all_Jvps[i].Norml2(), all_jvps[i]->Norml2(), 1e-12) << " " << all_Jvps[i].name() << std::endl;
+    EXPECT_NEAR(field_vjps_slow[i].Norml2(), field_vjps[i]->Norml2(), 1e-12) << " " << field_vjps_slow[i].name() << std::endl;
   }
 }
 
@@ -192,7 +185,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   // initialize the displacement and acceleration to a non-trivial field
   auto input_fields = constResidualPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[0].space(), "residual");
+  serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
   res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
@@ -203,43 +196,42 @@ TEST_F(ResidualFixture, JvpConsistency)
   };
 
   auto selectStates = [&](size_t i) {
-    auto pts = constResidualPointers(tangent_states, tangent_params);
-    for (size_t j = 0; j < pts.size(); ++j) {
+    auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+    for (size_t j = 0; j < field_tangents.size(); ++j) {
       if (i != j) {
-        pts[j] = nullptr;
+        field_tangents[j] = nullptr;
       }
     }
-    return pts;
+    return field_tangents;
   };
 
-  serac::FiniteElementDual jvp_slow(states[0].space(), "jvp_slow");
-  serac::FiniteElementDual jvp(states[0].space(), "jvp");
+  serac::FiniteElementDual jvp_slow(states[DISP].space(), "jvp_slow");
+  serac::FiniteElementDual jvp(states[DISP].space(), "jvp");
   jvp = 4.0;  // set to some value to test jvp resets these values
   auto jvps = residualPointers(jvp);
 
-  auto all_tangent_fields = constResidualPointers(tangent_states, tangent_params);
+  auto field_tangents = constResidualPointers(state_tangents, param_tangents);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
     auto J = residual->jacobian(time, dt, input_fields, jacobianWeights(i));
-    J->Mult(*all_tangent_fields[i], jvp_slow);
+    J->Mult(*field_tangents[i], jvp_slow);
     residual->jvp(time, dt, input_fields, selectStates(i), jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 
   // test jacobians in weighted combinations
   {
-    all_tangent_fields[SHAPE_DISP] = nullptr;
-    all_tangent_fields[3] = nullptr;
+    field_tangents[SHAPE_DISP] = nullptr;
+    field_tangents[3] = nullptr;
 
     double velo_factor = 0.2;
     std::vector<double> jacobian_weights = {0.0, 1.0, velo_factor, 0.0};
 
     auto J = residual->jacobian(time, dt, input_fields, jacobian_weights);
-    J->Mult(*all_tangent_fields[DISP], jvp_slow);
+    J->Mult(*field_tangents[DISP], jvp_slow);
 
-    tangent_states[VELO] = tangent_states[0];
-    tangent_states[VELO] *= velo_factor;
-    residual->jvp(time, dt, input_fields, all_tangent_fields, jvps);
+    state_tangents[VELO] *= velo_factor;
+    residual->jvp(time, dt, input_fields, field_tangents, jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 }

--- a/src/serac/physics/tests/test_heat_residual.cpp
+++ b/src/serac/physics/tests/test_heat_residual.cpp
@@ -103,8 +103,8 @@ struct ResidualFixture : public testing::Test {
       dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
     }
 
-    v_rhs_states = states;
-    v_rhs_params = params;
+    tangent_states = states;
+    tangent_params = params;
 
     std::string physics_name = "heat";
 
@@ -121,10 +121,10 @@ struct ResidualFixture : public testing::Test {
     heat_transfer_residual->addBoundaryIntegral(source_name,
                                                 [](auto /* t */, auto /* x */, auto /* n */) { return -1.0; });
 
-    for (auto& s : v_rhs_states) {
+    for (auto& s : tangent_states) {
       pseudoRand(s);
     }
-    for (auto& p : v_rhs_params) {
+    for (auto& p : tangent_params) {
       pseudoRand(p);
     }
 
@@ -153,8 +153,8 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementDual> dual_states;
   std::vector<serac::FiniteElementDual> dual_params;
 
-  std::vector<serac::FiniteElementState> v_rhs_states;
-  std::vector<serac::FiniteElementState> v_rhs_params;
+  std::vector<serac::FiniteElementState> tangent_states;
+  std::vector<serac::FiniteElementState> tangent_params;
 };
 
 TEST_F(ResidualFixture, VjpConsistency)
@@ -203,7 +203,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   };
 
   auto selectStates = [&](size_t i) {
-    auto pts = getPointers(v_rhs_states, v_rhs_params);
+    auto pts = getPointers(tangent_states, tangent_params);
     for (size_t j = 0; j < pts.size(); ++j) {
       if (i != j) {
         pts[j] = nullptr;
@@ -217,7 +217,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   jvp = 4.0;
   std::vector<serac::FiniteElementDual*> jvps = getPointers(jvp);
 
-  auto all_v_rhs_states = getPointers(v_rhs_states, v_rhs_params);
+  auto all_v_rhs_states = getPointers(tangent_states, tangent_params);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
     auto J = residual->jacobian(time, dt, all_states, jacobianWeights(i));

--- a/src/serac/physics/tests/test_heat_residual.cpp
+++ b/src/serac/physics/tests/test_heat_residual.cpp
@@ -57,8 +57,9 @@ struct ResidualFixture : public testing::Test {
 
     std::string physics_name = "heat";
 
-    auto heat_transfer_residual = std::make_shared<HeatResidualT>(physics_name, mesh, states[HeatResidualT::SHAPE_DISPLACEMENT].space(),
-                                                                  states[HeatResidualT::TEMPERATURE].space(), getSpaces(params));
+    auto heat_transfer_residual =
+        std::make_shared<HeatResidualT>(physics_name, mesh, states[HeatResidualT::SHAPE_DISPLACEMENT].space(),
+                                        states[HeatResidualT::TEMPERATURE].space(), getSpaces(params));
 
     ThermalMaterial mat(1.0, 1.0, 1.0);
     heat_transfer_residual->setMaterial(serac::DependsOn<0>{}, mesh->entireBodyName(), mat);
@@ -76,7 +77,8 @@ struct ResidualFixture : public testing::Test {
       pseudoRand(p);
     }
 
-    state_duals[HeatResidualT::TEMPERATURE] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
+    state_duals[HeatResidualT::TEMPERATURE] =
+        1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
 
     states[HeatResidualT::TEMPERATURE].setFromFieldFunction(
         [](serac::tensor<double, dim> x) { return 0.1 * std::pow(std::pow(x[0], 2.0) + std::pow(x[1], 2.0), 0.5); });
@@ -109,7 +111,7 @@ struct ResidualFixture : public testing::Test {
 
 TEST_F(ResidualFixture, VjpConsistency)
 {
-  auto input_fields = constResidualPointers(states, params);
+  auto input_fields = getConstFieldPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[HeatResidualT::TEMPERATURE].space(), "residual");
   res_vector = residual->residual(time, dt, input_fields);
@@ -124,9 +126,9 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
-  auto field_vjps = residualPointers(state_duals, state_params);
+  auto field_vjps = getFieldPointers(state_duals, state_params);
 
-  residual->vjp(time, dt, input_fields, constResidualPointers(v), field_vjps);
+  residual->vjp(time, dt, input_fields, getConstFieldPointers(v), field_vjps);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
     serac::FiniteElementState vjp = *input_fields[i];
@@ -140,7 +142,7 @@ TEST_F(ResidualFixture, VjpConsistency)
 
 TEST_F(ResidualFixture, JvpConsistency)
 {
-  auto input_fields = constResidualPointers(states, params);
+  auto input_fields = getConstFieldPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[HeatResidualT::TEMPERATURE].space(), "residual");
   res_vector = residual->residual(time, dt, input_fields);
@@ -153,7 +155,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   };
 
   auto selectStates = [&](size_t i) {
-    auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+    auto field_tangents = getConstFieldPointers(state_tangents, param_tangents);
     for (size_t j = 0; j < field_tangents.size(); ++j) {
       if (i != j) {
         field_tangents[j] = nullptr;
@@ -165,9 +167,9 @@ TEST_F(ResidualFixture, JvpConsistency)
   serac::FiniteElementDual jvp_slow(states[HeatResidualT::TEMPERATURE].space(), "jvp_slow");
   serac::FiniteElementDual jvp(states[HeatResidualT::TEMPERATURE].space(), "jvp");
   jvp = 4.0;
-  auto jvps = residualPointers(jvp);
+  auto jvps = getFieldPointers(jvp);
 
-  auto field_tangents = residualPointers(state_tangents, param_tangents);
+  auto field_tangents = getFieldPointers(state_tangents, param_tangents);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
     auto J = residual->jacobian(time, dt, input_fields, jacobianWeights(i));

--- a/src/serac/physics/tests/test_heat_residual.cpp
+++ b/src/serac/physics/tests/test_heat_residual.cpp
@@ -77,14 +77,15 @@ struct ResidualFixture : public testing::Test {
       pseudoRand(p);
     }
 
-    state_duals[HeatResidualT::TEMPERATURE] =
-        1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
+    // used to test that vjp acts via +=, add initial value to shape displacement dual
+    state_duals[HeatResidualT::TEMPERATURE] = 1.0;
 
+    states[HeatResidualT::SHAPE_DISPLACEMENT] = 0.0;
     states[HeatResidualT::TEMPERATURE].setFromFieldFunction(
         [](serac::tensor<double, dim> x) { return 0.1 * std::pow(std::pow(x[0], 2.0) + std::pow(x[1], 2.0), 0.5); });
-    states[HeatResidualT::TEMPERATURE_RATE].setFromFieldFunction(
-        [](serac::tensor<double, dim> x) { return 0.01 * std::pow(std::pow(x[0], 2.0) + std::pow(x[1], 2.0), 0.5); });
-    states[HeatResidualT::SHAPE_DISPLACEMENT] = 0.0;
+    states[HeatResidualT::TEMPERATURE_RATE].setFromFieldFunction([](serac::tensor<double, dim> x) {
+      return 0.01 * std::pow(std::pow(x[0], 2.0) + std::pow(0.5 * x[1], 2.0), 0.5);
+    });
     params[0] = 0.5;
 
     residual = heat_transfer_residual;
@@ -135,7 +136,7 @@ TEST_F(ResidualFixture, VjpConsistency)
     vjp = 0.0;
     auto J = residual->jacobian(time, dt, input_fields, jacobian_weights(i));
     J->MultTranspose(v, vjp);
-    if (i == 0) vjp += 1.0;  // make sure vjp uses +=
+    if (i == HeatResidualT::TEMPERATURE) vjp += 1.0;  // make sure vjp uses +=
     EXPECT_NEAR(vjp.Norml2(), field_vjps[i]->Norml2(), 1e-12);
   }
 }

--- a/src/serac/physics/tests/test_heat_residual.cpp
+++ b/src/serac/physics/tests/test_heat_residual.cpp
@@ -11,55 +11,11 @@
 #include "serac/physics/materials/parameterized_thermal_material.hpp"
 #include "serac/physics/mesh.hpp"
 #include "serac/physics/state/state_manager.hpp"
+
+#include "serac/physics/tests/physics_test_utils.hpp"
 #include "serac/physics/heat_transfer_residual.hpp"
 
 auto element_shape = mfem::Element::QUADRILATERAL;
-
-template <typename T>
-auto getPointers(std::vector<T>& values)
-{
-  std::vector<T*> pointers;
-  for (auto& t : values) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto getPointers(std::vector<T>& states, std::vector<T>& params)
-{
-  assert(params.size() > 0);
-  std::vector<T*> pointers;
-  for (auto& t : states) {
-    pointers.push_back(&t);
-  }
-  for (auto& t : params) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto getPointers(T& v)
-{
-  return std::vector<T*>{&v};
-}
-
-void pseudoRand(serac::FiniteElementState& dual)
-{
-  int sz = dual.Size();
-  for (int i = 0; i < sz; ++i) {
-    dual(i) = -1.2 + 2.02 * (double(i) / sz);
-  }
-}
-
-void pseudoRand(serac::FiniteElementDual& dual)
-{
-  int sz = dual.Size();
-  for (int i = 0; i < sz; ++i) {
-    dual(i) = -1.2 + 2.02 * (double(i) / sz);
-  }
-}
 
 struct ResidualFixture : public testing::Test {
   static constexpr int dim = 2;
@@ -70,13 +26,6 @@ struct ResidualFixture : public testing::Test {
   using ParamSpace = serac::L2<order - 1>;
 
   using ThermalMaterial = serac::heat_transfer::ParameterizedLinearIsotropicConductor;
-
-  enum StateOrder
-  {
-    SHAPE,
-    TEMP,
-    TRATE
-  };
 
   void SetUp()
   {
@@ -97,20 +46,19 @@ struct ResidualFixture : public testing::Test {
     params = {conductivity_offset};
 
     for (auto s : states) {
-      dual_states.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
+      state_duals.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
     }
     for (auto p : params) {
-      dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
+      state_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
     }
 
-    tangent_states = states;
-    tangent_params = params;
+    state_tangents = states;
+    param_tangents = params;
 
     std::string physics_name = "heat";
 
-    using HeatResidualT = serac::HeatTransferResidual<order, dim, serac::Parameters<ParamSpace>>;
-    auto heat_transfer_residual = std::make_shared<HeatResidualT>(physics_name, mesh, states[SHAPE].space(),
-                                                                  states[TEMP].space(), getSpaces(params));
+    auto heat_transfer_residual = std::make_shared<HeatResidualT>(physics_name, mesh, states[HeatResidualT::SHAPE_DISPLACEMENT].space(),
+                                                                  states[HeatResidualT::TEMPERATURE].space(), getSpaces(params));
 
     ThermalMaterial mat(1.0, 1.0, 1.0);
     heat_transfer_residual->setMaterial(serac::DependsOn<0>{}, mesh->entireBodyName(), mat);
@@ -121,24 +69,26 @@ struct ResidualFixture : public testing::Test {
     heat_transfer_residual->addBoundaryIntegral(source_name,
                                                 [](auto /* t */, auto /* x */, auto /* n */) { return -1.0; });
 
-    for (auto& s : tangent_states) {
+    for (auto& s : state_tangents) {
       pseudoRand(s);
     }
-    for (auto& p : tangent_params) {
+    for (auto& p : param_tangents) {
       pseudoRand(p);
     }
 
-    dual_states[0] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
+    state_duals[HeatResidualT::TEMPERATURE] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
 
-    states[TEMP].setFromFieldFunction(
+    states[HeatResidualT::TEMPERATURE].setFromFieldFunction(
         [](serac::tensor<double, dim> x) { return 0.1 * std::pow(std::pow(x[0], 2.0) + std::pow(x[1], 2.0), 0.5); });
-    states[TRATE].setFromFieldFunction(
+    states[HeatResidualT::TEMPERATURE_RATE].setFromFieldFunction(
         [](serac::tensor<double, dim> x) { return 0.01 * std::pow(std::pow(x[0], 2.0) + std::pow(x[1], 2.0), 0.5); });
-    states[SHAPE] = 0.0;
+    states[HeatResidualT::SHAPE_DISPLACEMENT] = 0.0;
     params[0] = 0.5;
 
     residual = heat_transfer_residual;
   }
+
+  using HeatResidualT = serac::HeatTransferResidual<order, dim, serac::Parameters<ParamSpace>>;
 
   const double time = 0.0;
   const double dt = 1.0;
@@ -150,23 +100,23 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementState> states;
   std::vector<serac::FiniteElementState> params;
 
-  std::vector<serac::FiniteElementDual> dual_states;
-  std::vector<serac::FiniteElementDual> dual_params;
+  std::vector<serac::FiniteElementDual> state_duals;
+  std::vector<serac::FiniteElementDual> state_params;
 
-  std::vector<serac::FiniteElementState> tangent_states;
-  std::vector<serac::FiniteElementState> tangent_params;
+  std::vector<serac::FiniteElementState> state_tangents;
+  std::vector<serac::FiniteElementState> param_tangents;
 };
 
 TEST_F(ResidualFixture, VjpConsistency)
 {
-  auto all_states = getPointers(states, params);
+  auto input_fields = constResidualPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[TEMP].space(), "residual");
-  res_vector = residual->residual(time, dt, all_states);
+  serac::FiniteElementDual res_vector(states[HeatResidualT::TEMPERATURE].space(), "residual");
+  res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobian_weights = [&](size_t i) {
-    std::vector<double> tangents(all_states.size());
+    std::vector<double> tangents(input_fields.size());
     tangents[i] = 1.0;
     return tangents;
   };
@@ -174,55 +124,55 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
-  auto all_vjps = getPointers(dual_states, dual_params);
+  auto field_vjps = residualPointers(state_duals, state_params);
 
-  residual->vjp(time, dt, all_states, getPointers(v), all_vjps);
+  residual->vjp(time, dt, input_fields, constResidualPointers(v), field_vjps);
 
-  for (size_t i = 0; i < all_states.size(); ++i) {
-    serac::FiniteElementState vjp = *all_states[i];
+  for (size_t i = 0; i < input_fields.size(); ++i) {
+    serac::FiniteElementState vjp = *input_fields[i];
     vjp = 0.0;
-    auto J = residual->jacobian(time, dt, all_states, jacobian_weights(i));
+    auto J = residual->jacobian(time, dt, input_fields, jacobian_weights(i));
     J->MultTranspose(v, vjp);
     if (i == 0) vjp += 1.0;  // make sure vjp uses +=
-    EXPECT_NEAR(vjp.Norml2(), all_vjps[i]->Norml2(), 1e-12);
+    EXPECT_NEAR(vjp.Norml2(), field_vjps[i]->Norml2(), 1e-12);
   }
 }
 
 TEST_F(ResidualFixture, JvpConsistency)
 {
-  auto all_states = getPointers(states, params);
+  auto input_fields = constResidualPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[TEMP].space(), "residual");
-  res_vector = residual->residual(time, dt, all_states);
+  serac::FiniteElementDual res_vector(states[HeatResidualT::TEMPERATURE].space(), "residual");
+  res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobianWeights = [&](size_t i) {
-    std::vector<double> tangents(all_states.size());
+    std::vector<double> tangents(input_fields.size());
     tangents[i] = 1.0;
     return tangents;
   };
 
   auto selectStates = [&](size_t i) {
-    auto pts = getPointers(tangent_states, tangent_params);
-    for (size_t j = 0; j < pts.size(); ++j) {
+    auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+    for (size_t j = 0; j < field_tangents.size(); ++j) {
       if (i != j) {
-        pts[j] = nullptr;
+        field_tangents[j] = nullptr;
       }
     }
-    return pts;
+    return field_tangents;
   };
 
-  serac::FiniteElementDual jvp_slow(states[TEMP].space(), "jvp_slow");
-  serac::FiniteElementDual jvp(states[TEMP].space(), "jvp");
+  serac::FiniteElementDual jvp_slow(states[HeatResidualT::TEMPERATURE].space(), "jvp_slow");
+  serac::FiniteElementDual jvp(states[HeatResidualT::TEMPERATURE].space(), "jvp");
   jvp = 4.0;
-  std::vector<serac::FiniteElementDual*> jvps = getPointers(jvp);
+  auto jvps = residualPointers(jvp);
 
-  auto all_v_rhs_states = getPointers(tangent_states, tangent_params);
+  auto field_tangents = residualPointers(state_tangents, param_tangents);
 
-  for (size_t i = 0; i < all_states.size(); ++i) {
-    auto J = residual->jacobian(time, dt, all_states, jacobianWeights(i));
-    J->Mult(*all_v_rhs_states[i], jvp_slow);
-    residual->jvp(time, dt, all_states, selectStates(i), jvps);
+  for (size_t i = 0; i < input_fields.size(); ++i) {
+    auto J = residual->jacobian(time, dt, input_fields, jacobianWeights(i));
+    J->Mult(*field_tangents[i], jvp_slow);
+    residual->jvp(time, dt, input_fields, selectStates(i), jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 }

--- a/src/serac/physics/tests/test_kinematic_objective.cpp
+++ b/src/serac/physics/tests/test_kinematic_objective.cpp
@@ -64,12 +64,12 @@ struct ConstrainedResidualFixture : public testing::Test {
 
     double time = 0.0;
     double dt = 0.0;
-    auto all_states = getPointers(states, params);
-    auto objective_states = {all_states[SHAPE_DISP], all_states[DISP], all_states[DENSITY]};
+    auto input_fields = constResidualPointers(states, params);
+    auto objective_states = {input_fields[SHAPE_DISP], input_fields[DISP], input_fields[DENSITY]};
 
-    ObjectiveT::SpacesT param_space_ptrs{&all_states[DISP]->space(), &all_states[DENSITY]->space()};
+    ObjectiveT::SpacesT param_space_ptrs{&input_fields[DISP]->space(), &input_fields[DENSITY]->space()};
 
-    ObjectiveT mass_objective("mass constraining", mesh, all_states[SHAPE_DISP]->space(), param_space_ptrs);
+    ObjectiveT mass_objective("mass constraining", mesh, input_fields[SHAPE_DISP]->space(), param_space_ptrs);
     mass_objective.addBodyIntegral(serac::DependsOn<1>{}, mesh->entireBodyName(),
                                    [](double /*time*/, auto /*X*/, auto RHO) { return get<serac::VALUE>(RHO); });
 
@@ -79,7 +79,7 @@ struct ConstrainedResidualFixture : public testing::Test {
 
     for (int i = 0; i < dim; ++i) {
       auto cg_objective = std::make_shared<ObjectiveT>("translation" + std::to_string(i), mesh,
-                                                       all_states[SHAPE_DISP]->space(), param_space_ptrs);
+                                                       input_fields[SHAPE_DISP]->space(), param_space_ptrs);
       cg_objective->addBodyIntegral(
           serac::DependsOn<0, 1>{}, mesh->entireBodyName(),
           [i](double
@@ -92,7 +92,7 @@ struct ConstrainedResidualFixture : public testing::Test {
 
     for (int i = 0; i < dim; ++i) {
       auto center_rotation_objective = std::make_shared<ObjectiveT>("rotation" + std::to_string(i), mesh,
-                                                                    all_states[SHAPE_DISP]->space(), param_space_ptrs);
+                                                                    input_fields[SHAPE_DISP]->space(), param_space_ptrs);
       center_rotation_objective->addBodyIntegral(serac::DependsOn<0, 1>{}, mesh->entireBodyName(),
                                                  [i, initial_cg](double /*time*/, auto X, auto U, auto RHO) {
                                                    auto u = get<serac::VALUE>(U);
@@ -153,13 +153,13 @@ TEST_F(ConstrainedResidualFixture, CanComputeResidualObjectivesAndTheirGradients
 {
   double time = 0.0;
   double dt = 1.0;
-  auto all_states = getPointers(states, params);
+  auto input_fields = constResidualPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
-  res_vector = residual->residual(time, dt, all_states);
+  res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
-  auto objective_states = {all_states[SHAPE_DISP], all_states[DISP], all_states[DENSITY]};
+  auto objective_states = {input_fields[SHAPE_DISP], input_fields[DISP], input_fields[DENSITY]};
   for (const auto& c : constraints) {
     ASSERT_NE(0.0, c->evaluate(time, dt, objective_states));
     for (int i = 0; i < dim; ++i) {

--- a/src/serac/physics/tests/test_kinematic_objective.cpp
+++ b/src/serac/physics/tests/test_kinematic_objective.cpp
@@ -64,7 +64,7 @@ struct ConstrainedResidualFixture : public testing::Test {
 
     double time = 0.0;
     double dt = 0.0;
-    auto input_fields = constResidualPointers(states, params);
+    auto input_fields = getConstFieldPointers(states, params);
     auto objective_states = {input_fields[SHAPE_DISP], input_fields[DISP], input_fields[DENSITY]};
 
     ObjectiveT::SpacesT param_space_ptrs{&input_fields[DISP]->space(), &input_fields[DENSITY]->space()};
@@ -91,8 +91,8 @@ struct ConstrainedResidualFixture : public testing::Test {
     }
 
     for (int i = 0; i < dim; ++i) {
-      auto center_rotation_objective = std::make_shared<ObjectiveT>("rotation" + std::to_string(i), mesh,
-                                                                    input_fields[SHAPE_DISP]->space(), param_space_ptrs);
+      auto center_rotation_objective = std::make_shared<ObjectiveT>(
+          "rotation" + std::to_string(i), mesh, input_fields[SHAPE_DISP]->space(), param_space_ptrs);
       center_rotation_objective->addBodyIntegral(serac::DependsOn<0, 1>{}, mesh->entireBodyName(),
                                                  [i, initial_cg](double /*time*/, auto X, auto U, auto RHO) {
                                                    auto u = get<serac::VALUE>(U);
@@ -153,7 +153,7 @@ TEST_F(ConstrainedResidualFixture, CanComputeResidualObjectivesAndTheirGradients
 {
   double time = 0.0;
   double dt = 1.0;
-  auto input_fields = constResidualPointers(states, params);
+  auto input_fields = getConstFieldPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
   res_vector = residual->residual(time, dt, input_fields);

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -96,8 +96,9 @@ struct ResidualFixture : public testing::Test {
 
     std::string physics_name = "solid";
 
-    auto solid_mechanics_residual = std::make_shared<SolidResidualT>(
-        physics_name, mesh, states[SolidResidualT::SHAPE_DISPLACEMENT].space(), states[SolidResidualT::DISPLACEMENT].space(), getSpaces(params));
+    auto solid_mechanics_residual =
+        std::make_shared<SolidResidualT>(physics_name, mesh, states[SolidResidualT::SHAPE_DISPLACEMENT].space(),
+                                         states[SolidResidualT::DISPLACEMENT].space(), getSpaces(params));
     SolidMaterial mat;
     mat.K = 1.0;
     mat.G = 0.5;
@@ -168,7 +169,7 @@ struct ResidualFixture : public testing::Test {
 TEST_F(ResidualFixture, VjpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto input_fields = constResidualPointers(states, params);
+  auto input_fields = getConstFieldPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[SolidResidualT::DISPLACEMENT].space(), "residual");
   res_vector = residual->residual(time, dt, input_fields);
@@ -183,9 +184,9 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
-  auto field_vjps = residualPointers(state_duals, state_params);
+  auto field_vjps = getFieldPointers(state_duals, state_params);
 
-  residual->vjp(time, dt, input_fields, constResidualPointers(v), field_vjps);
+  residual->vjp(time, dt, input_fields, getConstFieldPointers(v), field_vjps);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
     serac::FiniteElementState vjp_slow = *input_fields[i];
@@ -200,7 +201,7 @@ TEST_F(ResidualFixture, VjpConsistency)
 TEST_F(ResidualFixture, JvpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto input_fields = constResidualPointers(states, params);
+  auto input_fields = getConstFieldPointers(states, params);
 
   serac::FiniteElementDual res_vector(states[SolidResidualT::DISPLACEMENT].space(), "residual");
   res_vector = residual->residual(time, dt, input_fields);
@@ -213,7 +214,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   };
 
   auto selectStates = [&](size_t i) {
-    auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+    auto field_tangents = getConstFieldPointers(state_tangents, param_tangents);
     for (size_t j = 0; j < field_tangents.size(); ++j) {
       if (i != j) {
         field_tangents[j] = nullptr;
@@ -225,9 +226,9 @@ TEST_F(ResidualFixture, JvpConsistency)
   serac::FiniteElementDual jvp_slow(states[SolidResidualT::DISPLACEMENT].space(), "jvp_slow");
   serac::FiniteElementDual jvp(states[SolidResidualT::DISPLACEMENT].space(), "jvp");
   jvp = 4.0;  // set to some value to test jvp resets these values
-  auto jvps = residualPointers(jvp);
+  auto jvps = getFieldPointers(jvp);
 
-  auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+  auto field_tangents = getConstFieldPointers(state_tangents, param_tangents);
 
   for (size_t i = 0; i < input_fields.size(); ++i) {
     auto J = residual->jacobian(time, dt, input_fields, jacobianWeights(i));

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -138,14 +138,14 @@ struct ResidualFixture : public testing::Test {
       dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
     }
 
-    v_rhs_states = states;
-    v_rhs_params = params;
+    tangent_states = states;
+    tangent_params = params;
 
     std::string physics_name = "solid";
 
     using SolidResidualT = serac::SolidResidual<disp_order, dim, serac::Parameters<DensitySpace>>;
-    auto solid_mechanics_residual = std::make_shared<SolidResidualT>(physics_name, mesh, states[SHAPE].space(),
-                                                                     states[DISP].space(), getSpaces(params));
+    auto solid_mechanics_residual = std::make_shared<SolidResidualT>(
+        physics_name, mesh, states[SHAPE].space(), states[SolidResidualT::DISPLACEMENT].space(), getSpaces(params));
     SolidMaterial mat;
     mat.K = 1.0;
     mat.G = 0.5;
@@ -164,10 +164,10 @@ struct ResidualFixture : public testing::Test {
     solid_mechanics_residual->addPressure(surface_name, [](auto /*t*/, auto /*x*/) { return 0.6; });
 
     // initialize fields for testing
-    for (auto& s : v_rhs_states) {
+    for (auto& s : tangent_states) {
       pseudoRand(s);
     }
-    for (auto& p : v_rhs_params) {
+    for (auto& p : tangent_params) {
       pseudoRand(p);
     }
 
@@ -207,8 +207,8 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementDual> dual_states;
   std::vector<serac::FiniteElementDual> dual_params;
 
-  std::vector<serac::FiniteElementState> v_rhs_states;
-  std::vector<serac::FiniteElementState> v_rhs_params;
+  std::vector<serac::FiniteElementState> tangent_states;
+  std::vector<serac::FiniteElementState> tangent_params;
 };
 
 TEST_F(ResidualFixture, VjpConsistency)
@@ -259,7 +259,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   };
 
   auto selectStates = [&](size_t i) {
-    auto pts = getPointers(v_rhs_states, v_rhs_params);
+    auto pts = getPointers(tangent_states, tangent_params);
     for (size_t j = 0; j < pts.size(); ++j) {
       if (i != j) {
         pts[j] = nullptr;
@@ -273,7 +273,7 @@ TEST_F(ResidualFixture, JvpConsistency)
   jvp = 4.0;  // set to some value to test jvp resets these values
   std::vector<serac::FiniteElementDual*> jvps = getPointers(jvp);
 
-  auto all_v_rhs_states = getPointers(v_rhs_states, v_rhs_params);
+  auto all_v_rhs_states = getPointers(tangent_states, tangent_params);
 
   for (size_t i = 0; i < all_states.size(); ++i) {
     auto J = residual->jacobian(time, dt, all_states, jacobianWeights(i));

--- a/src/serac/physics/tests/test_solid_residual.cpp
+++ b/src/serac/physics/tests/test_solid_residual.cpp
@@ -11,55 +11,11 @@
 #include "serac/physics/materials/solid_material.hpp"
 #include "serac/physics/mesh.hpp"
 #include "serac/physics/state/state_manager.hpp"
+
+#include "serac/physics/tests/physics_test_utils.hpp"
 #include "serac/physics/solid_residual.hpp"
 
 auto element_shape = mfem::Element::QUADRILATERAL;
-
-template <typename T>
-auto getPointers(std::vector<T>& values)
-{
-  std::vector<T*> pointers;
-  for (auto& t : values) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto getPointers(std::vector<T>& states, std::vector<T>& params)
-{
-  assert(params.size() > 0);
-  std::vector<T*> pointers;
-  for (auto& t : states) {
-    pointers.push_back(&t);
-  }
-  for (auto& t : params) {
-    pointers.push_back(&t);
-  }
-  return pointers;
-}
-
-template <typename T>
-auto getPointers(T& v)
-{
-  return std::vector<T*>{&v};
-}
-
-void pseudoRand(serac::FiniteElementState& dual)
-{
-  int sz = dual.Size();
-  for (int i = 0; i < sz; ++i) {
-    dual(i) = -1.2 + 2.02 * (double(i) / sz);
-  }
-}
-
-void pseudoRand(serac::FiniteElementDual& dual)
-{
-  int sz = dual.Size();
-  for (int i = 0; i < sz; ++i) {
-    dual(i) = -1.2 + 2.02 * (double(i) / sz);
-  }
-}
 
 namespace serac {
 
@@ -103,12 +59,9 @@ struct ResidualFixture : public testing::Test {
   using SolidMaterial = serac::solid_mechanics::NeoHookeanWithFieldDensity;
   using SolidRateMaterial = serac::NeoHookeanWithFieldWithRateForTesting;
 
-  enum StateOrder
+  enum PARAMS
   {
-    SHAPE,
-    DISP,
-    VELO,
-    ACCEL
+    DENSITY
   };
 
   void SetUp()
@@ -132,20 +85,19 @@ struct ResidualFixture : public testing::Test {
     params = {density};
 
     for (auto s : states) {
-      dual_states.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
+      state_duals.push_back(serac::FiniteElementDual(s.space(), s.name() + "_dual"));
     }
     for (auto p : params) {
-      dual_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
+      state_params.push_back(serac::FiniteElementDual(p.space(), p.name() + "_dual"));
     }
 
-    tangent_states = states;
-    tangent_params = params;
+    state_tangents = states;
+    param_tangents = params;
 
     std::string physics_name = "solid";
 
-    using SolidResidualT = serac::SolidResidual<disp_order, dim, serac::Parameters<DensitySpace>>;
     auto solid_mechanics_residual = std::make_shared<SolidResidualT>(
-        physics_name, mesh, states[SHAPE].space(), states[SolidResidualT::DISPLACEMENT].space(), getSpaces(params));
+        physics_name, mesh, states[SolidResidualT::SHAPE_DISPLACEMENT].space(), states[SolidResidualT::DISPLACEMENT].space(), getSpaces(params));
     SolidMaterial mat;
     mat.K = 1.0;
     mat.G = 0.5;
@@ -164,33 +116,35 @@ struct ResidualFixture : public testing::Test {
     solid_mechanics_residual->addPressure(surface_name, [](auto /*t*/, auto /*x*/) { return 0.6; });
 
     // initialize fields for testing
-    for (auto& s : tangent_states) {
+    for (auto& s : state_tangents) {
       pseudoRand(s);
     }
-    for (auto& p : tangent_params) {
+    for (auto& p : param_tangents) {
       pseudoRand(p);
     }
 
-    dual_states[0] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
+    state_duals[0] = 1.0;  // used to test that vjp acts via +=, add initial value to shape displacement dual
 
-    states[DISP].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[SolidResidualT::DISPLACEMENT].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = 0.1 * x;
       return u;
     });
-    states[VELO].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[SolidResidualT::VELOCITY].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = -0.1 * x;
       return u;
     });
-    states[ACCEL].setFromFieldFunction([](serac::tensor<double, dim> x) {
+    states[SolidResidualT::ACCELERATION].setFromFieldFunction([](serac::tensor<double, dim> x) {
       auto u = -0.01 * x;
       return u;
     });
-    states[SHAPE] = 0.0;
+    states[SolidResidualT::SHAPE_DISPLACEMENT] = 0.0;
     params[0] = 1.2;
 
     // residual is abstract Residual class to ensure usage only through BasePhysics interface
     residual = solid_mechanics_residual;
   }
+
+  using SolidResidualT = serac::SolidResidual<disp_order, dim, serac::Parameters<DensitySpace>>;
 
   const double time = 0.0;
   const double dt = 1.0;
@@ -204,24 +158,24 @@ struct ResidualFixture : public testing::Test {
   std::vector<serac::FiniteElementState> states;
   std::vector<serac::FiniteElementState> params;
 
-  std::vector<serac::FiniteElementDual> dual_states;
-  std::vector<serac::FiniteElementDual> dual_params;
+  std::vector<serac::FiniteElementDual> state_duals;
+  std::vector<serac::FiniteElementDual> state_params;
 
-  std::vector<serac::FiniteElementState> tangent_states;
-  std::vector<serac::FiniteElementState> tangent_params;
+  std::vector<serac::FiniteElementState> state_tangents;
+  std::vector<serac::FiniteElementState> param_tangents;
 };
 
 TEST_F(ResidualFixture, VjpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto all_states = getPointers(states, params);
+  auto input_fields = constResidualPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
-  res_vector = residual->residual(time, dt, all_states);
+  serac::FiniteElementDual res_vector(states[SolidResidualT::DISPLACEMENT].space(), "residual");
+  res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobian_weights = [&](size_t i) {
-    std::vector<double> tangents(all_states.size());
+    std::vector<double> tangents(input_fields.size());
     tangents[i] = 1.0;
     return tangents;
   };
@@ -229,75 +183,74 @@ TEST_F(ResidualFixture, VjpConsistency)
   // test vjp
   serac::FiniteElementState v(res_vector.space(), "v");
   pseudoRand(v);
-  auto all_vjps = getPointers(dual_states, dual_params);
+  auto field_vjps = residualPointers(state_duals, state_params);
 
-  residual->vjp(time, dt, all_states, getPointers(v), all_vjps);
+  residual->vjp(time, dt, input_fields, constResidualPointers(v), field_vjps);
 
-  for (size_t i = 0; i < all_states.size(); ++i) {
-    serac::FiniteElementState vjp = *all_states[i];
-    vjp = 0.0;
-    auto J = residual->jacobian(time, dt, all_states, jacobian_weights(i));
-    J->MultTranspose(v, vjp);
-    if (i == 0) vjp += 1.0;  // make sure vjp uses +=
-    EXPECT_NEAR(vjp.Norml2(), all_vjps[i]->Norml2(), 1e-12);
+  for (size_t i = 0; i < input_fields.size(); ++i) {
+    serac::FiniteElementState vjp_slow = *input_fields[i];
+    vjp_slow = 0.0;
+    auto J = residual->jacobian(time, dt, input_fields, jacobian_weights(i));
+    J->MultTranspose(v, vjp_slow);
+    if (i == 0) vjp_slow += 1.0;  // make sure vjp uses +=
+    EXPECT_NEAR(vjp_slow.Norml2(), field_vjps[i]->Norml2(), 1e-12);
   }
 }
 
 TEST_F(ResidualFixture, JvpConsistency)
 {
   // initialize the displacement and acceleration to a non-trivial field
-  auto all_states = getPointers(states, params);
+  auto input_fields = constResidualPointers(states, params);
 
-  serac::FiniteElementDual res_vector(states[DISP].space(), "residual");
-  res_vector = residual->residual(time, dt, all_states);
+  serac::FiniteElementDual res_vector(states[SolidResidualT::DISPLACEMENT].space(), "residual");
+  res_vector = residual->residual(time, dt, input_fields);
   ASSERT_NE(0.0, res_vector.Norml2());
 
   auto jacobianWeights = [&](size_t i) {
-    std::vector<double> tangents(all_states.size());
+    std::vector<double> tangents(input_fields.size());
     tangents[i] = 1.0;
     return tangents;
   };
 
   auto selectStates = [&](size_t i) {
-    auto pts = getPointers(tangent_states, tangent_params);
-    for (size_t j = 0; j < pts.size(); ++j) {
+    auto field_tangents = constResidualPointers(state_tangents, param_tangents);
+    for (size_t j = 0; j < field_tangents.size(); ++j) {
       if (i != j) {
-        pts[j] = nullptr;
+        field_tangents[j] = nullptr;
       }
     }
-    return pts;
+    return field_tangents;
   };
 
-  serac::FiniteElementDual jvp_slow(states[DISP].space(), "jvp_slow");
-  serac::FiniteElementDual jvp(states[DISP].space(), "jvp");
+  serac::FiniteElementDual jvp_slow(states[SolidResidualT::DISPLACEMENT].space(), "jvp_slow");
+  serac::FiniteElementDual jvp(states[SolidResidualT::DISPLACEMENT].space(), "jvp");
   jvp = 4.0;  // set to some value to test jvp resets these values
-  std::vector<serac::FiniteElementDual*> jvps = getPointers(jvp);
+  auto jvps = residualPointers(jvp);
 
-  auto all_v_rhs_states = getPointers(tangent_states, tangent_params);
+  auto field_tangents = constResidualPointers(state_tangents, param_tangents);
 
-  for (size_t i = 0; i < all_states.size(); ++i) {
-    auto J = residual->jacobian(time, dt, all_states, jacobianWeights(i));
-    J->Mult(*all_v_rhs_states[i], jvp_slow);
-    residual->jvp(time, dt, all_states, selectStates(i), jvps);
+  for (size_t i = 0; i < input_fields.size(); ++i) {
+    auto J = residual->jacobian(time, dt, input_fields, jacobianWeights(i));
+    J->Mult(*field_tangents[i], jvp_slow);
+    residual->jvp(time, dt, input_fields, selectStates(i), jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 
   // test jacobians in weighted combinations
   {
-    all_v_rhs_states[SHAPE] = nullptr;
-    all_v_rhs_states[VELO] = nullptr;
-    all_v_rhs_states[4] = nullptr;
+    field_tangents[SolidResidualT::SHAPE_DISPLACEMENT] = nullptr;
+    field_tangents[SolidResidualT::VELOCITY] = nullptr;
+    field_tangents[size_t(SolidResidualT::NUM_STATES) + size_t(DENSITY)] = nullptr;
 
     double acceleration_factor = 0.2;
     std::vector<double> jacobian_weights = {0.0, 1.0, 0.0, acceleration_factor, 0.0};
 
-    auto J = residual->jacobian(time, dt, all_states, jacobian_weights);
-    J->Mult(*all_v_rhs_states[DISP], jvp_slow);
+    auto J = residual->jacobian(time, dt, input_fields, jacobian_weights);
+    J->Mult(*field_tangents[SolidResidualT::DISPLACEMENT], jvp_slow);
 
-    *all_v_rhs_states[ACCEL] = *all_v_rhs_states[DISP];
-    *all_v_rhs_states[ACCEL] *= acceleration_factor;
+    state_tangents[SolidResidualT::ACCELERATION] *= acceleration_factor;
 
-    residual->jvp(time, dt, all_states, all_v_rhs_states, jvps);
+    residual->jvp(time, dt, input_fields, field_tangents, jvps);
     EXPECT_NEAR(jvp_slow.Norml2(), jvp.Norml2(), 1e-12);
   }
 }


### PR DESCRIPTION
The goal of this is

1. Modify the new residual and scalar_objective interfaces to that they are more const correct (the pointers are pointing to const things when fields are used as inputs).
2. Flip the sign of the solid mechanics and thermal residuals.  This means tractions and body forces will now have the sign convention that most people know and expect.
3. We were not calling the   ->EnsureNodes() and ->ExchangeFaceNbrData() when the new serac::mesh structure is passed a ParMesh.  Now we will do it, to ensure the mesh is in a valid state.
4. There was a lot of duplicated functions to create vectors of pointers for the new interface.  These are now unified and available in a new header file, along with useful and consolidated type information.

closes #1399 