### PR TITLE
Fix zlib path on mac mini spack env file

### DIFF
--- a/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
+++ b/scripts/spack/configs/macos_sonoma_aarch64/spack.yaml
@@ -62,7 +62,7 @@ spack:
       buildable: false
       externals:
       - spec: zlib@1.3.1
-        prefix: /opt/homebrew
+        prefix: /opt/homebrew/opt/zlib
 
     # External packages from Homebrew
     automake:


### PR DESCRIPTION
thanks to @ebchin for pointing this out. zlib does get symlinked to `/opt/homebrew`, so the path needed to be slightly modified so spack can include it as an external package.