### PR TITLE
don't override self.compiler!

### DIFF
--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -247,8 +247,8 @@ class Serac(CachedCMakePackage, CudaPackage, ROCmPackage):
     #
 
     # Enzyme required an LLVM-based compiler
-    for compiler in ["aocc", "cce", "gcc", "nag", "fj", "intel", "nvhpc", "xl"]:
-        conflicts("+enzyme", when=f"%[virtuals=c,cxx] {compiler}")
+    for compiler_ in ["aocc", "cce", "gcc", "nag", "fj", "intel", "nvhpc", "xl"]:
+        conflicts("+enzyme", when=f"%[virtuals=c,cxx] {compiler_}")
 
     conflicts("+openmp", when="+rocm")
     conflicts("+cuda", when="+rocm")


### PR DESCRIPTION
fixes the following error when building smith/ serac in lido

```
==> smith: Executing phase: 'initconfig'
==> smith: Executing phase: 'cmake'
==> Error: AttributeError: 'str' object has no attribute 'name'

The 'smith' package cannot find an attribute while trying to build from sources. You can fix this by updating the build recipe, and you can also report the issue as a build-error or a bug at https://github.com/spack/spack/issues

/usr/WS2/meemee/lido-2.0/repo/smith/scripts/spack/packages/smith/package.py:580, in cmake_args:
        578    def cmake_args(self):
        579        is_asan_compiler = self.compiler.name in self.asan_compiler_allowlist
  >>    580        if self.spec.satisfies("+asan") and not is_asan_compiler:
        581            raise UnsupportedCompilerError(
        582                "Smith cannot be built with Address Sanitizer flags "
        583                "using {0} compilers".format(self.compiler.name)

```

also in smith https://lc.llnl.gov/gitlab/smith/smith/-/merge_requests/181/diffs?commit_id=7905b6789411a74028b9ed405b3c22befe99e07c