### PR TITLE
Reduce CI allocation times

### DIFF
--- a/.gitlab/build_blueos.yml
+++ b/.gitlab/build_blueos.yml
@@ -49,7 +49,7 @@ blueos-clang_14_0_5-src:
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}_cuda.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON -DENABLE_DOCS=OFF"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "60"
+    ALLOC_TIME: "30"
   extends: [.src_build_on_blueos, .with_cuda]
 
 # NOTE: SPEC should matches specs.json, but devtools and profiling variants removed
@@ -58,7 +58,7 @@ blueos-clang_14_0_5-tpl:
     COMPILER: "clang@14.0.5"
     SPEC: "--spec %${COMPILER}+cuda~strumpack cuda_arch=70"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "90"
+    ALLOC_TIME: "75"
   extends: [.tpl_build_on_blueos, .with_cuda]
 
 blueos-clang_14_0_5-examples:
@@ -66,7 +66,7 @@ blueos-clang_14_0_5-examples:
     COMPILER: "clang@14.0.5"
     HOST_CONFIG: "lassen-blueos_3_ppc64le_ib_p9-${COMPILER}_cuda.cmake"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "90"
+    ALLOC_TIME: "60"
   extends: [.examples_build_on_blueos, .with_cuda]
 
 blueos-clang_14_0_5-benchmarks:

--- a/.gitlab/build_toss4.yml
+++ b/.gitlab/build_toss4.yml
@@ -45,7 +45,7 @@ toss4-clang_14_0_6-src:
     COMPILER: "clang@14.0.6"
     HOST_CONFIG: "ruby-toss_4_x86_64_ib-${COMPILER}.cmake"
     EXTRA_CMAKE_OPTIONS: "-DENABLE_BENCHMARKS=ON"
-    #DO_INTEGRATION_TESTS: "yes"
+    # DO_INTEGRATION_TESTS: "yes"
     ALLOC_NODES: "2"
     ALLOC_TIME: "30"
   extends: .src_build_on_toss4
@@ -92,7 +92,7 @@ toss4-clang_16_0_6-tpl:
     COMPILER: "clang@16.0.6"
     SPEC: "--spec %${COMPILER}~openmp"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "70"
+    ALLOC_TIME: "45"
   extends: .tpl_build_on_toss4
 
 toss4-clang_14_0_6-tpl:
@@ -100,7 +100,7 @@ toss4-clang_14_0_6-tpl:
     COMPILER: "clang@14.0.6"
     SPEC: "--spec %${COMPILER}"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "70"
+    ALLOC_TIME: "45"
   extends: .tpl_build_on_toss4
 
 toss4-gcc_10_3_1-tpl:
@@ -108,7 +108,7 @@ toss4-gcc_10_3_1-tpl:
     COMPILER: "gcc@10.3.1"
     SPEC: "--spec %${COMPILER}"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "70"
+    ALLOC_TIME: "45"
   extends: .tpl_build_on_toss4
 
 toss4-clang_16_0_6-examples:
@@ -116,7 +116,7 @@ toss4-clang_16_0_6-examples:
     COMPILER: "clang@16.0.6"
     HOST_CONFIG: "dane-toss_4_x86_64_ib-${COMPILER}.cmake"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "140"
+    ALLOC_TIME: "30"
   extends: .examples_build_on_toss4
 
 toss4-clang_14_0_6-examples:
@@ -124,7 +124,7 @@ toss4-clang_14_0_6-examples:
     COMPILER: "clang@14.0.6"
     HOST_CONFIG: "ruby-toss_4_x86_64_ib-${COMPILER}.cmake"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "90"
+    ALLOC_TIME: "30"
   extends: .examples_build_on_toss4
 
 toss4-gcc_10_3_1-examples:
@@ -132,7 +132,7 @@ toss4-gcc_10_3_1-examples:
     COMPILER: "gcc@10.3.1"
     HOST_CONFIG: "ruby-toss_4_x86_64_ib-${COMPILER}.cmake"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "90"
+    ALLOC_TIME: "30"
   extends: .examples_build_on_toss4
 
 toss4-clang_14_0_6-benchmarks:
@@ -140,7 +140,7 @@ toss4-clang_14_0_6-benchmarks:
     COMPILER: "clang@14.0.6"
     HOST_CONFIG: "ruby-toss_4_x86_64_ib-${COMPILER}.cmake"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "120"
+    ALLOC_TIME: "75"
   extends: .benchmarks_build_on_toss4
 
 toss4-gcc_10_3_1-benchmarks:
@@ -148,7 +148,7 @@ toss4-gcc_10_3_1-benchmarks:
     COMPILER: "gcc@10.3.1"
     HOST_CONFIG: "ruby-toss_4_x86_64_ib-${COMPILER}.cmake"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "120"
+    ALLOC_TIME: "75"
   extends: .benchmarks_build_on_toss4
 
 # This comparison job simply runs Hatchet and compares against benchmarks generated across all configurations

--- a/.gitlab/build_toss4_cray.yml
+++ b/.gitlab/build_toss4_cray.yml
@@ -57,7 +57,7 @@ toss4_cray-rocmcc_6_2_1-tpl:
     COMPILER: "rocmcc@6.2.1"
     SPEC: "--spec %${COMPILER}~openmp+rocm~petsc amdgpu_target=gfx90a ^hip@6.2.1 ^rocprim@6.2.1 ^hsa-rocr-dev@6.2.1 ^llvm-amdgpu@6.2.1 ^hdf5 cflags=-Wno-int-conversion"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "70"
+    ALLOC_TIME: "45"
   extends: .tpl_build_on_toss4_cray
 
 toss4_cray-rocmcc_6_2_1-examples:
@@ -73,5 +73,5 @@ toss4_cray-rocmcc_6_2_1-benchmarks:
     COMPILER: "rocmcc@6.2.1"
     HOST_CONFIG: "tioga-toss_4_x86_64_ib_cray-${COMPILER}_hip.cmake"
     ALLOC_NODES: "1"
-    ALLOC_TIME: "120"
+    ALLOC_TIME: "60"
   extends: .benchmarks_build_on_toss4_cray


### PR DESCRIPTION
i can't help but create another tiny PR..

this change was motivated by me having to increase lassen CI alloc time to 60. but, it was probably a fluke, since now its running back at ~20 minutes. https://lc.llnl.gov/gitlab/smith/serac/-/jobs/2830694

i noticed i kept increasing CI alloc times, when they were likely unnecessary. also in this PR, i compared the recent run-times of each CI pipeline and reduced them reasonably such that they won't time out, but won't wait in the queue longer than they need to be.