### PR TITLE
Add extra argument to allow specification of the communicator

### DIFF
--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -22,9 +22,10 @@ Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_s
   createDomains();
 }
 
-Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int refine_parallel) : mesh_tag_(meshtag)
+Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int refine_parallel, MPI_Comm comm)
+    : mesh_tag_(meshtag)
 {
-  auto meshtmp = serac::mesh::refineAndDistribute(std::move(mesh), refine_serial, refine_parallel);
+  auto meshtmp = serac::mesh::refineAndDistribute(std::move(mesh), refine_serial, refine_parallel, comm);
   mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
   createDomains();
 }

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -13,10 +13,11 @@
 
 namespace serac {
 
-Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_serial, int refine_parallel)
+Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_serial, int refine_parallel,
+           MPI_Comm comm)
     : mesh_tag_(meshtag)
 {
-  auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel);
+  auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel, comm);
   mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
   createDomains();
 }

--- a/src/serac/physics/mesh.hpp
+++ b/src/serac/physics/mesh.hpp
@@ -34,7 +34,9 @@ class Mesh {
   /// @param meshtag string tag name for mesh
   /// @param serial_refine number of serial refinements
   /// @param parallel_refine number of parallel refinements
-  Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int serial_refine = 0, int parallel_refine = 0);
+  /// @param comm the communicator that the parallel form of @p mesh should be made with
+  Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int serial_refine = 0, int parallel_refine = 0,
+       MPI_Comm comm = MPI_COMM_WORLD);
 
   /// @brief Construct from existing parallel mfem mesh
   /// @param mesh parallel mfem mesh

--- a/src/serac/physics/mesh.hpp
+++ b/src/serac/physics/mesh.hpp
@@ -48,7 +48,9 @@ class Mesh {
   /// @param meshtag string tag name for mesh
   /// @param serial_refine number of serial refinements
   /// @param parallel_refine number of parallel refinements
-  Mesh(const std::string& meshfile, const std::string& meshtag, int serial_refine = 0, int parallel_refine = 0);
+  /// @param comm the communicator that the parallel form of @p mesh should be made with
+  Mesh(const std::string& meshfile, const std::string& meshtag, int serial_refine = 0, int parallel_refine = 0,
+       MPI_Comm comm = MPI_COMM_WORLD);
 
   /// @brief Returns string tag for mesh
   const std::string& tag() const { return mesh_tag_; }


### PR DESCRIPTION
`serac::Mesh::Mesh(mfem::Mesh &&mesh...)` should have an argument for the communicator. Otherwise, it only works with meshes that are defined over `MPI_COMM_WORLD`. For optimization under uncertainty problems in LiDO, it's common to define the meshes over a strict subset of `MPI_COMM_WORLD`.

@chapman39 for awareness.