### PR TITLE
remove newton convergence rate info.  

### DIFF
--- a/src/serac/numerics/equation_solver.cpp
+++ b/src/serac/numerics/equation_solver.cpp
@@ -85,7 +85,7 @@ class NewtonSolver : public mfem::NewtonSolver {
 
     using real_t = mfem::real_t;
 
-    real_t norm, norm_goal, prev_norm = 0;
+    real_t norm, norm_goal = 0;
     norm = initial_norm = evaluateNorm(x, r);
 
     if (print_options.first_and_last && !print_options.iterations) {
@@ -102,13 +102,12 @@ class NewtonSolver : public mfem::NewtonSolver {
         mfem::out << "Newton iteration " << std::setw(3) << it << " : ||r|| = " << std::setw(13) << norm;
         if (it > 0) {
           mfem::out << ", ||r||/||r_0|| = " << std::setw(13) << (initial_norm != 0.0 ? norm / initial_norm : norm);
-          mfem::out << ", Rate = " << std::setw(10) << std::log10(prev_norm / norm);
         }
         mfem::out << '\n';
       }
 
       if (norm != norm) {
-        mfem::out << "Initial residual for Newton iteration is undefined/nan." << std::endl;
+        mfem::out << "Initial residual for Newton iteration is undefined/nan.\n";
         mfem::out << "Newton: No convergence!\n";
         return;
       }
@@ -131,8 +130,6 @@ class NewtonSolver : public mfem::NewtonSolver {
       x0.SetSize(x.Size());
       x0 = 0.0;
       x0.Add(1.0, x);
-
-      prev_norm = norm;
 
       real_t stepScale = 1.0;
       add(x0, -stepScale, c, x);
@@ -628,7 +625,7 @@ class TrustRegion : public mfem::NewtonSolver {
     num_subspace_solves = 0;
     num_jacobian_assembles = 0;
 
-    real_t norm, norm_goal, prev_norm = 0.0;
+    real_t norm, norm_goal = 0.0;
     norm = initial_norm = computeResidual(X, r);
     norm_goal = std::max(rel_tol * initial_norm, abs_tol);
     if (print_options.first_and_last && !print_options.iterations) {
@@ -665,10 +662,9 @@ class TrustRegion : public mfem::NewtonSolver {
         mfem::out << "Newton iteration " << std::setw(3) << it << " : ||r|| = " << std::setw(13) << norm;
         if (it > 0) {
           mfem::out << ", ||r||/||r_0|| = " << std::setw(13) << (initial_norm != 0.0 ? norm / initial_norm : norm);
-          mfem::out << ", Rate = " << std::setw(10) << std::log10(prev_norm / norm);
           mfem::out << ", x_incr = " << std::setw(13) << trResults.d.Norml2();
         } else {
-          mfem::out << ", norm goal = " << std::setw(13) << norm_goal << "\n";
+          mfem::out << ", norm goal = " << std::setw(13) << norm_goal;
         }
         mfem::out << '\n';
       }
@@ -688,8 +684,6 @@ class TrustRegion : public mfem::NewtonSolver {
       }
 
       assembleJacobian(X);
-
-      prev_norm = norm;
 
       if (it == 0 || (trResults.cg_iterations_count >= settings.max_cg_iterations ||
                       cumulative_cg_iters_from_last_precond_update >= settings.max_cumulative_iteration)) {


### PR DESCRIPTION
It can be post-processed from the current output, and it had a potential divide by 0 issue.

This was resulting in divide by zero issues in LiDO, when the initial residual starts at 0 (which is apparently not uncommon)