### PR TITLE
update devtools for spack 1.0 on toss4

### DIFF
--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -541,7 +541,7 @@ def build_devtools(builds_dir, timestamp, short_path, report_to_stdout = False):
     project_file = "scripts/spack/devtools.json"
 
     if "toss_4" in sys_type:
-        compiler_spec = "%gcc@10.3.1"
+        compiler_spec = "%gcc_13"
     elif "blueos" in sys_type:
         compiler_spec = "%gcc@8.3.1"
 

--- a/scripts/spack/devtools.json
+++ b/scripts/spack/devtools.json
@@ -5,8 +5,9 @@
 "package_final_phase" : "",
 "spack_build_mode" : "install",
 "spack_url": "https://github.com/spack/spack.git",
-"spack_commit": "fbdf9d9e0120c5dcdb3fd1f6573ec321449919bc",
+"spack_commit": "b4b1c5f271c75e918ce922ff1bcc77542eda3ec9",
+"spack_packages_url": "https://github.com/spack/spack-packages.git",
+"spack_packages_commit": "a75a7f75182ffc7a51c6ca7f0fec4bf9b2705be8",
 "spack_configs_path": "scripts/spack/devtools_configs",
-"spack_packages_path": ["scripts/spack/radiuss-spack-configs/packages", "scripts/spack/packages"],
-"spack_concretizer": "clingo"
+"spack_packages_path": ["scripts/spack/radiuss-spack-configs/spack_repo/llnl_radiuss/packages", "scripts/spack/packages"]
 }

--- a/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
+++ b/scripts/spack/devtools_configs/toss_4_x86_64_ib/spack.yaml
@@ -16,21 +16,16 @@ spack:
       projections:
         all: '{name}-{version}'
 
-  compilers::
-  - compiler:
-      environment: {}
-      extra_rpaths: []
-      flags: {}
-      modules:
-      - gcc/13.3.1
-      operating_system: rhel8
-      paths:
-        cc: /usr/tce/packages/gcc/gcc-13.3.1/bin/gcc
-        cxx: /usr/tce/packages/gcc/gcc-13.3.1/bin/g++
-        f77: /usr/tce/packages/gcc/gcc-13.3.1/bin/gfortran
-        fc: /usr/tce/packages/gcc/gcc-13.3.1/bin/gfortran
-      spec: gcc@13.3.1
-      target: x86_64
+  toolchains:
+    gcc_13:
+    - spec: '%c=gcc'
+      when: '%c'
+    - spec: '%cxx=gcc'
+      when: '%cxx'
+    - spec: '%fortran=gcc'
+      when: '%fortran'
+    - spec: '%mvapich2@2.3.7.gcc_13'
+      when: '%mpi'
 
   packages:
     all:
@@ -45,6 +40,17 @@ spack:
         gl: [opengl]
         glu: [openglu]
         zlib-api: [zlib]
+
+    #Compiler packages
+    gcc:
+      externals:
+      - spec: gcc@13.3.1 languages:=c,c++,fortran
+        prefix: /usr/tce/packages/gcc/gcc-13.3.1
+        extra_attributes:
+          compilers:
+            c: /usr/tce/packages/gcc/gcc-13.3.1/bin/gcc
+            cxx: /usr/tce/packages/gcc/gcc-13.3.1/bin/g++
+            fortran: /usr/tce/packages/gcc/gcc-13.3.1/bin/gfortran
 
     openblas:
       buildable: false
@@ -68,8 +74,8 @@ spack:
     mvapich2:
       buildable: false
       externals:
-      - spec: mvapich2@2.3.7~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple %gcc@10.3.1
-        prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-10.3.1
+      - spec: mvapich2@2.3.7.gcc_13~alloca~cuda~debug~hwloc_graphics~hwlocv2+regcache+wrapperrpath build_system=autotools ch3_rank_bits=32 fabrics=mrail file_systems=auto process_managers=slurm threads=multiple
+        prefix: /usr/tce/packages/mvapich2/mvapich2-2.3.7-gcc-13.3.1
 
     netlib-lapack:
       buildable: false
@@ -144,16 +150,6 @@ spack:
       externals:
       - spec: findutils@4.6.0
         prefix: /usr
-    gcc:
-      externals:
-      - spec: gcc@10.3.1 languages='c,c++,fortran'
-        prefix: /usr/tce/packages/gcc/gcc-10.3.1
-        extra_attributes:
-          compilers:
-            c: /usr/tce/packages/gcc/gcc-10.3.1/bin/gcc
-            cxx: /usr/tce/packages/gcc/gcc-10.3.1/bin/g++
-            fortran: /usr/tce/packages/gcc/gcc-10.3.1/bin/gfortran
-      buildable: false
     gettext:
       buildable: false
       externals:


### PR DESCRIPTION
Needed this to test clang@19 spack build for the always rebuilding issue. Didn't want to lose it. I did not rebuild the devtools due to an issue with creating the view. It is seems to be adding them to the python directory.