### PR TITLE
ContactAMGF bugfix for no warm start contact

### DIFF
--- a/src/smith/physics/solid_mechanics_contact.hpp
+++ b/src/smith/physics/solid_mechanics_contact.hpp
@@ -323,6 +323,25 @@ class SolidMechanicsContact<order, dim, Parameters<parameter_space...>,
       du_[j] -= displacement_(j);
     }
 
+    auto amgf_prec = dynamic_cast<mfem::AMGFSolver*>(&nonlin_solver_->preconditioner());
+    if (amgf_prec) {
+      // compute contact_dof_prolongation
+      computeContactSubspaceTransferOperator();
+      // set AMGF subspace transfer operator
+      amgf_prec->SetFilteredSubspaceTransferOperator(*(contact_dof_prolongation_.get()));
+      // set the filteredsubspace solver component of AMGF
+      // better solution: retrieve print level from .preconditioner_print_level from linear_solver_options
+      int filter_solver_print_level = 0;
+      filter_solver_ =
+          std::make_unique<StrumpackSolver>(filter_solver_print_level, contact_dof_prolongation_->GetComm());
+      amgf_prec->SetFilteredSubspaceSolver(*filter_solver_.get());
+
+      auto& lin_solver = nonlin_solver_->linearSolver();
+      auto iterative_solver = dynamic_cast<mfem::IterativeSolver*>(&lin_solver);
+      SLIC_WARNING_ROOT_IF(!iterative_solver,
+                           "AMGFContact should only be used as a preconditioner for an iterative solver");
+    }
+
     if (use_warm_start_) {
       // Update the system residual
       mfem::Vector augmented_residual(displacement_.Size() + contact_.numPressureDofs());
@@ -388,23 +407,6 @@ class SolidMechanicsContact<order, dim, Parameters<parameter_space...>,
       }
 
       auto& lin_solver = nonlin_solver_->linearSolver();
-
-      auto amgf_prec = dynamic_cast<mfem::AMGFSolver*>(&nonlin_solver_->preconditioner());
-      if (amgf_prec) {
-        // compute contact_dof_prolongation
-        computeContactSubspaceTransferOperator();
-        // set AMGF subspace transfer operator
-        amgf_prec->SetFilteredSubspaceTransferOperator(*(contact_dof_prolongation_.get()));
-        // set the filteredsubspace solver component of AMGF
-        auto iterative_solver = dynamic_cast<mfem::IterativeSolver*>(&lin_solver);
-        SLIC_ERROR_ROOT_IF(!iterative_solver,
-                           "AMGFContact should only be used as a preconditioner for an iterative solver");
-        // better solution: retrieve print level from .preconditioner_print_level from linear_solver_options
-        int filter_solver_print_level = 0;
-        filter_solver_ =
-            std::make_unique<StrumpackSolver>(filter_solver_print_level, contact_dof_prolongation_->GetComm());
-        amgf_prec->SetFilteredSubspaceSolver(*filter_solver_.get());
-      }
       lin_solver.SetOperator(*J_operator_);
       lin_solver.Mult(augmented_residual, augmented_solution);
 

--- a/src/smith/physics/tests/contact_beam_amgf.cpp
+++ b/src/smith/physics/tests/contact_beam_amgf.cpp
@@ -26,10 +26,8 @@
 
 namespace smith {
 
-class ContactTestAMGF
-    : public testing::TestWithParam<std::tuple<ContactEnforcement, ContactType, ContactJacobian, std::string, bool>> {};
-
-TEST_P(ContactTestAMGF, beam)
+void contact_beam_amgf_test(ContactEnforcement contact_enforcement, ContactType contact_type, std::string name_ext,
+                            bool use_warm_start)
 {
   // NOTE: p must be equal to 1 for now
   constexpr int p = 1;
@@ -38,7 +36,7 @@ TEST_P(ContactTestAMGF, beam)
   MPI_Barrier(MPI_COMM_WORLD);
 
   // Create DataStore
-  std::string name = "contact_beam_" + std::get<3>(GetParam());
+  std::string name = "contact_beam_" + name_ext;
   axom::sidre::DataStore datastore;
   StateManager::initialize(datastore, name + "_data");
 
@@ -66,16 +64,15 @@ TEST_P(ContactTestAMGF, beam)
                                            .print_level = 1};
 
   ContactOptions contact_options{.method = ContactMethod::SingleMortar,
-                                 .enforcement = std::get<0>(GetParam()),
-                                 .type = std::get<1>(GetParam()),
+                                 .enforcement = contact_enforcement,
+                                 .type = contact_type,
                                  .penalty = 1.0e4,
-                                 .jacobian = std::get<2>(GetParam())};
+                                 .jacobian = ContactJacobian::Approximate};
 
   std::vector<std::string> parameter_names = {};
   int cycle = 0;
   double time = 0.0;
   bool checkpoint_to_disk = false;
-  bool use_warm_start = std::get<4>(GetParam());
 
   SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
                                              solid_mechanics::default_quasistatic_options, name, mesh, parameter_names,
@@ -115,27 +112,37 @@ TEST_P(ContactTestAMGF, beam)
 
   // Check the l2 norm of the displacement dofs
   auto u_l2 = mfem::ParNormlp(solid_solver.displacement(), 2, MPI_COMM_WORLD);
-  if (std::get<1>(GetParam()) == ContactType::TiedNormal) {
+  if (contact_type == ContactType::TiedNormal) {
     EXPECT_NEAR(1.465, u_l2, 1.0e-2);
-  } else if (std::get<1>(GetParam()) == ContactType::Frictionless) {
+  } else if (contact_type == ContactType::Frictionless) {
     EXPECT_NEAR(1.526, u_l2, 1.0e-2);
   }
 }
 
-// NOTE: if Penalty is first and Lagrange Multiplier is second, SuperLU gives a zero diagonal error
-INSTANTIATE_TEST_SUITE_P(
-    tribol, ContactTestAMGF,
-    testing::Values(std::make_tuple(ContactEnforcement::Penalty, ContactType::TiedNormal, ContactJacobian::Approximate,
-                                    "penalty_tiednormal_Japprox_amgf", true),
-                    std::make_tuple(ContactEnforcement::Penalty, ContactType::Frictionless,
-                                    ContactJacobian::Approximate, "penalty_frictionless_Japprox_amgf", true),
-                    std::make_tuple(ContactEnforcement::Penalty, ContactType::TiedNormal, ContactJacobian::Approximate,
-                                    "penalty_tiednormal_Japprox_amgf_nowarmstart", false),
-                    std::make_tuple(ContactEnforcement::Penalty, ContactType::Frictionless,
-                                    ContactJacobian::Approximate, "penalty_frictionless_Japprox_amgf_nowarmstart",
-                                    false)
-
-                        ));
+TEST(ContactBeamAMGF, PenaltyTiedNormalWarmStart)
+{
+  bool use_warm_start = true;
+  contact_beam_amgf_test(ContactEnforcement::Penalty, ContactType::TiedNormal, "penalty_tiednormal_amgf",
+                         use_warm_start);
+}
+TEST(ContactBeamAMGF, PenaltyFrictionlessWarmStart)
+{
+  bool use_warm_start = true;
+  contact_beam_amgf_test(ContactEnforcement::Penalty, ContactType::Frictionless, "penalty_frictionless_amgf",
+                         use_warm_start);
+}
+TEST(ContactBeamAMGF, PenaltyTiedNormalNoWarmStart)
+{
+  bool use_warm_start = false;
+  contact_beam_amgf_test(ContactEnforcement::Penalty, ContactType::TiedNormal, "penalty_tiednormal_amgf_nowarmstart",
+                         use_warm_start);
+}
+TEST(ContactBeamAMGF, PenaltyFrictionlessNoWarmStart)
+{
+  bool use_warm_start = false;
+  contact_beam_amgf_test(ContactEnforcement::Penalty, ContactType::Frictionless,
+                         "penalty_frictionless_amgf_nowarmstart", use_warm_start);
+}
 
 }  // namespace smith
 

--- a/src/smith/physics/tests/contact_beam_amgf.cpp
+++ b/src/smith/physics/tests/contact_beam_amgf.cpp
@@ -27,7 +27,7 @@
 namespace smith {
 
 class ContactTestAMGF
-    : public testing::TestWithParam<std::tuple<ContactEnforcement, ContactType, ContactJacobian, std::string>> {};
+    : public testing::TestWithParam<std::tuple<ContactEnforcement, ContactType, ContactJacobian, std::string, bool>> {};
 
 TEST_P(ContactTestAMGF, beam)
 {
@@ -48,7 +48,7 @@ TEST_P(ContactTestAMGF, beam)
   auto mesh = std::make_shared<smith::Mesh>(buildMeshFromFile(filename), "beam_mesh", 1, 0);
 
 #ifdef MFEM_USE_STRUMPACK
-  LinearSolverOptions linear_options{.linear_solver = LinearSolver::CG,
+  LinearSolverOptions linear_options{.linear_solver = LinearSolver::GMRES,
                                      .preconditioner = Preconditioner::AMGFContact,
                                      .relative_tol = 0.0,
                                      .absolute_tol = 1.0e-13,
@@ -71,8 +71,15 @@ TEST_P(ContactTestAMGF, beam)
                                  .penalty = 1.0e4,
                                  .jacobian = std::get<2>(GetParam())};
 
+  std::vector<std::string> parameter_names = {};
+  int cycle = 0;
+  double time = 0.0;
+  bool checkpoint_to_disk = false;
+  bool use_warm_start = std::get<4>(GetParam());
+
   SolidMechanicsContact<p, dim> solid_solver(nonlinear_options, linear_options,
-                                             solid_mechanics::default_quasistatic_options, name, mesh);
+                                             solid_mechanics::default_quasistatic_options, name, mesh, parameter_names,
+                                             cycle, time, checkpoint_to_disk, use_warm_start);
 
   double K = 10.0;
   double G = 0.25;
@@ -119,9 +126,16 @@ TEST_P(ContactTestAMGF, beam)
 INSTANTIATE_TEST_SUITE_P(
     tribol, ContactTestAMGF,
     testing::Values(std::make_tuple(ContactEnforcement::Penalty, ContactType::TiedNormal, ContactJacobian::Approximate,
-                                    "penalty_tiednormal_Japprox_amgf"),
+                                    "penalty_tiednormal_Japprox_amgf", true),
                     std::make_tuple(ContactEnforcement::Penalty, ContactType::Frictionless,
-                                    ContactJacobian::Approximate, "penalty_frictionless_Japprox_amgf")));
+                                    ContactJacobian::Approximate, "penalty_frictionless_Japprox_amgf", true),
+                    std::make_tuple(ContactEnforcement::Penalty, ContactType::TiedNormal, ContactJacobian::Approximate,
+                                    "penalty_tiednormal_Japprox_amgf_nowarmstart", false),
+                    std::make_tuple(ContactEnforcement::Penalty, ContactType::Frictionless,
+                                    ContactJacobian::Approximate, "penalty_frictionless_Japprox_amgf_nowarmstart",
+                                    false)
+
+                        ));
 
 }  // namespace smith
 


### PR DESCRIPTION
This small PR addresses a bug when using `AMGFContact` when `use_warm_start` is set to false. As important calls for setting up AMGFContact was previously in a `if (use_warm_start)` block.

The contact_beam_amgf test now includes tests with and without warm starting. The test code has been reformatted for (in my opinion) easier readability.