### PR TITLE
Eliminate spurious warning about unused command line args

### DIFF
--- a/examples/buckling/cylinder.cpp
+++ b/examples/buckling/cylinder.cpp
@@ -120,7 +120,8 @@ int main(int argc, char* argv[])
 
   // Need to allow extra arguments for PETSc support
   app.set_help_flag("--help");
-  app.allow_extras()->parse(argc, argv);
+  app.allow_extras();
+  CLI11_PARSE(app, argc, argv);
 
   if (use_fast_options) {
     dt = 1;

--- a/src/serac/infrastructure/application_manager.cpp
+++ b/src/serac/infrastructure/application_manager.cpp
@@ -101,6 +101,11 @@ ApplicationManager::ApplicationManager(int argc, char* argv[], MPI_Comm comm) : 
 #endif
 
 #ifdef SERAC_USE_PETSC
+  // PETSc tries to parse all command line options, but Serac applications
+  // may have others intended for MPI or the application itself.
+  // Silence the PETSc warning that there are leftover options it doesn't
+  // know.
+  PetscOptionsSetValue(NULL, "-options_left", "no");
 #ifdef SERAC_USE_SLEPC
   mfem::MFEMInitializeSlepc(&argc, &argv);
 #else


### PR DESCRIPTION
If you've ever run an example with command line arguments, you've seen this incorrect annoying warning:

```
WARNING! There are options you set that were not used!
WARNING! could be spelling mistake, etc!
```

This PR silences that warning.

Longer story:
This is coming from PETSc. We send all our command line args unmodified to MPI and PETSc, in addition to the calling application itself. By default, PETSc issues this warning if there are any command line options it doesn't recognize. That means we will see this warning if there are any args at all parsed in the application. This PR sets an option on PETSc to suppress this warning. Apparently it used to be issued only in the debug variant, but now it happens also in the release build, annoyingly.

It's a separate question whether we should handle command line args this way. There is a risk of collision if the author of an example picks an argument name that matches a PETSc option. But that's an issue for another day.

I also snuck a quick fix into the options parsing of the buckling_cylinder example. The arg parsing was invoked incorrectly, so that if you invoked the help option, it print the help banner and then crash with an unhandled exception.