### PR TITLE
Fix ARPACK include path

### DIFF
--- a/cmake/thirdparty/FindARPACK.cmake
+++ b/cmake/thirdparty/FindARPACK.cmake
@@ -22,7 +22,7 @@ endif()
 # Find include dirs
 find_path(ARPACK_INCLUDE_DIRS
   NAMES arpackdef.h
-  PATHS ${ARPACK_DIR}/include/arpack-ng
+  PATHS ${ARPACK_DIR}/include/arpack ${ARPACK_DIR}/include/arpack-ng
   NO_DEFAULT_PATH
   NO_CMAKE_ENVIRONMENT_PATH
   NO_CMAKE_PATH

--- a/scripts/spack/configs/versions.yaml
+++ b/scripts/spack/configs/versions.yaml
@@ -1,9 +1,5 @@
 # Globally lock version of third party libraries
 packages:
-  arpack-ng:
-    # 3.9.1 has this error: undefined reference to `pdsaupd_'
-    require:
-    - spec: "@3.9.0"
   axom:
     require:
     - spec: "@0.10.1.1"

--- a/scripts/spack/configs/versions.yaml
+++ b/scripts/spack/configs/versions.yaml
@@ -1,5 +1,11 @@
 # Globally lock version of third party libraries
 packages:
+  arpack-ng:
+    # 3.9.1 has this error: undefined reference to `pdsaupd_'
+    # NOTE (EBC): i think this is fixed by https://github.com/LLNL/serac/pull/1404, but needs to be verified with a new
+    # TPL build
+    require:
+    - spec: "@3.9.0"
   axom:
     require:
     - spec: "@0.10.1.1"


### PR DESCRIPTION
ARPACK 3.9.1 changed the include path.  See https://github.com/opencollab/arpack-ng/commit/459f46a6dd6b9ea4b00fbdaee10d7d146edec87a.  This adds the new path so the `FindARPACK.cmake` script works for old and new versions.