### PR TITLE
Fix Build Status badge workflow link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # <img src="/share/smith/logo/smith-logo-orange.png?raw=true" width="150" alt="Smith"/>
 
-[![Build Status](https://github.com/LLNL/smith/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/LLNL/smith/actions/workflows/unit-tests.yml)
+[![Build Status](https://github.com/LLNL/smith/actions/workflows/ci-tests.yml/badge.svg)](https://github.com/LLNL/smith/actions/workflows/ci-tests.yml)
 [![Documentation Status](https://readthedocs.org/projects/serac/badge/?version=latest)](https://llnlsmith.readthedocs.io/en/latest/?badge=latest)
 [![codecov](https://codecov.io/gh/LLNL/serac/branch/develop/graph/badge.svg?token=DO4KFMPNM0)](https://codecov.io/gh/LLNL/serac)
 [![License](https://img.shields.io/badge/license-BSD%203--Clause-blue.svg)](./LICENSE)


### PR DESCRIPTION
this is a small PR. i thought i fixed this. but while playing around with codex i realized the ci button in the README is pointing to the wrong yaml file.

unrelated: codex was able to create the new branch and commit its changes, but didn't have permissions to push to origin for some reason. maybe that's for the best though, lol.