### PR TITLE
Temp change tioga CI queue to "pdebug"

### DIFF
--- a/.gitlab/build_toss4_cray.yml
+++ b/.gitlab/build_toss4_cray.yml
@@ -2,7 +2,7 @@
 # This is the shared configuration of jobs for toss4_cray
 .on_toss4_cray:
   variables:
-    SCHEDULER_PARAMETERS: "--queue pci --exclusive --time-limit=${ALLOC_TIME}m --nodes=${ALLOC_NODES}"
+    SCHEDULER_PARAMETERS: "--queue pdebug --exclusive --time-limit=${ALLOC_TIME}m --nodes=${ALLOC_NODES}"
   tags:
     - batch
     - tioga


### PR DESCRIPTION
The `pci` queue on tioga is broken after its update. Some people who should have access to it get the following message:

```
[meemee@tioga10:~]$ flux alloc --queue pci --nodes=1 echo "hello"
flux-alloc: ERROR: Queue not valid for user: pci
```

It is being actively investigated (hopefully) https://llnl.servicenowservices.com/ess?id=ticket&table=incident&sys_id=deb5a54987f7a294e87ffff5cebb359b 