### PR TITLE
Removing check for no elements on rank

### DIFF
--- a/src/smith/physics/mesh.cpp
+++ b/src/smith/physics/mesh.cpp
@@ -24,7 +24,6 @@ Mesh::Mesh(const std::string& meshfile, const std::string& meshtag, int refine_s
 {
   auto meshtmp = mesh::refineAndDistribute(buildMeshFromFile(meshfile), refine_serial, refine_parallel, comm);
   mfem_mesh_ = &smith::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
-  errorIfRankHasNoElements();
   createDomains();
 }
 
@@ -33,7 +32,6 @@ Mesh::Mesh(mfem::Mesh&& mesh, const std::string& meshtag, int refine_serial, int
 {
   auto meshtmp = smith::mesh::refineAndDistribute(std::move(mesh), refine_serial, refine_parallel, comm);
   mfem_mesh_ = &smith::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
-  errorIfRankHasNoElements();
   createDomains();
 }
 
@@ -43,13 +41,7 @@ Mesh::Mesh(mfem::ParMesh&& mesh, const std::string& meshtag) : mesh_tag_(meshtag
   meshtmp->EnsureNodes();
   meshtmp->ExchangeFaceNbrData();
   mfem_mesh_ = &smith::StateManager::setMesh(std::move(meshtmp), mesh_tag_);
-  errorIfRankHasNoElements();
   createDomains();
-}
-
-void Mesh::errorIfRankHasNoElements() const
-{
-  SLIC_ERROR_IF(mfem_mesh_->GetNE() == 0, "After refining and distributing mesh, local size of mesh is 0");
 }
 
 MPI_Comm Mesh::getComm() const { return mfem_mesh_->GetComm(); }

--- a/src/smith/physics/mesh.hpp
+++ b/src/smith/physics/mesh.hpp
@@ -129,9 +129,6 @@ class Mesh {
   smith::FiniteElementDual newShapeDisplacementDual();
 
  private:
-  /// @brief Helper function used to throw exception if the size of the mesh on the local rank is 0
-  void errorIfRankHasNoElements() const;
-
   /// @brief Sets up some initial domains: entire domain, entire boundary, and interior faces. Eventually we can read
   /// off names/blocks/attributes from the mesh and create default domains.
   void createDomains();


### PR DESCRIPTION
This PR is basically an undo of a PR I merged a while back that check for ranks without any elements. At the time I would get confusing error messages when this occurred so I merged a check to provided a more descriptive error check. We have recently decided to allow this behavior so this check must be removed.