### PR TITLE
WIP: Update Sundials

### DIFF
--- a/scripts/spack/configs/versions.yaml
+++ b/scripts/spack/configs/versions.yaml
@@ -29,7 +29,7 @@ packages:
     - spec: "@2024.07.0"
   sundials:
     require:
-    - spec: "@6.7.0"
+    - spec: "@7.4.0"
   tribol:
     require:
     - spec: "@0.1.0.21"

--- a/scripts/spack/packages/serac/package.py
+++ b/scripts/spack/packages/serac/package.py
@@ -104,9 +104,8 @@ class Serac(CachedCMakePackage, CudaPackage, ROCmPackage):
         depends_on("py-sphinx")
 
     with when("+sundials"):
-        # Going to sundials@7: causes 80%+ test failures
-        depends_on("sundials@:6.999")
         # MFEM is deprecating the monitoring support with sundials v6.0 and later
+        depends_on("sundials@6:")
         # NOTE: Sundials must be built static to prevent the following runtime error:
         # "error while loading shared libraries: libsundials_nvecserial.so.6:
         # cannot open shared object file: No such file or directory"

--- a/src/serac/infrastructure/application_manager.cpp
+++ b/src/serac/infrastructure/application_manager.cpp
@@ -65,6 +65,10 @@ void finalizer()
 #endif
 #endif
 
+#ifdef SERAC_USE_SUNDIALS
+  mfem::Sundials::Finalize();
+#endif
+
   profiling::finalize();
 
   int mpi_initialized = 0;


### PR DESCRIPTION
* Updates SUNDIALS past 7.0
* Calls new MFEM Sundials Finalize to avoid calling MPI after our `MPI_Finalize` due to previous RAII static destructor logic


This cannot be merged until https://github.com/mfem/mfem/pull/5073 goes into MFEM. Thanks @balos1 !