### PR TITLE
Set Tribol displacements after nonlinear solve

### DIFF
--- a/src/smith/physics/solid_mechanics_contact.hpp
+++ b/src/smith/physics/solid_mechanics_contact.hpp
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "smith/physics/base_physics.hpp"
 #include "smith/physics/solid_mechanics.hpp"
 #include "smith/physics/contact/contact_data.hpp"
 
@@ -269,6 +270,7 @@ class SolidMechanicsContact<order, dim, Parameters<parameter_space...>,
     // solve the non-linear system resid = 0 and pressure * gap = 0
     nonlin_solver_->solve(augmented_solution);
     displacement_.Set(1.0, mfem::Vector(augmented_solution, 0, displacement_.Size()));
+    contact_.setDisplacements(BasePhysics::shapeDisplacement(), displacement_);
     contact_.setPressures(mfem::Vector(augmented_solution, displacement_.Size(), contact_.numPressureDofs()));
     contact_.update(cycle_, time_, dt);
     forces_.SetVector(contact_.forces(), 0);


### PR DESCRIPTION
The displacement Tribol sees is usually changed after calling `nonlin_solver_->solve()` and this displacement doesn't necessarily match the final displacement at the converged solution (e.g. if the residual is already at 0, TrustRegion will put NaNs in for displacement).  This fix just resets the displacements to the value returned by the nonlinear solver, ensuring the `contact_.update()` call sees the right values.