### PR TITLE
in CI, run make clean after tests pass

### DIFF
--- a/scripts/llnl/build_src.py
+++ b/scripts/llnl/build_src.py
@@ -57,6 +57,11 @@ def parse_args():
                       dest="verbose",
                       default=False,
                       help="Output logs to screen as well as to files")
+    parser.add_argument("--clean-up-build",
+                      action="store_true",
+                      dest="clean_up_build",
+                      default=True,
+                      help="Choose whether to clean the build directory after tests have run successfully.")
     parser.add_argument("-j", "--jobs",
                       dest="jobs",
                       default="",
@@ -140,7 +145,8 @@ def main():
             test_root = get_build_and_test_root(repo_dir, timestamp)
             os.mkdir(test_root)
             res = build_and_test_host_config(test_root, hostconfig_path, args["verbose"], args["extra_cmake_options"],
-                                             args["skip_install"], args["skip_tests"], args["jobs"])
+                                             args["skip_install"], args["skip_tests"], args["jobs"],
+                                             args["clean_up_build"])
 
     finally:
         os.chdir(original_wd)

--- a/scripts/llnl/common_build_functions.py
+++ b/scripts/llnl/common_build_functions.py
@@ -254,7 +254,7 @@ def test_examples(host_config, build_dir, install_dir, report_to_stdout = False,
 
     return 0
 
-def build_and_test_host_config(test_root, host_config, report_to_stdout=False, extra_cmake_options="", skip_install=False, skip_tests=False, job_count=""):
+def build_and_test_host_config(test_root, host_config, report_to_stdout=False, extra_cmake_options="", skip_install=False, skip_tests=False, job_count="", clean_up_build=False):
     host_config_root = get_host_config_root(host_config)
     # setup build and install dirs
     build_dir   = pjoin(test_root,"build-%s"   % host_config_root)
@@ -372,6 +372,12 @@ def build_and_test_host_config(test_root, host_config, report_to_stdout=False, e
 
     set_group_and_perms(build_dir)
     set_group_and_perms(install_dir)
+
+    if clean_up_build:
+        print("[running `make clean`]")
+        res = shell_exec(f"cd {build_dir} && make clean",
+                        print_output=report_to_stdout,
+                        echo=True)
 
     return 0
 


### PR DESCRIPTION
this PR is an idea im testing out and should not be merged.

pretty much if we can `make clean` the builds after running tests, it will reduce the build size from ~14GB to less than a gigabyte.