### PR TITLE
Trigger Smith CZ Pipeline

### DIFF
--- a/.github/workflows/trigger-smith-cz.yml
+++ b/.github/workflows/trigger-smith-cz.yml
@@ -13,7 +13,6 @@ jobs:
       - name: Trigger Smith CZ Pipeline
         run: |
           curl -X POST \
-          --fail \
           --form token=$SMITH_CZ_TRIGGER_TOKEN \
           --form ref=develop \
           "https://lc.llnl.gov/gitlab/api/v4/projects/521/trigger/pipeline"

--- a/.github/workflows/trigger-smith-cz.yml
+++ b/.github/workflows/trigger-smith-cz.yml
@@ -1,0 +1,21 @@
+name: Trigger Smith CZ Pipeline
+
+on:
+  pull_request:
+  push:
+    branches:
+    - develop
+
+jobs:
+  trigger-smith-cz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Smith CZ Pipeline
+        run: |
+          curl -X POST \
+          --fail \
+          --form token=$SMITH_CZ_TRIGGER_TOKEN \
+          --form ref=develop \
+          "https://lc.llnl.gov/gitlab/api/v4/projects/521/trigger/pipeline"
+        env:
+          SMITH_CZ_TRIGGER_TOKEN: ${{ secrets.SMITH_CZ_TRIGGER_TOKEN }}


### PR DESCRIPTION
A GitHub action that will trigger a Smith CZ pipeline. This will ensure changes to Smith do not break Smith CZ. Or if they do, they should respond by creating a fix in Smith CZ.