### PR TITLE
Enable coverage using GCC docker image

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -100,13 +100,18 @@ jobs:
     strategy:
       # If any of checks (e.g. style) fail, allow other jobs to continue running.
       fail-fast: false
+      # TODO Simplify this matrix once coverage can run with LLVM https://github.com/LLNL/smith/issues/1481
       matrix:
-        check_type: [ style, header, docs ]
-        docker_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
-        host_config: llvm@19.1.1.cmake
-        # NOTE: coverage should be moved to above `check_type` matrix once this issue is resolved
-        # https://github.com/LLNL/smith/issues/1481
         include:
+        - check_type: style
+          docker_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
+          host_config: llvm@19.1.1.cmake
+        - check_type: header
+          docker_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
+          host_config: llvm@19.1.1.cmake
+        - check_type: docs
+          docker_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
+          host_config: llvm@19.1.1.cmake
         - check_type: coverage
           docker_image: ${{ needs.set_image_vars.outputs.gcc_docker_image }}
           host_config: gcc@14.2.0.cmake
@@ -118,7 +123,7 @@ jobs:
       options: --user root
       env:
         CHECK_TYPE: ${{ matrix.check_type }}
-        HOST_CONFIG: llvm@19.1.1.cmake
+        HOST_CONFIG: ${{ matrix.host_config }}
     steps:
     - name: Checkout Smith
       uses: actions/checkout@v4

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -101,10 +101,17 @@ jobs:
       # If any of checks (e.g. style) fail, allow other jobs to continue running.
       fail-fast: false
       matrix:
-        # TODO re-enable coverage https://github.com/LLNL/smith/issues/1481
-        check_type: [style, header, docs] #[coverage, docs, style, header]
+        check_type: [ style, header, docs ]
+        docker_image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
+        host_config: llvm@19.1.1.cmake
+        # NOTE: coverage should be moved to above `check_type` matrix once this issue is resolved
+        # https://github.com/LLNL/smith/issues/1481
+        include:
+        - check_type: coverage
+          docker_image: ${{ needs.set_image_vars.outputs.gcc_docker_image }}
+          host_config: gcc@14.2.0.cmake
     container:
-      image: ${{ needs.set_image_vars.outputs.clang_docker_image }}
+      image: ${{ matrix.docker_image }}
       volumes:
       - /home/smith/smith
       # Required - default is set to user "smith"

--- a/scripts/github-actions/linux-check.sh
+++ b/scripts/github-actions/linux-check.sh
@@ -25,8 +25,8 @@ cmake_args="-DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=ON -DENABLE_CLANGTIDY=O
 
 if [[ "$CHECK_TYPE" == "coverage" ]] ; then
     # Alias llvm-cov to gcov so it acts like gcov
-    ln -s `which llvm-cov` /home/serac/gcov
-    cmake_args="$cmake_args -DENABLE_COVERAGE=ON -DGCOV_EXECUTABLE=/home/serac/gcov"
+    ln -s `which llvm-cov` /home/smith/gcov
+    cmake_args="$cmake_args -DENABLE_COVERAGE=ON -DGCOV_EXECUTABLE=/home/smith/gcov"
 fi
 
 if [[ "$CHECK_TYPE" == "docs" ]] ; then


### PR DESCRIPTION
eventually we should use the llvm image but enzyme doesn't seem to pair well with llvm

related issue https://github.com/LLNL/smith/issues/1481