### PR TITLE
Add check for no elements on by local rank

### DIFF
--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -49,7 +49,7 @@ Mesh::Mesh(mfem::ParMesh&& mesh, const std::string& meshtag) : mesh_tag_(meshtag
 
 Mesh::errorIfRankHasNoElements() const
 {
-  SLIC_ERROR_IF(mfem_mesh_.GetNE() == 0, "Local size of mesh is 0 which will cause out-of-range error");
+  SLIC_ERROR_IF(mfem_mesh_->GetNE() == 0, "Local size of mesh is 0 which will cause out-of-range error");
 }
 
 MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -47,7 +47,7 @@ Mesh::Mesh(mfem::ParMesh&& mesh, const std::string& meshtag) : mesh_tag_(meshtag
   createDomains();
 }
 
-Mesh::errorIfRankHasNoElements() const
+void Mesh::errorIfRankHasNoElements() const
 {
   SLIC_ERROR_IF(mfem_mesh_->GetNE() == 0, "Local size of mesh is 0 which will cause out-of-range error");
 }

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -49,7 +49,7 @@ Mesh::Mesh(mfem::ParMesh&& mesh, const std::string& meshtag) : mesh_tag_(meshtag
 
 void Mesh::errorIfRankHasNoElements() const
 {
-  SLIC_ERROR_IF(mfem_mesh_->GetNE() == 0, "Local size of mesh is 0 which will cause out-of-range error");
+  SLIC_ERROR_IF(mfem_mesh_->GetNE() == 0, "After refining and distributing mesh, local size of mesh is 0");
 }
 
 MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }

--- a/src/serac/physics/mesh.cpp
+++ b/src/serac/physics/mesh.cpp
@@ -24,6 +24,7 @@ Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_s
 {
   auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel, comm);
   mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
+  errorIfRankHasNoElements();
   createDomains();
 }
 
@@ -32,6 +33,7 @@ Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int
 {
   auto meshtmp = serac::mesh::refineAndDistribute(std::move(mesh), refine_serial, refine_parallel, comm);
   mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
+  errorIfRankHasNoElements();
   createDomains();
 }
 
@@ -41,7 +43,13 @@ Mesh::Mesh(mfem::ParMesh&& mesh, const std::string& meshtag) : mesh_tag_(meshtag
   meshtmp->EnsureNodes();
   meshtmp->ExchangeFaceNbrData();
   mfem_mesh_ = &serac::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
+  errorIfRankHasNoElements();
   createDomains();
+}
+
+Mesh::errorIfRankHasNoElements() const
+{
+  SLIC_ERROR_IF(mfem_mesh_.GetNE() == 0, "Local size of mesh is 0 which will cause out-of-range error");
 }
 
 MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }

--- a/src/serac/physics/mesh.hpp
+++ b/src/serac/physics/mesh.hpp
@@ -129,6 +129,9 @@ class Mesh {
   serac::FiniteElementDual newShapeDisplacementDual();
 
  private:
+  /// @brief Helper function used to throw exception if the size of the mesh on the local rank is 0
+  void errorIfRankHasNoElements() const;
+
   /// @brief Sets up some initial domains: entire domain, entire boundary, and interior faces. Eventually we can read
   /// off names/blocks/attributes from the mesh and create default domains.
   void createDomains();


### PR DESCRIPTION
On multiple occasions I've lost hours debugging when a mesh has no elements on a particular rank (this usually comes up when I have both a 2D and a 3D mesh on the same communicator). I'm not 100% sure where the error message comes from but it's a cryptic out-of-range error that isn't easy to debug, so I thought this check would be useful to alert users of what is happening.