### PR TITLE
Implement support for hdiv.  Some testing, documentation.

### DIFF
--- a/src/smith/numerics/functional/boundary_integral_kernels.hpp
+++ b/src/smith/numerics/functional/boundary_integral_kernels.hpp
@@ -74,6 +74,25 @@ struct QFunctionArgument<L2<p, c>, Dimension<dim>> {
 };
 
 /// @overload
+/// Hdiv on a segment boundary element (boundary of a 2D mesh).
+/// The face trace of Hdiv is the scalar normal flux sigma dot n.
+/// The second component is the tangential derivative of the normal flux.
+template <int p>
+struct QFunctionArgument<Hdiv<p>, Dimension<1>> {
+  using type = smith::tuple<double, double>;  ///< (normal_flux, tangential_derivative) passed to the q-function
+};
+
+/// @overload
+/// Hdiv on a face boundary element (boundary of a 3D mesh).
+/// The face trace of Hdiv is the scalar normal flux sigma dot n.
+/// The second component is the tangential derivative of the normal flux.
+template <int p>
+struct QFunctionArgument<Hdiv<p>, Dimension<2>> {
+  using type =
+      smith::tuple<double, tensor<double, 2>>;  ///< (normal_flux, tangential_derivative) passed to the q-function
+};
+
+/// @overload
 SMITH_SUPPRESS_NVCC_HOSTDEVICE_WARNING
 template <typename lambda, typename T, int... i>
 SMITH_HOST_DEVICE auto apply_qf_helper(const lambda& qf, double t, const tensor<double, 2>& x_q, const T& arg_tuple,
@@ -231,7 +250,7 @@ SMITH_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, c
  *
  * @tparam test The type of the test function space
  * @tparam trial The type of the trial function space
- * The above spaces can be any combination of {H1, Hcurl, Hdiv (TODO), L2 (TODO)}
+ * The above spaces can be any combination of {H1, Hcurl, Hdiv, L2 (TODO)}
  *
  * Template parameters other than the test and trial spaces are used for customization + optimization
  * and are erased through the @p std::function members of @p BoundaryIntegral
@@ -282,7 +301,7 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
  *
  * @tparam test The type of the test function space
  * @tparam trial The type of the trial function space
- * The above spaces can be any combination of {H1, Hcurl, Hdiv (TODO), L2 (TODO), QOI}
+ * The above spaces can be any combination of {H1, Hcurl, Hdiv, L2 (TODO), QOI}
  *
  * Template parameters other than the test and trial spaces are used for customization + optimization
  * and are erased through the @p std::function members of @p Integral
@@ -329,8 +348,8 @@ template <uint32_t wrt, int Q, mfem::Geometry::Type geom, typename signature, ty
 auto evaluation_kernel(signature s, lambda_type qf, const double* positions, const double* jacobians,
                        std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
-  auto trial_elements = trial_elements_tuple<geom>(s);
-  auto test_element = get_test_element<geom>(s);
+  auto trial_elements = boundary_trial_elements_tuple<geom>(s);
+  auto test_element = get_boundary_test_element<geom>(s);
   return [=](double time, const std::vector<const double*>& inputs, double* outputs, bool /* update state */) {
     evaluation_kernel_impl<wrt, Q, geom>(trial_elements, test_element, time, inputs, outputs, positions, jacobians, qf,
                                          qf_derivatives.get(), num_elements, s.index_seq);
@@ -342,8 +361,9 @@ std::function<void(const double*, double*)> jacobian_vector_product_kernel(
     signature, std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
   return [=](const double* du, double* dr) {
-    using test_space = typename signature::return_type;
-    using trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using test_space = typename get_boundary_element<typename signature::return_type>::type;
+    using original_trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using trial_space = typename get_boundary_element<original_trial_space>::type;
     action_of_gradient_kernel<Q, geom, test_space, trial_space>(du, dr, qf_derivatives.get(), num_elements);
   };
 }
@@ -353,8 +373,9 @@ std::function<void(ExecArrayView<double, 3, ExecutionSpace::CPU>)> element_gradi
     signature, std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
   return [=](ExecArrayView<double, 3, ExecutionSpace::CPU> K_elem) {
-    using test_space = typename signature::return_type;
-    using trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using test_space = typename get_boundary_element<typename signature::return_type>::type;
+    using original_trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using trial_space = typename get_boundary_element<original_trial_space>::type;
     element_gradient_kernel<geom, test_space, trial_space, Q>(K_elem, qf_derivatives.get(), num_elements);
   };
 }

--- a/src/smith/numerics/functional/detail/chebyshev_utils.hpp
+++ b/src/smith/numerics/functional/detail/chebyshev_utils.hpp
@@ -1,0 +1,46 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file chebyshev_utils.hpp
+ *
+ * @brief Chebyshev polynomial evaluation utilities for simplex Hdiv elements
+ *
+ * These are used by the Vandermonde-based shape function construction in
+ * triangle_Hdiv.inl and tetrahedron_Hdiv.inl.
+ */
+
+#pragma once
+
+// NOTE: This header is included from within namespace smith {} in finite_element.hpp,
+// so no namespace wrapper is needed here.
+
+/// Evaluate Chebyshev polynomials T_0(2x-1), ..., T_order(2x-1) at x
+SMITH_HOST_DEVICE inline constexpr void chebyshev_eval(int order, double x, double* u)
+{
+  u[0] = 1.0;
+  if (order < 1) return;
+  double z = 2.0 * x - 1.0;
+  u[1] = z;
+  for (int i = 1; i < order; i++) {
+    u[i + 1] = 2.0 * z * u[i] - u[i - 1];
+  }
+}
+
+/// Evaluate Chebyshev polynomials and their derivatives (w.r.t. x, not z)
+SMITH_HOST_DEVICE inline constexpr void chebyshev_eval_d(int order, double x, double* u, double* d)
+{
+  u[0] = 1.0;
+  d[0] = 0.0;
+  if (order < 1) return;
+  double z = 2.0 * x - 1.0;
+  u[1] = z;
+  d[1] = 2.0;
+  for (int i = 1; i < order; i++) {
+    u[i + 1] = 2.0 * z * u[i] - u[i - 1];
+    d[i + 1] = double(i + 1) * (z * d[i] / double(i) + 2.0 * u[i]);
+  }
+}

--- a/src/smith/numerics/functional/detail/hexahedron_Hdiv.inl
+++ b/src/smith/numerics/functional/detail/hexahedron_Hdiv.inl
@@ -1,0 +1,440 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file hexahedron_Hdiv.inl
+ *
+ * @brief Specialization of finite_element for Hdiv on hexahedron geometry
+ */
+
+// this specialization defines shape functions (and their divergences) that
+// interpolate at Gauss-Lobatto nodes for closed intervals, and Gauss-Legendre
+// nodes for open intervals.
+//
+// note 1: mfem assumes the parent element domain is [0,1]x[0,1]x[0,1]
+// note 2: dofs are numbered by direction and then lexicographically in space.
+// note 3: H(div) is the "dual" of H(curl) -- the roles of open and closed
+//         nodes are swapped relative to hexahedron_Hcurl.inl:
+//         - Hcurl: open (Legendre) in component direction, closed (Lobatto) in transverse
+//         - Hdiv:  closed (Lobatto) in component direction, open (Legendre) in transverse
+// for additional information on the finite_element concept requirements, see finite_element.hpp
+/// @cond
+template <int p>
+struct finite_element<mfem::Geometry::CUBE, Hdiv<p>> {
+  static constexpr auto geometry = mfem::Geometry::CUBE;
+  static constexpr auto family = Family::HDIV;
+  static constexpr int dim = 3;
+  static constexpr int n = p + 1;
+  static constexpr int ndof = 3 * p * p * (p + 1);
+  static constexpr int components = 1;
+
+  static constexpr int VALUE = 0, DIV = 1;
+  static constexpr int SOURCE = 0, FLUX = 1;
+
+  using residual_type =
+      typename std::conditional<components == 1, tensor<double, ndof>, tensor<double, ndof, components>>::type;
+
+  // DOF layout: each component has closed (Lobatto, p+1) in its own direction,
+  // open (Legendre, p) in the two transverse directions.
+  // This is the transpose of Hcurl's layout.
+  struct dof_type {
+    tensor<double, p, p, p + 1> x;  // open-z, open-y, closed-x
+    tensor<double, p, p + 1, p> y;  // open-z, closed-y, open-x
+    tensor<double, p + 1, p, p> z;  // closed-z, open-y, open-x
+  };
+
+  template <int q>
+  using cpu_batched_values_type = tensor<tensor<double, 3>, q, q, q>;
+
+  template <int q>
+  using cpu_batched_derivatives_type = tensor<double, q, q, q>;
+
+  static constexpr auto directions = [] {
+    int dof_per_direction = p * p * (p + 1);
+
+    tensor<double, ndof, dim> directions{};
+    for (int i = 0; i < dof_per_direction; i++) {
+      directions[i + 0 * dof_per_direction] = {1.0, 0.0, 0.0};
+      directions[i + 1 * dof_per_direction] = {0.0, 1.0, 0.0};
+      directions[i + 2 * dof_per_direction] = {0.0, 0.0, 1.0};
+    }
+    return directions;
+  }();
+
+  static constexpr auto nodes = []() {
+    auto legendre_nodes = GaussLegendreNodes<p, mfem::Geometry::SEGMENT>();
+    auto lobatto_nodes = GaussLobattoNodes<p + 1>();
+
+    tensor<double, ndof, dim> nodes{};
+
+    int count = 0;
+    // x-facing DOFs: closed in x, open in y, open in z
+    for (int k = 0; k < p; k++) {
+      for (int j = 0; j < p; j++) {
+        for (int i = 0; i < p + 1; i++) {
+          nodes[count++] = {lobatto_nodes[i], legendre_nodes[j], legendre_nodes[k]};
+        }
+      }
+    }
+
+    // y-facing DOFs: open in x, closed in y, open in z
+    for (int k = 0; k < p; k++) {
+      for (int j = 0; j < p + 1; j++) {
+        for (int i = 0; i < p; i++) {
+          nodes[count++] = {legendre_nodes[i], lobatto_nodes[j], legendre_nodes[k]};
+        }
+      }
+    }
+
+    // z-facing DOFs: open in x, open in y, closed in z
+    for (int k = 0; k < p + 1; k++) {
+      for (int j = 0; j < p; j++) {
+        for (int i = 0; i < p; i++) {
+          nodes[count++] = {legendre_nodes[i], legendre_nodes[j], lobatto_nodes[k]};
+        }
+      }
+    }
+
+    return nodes;
+  }();
+
+  // B1/B2/G2 basis evaluation matrices — delegated to shared free functions
+  // in detail/tensor_product_basis.hpp
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_B1()
+  {
+    return basis_detail::calculate_B1<p, apply_weights, q>();
+  }
+
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_B2()
+  {
+    return basis_detail::calculate_B2<p, apply_weights, q>();
+  }
+
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_G2()
+  {
+    return basis_detail::calculate_G2<p, apply_weights, q>();
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> shape_functions(tensor<double, dim> xi)
+  {
+    tensor<double, ndof, dim> N{};
+
+    // f = open (Legendre), g = closed (Lobatto)
+    tensor<double, p> f[3] = {GaussLegendreInterpolation<p>(xi[0]), GaussLegendreInterpolation<p>(xi[1]),
+                              GaussLegendreInterpolation<p>(xi[2])};
+
+    tensor<double, p + 1> g[3] = {GaussLobattoInterpolation<p + 1>(xi[0]), GaussLobattoInterpolation<p + 1>(xi[1]),
+                                  GaussLobattoInterpolation<p + 1>(xi[2])};
+
+    int count = 0;
+
+    // x-facing DOFs: closed in x, open in y, open in z
+    for (int k = 0; k < p; k++) {
+      for (int j = 0; j < p; j++) {
+        for (int i = 0; i < p + 1; i++) {
+          N[count++] = {g[0][i] * f[1][j] * f[2][k], 0.0, 0.0};
+        }
+      }
+    }
+
+    // y-facing DOFs: open in x, closed in y, open in z
+    for (int k = 0; k < p; k++) {
+      for (int j = 0; j < p + 1; j++) {
+        for (int i = 0; i < p; i++) {
+          N[count++] = {0.0, f[0][i] * g[1][j] * f[2][k], 0.0};
+        }
+      }
+    }
+
+    // z-facing DOFs: open in x, open in y, closed in z
+    for (int k = 0; k < p + 1; k++) {
+      for (int j = 0; j < p; j++) {
+        for (int i = 0; i < p; i++) {
+          N[count++] = {0.0, 0.0, f[0][i] * f[1][j] * g[2][k]};
+        }
+      }
+    }
+
+    return N;
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_function_div(tensor<double, dim> xi)
+  {
+    tensor<double, ndof> div{};
+
+    tensor<double, p> f[3] = {GaussLegendreInterpolation<p>(xi[0]), GaussLegendreInterpolation<p>(xi[1]),
+                              GaussLegendreInterpolation<p>(xi[2])};
+
+    tensor<double, p + 1> dg[3] = {GaussLobattoInterpolationDerivative<p + 1>(xi[0]),
+                                   GaussLobattoInterpolationDerivative<p + 1>(xi[1]),
+                                   GaussLobattoInterpolationDerivative<p + 1>(xi[2])};
+
+    int count = 0;
+
+    // x-facing DOFs: d(g(x))/dx * f(y) * f(z)
+    for (int k = 0; k < p; k++) {
+      for (int j = 0; j < p; j++) {
+        for (int i = 0; i < p + 1; i++) {
+          div[count++] = dg[0][i] * f[1][j] * f[2][k];
+        }
+      }
+    }
+
+    // y-facing DOFs: f(x) * d(g(y))/dy * f(z)
+    for (int k = 0; k < p; k++) {
+      for (int j = 0; j < p + 1; j++) {
+        for (int i = 0; i < p; i++) {
+          div[count++] = f[0][i] * dg[1][j] * f[2][k];
+        }
+      }
+    }
+
+    // z-facing DOFs: f(x) * f(y) * d(g(z))/dz
+    for (int k = 0; k < p + 1; k++) {
+      for (int j = 0; j < p; j++) {
+        for (int i = 0; i < p; i++) {
+          div[count++] = f[0][i] * f[1][j] * dg[2][k];
+        }
+      }
+    }
+
+    return div;
+  }
+
+  template <typename in_t, int q>
+  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q * q> input, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr bool apply_weights = false;
+    constexpr tensor<double, q, p> B1 = calculate_B1<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> B2 = calculate_B2<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> G2 = calculate_G2<apply_weights, q>();
+
+    int dof_per_direction = p * p * (p + 1);
+    int jx, jy, jz;
+    int dir = j / dof_per_direction;
+    int remainder = j % dof_per_direction;
+    switch (dir) {
+      case 0:  // x-direction: closed-x(p+1), open-y(p), open-z(p)
+        jx = remainder % n;
+        jy = (remainder / n) % p;
+        jz = remainder / (n * p);
+        break;
+
+      case 1:  // y-direction: open-x(p), closed-y(p+1), open-z(p)
+        jx = remainder % p;
+        jy = (remainder / p) % n;
+        jz = remainder / (p * n);
+        break;
+
+      case 2:  // z-direction: open-x(p), open-y(p), closed-z(p+1)
+        jx = remainder % p;
+        jy = (remainder / p) % p;
+        jz = remainder / (p * p);
+        break;
+    }
+
+    using source_t = decltype(dot(get<0>(get<0>(in_t{})), vec3{}) + get<1>(get<0>(in_t{})) * double{});
+    using flux_t = decltype(dot(get<0>(get<1>(in_t{})), vec3{}) + get<1>(get<1>(in_t{})) * double{});
+
+    tensor<tuple<source_t, flux_t>, q * q * q> output;
+
+    for (int qz = 0; qz < q; qz++) {
+      for (int qy = 0; qy < q; qy++) {
+        for (int qx = 0; qx < q; qx++) {
+          tensor<double, 3> phi_j{};
+          double div_phi_j = 0.0;
+
+          switch (dir) {
+            case 0:
+              phi_j[0] = B2(qx, jx) * B1(qy, jy) * B1(qz, jz);
+              div_phi_j = G2(qx, jx) * B1(qy, jy) * B1(qz, jz);
+              break;
+
+            case 1:
+              phi_j[1] = B1(qx, jx) * B2(qy, jy) * B1(qz, jz);
+              div_phi_j = B1(qx, jx) * G2(qy, jy) * B1(qz, jz);
+              break;
+
+            case 2:
+              phi_j[2] = B1(qx, jx) * B1(qy, jy) * B2(qz, jz);
+              div_phi_j = B1(qx, jx) * B1(qy, jy) * G2(qz, jz);
+              break;
+          }
+
+          int Q = (qz * q + qy) * q + qx;
+          const auto& d00 = get<0>(get<0>(input(Q)));
+          const auto& d01 = get<1>(get<0>(input(Q)));
+          const auto& d10 = get<0>(get<1>(input(Q)));
+          const auto& d11 = get<1>(get<1>(input(Q)));
+
+          output[Q] = {dot(d00, phi_j) + d01 * div_phi_j, dot(d10, phi_j) + d11 * div_phi_j};
+        }
+      }
+    }
+
+    return output;
+  }
+
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr bool apply_weights = false;
+    constexpr tensor<double, q, p> B1 = calculate_B1<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> B2 = calculate_B2<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> G2 = calculate_G2<apply_weights, q>();
+
+    tensor<tensor<double, q, q, q>, 3> value{};
+    tensor<double, q, q, q> div{};
+
+    // to clarify which contractions correspond to which spatial dimensions
+    constexpr int x = 2, y = 1, z = 0;
+
+    // clang-format off
+    // x-component: closed(B2) in x, open(B1) in y, open(B1) in z
+    // element_values.x is (p, p, p+1) = (z_open, y_open, x_closed)
+    {
+      auto A1  = contract< x, 1 >(element_values.x, B2);
+      auto A2  = contract< y, 1 >(A1,  B1);
+      value[0] = contract< z, 1 >(A2, B1);
+
+      // divergence from x: dg/dx in x (G2), open in y,z (B1)
+      A1       = contract< x, 1 >(element_values.x, G2);
+      A2       = contract< y, 1 >(A1,  B1);
+      div      = contract< z, 1 >(A2, B1);
+    }
+
+    // y-component: open(B1) in x, closed(B2) in y, open(B1) in z
+    // element_values.y is (p, p+1, p) = (z_open, y_closed, x_open)
+    {
+      auto A1  = contract< y, 1 >(element_values.y, B2);
+      auto A2  = contract< x, 1 >(A1,  B1);
+      value[1] = contract< z, 1 >(A2, B1);
+
+      // divergence from y: open in x (B1), dg/dy in y (G2), open in z (B1)
+      A1       = contract< y, 1 >(element_values.y, G2);
+      A2       = contract< x, 1 >(A1,  B1);
+      div     += contract< z, 1 >(A2, B1);
+    }
+
+    // z-component: open(B1) in x, open(B1) in y, closed(B2) in z
+    // element_values.z is (p+1, p, p) = (z_closed, y_open, x_open)
+    {
+      auto A1  = contract< z, 1 >(element_values.z, B2);
+      auto A2  = contract< y, 1 >(A1,  B1);
+      value[2] = contract< x, 1 >(A2, B1);
+
+      // divergence from z: open in x,y (B1), dg/dz in z (G2)
+      A1       = contract< z, 1 >(element_values.z, G2);
+      A2       = contract< y, 1 >(A1,  B1);
+      div     += contract< x, 1 >(A2, B1);
+    }
+    // clang-format on
+
+    tensor<tuple<tensor<double, 3>, double>, q * q * q> qf_inputs;
+
+    int count = 0;
+    for (int qz = 0; qz < q; qz++) {
+      for (int qy = 0; qy < q; qy++) {
+        for (int qx = 0; qx < q; qx++) {
+          for (int i = 0; i < 3; i++) {
+            get<VALUE>(qf_inputs(count))[i] = value[i](qz, qy, qx);
+          }
+          get<DIV>(qf_inputs(count)) = div(qz, qy, qx);
+          count++;
+        }
+      }
+    }
+
+    return qf_inputs;
+  }
+
+  template <typename source_type, typename flux_type, int q>
+  SMITH_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q * q>& qf_output,
+                                          const TensorProductQuadratureRule<q>&, dof_type* element_residual,
+                                          [[maybe_unused]] int step = 1)
+  {
+    if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) return;
+
+    constexpr bool apply_weights = true;
+    constexpr tensor<double, q, p> B1 = calculate_B1<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> B2 = calculate_B2<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> G2 = calculate_G2<apply_weights, q>();
+
+    using source_buf_t = std::conditional_t<is_zero<source_type>{}, zero, tensor<double, 3, q, q, q>>;
+    using flux_buf_t = std::conditional_t<is_zero<flux_type>{}, zero, tensor<double, q, q, q>>;
+
+    source_buf_t source{};
+    flux_buf_t flux{};
+
+    for (int qz = 0; qz < q; qz++) {
+      for (int qy = 0; qy < q; qy++) {
+        for (int qx = 0; qx < q; qx++) {
+          int k = (qz * q + qy) * q + qx;
+          if constexpr (!is_zero<source_type>{}) {
+            tensor<double, 3> s{get<SOURCE>(qf_output[k])};
+            for (int i = 0; i < 3; i++) {
+              source(i, qz, qy, qx) = s[i];
+            }
+          }
+          if constexpr (!is_zero<flux_type>{}) {
+            flux(qz, qy, qx) = get<FLUX>(qf_output[k]);
+          }
+        }
+      }
+    }
+
+    // to clarify which contractions correspond to which spatial dimensions
+    constexpr int x = 2, y = 1, z = 0;
+
+    // clang-format off
+    if constexpr (!is_zero<source_type>{}) {
+      // x-component: source[0] tested with B2(x)*B1(y)*B1(z)
+      {
+        auto A2  = contract< z, 0 >(source[0], B1);
+        auto A1  = contract< y, 0 >(A2, B1);
+        element_residual[0].x += contract< x, 0 >(A1, B2);
+      }
+      // y-component: source[1] tested with B1(x)*B2(y)*B1(z)
+      {
+        auto A2  = contract< z, 0 >(source[1], B1);
+        auto A1  = contract< x, 0 >(A2, B1);
+        element_residual[0].y += contract< y, 0 >(A1, B2);
+      }
+      // z-component: source[2] tested with B1(x)*B1(y)*B2(z)
+      {
+        auto A2  = contract< y, 0 >(source[2], B1);
+        auto A1  = contract< x, 0 >(A2, B1);
+        element_residual[0].z += contract< z, 0 >(A1, B2);
+      }
+    }
+
+    if constexpr (!is_zero<flux_type>{}) {
+      // x-component: flux tested with G2(x)*B1(y)*B1(z)
+      {
+        auto A2  = contract< z, 0 >(flux, B1);
+        auto A1  = contract< y, 0 >(A2, B1);
+        element_residual[0].x += contract< x, 0 >(A1, G2);
+      }
+      // y-component: flux tested with B1(x)*G2(y)*B1(z)
+      {
+        auto A2  = contract< z, 0 >(flux, B1);
+        auto A1  = contract< x, 0 >(A2, B1);
+        element_residual[0].y += contract< y, 0 >(A1, G2);
+      }
+      // z-component: flux tested with B1(x)*B1(y)*G2(z)
+      {
+        auto A2  = contract< y, 0 >(flux, B1);
+        auto A1  = contract< x, 0 >(A2, B1);
+        element_residual[0].z += contract< z, 0 >(A1, G2);
+      }
+    }
+    // clang-format on
+  }
+};
+/// @endcond

--- a/src/smith/numerics/functional/detail/quadrilateral_Hdiv.inl
+++ b/src/smith/numerics/functional/detail/quadrilateral_Hdiv.inl
@@ -1,0 +1,340 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file quadrilateral_Hdiv.inl
+ *
+ * @brief Specialization of finite_element for Hdiv on quadrilateral geometry
+ */
+
+// this specialization defines shape functions (and their divergences) that
+// interpolate at Gauss-Lobatto nodes for closed intervals, and Gauss-Legendre
+// nodes for open intervals.
+//
+// note 1: mfem assumes the parent element domain is [0,1]x[0,1]
+// note 2: dofs are numbered by direction and then lexicographically in space.
+//         see below
+// note 3: H(div) is the "dual" of H(curl) -- the roles of open and closed
+//         nodes are swapped relative to quadrilateral_Hcurl.inl:
+//         - Hcurl: open (Legendre) in component direction, closed (Lobatto) in transverse
+//         - Hdiv:  closed (Lobatto) in component direction, open (Legendre) in transverse
+// for additional information on the finite_element concept requirements, see finite_element.hpp
+/// @cond
+template <int p>
+struct finite_element<mfem::Geometry::SQUARE, Hdiv<p>> {
+  static constexpr auto geometry = mfem::Geometry::SQUARE;
+  static constexpr auto family = Family::HDIV;
+  static constexpr int dim = 2;
+  static constexpr int n = (p + 1);
+  static constexpr int ndof = 2 * p * (p + 1);
+  static constexpr int components = 1;
+
+  static constexpr int VALUE = 0, DIV = 1;
+  static constexpr int SOURCE = 0, FLUX = 1;
+
+  using residual_type =
+      typename std::conditional<components == 1, tensor<double, ndof>, tensor<double, ndof, components>>::type;
+
+  // DOF layout: x-component has closed(p+1) in x, open(p) in y
+  //             y-component has open(p) in x, closed(p+1) in y
+  // This is the transpose of Hcurl's layout
+  struct dof_type {
+    tensor<double, p, p + 1> x;
+    tensor<double, p + 1, p> y;
+  };
+  using dof_type_if = dof_type;
+
+  template <int q>
+  using cpu_batched_values_type = tensor<tensor<double, 2>, q, q>;
+
+  template <int q>
+  using cpu_batched_derivatives_type = tensor<double, q, q>;
+
+  static constexpr auto directions = [] {
+    int dof_per_direction = p * (p + 1);
+
+    tensor<double, ndof, dim> directions{};
+    for (int i = 0; i < dof_per_direction; i++) {
+      directions[i + 0 * dof_per_direction] = {1.0, 0.0};
+      directions[i + 1 * dof_per_direction] = {0.0, 1.0};
+    }
+    return directions;
+  }();
+
+  static constexpr auto nodes = [] {
+    auto legendre_nodes = GaussLegendreNodes<p, mfem::Geometry::SEGMENT>();
+    auto lobatto_nodes = GaussLobattoNodes<p + 1>();
+
+    tensor<double, ndof, dim> nodes{};
+
+    int count = 0;
+    // x-facing DOFs: closed (Lobatto) in x, open (Legendre) in y
+    for (int j = 0; j < p; j++) {
+      for (int i = 0; i < p + 1; i++) {
+        nodes[count++] = {lobatto_nodes[i], legendre_nodes[j]};
+      }
+    }
+
+    // y-facing DOFs: open (Legendre) in x, closed (Lobatto) in y
+    for (int j = 0; j < p + 1; j++) {
+      for (int i = 0; i < p; i++) {
+        nodes[count++] = {legendre_nodes[i], lobatto_nodes[j]};
+      }
+    }
+
+    return nodes;
+  }();
+
+  // B1/B2/G2 basis evaluation matrices — delegated to shared free functions
+  // in detail/tensor_product_basis.hpp
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_B1()
+  {
+    return basis_detail::calculate_B1<p, apply_weights, q>();
+  }
+
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_B2()
+  {
+    return basis_detail::calculate_B2<p, apply_weights, q>();
+  }
+
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_G2()
+  {
+    return basis_detail::calculate_G2<p, apply_weights, q>();
+  }
+
+  /*
+
+    interpolate nodes/directions and their associated numbering:
+
+    For Hdiv, closed (Lobatto) nodes are in the component direction,
+    and open (Legendre) nodes are in the transverse direction.
+
+                   linear
+
+    o-----↑-----o         o-----3-----o
+    |           |         |           |
+    |           |         |           |
+    →           →         0           1
+    |           |         |           |
+    |           |         |           |
+    o-----↑-----o         o-----2-----o
+
+
+                 quadratic
+
+    o---↑---↑---o         o---9--10---o
+    |           |         |           |
+    →     →     →         3     4     5
+    |   ↑   ↑   |         |   7   8   |
+    →     →     →         0     1     2
+    |           |         |           |
+    o---↑---↑---o         o---6---7---o
+
+  */
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> shape_functions(tensor<double, dim> xi)
+  {
+    int count = 0;
+    tensor<double, ndof, dim> N{};
+
+    // x-facing DOFs: closed (Lobatto) in x, open (Legendre) in y
+    tensor<double, p + 1> N_closed = GaussLobattoInterpolation<p + 1>(xi[0]);
+    tensor<double, p> N_open = GaussLegendreInterpolation<p>(xi[1]);
+    for (int j = 0; j < p; j++) {
+      for (int i = 0; i < p + 1; i++) {
+        N[count++] = {N_closed[i] * N_open[j], 0.0};
+      }
+    }
+
+    // y-facing DOFs: open (Legendre) in x, closed (Lobatto) in y
+    N_closed = GaussLobattoInterpolation<p + 1>(xi[1]);
+    N_open = GaussLegendreInterpolation<p>(xi[0]);
+    for (int j = 0; j < p + 1; j++) {
+      for (int i = 0; i < p; i++) {
+        N[count++] = {0.0, N_open[i] * N_closed[j]};
+      }
+    }
+    return N;
+  }
+
+  // the divergence of a 2D vector field is a scalar: d(Nx)/dx + d(Ny)/dy
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_function_div(tensor<double, dim> xi)
+  {
+    int count = 0;
+    tensor<double, ndof> div{};
+
+    // x-facing DOFs: derivative of closed (Lobatto) in x, open (Legendre) in y
+    tensor<double, p + 1> dN_closed = GaussLobattoInterpolationDerivative<p + 1>(xi[0]);
+    tensor<double, p> N_open = GaussLegendreInterpolation<p>(xi[1]);
+    for (int j = 0; j < p; j++) {
+      for (int i = 0; i < p + 1; i++) {
+        div[count++] = dN_closed[i] * N_open[j];
+      }
+    }
+
+    // y-facing DOFs: open (Legendre) in x, derivative of closed (Lobatto) in y
+    dN_closed = GaussLobattoInterpolationDerivative<p + 1>(xi[1]);
+    N_open = GaussLegendreInterpolation<p>(xi[0]);
+    for (int j = 0; j < p + 1; j++) {
+      for (int i = 0; i < p; i++) {
+        div[count++] = N_open[i] * dN_closed[j];
+      }
+    }
+
+    return div;
+  }
+
+  template <typename in_t, int q>
+  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr bool apply_weights = false;
+    constexpr tensor<double, q, p> B1 = calculate_B1<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> B2 = calculate_B2<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> G2 = calculate_G2<apply_weights, q>();
+
+    int jx, jy;
+    int dir = j / ((p + 1) * p);
+    if (dir == 0) {
+      // x-facing: closed in x (p+1 nodes), open in y (p nodes)
+      jx = j % n;
+      jy = j / n;
+    } else {
+      // y-facing: open in x (p nodes), closed in y (p+1 nodes)
+      jx = (j % ((p + 1) * p)) % p;
+      jy = (j % ((p + 1) * p)) / p;
+    }
+
+    using source_t = decltype(dot(get<0>(get<0>(in_t{})), tensor<double, 2>{}) + get<1>(get<0>(in_t{})) * double{});
+    using flux_t = decltype(dot(get<0>(get<1>(in_t{})), tensor<double, 2>{}) + get<1>(get<1>(in_t{})) * double{});
+
+    tensor<tuple<source_t, flux_t>, q * q> output;
+
+    for (int qy = 0; qy < q; qy++) {
+      for (int qx = 0; qx < q; qx++) {
+        // Hdiv shape function: x-component uses B2 in x (closed), B1 in y (open)
+        //                      y-component uses B1 in x (open), B2 in y (closed)
+        tensor<double, 2> phi_j{(dir == 0) * B2(qx, jx) * B1(qy, jy), (dir == 1) * B1(qx, jx) * B2(qy, jy)};
+
+        // divergence: x-component uses G2 in x, B1 in y
+        //             y-component uses B1 in x, G2 in y
+        double div_phi_j = (dir == 0) * G2(qx, jx) * B1(qy, jy) + (dir == 1) * B1(qx, jx) * G2(qy, jy);
+
+        int Q = qy * q + qx;
+        const auto& d00 = get<0>(get<0>(input(Q)));
+        const auto& d01 = get<1>(get<0>(input(Q)));
+        const auto& d10 = get<0>(get<1>(input(Q)));
+        const auto& d11 = get<1>(get<1>(input(Q)));
+
+        output[Q] = {dot(d00, phi_j) + d01 * div_phi_j, dot(d10, phi_j) + d11 * div_phi_j};
+      }
+    }
+
+    return output;
+  }
+
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr bool apply_weights = false;
+    constexpr tensor<double, q, p> B1 = calculate_B1<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> B2 = calculate_B2<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> G2 = calculate_G2<apply_weights, q>();
+
+    tensor<double, 2, q, q> value{};
+    tensor<double, q, q> div{};
+
+    // to clarify which contractions correspond to which spatial dimensions
+    constexpr int x = 1, y = 0;
+
+    // x-component: closed (B2) in x, open (B1) in y
+    // element_values.x is (p, p+1) = (y_open, x_closed)
+    auto Ax = contract<x, 1>(element_values.x, B2);
+    value[0] = contract<y, 1>(Ax, B1);
+    // divergence contribution from x: dN_closed/dx in x (G2), open in y (B1)
+    Ax = contract<x, 1>(element_values.x, G2);
+    div = contract<y, 1>(Ax, B1);
+
+    // y-component: open (B1) in x, closed (B2) in y
+    // element_values.y is (p+1, p) = (y_closed, x_open)
+    auto Ay = contract<x, 1>(element_values.y, B1);
+    value[1] = contract<y, 1>(Ay, B2);
+    // divergence contribution from y: open in x (B1), dN_closed/dy in y (G2)
+    div += contract<y, 1>(Ay, G2);
+
+    tensor<tuple<tensor<double, 2>, double>, q * q> qf_inputs;
+
+    int count = 0;
+    for (int qy = 0; qy < q; qy++) {
+      for (int qx = 0; qx < q; qx++) {
+        for (int i = 0; i < dim; i++) {
+          get<VALUE>(qf_inputs(count))[i] = value[i](qy, qx);
+        }
+        get<DIV>(qf_inputs(count)) = div(qy, qx);
+        count++;
+      }
+    }
+
+    return qf_inputs;
+  }
+
+  template <typename source_type, typename flux_type, int q>
+  SMITH_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
+                                          const TensorProductQuadratureRule<q>&, dof_type* element_residual,
+                                          [[maybe_unused]] int step = 1)
+  {
+    if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) return;
+
+    constexpr bool apply_weights = true;
+    constexpr tensor<double, q, p> B1 = calculate_B1<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> B2 = calculate_B2<apply_weights, q>();
+    constexpr tensor<double, q, p + 1> G2 = calculate_G2<apply_weights, q>();
+
+    using source_buf_t = std::conditional_t<is_zero<source_type>{}, zero, tensor<double, 2, q, q>>;
+    using flux_buf_t = std::conditional_t<is_zero<flux_type>{}, zero, tensor<double, q, q>>;
+
+    source_buf_t source{};
+    flux_buf_t flux{};
+
+    for (int qy = 0; qy < q; qy++) {
+      for (int qx = 0; qx < q; qx++) {
+        int Q = qy * q + qx;
+        if constexpr (!is_zero<source_type>{}) {
+          tensor<double, dim> s{get<SOURCE>(qf_output[Q])};
+          for (int i = 0; i < dim; i++) {
+            source(i, qy, qx) = s[i];
+          }
+        }
+        if constexpr (!is_zero<flux_type>{}) {
+          flux(qy, qx) = get<FLUX>(qf_output[Q]);
+        }
+      }
+    }
+
+    // to clarify which contractions correspond to which spatial dimensions
+    constexpr int x = 1, y = 0;
+
+    // x-component residual:
+    //   source[0] is dual to the x-value -> tested with closed(x) * open(y) = B2(x) * B1(y)
+    //   flux is dual to the divergence -> tested with dg_closed/dx * open(y) = G2(x) * B1(y)
+    if constexpr (!is_zero<source_type>{}) {
+      auto Ax = contract<y, 0>(source[0], B1);
+      element_residual[0].x += contract<x, 0>(Ax, B2);
+      auto Ay = contract<x, 0>(source[1], B1);
+      element_residual[0].y += contract<y, 0>(Ay, B2);
+    }
+
+    if constexpr (!is_zero<flux_type>{}) {
+      auto Ax = contract<y, 0>(flux, B1);
+      element_residual[0].x += contract<x, 0>(Ax, G2);
+      auto Ay = contract<x, 0>(flux, B1);
+      element_residual[0].y += contract<y, 0>(Ay, G2);
+    }
+  }
+};
+/// @endcond

--- a/src/smith/numerics/functional/detail/quadrilateral_HdivBoundary.inl
+++ b/src/smith/numerics/functional/detail/quadrilateral_HdivBoundary.inl
@@ -1,0 +1,230 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file quadrilateral_HdivBoundary.inl
+ *
+ * @brief Specialization of finite_element for HdivBoundary on quadrilateral geometry
+ */
+
+// This element represents the face trace of a 3D Hdiv space on a quadrilateral
+// (face) boundary. On each face of an RT_{p-1} (Hdiv<p>) hex element,
+// there are p^2 DOFs representing the normal flux sigma dot n, located at
+// Gauss-Legendre (open) node positions in a tensor product structure.
+//
+// The "value" is the scalar normal flux and the "divergence" is the
+// tangential gradient of the normal flux along the face (2D vector).
+//
+// note: mfem assumes the parent element domain is [0,1]x[0,1]
+// for additional information on the finite_element concept requirements, see finite_element.hpp
+/// @cond
+template <int p, int c>
+struct finite_element<mfem::Geometry::SQUARE, HdivBoundary<p, c> > {
+  static constexpr auto geometry = mfem::Geometry::SQUARE;
+  static constexpr auto family = Family::HDIV;
+  static constexpr int components = c;
+  static constexpr int dim = 2;  // dimension of the face
+  static constexpr int n = p;    // number of 1D nodes
+  static constexpr int ndof = p * p;
+
+  static constexpr int VALUE = 0, DIV = 1;
+  static constexpr int SOURCE = 0, FLUX = 1;
+
+  using residual_type =
+      typename std::conditional<components == 1, tensor<double, ndof>, tensor<double, ndof, components> >::type;
+
+  using dof_type = tensor<double, c, p, p>;
+  using dof_type_if = dof_type;
+
+  using value_type = typename std::conditional<components == 1, double, tensor<double, components> >::type;
+  using derivative_type =
+      typename std::conditional<components == 1, tensor<double, dim>, tensor<double, components, dim> >::type;
+  using qf_input_type = tuple<value_type, derivative_type>;
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_functions(tensor<double, dim> xi)
+  {
+    auto N_xi = GaussLegendreInterpolation<p>(xi[0]);
+    auto N_eta = GaussLegendreInterpolation<p>(xi[1]);
+
+    int count = 0;
+    tensor<double, ndof> N{};
+    for (int j = 0; j < p; j++) {
+      for (int i = 0; i < p; i++) {
+        N[count++] = N_xi[i] * N_eta[j];
+      }
+    }
+    return N;
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> shape_function_div(tensor<double, dim> xi)
+  {
+    auto N_xi = GaussLegendreInterpolation<p>(xi[0]);
+    auto N_eta = GaussLegendreInterpolation<p>(xi[1]);
+    auto dN_xi = GaussLegendreInterpolationDerivative<p>(xi[0]);
+    auto dN_eta = GaussLegendreInterpolationDerivative<p>(xi[1]);
+
+    int count = 0;
+    tensor<double, ndof, dim> dN{};
+    for (int j = 0; j < p; j++) {
+      for (int i = 0; i < p; i++) {
+        dN[count++] = {dN_xi[i] * N_eta[j], N_xi[i] * dN_eta[j]};
+      }
+    }
+    return dN;
+  }
+
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_B()
+  {
+    constexpr auto points1D = GaussLegendreNodes<q, mfem::Geometry::SEGMENT>();
+    [[maybe_unused]] constexpr auto weights1D = GaussLegendreWeights<q, mfem::Geometry::SEGMENT>();
+    tensor<double, q, n> B{};
+    for (int i = 0; i < q; i++) {
+      B[i] = GaussLegendreInterpolation<n>(points1D[i]);
+      if constexpr (apply_weights) {
+        B[i] = B[i] * weights1D[i];
+      }
+    }
+    return B;
+  }
+
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_G()
+  {
+    constexpr auto points1D = GaussLegendreNodes<q, mfem::Geometry::SEGMENT>();
+    [[maybe_unused]] constexpr auto weights1D = GaussLegendreWeights<q, mfem::Geometry::SEGMENT>();
+    tensor<double, q, n> G{};
+    for (int i = 0; i < q; i++) {
+      G[i] = GaussLegendreInterpolationDerivative<n>(points1D[i]);
+      if constexpr (apply_weights) {
+        G[i] = G[i] * weights1D[i];
+      }
+    }
+    return G;
+  }
+
+  template <typename in_t, int q>
+  static auto batch_apply_shape_fn(int j, tensor<in_t, q * q> input, const TensorProductQuadratureRule<q>&)
+  {
+    static constexpr bool apply_weights = false;
+    static constexpr auto B = calculate_B<apply_weights, q>();
+    static constexpr auto G = calculate_G<apply_weights, q>();
+
+    int jx = j % n;
+    int jy = j / n;
+
+    using source_t = decltype(get<0>(get<0>(in_t{})) + dot(get<1>(get<0>(in_t{})), tensor<double, 2>{}));
+    using flux_t = decltype(get<0>(get<1>(in_t{})) + dot(get<1>(get<1>(in_t{})), tensor<double, 2>{}));
+
+    tensor<tuple<source_t, flux_t>, q * q> output;
+
+    for (int qy = 0; qy < q; qy++) {
+      for (int qx = 0; qx < q; qx++) {
+        double phi_j = B(qx, jx) * B(qy, jy);
+        tensor<double, dim> dphi_j_dxi = {G(qx, jx) * B(qy, jy), B(qx, jx) * G(qy, jy)};
+
+        int Q = qy * q + qx;
+        const auto& d00 = get<0>(get<0>(input(Q)));
+        const auto& d01 = get<1>(get<0>(input(Q)));
+        const auto& d10 = get<0>(get<1>(input(Q)));
+        const auto& d11 = get<1>(get<1>(input(Q)));
+
+        output[Q] = {d00 * phi_j + dot(d01, dphi_j_dxi), d10 * phi_j + dot(d11, dphi_j_dxi)};
+      }
+    }
+
+    return output;
+  }
+
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  {
+    static constexpr bool apply_weights = false;
+    static constexpr auto B = calculate_B<apply_weights, q>();
+    static constexpr auto G = calculate_G<apply_weights, q>();
+
+    tensor<double, c, q, q> value{};
+    tensor<double, c, dim, q, q> gradient{};
+
+    for (int i = 0; i < c; i++) {
+      auto A0 = contract<1, 1>(X[i], B);
+      auto A1 = contract<1, 1>(X[i], G);
+
+      value[i] = contract<0, 1>(A0, B);
+      gradient[i][0] = contract<0, 1>(A1, B);
+      gradient[i][1] = contract<0, 1>(A0, G);
+    }
+
+    tensor<qf_input_type, q * q> output;
+
+    for (int qy = 0; qy < q; qy++) {
+      for (int qx = 0; qx < q; qx++) {
+        for (int i = 0; i < c; i++) {
+          if constexpr (c == 1) {
+            get<VALUE>(output(qy * q + qx)) = value(0, qy, qx);
+            for (int j = 0; j < dim; j++) {
+              get<DIV>(output(qy * q + qx))[j] = gradient(0, j, qy, qx);
+            }
+          } else {
+            get<VALUE>(output(qy * q + qx))[i] = value(i, qy, qx);
+            for (int j = 0; j < dim; j++) {
+              get<DIV>(output(qy * q + qx))[i][j] = gradient(i, j, qy, qx);
+            }
+          }
+        }
+      }
+    }
+
+    return output;
+  }
+
+  template <typename source_type, typename flux_type, int q>
+  SMITH_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q * q>& qf_output,
+                                          const TensorProductQuadratureRule<q>&, dof_type* element_residual,
+                                          int step = 1)
+  {
+    if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {
+      return;
+    }
+
+    constexpr int ntrial = std::max(size(source_type{}), size(flux_type{}) / dim) / c;
+
+    using s_buffer_type = std::conditional_t<is_zero<source_type>{}, zero, tensor<double, q, q> >;
+    using f_buffer_type = std::conditional_t<is_zero<flux_type>{}, zero, tensor<double, dim, q, q> >;
+
+    static constexpr bool apply_weights = true;
+    static constexpr auto B = calculate_B<apply_weights, q>();
+    static constexpr auto G = calculate_G<apply_weights, q>();
+
+    for (int j = 0; j < ntrial; j++) {
+      for (int i = 0; i < c; i++) {
+        s_buffer_type source;
+        f_buffer_type flux;
+
+        for (int qy = 0; qy < q; qy++) {
+          for (int qx = 0; qx < q; qx++) {
+            [[maybe_unused]] int Q = qy * q + qx;
+            if constexpr (!is_zero<source_type>{}) {
+              source(qy, qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
+            }
+
+            if constexpr (!is_zero<flux_type>{}) {
+              for (int k = 0; k < dim; k++) {
+                flux(k, qy, qx) = reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+              }
+            }
+          }
+        }
+
+        auto A0 = contract<1, 0>(source, B) + contract<1, 0>(flux(0), G);
+        auto A1 = contract<1, 0>(flux(1), B);
+
+        element_residual[j * step][i] += contract<0, 0>(A0, B) + contract<0, 0>(A1, G);
+      }
+    }
+  }
+};
+/// @endcond

--- a/src/smith/numerics/functional/detail/segment_Hdiv.inl
+++ b/src/smith/numerics/functional/detail/segment_Hdiv.inl
@@ -1,0 +1,185 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file segment_Hdiv.inl
+ *
+ * @brief Specialization of finite_element for Hdiv on segment geometry
+ */
+
+// This element represents the face trace of a 2D Hdiv space on a segment
+// (edge) boundary.  On each face of an RT_{p-1} (Hdiv<p>) quad element,
+// there are p DOFs representing the normal flux sigma dot n, located at
+// Gauss-Legendre (open) node positions.
+//
+// The "value" is the scalar normal flux and the "divergence" is the
+// tangential derivative of the normal flux along the face.
+//
+// note: mfem assumes the parent element domain is [0,1]
+// for additional information on the finite_element concept requirements, see finite_element.hpp
+/// @cond
+template <int p, int c>
+struct finite_element<mfem::Geometry::SEGMENT, HdivBoundary<p, c> > {
+  static constexpr auto geometry = mfem::Geometry::SEGMENT;
+  static constexpr auto family = Family::HDIV;
+  static constexpr int components = c;
+  static constexpr int dim = 1;
+  static constexpr int ndof = p;
+
+  static constexpr int VALUE = 0, DIV = 1;
+  static constexpr int SOURCE = 0, FLUX = 1;
+
+  using residual_type =
+      typename std::conditional<components == 1, tensor<double, ndof>, tensor<double, ndof, components> >::type;
+
+  using dof_type = tensor<double, c, ndof>;
+  using dof_type_if = dof_type;
+
+  using value_type = typename std::conditional<components == 1, double, tensor<double, components> >::type;
+  using derivative_type = value_type;
+  using qf_input_type = tuple<value_type, derivative_type>;
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_functions(double xi)
+  {
+    return GaussLegendreInterpolation<ndof>(xi);
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_function_div(double xi)
+  {
+    return GaussLegendreInterpolationDerivative<ndof>(xi);
+  }
+
+  /**
+   * @brief B(i,j) is the jth Gauss-Legendre interpolating polynomial
+   * evaluated at the ith quadrature point
+   */
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_B()
+  {
+    constexpr auto points1D = GaussLegendreNodes<q, mfem::Geometry::SEGMENT>();
+    [[maybe_unused]] constexpr auto weights1D = GaussLegendreWeights<q, mfem::Geometry::SEGMENT>();
+    tensor<double, q, ndof> B{};
+    for (int i = 0; i < q; i++) {
+      B[i] = GaussLegendreInterpolation<ndof>(points1D[i]);
+      if constexpr (apply_weights) B[i] = B[i] * weights1D[i];
+    }
+    return B;
+  }
+
+  /**
+   * @brief G(i,j) is the derivative of the jth Gauss-Legendre interpolating
+   * polynomial evaluated at the ith quadrature point
+   */
+  template <bool apply_weights, int q>
+  static constexpr auto calculate_G()
+  {
+    constexpr auto points1D = GaussLegendreNodes<q, mfem::Geometry::SEGMENT>();
+    [[maybe_unused]] constexpr auto weights1D = GaussLegendreWeights<q, mfem::Geometry::SEGMENT>();
+    tensor<double, q, ndof> G{};
+    for (int i = 0; i < q; i++) {
+      G[i] = GaussLegendreInterpolationDerivative<ndof>(points1D[i]);
+      if constexpr (apply_weights) G[i] = G[i] * weights1D[i];
+    }
+    return G;
+  }
+
+  template <typename T, int q>
+  SMITH_HOST_DEVICE static auto batch_apply_shape_fn(int jx, tensor<T, q> input, const TensorProductQuadratureRule<q>&)
+  {
+    static constexpr bool apply_weights = false;
+    static constexpr auto B = calculate_B<apply_weights, q>();
+    static constexpr auto G = calculate_G<apply_weights, q>();
+
+    using source_t = decltype(get<0>(get<0>(T{})) + get<1>(get<0>(T{})));
+    using flux_t = decltype(get<0>(get<1>(T{})) + get<1>(get<1>(T{})));
+
+    tensor<tuple<source_t, flux_t>, q> output;
+
+    for (int qx = 0; qx < q; qx++) {
+      double phi_j = B(qx, jx);
+      double dphi_j_dxi = G(qx, jx);
+
+      const auto& d00 = get<0>(get<0>(input(qx)));
+      const auto& d01 = get<1>(get<0>(input(qx)));
+      const auto& d10 = get<0>(get<1>(input(qx)));
+      const auto& d11 = get<1>(get<1>(input(qx)));
+
+      output[qx] = {d00 * phi_j + d01 * dphi_j_dxi, d10 * phi_j + d11 * dphi_j_dxi};
+    }
+
+    return output;
+  }
+
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const dof_type& X, const TensorProductQuadratureRule<q>&)
+  {
+    static constexpr bool apply_weights = false;
+    static constexpr auto B = calculate_B<apply_weights, q>();
+    static constexpr auto G = calculate_G<apply_weights, q>();
+
+    tensor<double, c, q> value{};
+    tensor<double, c, q> gradient{};
+
+    for (int i = 0; i < c; i++) {
+      value(i) = dot(B, X[i]);
+      gradient(i) = dot(G, X[i]);
+    }
+
+    tensor<qf_input_type, q> output;
+
+    for (int qx = 0; qx < q; qx++) {
+      if constexpr (c == 1) {
+        get<VALUE>(output(qx)) = value(0, qx);
+        get<DIV>(output(qx)) = gradient(0, qx);
+      } else {
+        for (int i = 0; i < c; i++) {
+          get<VALUE>(output(qx))[i] = value(i, qx);
+          get<DIV>(output(qx))[i] = gradient(i, qx);
+        }
+      }
+    }
+
+    return output;
+  }
+
+  template <typename source_type, typename flux_type, int q>
+  SMITH_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q>& qf_output,
+                                          const TensorProductQuadratureRule<q>&, dof_type* element_residual,
+                                          [[maybe_unused]] int step = 1)
+  {
+    if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {
+      return;
+    }
+
+    constexpr int ntrial = std::max(size(source_type{}), size(flux_type{}) / dim) / c;
+
+    using s_buffer_type = std::conditional_t<is_zero<source_type>{}, zero, tensor<double, q> >;
+    using f_buffer_type = std::conditional_t<is_zero<flux_type>{}, zero, tensor<double, q> >;
+
+    static constexpr bool apply_weights = true;
+    static constexpr auto B = calculate_B<apply_weights, q>();
+    static constexpr auto G = calculate_G<apply_weights, q>();
+
+    for (int j = 0; j < ntrial; j++) {
+      for (int i = 0; i < c; i++) {
+        s_buffer_type source;
+        f_buffer_type flux;
+
+        for (int qx = 0; qx < q; qx++) {
+          if constexpr (!is_zero<source_type>{}) {
+            source(qx) = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[qx]))[i * ntrial + j];
+          }
+          if constexpr (!is_zero<flux_type>{}) {
+            flux(qx) = reinterpret_cast<const double*>(&get<FLUX>(qf_output[qx]))[i * ntrial + j];
+          }
+        }
+
+        element_residual[j * step](i) += dot(source, B) + dot(flux, G);
+      }
+    }
+  }
+};
+/// @endcond

--- a/src/smith/numerics/functional/detail/tensor_product_basis.hpp
+++ b/src/smith/numerics/functional/detail/tensor_product_basis.hpp
@@ -1,0 +1,85 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file tensor_product_basis.hpp
+ *
+ * @brief Shared 1D basis evaluation matrices for tensor-product Hcurl/Hdiv elements
+ *
+ * B1: Gauss-Legendre (open) interpolation at quadrature points
+ * B2: Gauss-Lobatto (closed) interpolation at quadrature points
+ * G2: Gauss-Lobatto (closed) derivative at quadrature points
+ *
+ * Used by quadrilateral_Hdiv.inl and hexahedron_Hdiv.inl (and their Hcurl
+ * counterparts use identical logic).
+ */
+
+#pragma once
+
+// NOTE: This header is included from within namespace smith {} in finite_element.hpp.
+// We use namespace basis_detail to avoid name collisions with member functions
+// of the same name inside finite_element specializations.
+
+namespace basis_detail {
+
+/**
+ * @brief Builds the Gauss-Legendre interpolation matrix for open 1D basis functions.
+ * @tparam p interpolation order
+ * @tparam apply_weights whether to scale rows by quadrature weights
+ * @tparam q quadrature order
+ */
+template <int p, bool apply_weights, int q>
+constexpr auto calculate_B1()
+{
+  constexpr auto points1D = GaussLegendreNodes<q, mfem::Geometry::SEGMENT>();
+  [[maybe_unused]] constexpr auto weights1D = GaussLegendreWeights<q, mfem::Geometry::SEGMENT>();
+  tensor<double, q, p> B1{};
+  for (int i = 0; i < q; i++) {
+    B1[i] = GaussLegendreInterpolation<p>(points1D[i]);
+    if constexpr (apply_weights) B1[i] = B1[i] * weights1D[i];
+  }
+  return B1;
+}
+
+/**
+ * @brief Builds the Gauss-Lobatto interpolation matrix for closed 1D basis functions.
+ * @tparam p interpolation order
+ * @tparam apply_weights whether to scale rows by quadrature weights
+ * @tparam q quadrature order
+ */
+template <int p, bool apply_weights, int q>
+constexpr auto calculate_B2()
+{
+  constexpr auto points1D = GaussLegendreNodes<q, mfem::Geometry::SEGMENT>();
+  [[maybe_unused]] constexpr auto weights1D = GaussLegendreWeights<q, mfem::Geometry::SEGMENT>();
+  tensor<double, q, p + 1> B2{};
+  for (int i = 0; i < q; i++) {
+    B2[i] = GaussLobattoInterpolation<p + 1>(points1D[i]);
+    if constexpr (apply_weights) B2[i] = B2[i] * weights1D[i];
+  }
+  return B2;
+}
+
+/**
+ * @brief Builds the Gauss-Lobatto derivative matrix for closed 1D basis functions.
+ * @tparam p interpolation order
+ * @tparam apply_weights whether to scale rows by quadrature weights
+ * @tparam q quadrature order
+ */
+template <int p, bool apply_weights, int q>
+constexpr auto calculate_G2()
+{
+  constexpr auto points1D = GaussLegendreNodes<q, mfem::Geometry::SEGMENT>();
+  [[maybe_unused]] constexpr auto weights1D = GaussLegendreWeights<q, mfem::Geometry::SEGMENT>();
+  tensor<double, q, p + 1> G2{};
+  for (int i = 0; i < q; i++) {
+    G2[i] = GaussLobattoInterpolationDerivative<p + 1>(points1D[i]);
+    if constexpr (apply_weights) G2[i] = G2[i] * weights1D[i];
+  }
+  return G2;
+}
+
+}  // namespace basis_detail

--- a/src/smith/numerics/functional/detail/tetrahedron_Hdiv.inl
+++ b/src/smith/numerics/functional/detail/tetrahedron_Hdiv.inl
@@ -1,0 +1,340 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file tetrahedron_Hdiv.inl
+ *
+ * @brief Specialization of finite_element for Hdiv (Raviart-Thomas) on tetrahedron geometry
+ */
+
+// This specialization defines RT shape functions on the reference tetrahedron
+// with vertices at {(0,0,0), (1,0,0), (0,1,0), (0,0,1)}.
+//
+// Convention: Hdiv<p> corresponds to RT_FECollection(p-1, dim) in mfem.
+// RT_{p-1} on tetrahedra has ndof = p*(p+1)*(p+3)/2 DOFs.
+//   Hdiv<1> -> RT_0: 4 DOFs (one per face)
+//   Hdiv<2> -> RT_1: 15 DOFs (3 per face + 3 interior)
+//   Hdiv<3> -> RT_2: 36 DOFs (6 per face + 12 interior)
+//
+// Shape functions are computed via a Vandermonde approach matching mfem:
+//   1. Build a raw polynomial basis (Chebyshev polynomials in barycentric coords)
+//   2. Build the Vandermonde matrix T at DOF nodes
+//   3. Shape functions = inv(T) * raw_basis
+//
+// for additional information on the finite_element concept requirements, see finite_element.hpp
+/// @cond
+template <int p>
+struct finite_element<mfem::Geometry::TETRAHEDRON, Hdiv<p> > {
+  static constexpr auto geometry = mfem::Geometry::TETRAHEDRON;
+  static constexpr auto family = Family::HDIV;
+  static constexpr int dim = 3;
+  static constexpr int n = p;
+  static constexpr int ndof = p * (p + 1) * (p + 3) / 2;
+  static constexpr int components = 1;
+
+  static constexpr int VALUE = 0, DIV = 1;
+  static constexpr int SOURCE = 0, FLUX = 1;
+
+  using residual_type =
+      typename std::conditional<components == 1, tensor<double, ndof>, tensor<double, ndof, components> >::type;
+
+  using dof_type = tensor<double, ndof>;
+  using dof_type_if = dof_type;
+
+  using value_type = tensor<double, dim>;
+  using derivative_type = double;
+  using qf_input_type = tuple<value_type, derivative_type>;
+
+  // mfem polynomial order (RT_{mp} element)
+  static constexpr int mp = p - 1;
+
+  // Raw (pre-Vandermonde) basis functions at point xi, matching mfem convention.
+  // Face DOFs: (s,0,0), (0,s,0), (0,0,s) where s = Tx_i * Ty_j * Tz_k * Tl_{mp-i-j-k}
+  // Interior DOFs: ((x-1/4)*s, (y-1/4)*s, (z-1/4)*s) where s = Tx_i * Ty_j * Tz_{mp-i-j}
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> raw_vshape(tensor<double, dim> xi)
+  {
+    double sx[mp + 1], sy[mp + 1], sz[mp + 1], sl[mp + 1];
+    chebyshev_eval(mp, xi[0], sx);
+    chebyshev_eval(mp, xi[1], sy);
+    chebyshev_eval(mp, xi[2], sz);
+    chebyshev_eval(mp, 1.0 - xi[0] - xi[1] - xi[2], sl);
+
+    tensor<double, ndof, dim> raw{};
+    int o = 0;
+    for (int k = 0; k <= mp; k++) {
+      for (int j = 0; j + k <= mp; j++) {
+        for (int i = 0; i + j + k <= mp; i++) {
+          double s = sx[i] * sy[j] * sz[k] * sl[mp - i - j - k];
+          raw[o][0] = s;
+          raw[o][1] = 0;
+          raw[o][2] = 0;
+          o++;
+          raw[o][0] = 0;
+          raw[o][1] = s;
+          raw[o][2] = 0;
+          o++;
+          raw[o][0] = 0;
+          raw[o][1] = 0;
+          raw[o][2] = s;
+          o++;
+        }
+      }
+    }
+    constexpr double c = 1.0 / 4.0;
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        double s = sx[i] * sy[j] * sz[mp - i - j];
+        raw[o][0] = (xi[0] - c) * s;
+        raw[o][1] = (xi[1] - c) * s;
+        raw[o][2] = (xi[2] - c) * s;
+        o++;
+      }
+    }
+    return raw;
+  }
+
+  // Raw divergence of the pre-Vandermonde basis
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> raw_divshape(tensor<double, dim> xi)
+  {
+    double sx[mp + 1], sy[mp + 1], sz[mp + 1], sl[mp + 1];
+    double dsx[mp + 1], dsy[mp + 1], dsz[mp + 1], dsl[mp + 1];
+    chebyshev_eval_d(mp, xi[0], sx, dsx);
+    chebyshev_eval_d(mp, xi[1], sy, dsy);
+    chebyshev_eval_d(mp, xi[2], sz, dsz);
+    chebyshev_eval_d(mp, 1.0 - xi[0] - xi[1] - xi[2], sl, dsl);
+
+    tensor<double, ndof> raw{};
+    int o = 0;
+    for (int k = 0; k <= mp; k++) {
+      for (int j = 0; j + k <= mp; j++) {
+        for (int i = 0; i + j + k <= mp; i++) {
+          int l = mp - i - j - k;
+          // div(s,0,0) = ds/dx;  dl/dx = -1
+          raw[o++] = (dsx[i] * sl[l] - sx[i] * dsl[l]) * sy[j] * sz[k];
+          // div(0,s,0) = ds/dy;  dl/dy = -1
+          raw[o++] = (dsy[j] * sl[l] - sy[j] * dsl[l]) * sx[i] * sz[k];
+          // div(0,0,s) = ds/dz;  dl/dz = -1
+          raw[o++] = (dsz[k] * sl[l] - sz[k] * dsl[l]) * sx[i] * sy[j];
+        }
+      }
+    }
+    constexpr double c = 1.0 / 4.0;
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        int k = mp - i - j;
+        // div((x-c)*s, (y-c)*s, (z-c)*s) = 3*s + (x-c)*ds/dx + (y-c)*ds/dy + (z-c)*ds/dz
+        raw[o++] = (sx[i] + (xi[0] - c) * dsx[i]) * sy[j] * sz[k] + (sy[j] + (xi[1] - c) * dsy[j]) * sx[i] * sz[k] +
+                   (sz[k] + (xi[2] - c) * dsz[k]) * sx[i] * sy[j];
+      }
+    }
+    return raw;
+  }
+
+  // DOF node locations matching mfem's RT_TetrahedronElement constructor.
+  // Face DOFs at barycentric GL points on each face, interior DOFs at barycentric GL points.
+  // face_dofs_per_face = p*(p+1)/2
+  static constexpr auto nodes = [] {
+    tensor<double, ndof, dim> nd{};
+    constexpr auto bop = GaussLegendreNodes<p, mfem::Geometry::SEGMENT>();
+    int o = 0;
+
+    // face 0: vertices (1,0,0),(0,1,0),(0,0,1)  -- nk[0]=(1,1,1)
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        double w = bop[i] + bop[j] + bop[mp - i - j];
+        nd[o++] = {bop[mp - i - j] / w, bop[i] / w, bop[j] / w};
+      }
+    }
+    // face 1: vertices (0,0,0),(0,0,1),(0,1,0), x=0  -- nk[1]=(-1,0,0)
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        double w = bop[i] + bop[j] + bop[mp - i - j];
+        nd[o++] = {0.0, bop[j] / w, bop[i] / w};
+      }
+    }
+    // face 2: vertices (0,0,0),(1,0,0),(0,0,1), y=0  -- nk[2]=(0,-1,0)
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        double w = bop[i] + bop[j] + bop[mp - i - j];
+        nd[o++] = {bop[i] / w, 0.0, bop[j] / w};
+      }
+    }
+    // face 3: vertices (0,0,0),(0,1,0),(1,0,0), z=0  -- nk[3]=(0,0,-1)
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        double w = bop[i] + bop[j] + bop[mp - i - j];
+        nd[o++] = {bop[j] / w, bop[i] / w, 0.0};
+      }
+    }
+
+    // interior DOFs (3 per interior point)
+    if constexpr (p > 1) {
+      constexpr auto iop = GaussLegendreNodes<p - 1, mfem::Geometry::SEGMENT>();
+      for (int k = 0; k < p - 1; k++) {
+        for (int j = 0; j + k < p - 1; j++) {
+          for (int i = 0; i + j + k < p - 1; i++) {
+            double w = iop[i] + iop[j] + iop[k] + iop[p - 2 - i - j - k];
+            nd[o++] = {iop[i] / w, iop[j] / w, iop[k] / w};
+            nd[o++] = {iop[i] / w, iop[j] / w, iop[k] / w};
+            nd[o++] = {iop[i] / w, iop[j] / w, iop[k] / w};
+          }
+        }
+      }
+    }
+    return nd;
+  }();
+
+  // Normal directions associated with each DOF
+  static constexpr auto directions = [] {
+    tensor<double, ndof, dim> d{};
+    int o = 0;
+    constexpr int fdofs = p * (p + 1) / 2;                      // DOFs per face
+    for (int i = 0; i < fdofs; i++) d[o++] = {1.0, 1.0, 1.0};   // face 0
+    for (int i = 0; i < fdofs; i++) d[o++] = {-1.0, 0.0, 0.0};  // face 1
+    for (int i = 0; i < fdofs; i++) d[o++] = {0.0, -1.0, 0.0};  // face 2
+    for (int i = 0; i < fdofs; i++) d[o++] = {0.0, 0.0, -1.0};  // face 3
+    if constexpr (p > 1) {
+      for (int k = 0; k < p - 1; k++) {
+        for (int j = 0; j + k < p - 1; j++) {
+          for (int i = 0; i + j + k < p - 1; i++) {
+            d[o++] = {-1.0, 0.0, 0.0};  // nk[1]
+            d[o++] = {0.0, -1.0, 0.0};  // nk[2]
+            d[o++] = {0.0, 0.0, -1.0};  // nk[3]
+          }
+        }
+      }
+    }
+    return d;
+  }();
+
+  // Inverse Vandermonde matrix
+  static constexpr auto Ti = [] {
+    tensor<double, ndof, ndof> T{};
+    for (int k = 0; k < ndof; k++) {
+      auto raw = raw_vshape(nodes[k]);
+      for (int r = 0; r < ndof; r++) {
+        T[r][k] = raw[r][0] * directions[k][0] + raw[r][1] * directions[k][1] + raw[r][2] * directions[k][2];
+      }
+    }
+    return inv(T);
+  }();
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> shape_functions([[maybe_unused]] tensor<double, dim> xi)
+  {
+    auto raw = raw_vshape(xi);
+    tensor<double, ndof, dim> N{};
+    for (int i = 0; i < ndof; i++) {
+      for (int j = 0; j < ndof; j++) {
+        N[i][0] += Ti[i][j] * raw[j][0];
+        N[i][1] += Ti[i][j] * raw[j][1];
+        N[i][2] += Ti[i][j] * raw[j][2];
+      }
+    }
+    return N;
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_function_div([[maybe_unused]] tensor<double, dim> xi)
+  {
+    auto raw = raw_divshape(xi);
+    tensor<double, ndof> div{};
+    for (int i = 0; i < ndof; i++) {
+      for (int j = 0; j < ndof; j++) {
+        div[i] += Ti[i][j] * raw[j];
+      }
+    }
+    return div;
+  }
+
+  template <typename in_t, int q>
+  static auto batch_apply_shape_fn(int j, tensor<in_t, q*(q + 1) * (q + 2) / 6> input,
+                                   const TensorProductQuadratureRule<q>&)
+  {
+    using source_t = decltype(dot(get<0>(get<0>(in_t{})), tensor<double, dim>{}) + get<1>(get<0>(in_t{})) * double{});
+    using flux_t = decltype(dot(get<0>(get<1>(in_t{})), tensor<double, dim>{}) + get<1>(get<1>(in_t{})) * double{});
+
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TETRAHEDRON>();
+
+    static constexpr int Q = q * (q + 1) * (q + 2) / 6;
+    tensor<tuple<source_t, flux_t>, Q> output;
+
+    for (int i = 0; i < Q; i++) {
+      auto all_shapes = shape_functions(xi[i]);
+      auto all_divs = shape_function_div(xi[i]);
+
+      tensor<double, dim> phi_j = all_shapes[j];
+      double div_phi_j = all_divs[j];
+
+      const auto& d00 = get<0>(get<0>(input(i)));
+      const auto& d01 = get<1>(get<0>(input(i)));
+      const auto& d10 = get<0>(get<1>(input(i)));
+      const auto& d11 = get<1>(get<1>(input(i)));
+
+      output[i] = {dot(d00, phi_j) + d01 * div_phi_j, dot(d10, phi_j) + d11 * div_phi_j};
+    }
+
+    return output;
+  }
+
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TETRAHEDRON>();
+    constexpr int Q = q * (q + 1) * (q + 2) / 6;
+
+    tensor<tuple<tensor<double, dim>, double>, Q> qf_inputs;
+
+    for (int i = 0; i < Q; i++) {
+      auto N = shape_functions(xi[i]);
+      auto divN = shape_function_div(xi[i]);
+
+      tensor<double, dim> val{};
+      double div_val = 0.0;
+
+      for (int j = 0; j < ndof; j++) {
+        for (int d = 0; d < dim; d++) {
+          val[d] += N[j][d] * element_values[j];
+        }
+        div_val += divN[j] * element_values[j];
+      }
+
+      get<VALUE>(qf_inputs(i)) = val;
+      get<DIV>(qf_inputs(i)) = div_val;
+    }
+
+    return qf_inputs;
+  }
+
+  template <typename source_type, typename flux_type, int q>
+  SMITH_HOST_DEVICE static void integrate(
+      const tensor<tuple<source_type, flux_type>, q*(q + 1) * (q + 2) / 6>& qf_output,
+      const TensorProductQuadratureRule<q>&, dof_type* element_residual, [[maybe_unused]] int step = 1)
+  {
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TETRAHEDRON>();
+    [[maybe_unused]] constexpr auto weights = GaussLegendreWeights<q, mfem::Geometry::TETRAHEDRON>();
+    constexpr int Q = q * (q + 1) * (q + 2) / 6;
+
+    if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) return;
+
+    for (int i = 0; i < Q; i++) {
+      auto N = shape_functions(xi[i]);
+      auto divN = shape_function_div(xi[i]);
+
+      for (int j = 0; j < ndof; j++) {
+        double contrib = 0.0;
+        if constexpr (!is_zero<source_type>{}) {
+          tensor<double, dim> s{get<SOURCE>(qf_output[i])};
+          contrib += dot(s, N[j]);
+        }
+        if constexpr (!is_zero<flux_type>{}) {
+          double f = get<FLUX>(qf_output[i]);
+          contrib += f * divN[j];
+        }
+        element_residual[0][j] += contrib * weights[i];
+      }
+    }
+  }
+};
+/// @endcond

--- a/src/smith/numerics/functional/detail/triangle_Hdiv.inl
+++ b/src/smith/numerics/functional/detail/triangle_Hdiv.inl
@@ -1,0 +1,297 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file triangle_Hdiv.inl
+ *
+ * @brief Specialization of finite_element for Hdiv (Raviart-Thomas) on triangle geometry
+ */
+
+// This specialization defines RT shape functions on the reference triangle
+// with vertices at {(0,0), (1,0), (0,1)}.
+//
+// Convention: Hdiv<p> corresponds to RT_FECollection(p-1, dim) in mfem,
+// matching the tensor-product convention where Hcurl<p> <-> ND_FECollection(p).
+// The de Rham sequence is:  H1<p> -> Hcurl<p> -> Hdiv<p> -> L2<p-1>
+//
+// RT_{p-1} on triangles has ndof = p*(p+2) DOFs.
+//   Hdiv<1> -> RT_0: 3 DOFs (one per edge)
+//   Hdiv<2> -> RT_1: 8 DOFs (2 per edge + 2 interior)
+//   Hdiv<3> -> RT_2: 15 DOFs (3 per edge + 6 interior)
+//
+// Shape functions are computed via a Vandermonde approach matching mfem:
+//   1. Build a raw polynomial basis (Chebyshev polynomials in barycentric coords)
+//   2. Build the Vandermonde matrix T at DOF nodes (Gauss-Legendre open points)
+//   3. Shape functions = inv(T) * raw_basis
+//
+// for additional information on the finite_element concept requirements, see finite_element.hpp
+/// @cond
+template <int p>
+struct finite_element<mfem::Geometry::TRIANGLE, Hdiv<p> > {
+  static constexpr auto geometry = mfem::Geometry::TRIANGLE;
+  static constexpr auto family = Family::HDIV;
+  static constexpr int dim = 2;
+  static constexpr int n = p;
+  static constexpr int ndof = p * (p + 2);
+  static constexpr int components = 1;
+
+  static constexpr int VALUE = 0, DIV = 1;
+  static constexpr int SOURCE = 0, FLUX = 1;
+
+  using residual_type =
+      typename std::conditional<components == 1, tensor<double, ndof>, tensor<double, ndof, components> >::type;
+
+  using dof_type = tensor<double, ndof>;
+  using dof_type_if = dof_type;
+
+  using value_type = tensor<double, dim>;
+  using derivative_type = double;
+  using qf_input_type = tuple<value_type, derivative_type>;
+
+  // mfem polynomial order (RT_{mp} element)
+  static constexpr int mp = p - 1;
+
+  // Raw (pre-Vandermonde) basis functions at point xi, matching mfem convention.
+  // Face DOFs: (s, 0) and (0, s)  where s = T_i(2x-1)*T_j(2y-1)*T_k(2(1-x-y)-1)
+  // Interior DOFs: ((x-1/3)*s, (y-1/3)*s)  where s = T_i(2x-1)*T_j(2y-1)
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> raw_vshape(tensor<double, dim> xi)
+  {
+    double sx[mp + 1], sy[mp + 1], sl[mp + 1];
+    chebyshev_eval(mp, xi[0], sx);
+    chebyshev_eval(mp, xi[1], sy);
+    chebyshev_eval(mp, 1.0 - xi[0] - xi[1], sl);
+
+    tensor<double, ndof, dim> raw{};
+    int o = 0;
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        double s = sx[i] * sy[j] * sl[mp - i - j];
+        raw[o][0] = s;
+        raw[o][1] = 0.0;
+        o++;
+        raw[o][0] = 0.0;
+        raw[o][1] = s;
+        o++;
+      }
+    }
+    constexpr double c = 1.0 / 3.0;
+    for (int i = 0; i <= mp; i++) {
+      double s = sx[i] * sy[mp - i];
+      raw[o][0] = (xi[0] - c) * s;
+      raw[o][1] = (xi[1] - c) * s;
+      o++;
+    }
+    return raw;
+  }
+
+  // Raw divergence of the pre-Vandermonde basis
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> raw_divshape(tensor<double, dim> xi)
+  {
+    double sx[mp + 1], sy[mp + 1], sl[mp + 1];
+    double dsx[mp + 1], dsy[mp + 1], dsl[mp + 1];
+    chebyshev_eval_d(mp, xi[0], sx, dsx);
+    chebyshev_eval_d(mp, xi[1], sy, dsy);
+    chebyshev_eval_d(mp, 1.0 - xi[0] - xi[1], sl, dsl);
+
+    tensor<double, ndof> raw{};
+    int o = 0;
+    for (int j = 0; j <= mp; j++) {
+      for (int i = 0; i + j <= mp; i++) {
+        int k = mp - i - j;
+        // div(s,0) = ds/dx;  dl/dx = -1 gives the subtraction
+        raw[o++] = (dsx[i] * sl[k] - sx[i] * dsl[k]) * sy[j];
+        // div(0,s) = ds/dy;  dl/dy = -1
+        raw[o++] = (dsy[j] * sl[k] - sy[j] * dsl[k]) * sx[i];
+      }
+    }
+    constexpr double c = 1.0 / 3.0;
+    for (int i = 0; i <= mp; i++) {
+      int j = mp - i;
+      // div((x-c)*s, (y-c)*s) = 2*s + (x-c)*ds/dx + (y-c)*ds/dy
+      raw[o++] = (sx[i] + (xi[0] - c) * dsx[i]) * sy[j] + (sy[j] + (xi[1] - c) * dsy[j]) * sx[i];
+    }
+    return raw;
+  }
+
+  // DOF node locations (matching mfem's RT_TriangleElement constructor)
+  // Edge DOFs at Gauss-Legendre open points, interior DOFs at barycentric-weighted points
+  static constexpr auto nodes = [] {
+    tensor<double, ndof, dim> nd{};
+    constexpr auto bop = GaussLegendreNodes<p, mfem::Geometry::SEGMENT>();
+    int o = 0;
+    // edge 0: (0,0)-(1,0), y=0
+    for (int i = 0; i < p; i++) {
+      nd[o++] = {bop[i], 0.0};
+    }
+    // edge 1: (1,0)-(0,1)
+    for (int i = 0; i < p; i++) {
+      nd[o++] = {bop[p - 1 - i], bop[i]};
+    }
+    // edge 2: (0,1)-(0,0), x=0
+    for (int i = 0; i < p; i++) {
+      nd[o++] = {0.0, bop[p - 1 - i]};
+    }
+    // interior DOFs (two per interior point, same location, different normals)
+    if constexpr (p > 1) {
+      constexpr auto iop = GaussLegendreNodes<p - 1, mfem::Geometry::SEGMENT>();
+      for (int j = 0; j < p - 1; j++) {
+        for (int i = 0; i + j < p - 1; i++) {
+          double w = iop[i] + iop[j] + iop[p - 2 - i - j];
+          nd[o++] = {iop[i] / w, iop[j] / w};
+          nd[o++] = {iop[i] / w, iop[j] / w};
+        }
+      }
+    }
+    return nd;
+  }();
+
+  // Normal directions associated with each DOF (for the DOF functional phi_i(x_j) . dir_j = delta_ij)
+  static constexpr auto directions = [] {
+    tensor<double, ndof, dim> d{};
+    int o = 0;
+    for (int i = 0; i < p; i++) d[o++] = {0.0, -1.0};  // edge 0
+    for (int i = 0; i < p; i++) d[o++] = {1.0, 1.0};   // edge 1
+    for (int i = 0; i < p; i++) d[o++] = {-1.0, 0.0};  // edge 2
+    if constexpr (p > 1) {
+      for (int j = 0; j < p - 1; j++) {
+        for (int i = 0; i + j < p - 1; i++) {
+          d[o++] = {0.0, -1.0};  // interior: nk index 0
+          d[o++] = {-1.0, 0.0};  // interior: nk index 2
+        }
+      }
+    }
+    return d;
+  }();
+
+  // Inverse Vandermonde matrix: Ti[i][j] transforms raw basis j into shape function i
+  // T[raw_idx][dof_idx] = raw_vshape[raw_idx](node[dof_idx]) . direction[dof_idx]
+  static constexpr auto Ti = [] {
+    tensor<double, ndof, ndof> T{};
+    for (int k = 0; k < ndof; k++) {
+      auto raw = raw_vshape(nodes[k]);
+      for (int r = 0; r < ndof; r++) {
+        T[r][k] = raw[r][0] * directions[k][0] + raw[r][1] * directions[k][1];
+      }
+    }
+    return inv(T);
+  }();
+
+  // Evaluate all ndof shape functions (vector-valued) at point xi
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> shape_functions([[maybe_unused]] tensor<double, dim> xi)
+  {
+    auto raw = raw_vshape(xi);
+    tensor<double, ndof, dim> N{};
+    for (int i = 0; i < ndof; i++) {
+      for (int j = 0; j < ndof; j++) {
+        N[i][0] += Ti[i][j] * raw[j][0];
+        N[i][1] += Ti[i][j] * raw[j][1];
+      }
+    }
+    return N;
+  }
+
+  // Evaluate divergence of all ndof shape functions at point xi
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_function_div([[maybe_unused]] tensor<double, dim> xi)
+  {
+    auto raw = raw_divshape(xi);
+    tensor<double, ndof> d{};
+    for (int i = 0; i < ndof; i++) {
+      for (int j = 0; j < ndof; j++) {
+        d[i] += Ti[i][j] * raw[j];
+      }
+    }
+    return d;
+  }
+
+  template <typename in_t, int q>
+  static auto batch_apply_shape_fn(int j, tensor<in_t, q*(q + 1) / 2> input, const TensorProductQuadratureRule<q>&)
+  {
+    using source_t = decltype(dot(get<0>(get<0>(in_t{})), tensor<double, dim>{}) + get<1>(get<0>(in_t{})) * double{});
+    using flux_t = decltype(dot(get<0>(get<1>(in_t{})), tensor<double, dim>{}) + get<1>(get<1>(in_t{})) * double{});
+
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+
+    static constexpr int Q = q * (q + 1) / 2;
+    tensor<tuple<source_t, flux_t>, Q> output;
+
+    for (int i = 0; i < Q; i++) {
+      auto all_shapes = shape_functions(xi[i]);
+      auto all_divs = shape_function_div(xi[i]);
+
+      tensor<double, dim> phi_j = all_shapes[j];
+      double div_phi_j = all_divs[j];
+
+      const auto& d00 = get<0>(get<0>(input(i)));
+      const auto& d01 = get<1>(get<0>(input(i)));
+      const auto& d10 = get<0>(get<1>(input(i)));
+      const auto& d11 = get<1>(get<1>(input(i)));
+
+      output[i] = {dot(d00, phi_j) + d01 * div_phi_j, dot(d10, phi_j) + d11 * div_phi_j};
+    }
+
+    return output;
+  }
+
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const dof_type& element_values, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+    constexpr int Q = q * (q + 1) / 2;
+
+    tensor<tuple<tensor<double, dim>, double>, Q> qf_inputs;
+
+    for (int i = 0; i < Q; i++) {
+      auto N = shape_functions(xi[i]);
+      auto divN = shape_function_div(xi[i]);
+
+      tensor<double, dim> val{};
+      double div_val = 0.0;
+
+      for (int j = 0; j < ndof; j++) {
+        for (int d = 0; d < dim; d++) {
+          val[d] += N[j][d] * element_values[j];
+        }
+        div_val += divN[j] * element_values[j];
+      }
+
+      get<VALUE>(qf_inputs(i)) = val;
+      get<DIV>(qf_inputs(i)) = div_val;
+    }
+
+    return qf_inputs;
+  }
+
+  template <typename source_type, typename flux_type, int q>
+  SMITH_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q*(q + 1) / 2>& qf_output,
+                                          const TensorProductQuadratureRule<q>&, dof_type* element_residual,
+                                          [[maybe_unused]] int step = 1)
+  {
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+    [[maybe_unused]] constexpr auto weights = GaussLegendreWeights<q, mfem::Geometry::TRIANGLE>();
+    constexpr int Q = q * (q + 1) / 2;
+
+    if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) return;
+
+    for (int i = 0; i < Q; i++) {
+      auto N = shape_functions(xi[i]);
+      auto divN = shape_function_div(xi[i]);
+
+      for (int j = 0; j < ndof; j++) {
+        double contrib = 0.0;
+        if constexpr (!is_zero<source_type>{}) {
+          tensor<double, dim> s{get<SOURCE>(qf_output[i])};
+          contrib += dot(s, N[j]);
+        }
+        if constexpr (!is_zero<flux_type>{}) {
+          double f = get<FLUX>(qf_output[i]);
+          contrib += f * divN[j];
+        }
+        element_residual[0][j] += contrib * weights[i];
+      }
+    }
+  }
+};
+/// @endcond

--- a/src/smith/numerics/functional/detail/triangle_HdivBoundary.inl
+++ b/src/smith/numerics/functional/detail/triangle_HdivBoundary.inl
@@ -1,0 +1,397 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file triangle_HdivBoundary.inl
+ *
+ * @brief Specialization of finite_element for HdivBoundary on triangle geometry
+ */
+
+// This element represents the face trace of a 3D Hdiv space on a triangle
+// (face) boundary. On each face of an RT_{p-1} (Hdiv<p>) tet element,
+// there are p*(p+1)/2 DOFs representing the normal flux sigma dot n,
+// which act as polynomials of degree p-1 on the triangle.
+//
+// for exact positions of nodes for different polynomial orders, see simplex_basis_function_unit_tests.cpp
+/// @cond
+template <int p, int c>
+struct finite_element<mfem::Geometry::TRIANGLE, HdivBoundary<p, c> > {
+  static constexpr auto geometry = mfem::Geometry::TRIANGLE;
+  static constexpr auto family = Family::HDIV;
+  static constexpr int components = c;
+  static constexpr int dim = 2;
+  static constexpr int n = p;
+  static constexpr int ndof = p * (p + 1) / 2;
+
+  static constexpr int VALUE = 0, DIV = 1;
+  static constexpr int SOURCE = 0, FLUX = 1;
+
+  using residual_type =
+      typename std::conditional<components == 1, tensor<double, ndof>, tensor<double, ndof, components> >::type;
+
+  using dof_type = tensor<double, c, ndof>;
+  using dof_type_if = tensor<double, c, 2, ndof>;
+
+  using value_type = typename std::conditional<components == 1, double, tensor<double, components> >::type;
+  using derivative_type =
+      typename std::conditional<components == 1, tensor<double, dim>, tensor<double, components, dim> >::type;
+  using qf_input_type = tuple<value_type, derivative_type>;
+
+  SMITH_HOST_DEVICE static constexpr double shape_function([[maybe_unused]] tensor<double, dim> xi,
+                                                           [[maybe_unused]] int i)
+  {
+    // constant
+    if constexpr (n == 1) {
+      return 1;
+    }
+
+    // linear
+    if constexpr (n == 2) {
+      switch (i) {
+        case 0:
+          return 1 - xi[0] - xi[1];
+        case 1:
+          return xi[0];
+        case 2:
+          return xi[1];
+      }
+    }
+
+    // quadratic
+    if constexpr (n == 3) {
+      switch (i) {
+        case 0:
+          return (-1 + xi[0] + xi[1]) * (-1 + 2 * xi[0] + 2 * xi[1]);
+        case 1:
+          return -4 * xi[0] * (-1 + xi[0] + xi[1]);
+        case 2:
+          return xi[0] * (-1 + 2 * xi[0]);
+        case 3:
+          return -4 * xi[1] * (-1 + xi[0] + xi[1]);
+        case 4:
+          return 4 * xi[0] * xi[1];
+        case 5:
+          return xi[1] * (-1 + 2 * xi[1]);
+      }
+    }
+
+    // cubic
+    if constexpr (n == 4) {
+      constexpr double sqrt5 = 2.23606797749978981;
+      switch (i) {
+        case 0:
+          return -((-1 + xi[0] + xi[1]) *
+                   (1 + 5 * xi[0] * xi[0] + 5 * (-1 + xi[1]) * xi[1] + xi[0] * (-5 + 11 * xi[1])));
+        case 1:
+          return (5 * xi[0] * (-1 + xi[0] + xi[1]) * (-1 - sqrt5 + 2 * sqrt5 * xi[0] + (3 + sqrt5) * xi[1])) / 2.;
+        case 2:
+          return (-5 * xi[0] * (-1 + xi[0] + xi[1]) * (1 - sqrt5 + 2 * sqrt5 * xi[0] + (-3 + sqrt5) * xi[1])) / 2.;
+        case 3:
+          return xi[0] * (1 + 5 * xi[0] * xi[0] + xi[1] - xi[1] * xi[1] - xi[0] * (5 + xi[1]));
+        case 4:
+          return (5 * xi[1] * (-1 + xi[0] + xi[1]) * (-1 - sqrt5 + (3 + sqrt5) * xi[0] + 2 * sqrt5 * xi[1])) / 2.;
+        case 5:
+          return -27 * xi[0] * xi[1] * (-1 + xi[0] + xi[1]);
+        case 6:
+          return (5 * xi[0] * xi[1] * (-2 + (3 + sqrt5) * xi[0] - (-3 + sqrt5) * xi[1])) / 2.;
+        case 7:
+          return (5 * xi[1] * (-1 + xi[0] + xi[1]) *
+                  (5 - 3 * sqrt5 + 2 * (-5 + 2 * sqrt5) * xi[0] + 5 * (-1 + sqrt5) * xi[1])) /
+                 (-5 + sqrt5);
+        case 8:
+          return (-5 * xi[0] * xi[1] * (2 + (-3 + sqrt5) * xi[0] - (3 + sqrt5) * xi[1])) / 2.;
+        case 9:
+          return xi[1] * (1 + xi[0] - xi[0] * xi[0] - xi[0] * xi[1] + 5 * (-1 + xi[1]) * xi[1]);
+      }
+    }
+
+    return 0.0;
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, dim> shape_function_gradient(
+      [[maybe_unused]] tensor<double, dim> xi, [[maybe_unused]] int i)
+  {
+    // constant
+    if constexpr (n == 1) {
+      return {0.0, 0.0};
+    }
+
+    // linear
+    if constexpr (n == 2) {
+      switch (i) {
+        case 0:
+          return {-1.0, -1.0};
+        case 1:
+          return {1.0, 0.0};
+        case 2:
+          return {0.0, 1.0};
+      }
+    }
+
+    // quadratic
+    if constexpr (n == 3) {
+      switch (i) {
+        case 0:
+          return {-3 + 4 * xi[0] + 4 * xi[1], -3 + 4 * xi[0] + 4 * xi[1]};
+        case 1:
+          return {-4 * (-1 + 2 * xi[0] + xi[1]), -4 * xi[0]};
+        case 2:
+          return {-1 + 4 * xi[0], 0};
+        case 3:
+          return {-4 * xi[1], -4 * (-1 + xi[0] + 2 * xi[1])};
+        case 4:
+          return {4 * xi[1], 4 * xi[0]};
+        case 5:
+          return {0, -1 + 4 * xi[1]};
+      }
+    }
+
+    // cubic
+    if constexpr (n == 4) {
+      constexpr double sqrt5 = 2.23606797749978981;
+      switch (i) {
+        case 0:
+          return {-6 - 15 * xi[0] * xi[0] + 4 * xi[0] * (5 - 8 * xi[1]) + (21 - 16 * xi[1]) * xi[1],
+                  -6 - 16 * xi[0] * xi[0] + xi[0] * (21 - 32 * xi[1]) + 5 * (4 - 3 * xi[1]) * xi[1]};
+        case 1:
+          return {(5 * (6 * sqrt5 * xi[0] * xi[0] + xi[0] * (-2 - 6 * sqrt5 + 6 * (1 + sqrt5) * xi[1]) +
+                        (-1 + xi[1]) * (-1 - sqrt5 + (3 + sqrt5) * xi[1]))) /
+                      2.,
+                  (5 * xi[0] * (-2 * (2 + sqrt5) + 3 * (1 + sqrt5) * xi[0] + 2 * (3 + sqrt5) * xi[1])) / 2.};
+        case 2:
+          return {(-5 * (6 * sqrt5 * xi[0] * xi[0] + (-1 + xi[1]) * (1 - sqrt5 + (-3 + sqrt5) * xi[1]) +
+                         xi[0] * (2 - 6 * sqrt5 + 6 * (-1 + sqrt5) * xi[1]))) /
+                      2.,
+                  (-5 * xi[0] * (4 - 2 * sqrt5 + 3 * (-1 + sqrt5) * xi[0] + 2 * (-3 + sqrt5) * xi[1])) / 2.};
+        case 3:
+          return {1 + 15 * xi[0] * xi[0] + xi[1] - xi[1] * xi[1] - 2 * xi[0] * (5 + xi[1]),
+                  -(xi[0] * (-1 + xi[0] + 2 * xi[1]))};
+        case 4:
+          return {(5 * xi[1] * (-2 * (2 + sqrt5) + 2 * (3 + sqrt5) * xi[0] + 3 * (1 + sqrt5) * xi[1])) / 2.,
+                  (5 * (1 + sqrt5 - 2 * (2 + sqrt5) * xi[0] + (3 + sqrt5) * xi[0] * xi[0] +
+                        6 * (1 + sqrt5) * xi[0] * xi[1] + 2 * xi[1] * (-1 - 3 * sqrt5 + 3 * sqrt5 * xi[1]))) /
+                      2.};
+        case 5:
+          return {-27 * xi[1] * (-1 + 2 * xi[0] + xi[1]), -27 * xi[0] * (-1 + xi[0] + 2 * xi[1])};
+        case 6:
+          return {(-5 * xi[1] * (2 - 2 * (3 + sqrt5) * xi[0] + (-3 + sqrt5) * xi[1])) / 2.,
+                  (5 * xi[0] * (-2 + (3 + sqrt5) * xi[0] - 2 * (-3 + sqrt5) * xi[1])) / 2.};
+        case 7:
+          return {(-5 * xi[1] * (4 - 2 * sqrt5 + 2 * (-3 + sqrt5) * xi[0] + 3 * (-1 + sqrt5) * xi[1])) / 2.,
+                  (-5 * (-1 + sqrt5 + (-3 + sqrt5) * xi[0] * xi[0] + 2 * xi[1] * (1 - 3 * sqrt5 + 3 * sqrt5 * xi[1]) +
+                         xi[0] * (4 - 2 * sqrt5 + 6 * (-1 + sqrt5) * xi[1]))) /
+                      2.};
+        case 8:
+          return {(5 * xi[1] * (-2 - 2 * (-3 + sqrt5) * xi[0] + (3 + sqrt5) * xi[1])) / 2.,
+                  (-5 * xi[0] * (2 + (-3 + sqrt5) * xi[0] - 2 * (3 + sqrt5) * xi[1])) / 2.};
+        case 9:
+          return {-(xi[1] * (-1 + 2 * xi[0] + xi[1])),
+                  1 + xi[0] - xi[0] * xi[0] - 2 * (5 + xi[0]) * xi[1] + 15 * xi[1] * xi[1]};
+      }
+    }
+
+    return {};
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof> shape_functions(tensor<double, dim> xi)
+  {
+    tensor<double, ndof> output{};
+    for (int i = 0; i < ndof; i++) {
+      output[i] = shape_function(xi, i);
+    }
+    return output;
+  }
+
+  SMITH_HOST_DEVICE static constexpr tensor<double, ndof, dim> shape_function_gradients(tensor<double, dim> xi)
+  {
+    tensor<double, ndof, dim> output{};
+    for (int i = 0; i < ndof; i++) {
+      output[i] = shape_function_gradient(xi, i);
+    }
+    return output;
+  }
+
+  template <typename in_t, int q>
+  static auto batch_apply_shape_fn(int j, const tensor<in_t, q*(q + 1) / 2>& input,
+                                   const TensorProductQuadratureRule<q>&)
+  {
+    using source_t = decltype(get<0>(get<0>(in_t{})) + dot(get<1>(get<0>(in_t{})), tensor<double, 2>{}));
+    using flux_t = decltype(get<0>(get<1>(in_t{})) + dot(get<1>(get<1>(in_t{})), tensor<double, 2>{}));
+
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+
+    static constexpr int Q = q * (q + 1) / 2;
+    tensor<tuple<source_t, flux_t>, Q> output;
+
+    for (int i = 0; i < Q; i++) {
+      double phi_j = shape_function(xi[i], j);
+      tensor<double, dim> dphi_j_dxi = shape_function_gradient(xi[i], j);
+
+      const auto& d00 = get<0>(get<0>(input(i)));
+      const auto& d01 = get<1>(get<0>(input(i)));
+      const auto& d10 = get<0>(get<1>(input(i)));
+      const auto& d11 = get<1>(get<1>(input(i)));
+
+      output[i] = {d00 * phi_j + dot(d01, dphi_j_dxi), d10 * phi_j + dot(d11, dphi_j_dxi)};
+    }
+
+    return output;
+  }
+
+  template <typename T, int q>
+  static auto batch_apply_shape_fn_interior_face(int jx, const tensor<T, q*(q + 1) / 2>& input,
+                                                 const TensorProductQuadratureRule<q>&)
+  {
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+
+    using source0_t = decltype(get<0>(get<0>(T{})) + get<1>(get<0>(T{})));
+    using source1_t = decltype(get<0>(get<1>(T{})) + get<1>(get<1>(T{})));
+
+    static constexpr int Q = q * (q + 1) / 2;
+    tensor<tuple<source0_t, source1_t>, Q> output;
+
+    for (int i = 0; i < Q; i++) {
+      int j = jx % ndof;
+      int s = jx / ndof;
+
+      double phi0_j = shape_function(xi[i], j) * (s == 0);
+      double phi1_j = shape_function(xi[i], j) * (s == 1);
+
+      const auto& d00 = get<0>(get<0>(input(i)));
+      const auto& d01 = get<1>(get<0>(input(i)));
+      const auto& d10 = get<0>(get<1>(input(i)));
+      const auto& d11 = get<1>(get<1>(input(i)));
+
+      output[i] = {d00 * phi0_j + d01 * phi1_j, d10 * phi0_j + d11 * phi1_j};
+    }
+
+    return output;
+  }
+
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const tensor<double, c, ndof>& X, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+    static constexpr int num_quadrature_points = q * (q + 1) / 2;
+
+    // transpose the quadrature data into a flat tensor of tuples
+    union {
+      tensor<tuple<tensor<double, c>, tensor<double, c, dim> >, num_quadrature_points> unflattened;
+      tensor<qf_input_type, num_quadrature_points> flattened;
+    } output{};
+
+    for (int i = 0; i < c; i++) {
+      for (int j = 0; j < num_quadrature_points; j++) {
+        for (int k = 0; k < ndof; k++) {
+          get<VALUE>(output.unflattened[j])[i] += X(i, k) * shape_function(xi[j], k);
+          get<DIV>(output.unflattened[j])[i] += X(i, k) * shape_function_gradient(xi[j], k);
+        }
+      }
+    }
+
+    return output.flattened;
+  }
+
+  // overload for two-sided interior face kernels
+  template <int q>
+  SMITH_HOST_DEVICE static auto interpolate(const dof_type_if& X, const TensorProductQuadratureRule<q>&)
+  {
+    constexpr auto xi = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+    static constexpr int num_quadrature_points = q * (q + 1) / 2;
+
+    tensor<tuple<value_type, value_type>, num_quadrature_points> output{};
+
+    // apply the shape functions
+    for (int i = 0; i < c; i++) {
+      for (int j = 0; j < num_quadrature_points; j++) {
+        for (int k = 0; k < ndof; k++) {
+          if constexpr (c == 1) {
+            get<0>(output[j]) += X[i][0][k] * shape_function(xi[j], k);
+            get<1>(output[j]) += X[i][1][k] * shape_function(xi[j], k);
+          } else {
+            get<0>(output[j])[i] += X[i][0][k] * shape_function(xi[j], k);
+            get<1>(output[j])[i] += X[i][1][k] * shape_function(xi[j], k);
+          }
+        }
+      }
+    }
+
+    return output;
+  }
+
+  template <typename source_type, typename flux_type, int q>
+  SMITH_HOST_DEVICE static void integrate(const tensor<tuple<source_type, flux_type>, q*(q + 1) / 2>& qf_output,
+                                          const TensorProductQuadratureRule<q>&,
+                                          tensor<double, c, ndof>* element_residual, int step = 1)
+  {
+    if constexpr (is_zero<source_type>{} && is_zero<flux_type>{}) {
+      return;
+    }
+
+    using source_component_type = std::conditional_t<is_zero<source_type>{}, zero, double>;
+    using flux_component_type = std::conditional_t<is_zero<flux_type>{}, zero, tensor<double, dim> >;
+
+    constexpr int num_quadrature_points = q * (q + 1) / 2;
+    constexpr int ntrial = std::max(size(source_type{}), size(flux_type{}) / dim) / c;
+    constexpr auto integration_points = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+    constexpr auto integration_weights = GaussLegendreWeights<q, mfem::Geometry::TRIANGLE>();
+
+    for (int j = 0; j < ntrial; j++) {
+      for (int i = 0; i < c; i++) {
+        for (int Q = 0; Q < num_quadrature_points; Q++) {
+          tensor<double, 2> xi = integration_points[Q];
+          double wt = integration_weights[Q];
+
+          source_component_type source;
+          if constexpr (!is_zero<source_type>{}) {
+            source = reinterpret_cast<const double*>(&get<SOURCE>(qf_output[Q]))[i * ntrial + j];
+          }
+
+          flux_component_type flux;
+          if constexpr (!is_zero<flux_type>{}) {
+            for (int k = 0; k < dim; k++) {
+              flux[k] = reinterpret_cast<const double*>(&get<FLUX>(qf_output[Q]))[(i * dim + k) * ntrial + j];
+            }
+          }
+
+          for (int k = 0; k < ndof; k++) {
+            element_residual[j * step](i, k) +=
+                (source * shape_function(xi, k) + dot(flux, shape_function_gradient(xi, k))) * wt;
+          }
+        }
+      }
+    }
+  }
+
+  template <typename T, int q>
+  SMITH_HOST_DEVICE static void integrate(const tensor<tuple<T, T>, (q * (q + 1)) / 2>& qf_output,
+                                          const TensorProductQuadratureRule<q>&, dof_type_if* element_residual,
+                                          [[maybe_unused]] int step = 1)
+  {
+    constexpr int ntrial = size(T{}) / c;
+    constexpr int num_quadrature_points = (q * (q + 1)) / 2;
+    constexpr auto integration_points = GaussLegendreNodes<q, mfem::Geometry::TRIANGLE>();
+    constexpr auto integration_weights = GaussLegendreWeights<q, mfem::Geometry::TRIANGLE>();
+
+    for (int j = 0; j < ntrial; j++) {
+      for (int i = 0; i < c; i++) {
+        for (int Q = 0; Q < num_quadrature_points; Q++) {
+          tensor<double, 2> xi = integration_points[Q];
+          double wt = integration_weights[Q];
+
+          double source_0 = reinterpret_cast<const double*>(&get<0>(qf_output[Q]))[i * ntrial + j];
+          double source_1 = reinterpret_cast<const double*>(&get<1>(qf_output[Q]))[i * ntrial + j];
+
+          for (int k = 0; k < ndof; k++) {
+            element_residual[j * step](i, 0, k) += (source_0 * shape_function(xi, k)) * wt;
+            element_residual[j * step](i, 1, k) += (source_1 * shape_function(xi, k)) * wt;
+          }
+        }
+      }
+    }
+  }
+};
+/// @endcond

--- a/src/smith/numerics/functional/domain_integral_kernels.hpp
+++ b/src/smith/numerics/functional/domain_integral_kernels.hpp
@@ -66,6 +66,18 @@ struct QFunctionArgument<Hcurl<p>, Dimension<3>> {
   using type = tuple<tensor<double, 3>, tensor<double, 3>>;  ///< what will be passed to the q-function
 };
 
+/// @overload
+template <int p>
+struct QFunctionArgument<Hdiv<p>, Dimension<2>> {
+  using type = tuple<tensor<double, 2>, double>;  ///< (value, divergence) passed to the q-function
+};
+
+/// @overload
+template <int p>
+struct QFunctionArgument<Hdiv<p>, Dimension<3>> {
+  using type = tuple<tensor<double, 3>, double>;  ///< (value, divergence) passed to the q-function
+};
+
 /// @brief layer of indirection needed to unpack the entries of the argument tuple
 SMITH_SUPPRESS_NVCC_HOSTDEVICE_WARNING
 template <typename lambda, typename coords_type, typename T, typename qpt_data_type, int... i>
@@ -257,7 +269,7 @@ SMITH_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, c
  *
  * @tparam test The type of the test function space
  * @tparam trial The type of the trial function space
- * The above spaces can be any combination of {H1, Hcurl, Hdiv (TODO), L2 (TODO), QOI}
+ * The above spaces can be any combination of {H1, Hcurl, Hdiv, L2 (TODO), QOI}
  *
  * Template parameters other than the test and trial spaces are used for customization + optimization
  * and are erased through the @p std::function members of @p DomainIntegral
@@ -311,7 +323,7 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
  *
  * @tparam test The type of the test function space
  * @tparam trial The type of the trial function space
- * The above spaces can be any combination of {H1, Hcurl, Hdiv (TODO), L2 (TODO), QOI}
+ * The above spaces can be any combination of {H1, Hcurl, Hdiv, L2 (TODO), QOI}
  *
  * Template parameters other than the test and trial spaces are used for customization + optimization
  * and are erased through the @p std::function members of @p Integral

--- a/src/smith/numerics/functional/element_restriction.cpp
+++ b/src/smith/numerics/functional/element_restriction.cpp
@@ -250,17 +250,14 @@ axom::Array<DoF, 2, smith::detail::host_memory_space> GetElementRestriction(cons
       }
     }
 
-    // the dofs mfem returns for Hcurl include information about
-    // dof orientation, but not for triangle faces on 3D elements.
-    // So, we need to manually
-    if (isHcurl(*fes)) {
-      // TODO
-      // TODO
-      // TODO
-      uint64_t sign = 1;
-      uint64_t orientation = 0;
+    // mfem uses negative dof values to indicate sign flips for Hcurl/Hdiv
+    if (isHcurl(*fes) || isHdiv(*fes)) {
       for (int k = 0; k < dofs.Size(); k++) {
-        elem_dofs.push_back({uint64_t(dofs[k]), sign, orientation});
+        if (dofs[k] >= 0) {
+          elem_dofs.push_back(DoF{uint64_t(dofs[k]), 0});
+        } else {
+          elem_dofs.push_back(DoF{uint64_t(-1 - dofs[k]), 1});
+        }
       }
     }
 
@@ -316,17 +313,44 @@ axom::Array<DoF, 2, smith::detail::host_memory_space> GetElementDofs(const smith
       }
     }
 
-    // the dofs mfem returns for Hcurl include information about
-    // dof orientation, but not for triangle faces on 3D elements.
-    // So, we need to manually
+    // mfem uses negative dof values to indicate sign flips for Hcurl/Hdiv
     if (isHcurl(*fes)) {
-      // TODO
-      // TODO
-      // TODO
-      uint64_t sign = 1;
-      uint64_t orientation = 0;
       for (int k = 0; k < dofs.Size(); k++) {
-        elem_dofs.push_back({uint64_t(dofs[k]), sign, orientation});
+        if (dofs[k] >= 0) {
+          elem_dofs.push_back(DoF{uint64_t(dofs[k]), 0});
+        } else {
+          elem_dofs.push_back(DoF{uint64_t(-1 - dofs[k]), 1});
+        }
+      }
+    }
+
+    // For Hdiv (RT) tensor elements, the element's dof_map permutation must be applied
+    // to reorder mfem's DOF-number order into smith's logical (i,j) order, and to
+    // combine the reference-element orientation sign with the mesh orientation sign.
+    // Simplex Hdiv elements fall back to the plain sign-only behavior.
+    if (isHdiv(*fes)) {
+      const auto* vtfe = dynamic_cast<const mfem::VectorTensorFiniteElement*>(fes->GetFE(elem));
+      if (vtfe != nullptr) {
+        const mfem::Array<int>& dof_perm = vtfe->GetDofMap();
+        for (int k = 0; k < dofs.Size(); k++) {
+          int dp = dof_perm[k];
+          int elem_sign = (dp < 0) ? 1 : 0;  // reference-element orientation sign bit
+          int local_idx = (dp >= 0) ? dp : -1 - dp;
+          int gd = dofs[local_idx];
+          int mesh_sign = (gd < 0) ? 1 : 0;  // mesh orientation sign bit
+          int global_idx = (gd >= 0) ? gd : -1 - gd;
+          int combined = (elem_sign + mesh_sign) % 2;
+          elem_dofs.push_back(DoF{uint64_t(global_idx), uint64_t(combined)});
+        }
+      } else {
+        // Simplex (triangle/tet): no dof_map reordering, only mesh sign
+        for (int k = 0; k < dofs.Size(); k++) {
+          if (dofs[k] >= 0) {
+            elem_dofs.push_back(DoF{uint64_t(dofs[k]), 0});
+          } else {
+            elem_dofs.push_back(DoF{uint64_t(-1 - dofs[k]), 1});
+          }
+        }
       }
     }
 
@@ -436,7 +460,7 @@ axom::Array<DoF, 2, smith::detail::host_memory_space> GetFaceDofs(const smith::f
 
       fes->GetFaceDofs(f, dofs);
 
-      if (isHcurl(*fes)) {
+      if (isHcurl(*fes) || isHdiv(*fes)) {
         for (int k = 0; k < dofs.Size(); k++) {
           if (dofs[k] >= 0) {
             face_dofs.push_back(DoF{uint64_t(dofs[k]), 0});
@@ -609,7 +633,7 @@ axom::Array<DoF, 2, smith::detail::host_memory_space> GetFaceDofs(const smith::f
 
       fes->GetFaceDofs(f, dofs);
 
-      if (isHcurl(*fes)) {
+      if (isHcurl(*fes) || isHdiv(*fes)) {
         for (int k = 0; k < dofs.Size(); k++) {
           if (dofs[k] >= 0) {
             face_dofs.push_back(DoF{uint64_t(dofs[k]), 0});
@@ -692,8 +716,8 @@ void ElementRestriction::Gather(const mfem::Vector& L_vector, mfem::Vector& E_ve
     for (uint64_t c = 0; c < components; c++) {
       for (uint64_t j = 0; j < nodes_per_elem; j++) {
         uint64_t E_id = (i * components + c) * nodes_per_elem + j;
-        uint64_t L_id = GetVDof(dof_info(i, j), c).index();
-        E_vector[int(E_id)] = L_vector[int(L_id)];
+        auto vdof = GetVDof(dof_info(i, j), c);
+        E_vector[int(E_id)] = double(vdof.sign()) * L_vector[int(vdof.index())];
       }
     }
   }
@@ -705,8 +729,8 @@ void ElementRestriction::ScatterAdd(const mfem::Vector& E_vector, mfem::Vector& 
     for (uint64_t c = 0; c < components; c++) {
       for (uint64_t j = 0; j < nodes_per_elem; j++) {
         uint64_t E_id = (i * components + c) * nodes_per_elem + j;
-        uint64_t L_id = GetVDof(dof_info(i, j), c).index();
-        L_vector[int(L_id)] += E_vector[int(E_id)];
+        auto vdof = GetVDof(dof_info(i, j), c);
+        L_vector[int(vdof.index())] += double(vdof.sign()) * E_vector[int(E_id)];
       }
     }
   }

--- a/src/smith/numerics/functional/element_restriction.hpp
+++ b/src/smith/numerics/functional/element_restriction.hpp
@@ -28,6 +28,11 @@ inline bool isHcurl(const mfem::FiniteElementSpace& fes)
   return (fes.FEColl()->GetContType() == mfem::FiniteElementCollection::TANGENTIAL);
 }
 
+inline bool isHdiv(const mfem::FiniteElementSpace& fes)
+{
+  return (fes.FEColl()->GetContType() == mfem::FiniteElementCollection::NORMAL);
+}
+
 inline bool isDG(const mfem::FiniteElementSpace& fes)
 {
   return (fes.FEColl()->GetContType() == mfem::FiniteElementCollection::DISCONTINUOUS);
@@ -48,7 +53,7 @@ struct DoF {
 
   static constexpr uint64_t sign_mask = 0x8000'0000'0000'0000;         ///< bits for sign field
   static constexpr uint64_t orientation_mask = 0x7000'0000'0000'0000;  ///< bits for orientation field
-  static constexpr uint64_t index_mask = 0x0000'FFFF'FFFF'FFFF'FFFF;   ///< bits for the index field
+  static constexpr uint64_t index_mask = 0x0000'FFFF'FFFF'FFFF;        ///< bits for the index field
 
   static constexpr uint64_t sign_shift = 63;         ///< number of trailing zeros in `sign_mask`
   static constexpr uint64_t orientation_shift = 60;  ///< number of trailing zeros in `orientation_mask`
@@ -74,7 +79,7 @@ struct DoF {
 
   /// create a `DoF` from the given index, sign and orientation values
   DoF(uint64_t index, uint64_t sign = 0, uint64_t orientation = 0)
-      : bits((sign & 0x1ULL << sign_shift) + ((orientation & 0x7ULL) << orientation_shift) + index)
+      : bits(((sign & 0x1ULL) << sign_shift) + ((orientation & 0x7ULL) << orientation_shift) + index)
   {
   }
 

--- a/src/smith/numerics/functional/finite_element.hpp
+++ b/src/smith/numerics/functional/finite_element.hpp
@@ -211,6 +211,30 @@ struct Hcurl {
 };
 
 /**
+ * @brief H(div) elements of order @p p
+ * @tparam p The order of the elements
+ * @tparam c The vector dimension
+ */
+template <int p, int c = 1>
+struct Hdiv {
+  static constexpr int order = p;                 ///< the polynomial order of the elements
+  static constexpr int components = c;            ///< the number of components at each node
+  static constexpr Family family = Family::HDIV;  ///< the family of the basis functions
+};
+
+/**
+ * @brief H(div) elements of order @p p defined on a domain boundary
+ * @tparam p The order of the elements
+ * @tparam c The vector dimension
+ */
+template <int p, int c = 1>
+struct HdivBoundary {
+  static constexpr int order = p;                 ///< the polynomial order of the elements
+  static constexpr int components = c;            ///< the number of components at each node
+  static constexpr Family family = Family::HDIV;  ///< the family of the basis functions
+};
+
+/**
  * @brief Discontinuous elements of order @p p
  * @tparam p The order of the elements
  * @tparam c The vector dimension
@@ -235,7 +259,7 @@ struct QOI {
  * @brief a small POD class for tracking function space metadata
  */
 struct FunctionSpace {
-  Family family;   ///< either H1, Hcurl, L2
+  Family family;   ///< either H1, Hcurl, Hdiv, L2
   int order;       ///< polynomial order
   int components;  ///< how many values are stored at each node
 
@@ -289,6 +313,13 @@ SMITH_HOST_DEVICE void parent_to_physical(tensor<T, q>& qf_input, const tensor<d
         get<DERIVATIVE>(qf_input[k]) = dot(get<DERIVATIVE>(qf_input[k]), transpose(J));
       }
     }
+
+    if constexpr (f == Family::HDIV) {
+      // contravariant Piola: phi = J * hat_phi / det(J)
+      get<VALUE>(qf_input[k]) = dot(J, get<VALUE>(qf_input[k])) / det(J);
+      // divergence: div(phi) = hat_div(hat_phi) / det(J)
+      get<DERIVATIVE>(qf_input[k]) = get<DERIVATIVE>(qf_input[k]) / det(J);
+    }
   }
 }
 
@@ -335,6 +366,15 @@ SMITH_HOST_DEVICE void physical_to_parent(tensor<T, q>& qf_output, const tensor<
       }
     }
 
+    // Hdiv (contravariant Piola) dual pullback:
+    //   source dual: ∫ s·φ_phys dx = ∫ (J^T s)·φ_ref dξ  (det(J) cancels Piola 1/det(J))
+    //   flux   dual: ∫ g·div_phys dx = ∫ g·div_ref dξ    (det(J) cancels div 1/det(J))
+    // dot(v, transpose(J_T)) computes J^T * v  (matches Hcurl 3D flux convention)
+    if constexpr (f == Family::HDIV) {
+      get<SOURCE>(qf_output[k]) = dot(get<SOURCE>(qf_output[k]), transpose(J_T));
+      get<FLUX>(qf_output[k]) = get<FLUX>(qf_output[k]);
+    }
+
     if constexpr (f == Family::QOI) {
       qf_output[k] = qf_output[k] * dv;
     }
@@ -369,22 +409,32 @@ SMITH_HOST_DEVICE void physical_to_parent(tensor<T, q>& qf_output, const tensor<
 template <mfem::Geometry::Type g, typename family>
 struct finite_element;
 
+#include "detail/chebyshev_utils.hpp"
+#include "detail/tensor_product_basis.hpp"
+
 #include "detail/segment_H1.inl"
 #include "detail/segment_Hcurl.inl"
+#include "detail/segment_Hdiv.inl"
 #include "detail/segment_L2.inl"
 
 #include "detail/triangle_H1.inl"
+#include "detail/triangle_Hdiv.inl"
+#include "detail/triangle_HdivBoundary.inl"
 #include "detail/triangle_L2.inl"
 
 #include "detail/quadrilateral_H1.inl"
 #include "detail/quadrilateral_Hcurl.inl"
+#include "detail/quadrilateral_Hdiv.inl"
+#include "detail/quadrilateral_HdivBoundary.inl"
 #include "detail/quadrilateral_L2.inl"
 
 #include "detail/tetrahedron_H1.inl"
+#include "detail/tetrahedron_Hdiv.inl"
 #include "detail/tetrahedron_L2.inl"
 
 #include "detail/hexahedron_H1.inl"
 #include "detail/hexahedron_Hcurl.inl"
+#include "detail/hexahedron_Hdiv.inl"
 #include "detail/hexahedron_L2.inl"
 
 #include "detail/qoi.inl"

--- a/src/smith/numerics/functional/function_signature.hpp
+++ b/src/smith/numerics/functional/function_signature.hpp
@@ -45,6 +45,31 @@ auto trial_elements_tuple(FunctionSignature<test(trials...)>)
 }
 
 /**
+ * @brief Maps an element space to the corresponding boundary element space.
+ * @tparam T element space type
+ */
+template <typename T>
+struct get_boundary_element {
+  using type = T;  ///< Boundary element type associated with `T`.
+};
+
+/**
+ * @brief Specialization mapping `Hdiv` spaces to their boundary trace spaces.
+ * @tparam p polynomial order
+ * @tparam c vector component count
+ */
+template <int p, int c>
+struct get_boundary_element<smith::Hdiv<p, c>> {
+  using type = smith::HdivBoundary<p, c>;  ///< Boundary trace space for `smith::Hdiv<p, c>`.
+};
+
+template <mfem::Geometry::Type geom, typename test, typename... trials>
+auto boundary_trial_elements_tuple(FunctionSignature<test(trials...)>)
+{
+  return smith::tuple<smith::finite_element<geom, typename get_boundary_element<trials>::type>...>{};
+}
+
+/**
  * @brief This helper function template returns a finite element based on the output
  * type of FunctionSignature.
  *
@@ -55,4 +80,10 @@ template <mfem::Geometry::Type geom, typename test, typename... trials>
 auto get_test_element(FunctionSignature<test(trials...)>)
 {
   return smith::finite_element<geom, test>{};
+}
+
+template <mfem::Geometry::Type geom, typename test, typename... trials>
+auto get_boundary_test_element(FunctionSignature<test(trials...)>)
+{
+  return smith::finite_element<geom, typename get_boundary_element<test>::type>{};
 }

--- a/src/smith/numerics/functional/functional.hpp
+++ b/src/smith/numerics/functional/functional.hpp
@@ -132,7 +132,10 @@ generateParFiniteElementSpace(mfem::ParMesh* mesh)
       fec = std::make_unique<mfem::ND_FECollection>(function_space::order, dim);
       break;
     case Family::HDIV:
-      fec = std::make_unique<mfem::RT_FECollection>(function_space::order, dim);
+      // Hdiv<p> corresponds to RT_FECollection(p-1): our shape functions use
+      // the same tensor-product node counts as Hcurl<p>/ND(p), so order p in
+      // smith maps to RT order p-1 in mfem.  The minimum usable order is p=1.
+      fec = std::make_unique<mfem::RT_FECollection>(function_space::order - 1, dim);
       break;
     case Family::L2:
       // We use GaussLobatto basis functions as this is what is used for the smith::Functional FE kernels
@@ -908,10 +911,12 @@ class Functional<test(trials...), exec> {
 
               for (uint32_t i = 0; i < cols_per_elem; i++) {
                 int col = int(trial_vdofs[i].index());
+                double trial_sign = double(trial_vdofs[i].sign());
 
                 for (uint32_t j = 0; j < rows_per_elem; j++) {
                   int row = int(test_vdofs[j].index());
-                  A_local.SearchRow(row, col) += K_e(e, i, j);
+                  double test_sign = double(test_vdofs[j].sign());
+                  A_local.SearchRow(row, col) += test_sign * K_e(e, i, j) * trial_sign;
                 }
               }
             }

--- a/src/smith/numerics/functional/interior_face_integral_kernels.hpp
+++ b/src/smith/numerics/functional/interior_face_integral_kernels.hpp
@@ -63,6 +63,23 @@ struct QFunctionArgument<L2<p, c>, Dimension<dim>> {
 };
 
 /// @overload
+/// Hdiv on a segment face element (face of a 2D mesh).
+/// The face trace of Hdiv is the scalar normal flux sigma dot n.
+template <int p>
+struct QFunctionArgument<Hdiv<p>, Dimension<1>> {
+  using type = smith::tuple<double, double>;  ///< (normal_flux, tangential_derivative) passed to the q-function
+};
+
+/// @overload
+/// Hdiv on a face element (face of a 3D mesh).
+/// The face trace of Hdiv is the scalar normal flux sigma dot n.
+template <int p>
+struct QFunctionArgument<Hdiv<p>, Dimension<2>> {
+  using type =
+      smith::tuple<double, tensor<double, 2>>;  ///< (normal_flux, tangential_derivative) passed to the q-function
+};
+
+/// @overload
 SMITH_SUPPRESS_NVCC_HOSTDEVICE_WARNING
 template <typename lambda, typename T, int... i>
 SMITH_HOST_DEVICE auto apply_qf_helper(const lambda& qf, double t, const tensor<double, 2>& x_q, const T& arg_tuple,
@@ -228,7 +245,7 @@ SMITH_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, c
  *
  * @tparam test The type of the test function space
  * @tparam trial The type of the trial function space
- * The above spaces can be any combination of {H1, Hcurl, Hdiv (TODO), L2 (TODO)}
+ * The above spaces can be any combination of {H1, Hcurl, Hdiv, L2 (TODO)}
  *
  * Template parameters other than the test and trial spaces are used for customization + optimization
  * and are erased through the @p std::function members of @p BoundaryIntegral
@@ -280,7 +297,7 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
  *
  * @tparam test The type of the test function space
  * @tparam trial The type of the trial function space
- * The above spaces can be any combination of {H1, Hcurl, Hdiv (TODO), L2 (TODO), QOI}
+ * The above spaces can be any combination of {H1, Hcurl, Hdiv, L2 (TODO), QOI}
  *
  * Template parameters other than the test and trial spaces are used for customization + optimization
  * and are erased through the @p std::function members of @p Integral
@@ -342,8 +359,8 @@ template <uint32_t wrt, int Q, mfem::Geometry::Type geom, typename signature, ty
 auto evaluation_kernel(signature s, lambda_type qf, const double* positions, const double* jacobians,
                        std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
-  auto trial_elements = trial_elements_tuple<geom>(s);
-  auto test_element = get_test_element<geom>(s);
+  auto trial_elements = boundary_trial_elements_tuple<geom>(s);
+  auto test_element = get_boundary_test_element<geom>(s);
   return [=](double time, const std::vector<const double*>& inputs, double* outputs, bool /* update state */) {
     evaluation_kernel_impl<wrt, Q, geom>(trial_elements, test_element, time, inputs, outputs, positions, jacobians, qf,
                                          qf_derivatives.get(), num_elements, s.index_seq);
@@ -355,8 +372,9 @@ std::function<void(const double*, double*)> jacobian_vector_product_kernel(
     signature, std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
   return [=](const double* du, double* dr) {
-    using test_space = typename signature::return_type;
-    using trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using test_space = typename get_boundary_element<typename signature::return_type>::type;
+    using original_trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using trial_space = typename get_boundary_element<original_trial_space>::type;
     action_of_gradient_kernel<Q, geom, test_space, trial_space>(du, dr, qf_derivatives.get(), num_elements);
   };
 }
@@ -366,8 +384,9 @@ std::function<void(ExecArrayView<double, 3, ExecutionSpace::CPU>)> element_gradi
     signature, std::shared_ptr<derivative_type> qf_derivatives, uint32_t num_elements)
 {
   return [=](ExecArrayView<double, 3, ExecutionSpace::CPU> K_elem) {
-    using test_space = typename signature::return_type;
-    using trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using test_space = typename get_boundary_element<typename signature::return_type>::type;
+    using original_trial_space = typename std::tuple_element<wrt, typename signature::parameter_types>::type;
+    using trial_space = typename get_boundary_element<original_trial_space>::type;
     element_gradient_kernel<geom, test_space, trial_space, Q>(K_elem, qf_derivatives.get(), num_elements);
   };
 }

--- a/src/smith/numerics/functional/tests/CMakeLists.txt
+++ b/src/smith/numerics/functional/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(functional_serial_test_sources
     domain_tests.cpp
     geometric_factors_tests.cpp
     hcurl_unit_tests.cpp
+    hdiv_unit_tests.cpp
     functional_tet_quality.cpp
     test_tensor_ad.cpp
     tuple_arithmetic_unit_tests.cpp
@@ -35,6 +36,9 @@ smith_add_tests(SOURCES    ${functional_serial_test_sources}
 # Then add the examples/tests
 set(functional_parallel_test_sources
     #functional_basic_hcurl.cpp
+    functional_basic_hdiv.cpp
+    darcy_patch_test.cpp
+    hdiv_convergence_test.cpp
     functional_with_domain.cpp
     functional_basic_h1_scalar.cpp
     functional_basic_h1_vector.cpp
@@ -53,6 +57,8 @@ smith_add_tests(SOURCES       ${functional_parallel_test_sources}
                 NUM_MPI_TASKS 4 )
 
 target_link_libraries(bug_boundary_qoi PUBLIC smith_physics)
+target_link_libraries(darcy_patch_test PUBLIC smith_numerics)
+target_link_libraries(hdiv_convergence_test PUBLIC smith_numerics)
 
 if(SMITH_ENABLE_CUDA)
 

--- a/src/smith/numerics/functional/tests/darcy_patch_test.cpp
+++ b/src/smith/numerics/functional/tests/darcy_patch_test.cpp
@@ -1,0 +1,376 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file darcy_patch_test.cpp
+ *
+ * @brief Patch test for the mixed Hdiv × L2 (Darcy flow) formulation
+ *
+ * Mixed weak form: find (σ, u) in Hdiv × L2 such that
+ *   (K⁻¹ σ, τ)  − (u, div τ)  = 0    ∀ τ ∈ Hdiv   [flux equation]
+ *   (div σ,  v)                = (f, v) ∀ v ∈ L2    [continuity]
+ *
+ * Exact affine solution (exactly representable in Hdiv<2> × L2<1>):
+ *   u_exact(x,y) = x + 2y          (linear pressure)
+ *   σ_exact      = (−1, −2)        (constant flux = −K ∇u with K = I)
+ *   f            = div σ = 0
+ *
+ * Essential BCs:  σ·n = σ_exact·n  on entire ∂Ω  (enforced via mfem DOF elimination)
+ * Null-space fix: add ε (u,v) to equation 2 so the system is non-singular.
+ *                 ε = 1e-10 causes O(ε) error in u, negligible error in σ.
+ *
+ * The assembled block system is solved with smith::SuperLUSolver.
+ */
+
+#include "gtest/gtest.h"
+#include "mfem.hpp"
+
+#include "smith/infrastructure/application_manager.hpp"
+#include "smith/smith_config.hpp"
+#include "smith/mesh_utils/mesh_utils.hpp"
+#include "smith/numerics/equation_solver.hpp"
+#include "smith/numerics/functional/differentiate_wrt.hpp"
+#include "smith/numerics/functional/domain.hpp"
+#include "smith/numerics/functional/functional.hpp"
+
+using namespace smith;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+static void sigma_exact_fn(const mfem::Vector& /*x*/, mfem::Vector& v)
+{
+  v(0) = -1.0;
+  v(1) = -2.0;
+}
+
+static double u_exact_fn(const mfem::Vector& x) { return x(0) + 2.0 * x(1); }
+
+// ─── main solve ──────────────────────────────────────────────────────────────
+
+/**
+ * @brief Assemble and solve the Darcy block system, return relative σ error.
+ *
+ * @tparam p  smith Hdiv order  (Hdiv<p> ↔ RT_FECollection(p-1))
+ *            Minimum p=2 so that σ_exact (constant) and u_exact (linear)
+ *            are exactly representable in Hdiv<p> × L2<p-1>.
+ */
+template <int p>
+double darcy_solve()
+{
+  constexpr int dim = 2;
+
+  // 1. Mesh: 4×4 Cartesian quad mesh on [0,1]²
+  auto mesh =
+      mesh::refineAndDistribute(mfem::Mesh::MakeCartesian2D(4, 4, mfem::Element::QUADRILATERAL, true, 1.0, 1.0), 0);
+
+  // 2. FE spaces
+  //    Hdiv<p>  ↔ RT_FECollection(p-1)  — flux space
+  //    L2<p-1>  ↔ L2_FECollection(p-1) — pressure space
+  auto [fes_sigma, fec_sigma] = generateParFiniteElementSpace<Hdiv<p>>(mesh.get());
+  auto [fes_u, fec_u] = generateParFiniteElementSpace<L2<p - 1>>(mesh.get());
+
+  // 3. Project exact solution
+  mfem::VectorFunctionCoefficient sigma_coeff(dim, sigma_exact_fn);
+  mfem::ParGridFunction sigma_gf(fes_sigma.get());
+  sigma_gf.ProjectCoefficient(sigma_coeff);
+
+  mfem::FunctionCoefficient u_coeff(u_exact_fn);
+  mfem::ParGridFunction u_gf(fes_u.get());
+  u_gf.ProjectCoefficient(u_coeff);
+
+  mfem::Vector sigma_exact(fes_sigma->TrueVSize());
+  sigma_gf.GetTrueDofs(sigma_exact);
+  mfem::Vector u_exact(fes_u->TrueVSize());
+  u_gf.GetTrueDofs(u_exact);
+
+  // 4. Working vectors (linearization point = zero)
+  mfem::Vector sigma_zero(fes_sigma->TrueVSize());
+  sigma_zero = 0.0;
+  mfem::Vector u_zero(fes_u->TrueVSize());
+  u_zero = 0.0;
+
+  // 5. Build Functionals
+  //
+  // Flux equation (Hdiv test, trials = {Hdiv, L2}):
+  //   R_σ(σ,u;τ) = ∫ (K⁻¹ σ)·τ dx − ∫ u div(τ) dx
+  //   source = K⁻¹ σ  (dual to τ),  flux = −u  (dual to div τ)
+  Functional<Hdiv<p>(Hdiv<p>, L2<p - 1>)> res_sigma(fes_sigma.get(), {fes_sigma.get(), fes_u.get()});
+
+  Domain whole_domain = EntireDomain(*mesh);
+
+  res_sigma.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0, 1>{},
+      [](double, auto, auto sigma_arg, auto u_arg) {
+        auto [sigma_val, sigma_div] = sigma_arg;
+        auto [u_val, u_grad] = u_arg;
+        return smith::tuple{sigma_val, -u_val};  // K = I
+      },
+      whole_domain);
+
+  // Continuity equation (L2 test, trials = {Hdiv, L2}):
+  //   R_u(σ,u;v) = ∫ div(σ) v dx + ε ∫ u v dx − ∫ f v dx,  f = 0
+  //   source = div(σ) + ε u  (dual to v),  flux = 0  (dual to grad v)
+  //   Small ε removes the pressure null-space so SuperLU can invert.
+  constexpr double eps = 1.0e-10;
+  Functional<L2<p - 1>(Hdiv<p>, L2<p - 1>)> res_u(fes_u.get(), {fes_sigma.get(), fes_u.get()});
+
+  res_u.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0, 1>{},
+      [=](double, auto, auto sigma_arg, auto u_arg) {
+        auto [sigma_val, sigma_div] = sigma_arg;
+        auto [u_val, u_grad] = u_arg;
+        // source = div(σ) + ε u,  flux = 0
+        return smith::tuple{sigma_div + eps * u_val, tensor<double, dim>{}};
+      },
+      whole_domain);
+
+  // 6. Assemble Jacobian blocks
+  double t = 0.0;
+
+  auto [r_sigma_0, dRsigma_dsigma] = res_sigma(t, differentiate_wrt(sigma_zero), u_zero);
+  auto [dummy0, dRsigma_du] = res_sigma(t, sigma_zero, differentiate_wrt(u_zero));
+  auto [r_u_0, dRu_dsigma] = res_u(t, differentiate_wrt(sigma_zero), u_zero);
+  auto [dummy1, dRu_du] = res_u(t, sigma_zero, differentiate_wrt(u_zero));
+
+  auto J_00 = assemble(dRsigma_dsigma);  //  K⁻¹ mass matrix (Hdiv × Hdiv)
+  auto J_01 = assemble(dRsigma_du);      // −B^T               (Hdiv × L2)
+  auto J_10 = assemble(dRu_dsigma);      //  B = divergence     (L2 × Hdiv)
+  auto J_11 = assemble(dRu_du);          //  ε M_L2             (L2 × L2)
+
+  // 7. Essential BCs: fix σ·n on entire boundary
+  mfem::Array<int> ess_bdr(mesh->bdr_attributes.Max());
+  ess_bdr = 1;
+  mfem::Array<int> ess_tdofs_sigma;
+  fes_sigma->GetEssentialTrueDofs(ess_bdr, ess_tdofs_sigma);
+
+  // Build BC vector (exact σ at boundary DOFs, 0 elsewhere)
+  mfem::Vector sigma_bc(fes_sigma->TrueVSize());
+  sigma_bc = 0.0;
+  for (int i = 0; i < ess_tdofs_sigma.Size(); i++) {
+    sigma_bc[ess_tdofs_sigma[i]] = sigma_exact[ess_tdofs_sigma[i]];
+  }
+
+  // RHS from linearization at (0,0) is zero (linear, no source).
+  // Modify RHS for the known BC values: rhs -= J_col_bc * sigma_bc
+  mfem::Vector rhs_sigma(fes_sigma->TrueVSize());
+  rhs_sigma = 0.0;
+  {
+    mfem::Vector tmp(rhs_sigma.Size());
+    J_00->Mult(sigma_bc, tmp);
+    rhs_sigma -= tmp;  // contribution of BC values through J_00
+  }
+
+  mfem::Vector rhs_u(fes_u->TrueVSize());
+  rhs_u = 0.0;
+  {
+    mfem::Vector tmp(rhs_u.Size());
+    J_10->Mult(sigma_bc, tmp);
+    rhs_u -= tmp;  // contribution of BC values through J_10
+  }
+
+  // Eliminate BC rows / cols from the system
+  {
+    auto* elim = J_00->EliminateRowsCols(ess_tdofs_sigma);
+    delete elim;
+  }
+  J_01->EliminateRows(ess_tdofs_sigma);
+  J_10->EliminateCols(ess_tdofs_sigma);
+
+  // Enforce BC values in the σ rows of the RHS
+  for (int i = 0; i < ess_tdofs_sigma.Size(); i++) {
+    rhs_sigma[ess_tdofs_sigma[i]] = sigma_exact[ess_tdofs_sigma[i]];
+  }
+
+  // 8. Assemble block operator and block RHS
+  mfem::Array<int> offsets;
+  offsets.SetSize(3);
+  offsets[0] = 0;
+  offsets[1] = fes_sigma->TrueVSize();
+  offsets[2] = fes_sigma->TrueVSize() + fes_u->TrueVSize();
+
+  mfem::BlockOperator block_op(offsets);
+  block_op.SetBlock(0, 0, J_00.get());
+  block_op.SetBlock(0, 1, J_01.get());
+  block_op.SetBlock(1, 0, J_10.get());
+  block_op.SetBlock(1, 1, J_11.get());
+
+  mfem::BlockVector rhs_block(offsets), sol_block(offsets);
+  rhs_block.GetBlock(0) = rhs_sigma;
+  rhs_block.GetBlock(1) = rhs_u;
+  sol_block = 0.0;
+
+  // 9. Solve with SuperLU
+  smith::SuperLUSolver superlu(0 /*print_level*/, mesh->GetComm());
+  superlu.SetOperator(block_op);
+  superlu.Mult(rhs_block, sol_block);
+
+  // 10. Compute relative σ error
+  mfem::Vector sigma_err(sol_block.GetBlock(0));
+  sigma_err -= sigma_exact;
+  double err = sigma_err.Norml2();
+  double norm_ref = sigma_exact.Norml2();
+  return err / (norm_ref > 0.0 ? norm_ref : 1.0);
+}
+
+// ─── 3D Darcy solve ──────────────────────────────────────────────────────────
+
+static void sigma_exact_3d_fn(const mfem::Vector& /*x*/, mfem::Vector& v)
+{
+  v(0) = -1.0;
+  v(1) = -2.0;
+  v(2) = -3.0;
+}
+
+static double u_exact_3d_fn(const mfem::Vector& x) { return x(0) + 2.0 * x(1) + 3.0 * x(2); }
+
+template <int p>
+double darcy_solve_3d()
+{
+  constexpr int dim = 3;
+
+  auto mesh =
+      mesh::refineAndDistribute(mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::HEXAHEDRON, 1.0, 1.0, 1.0), 0);
+
+  auto [fes_sigma, fec_sigma] = generateParFiniteElementSpace<Hdiv<p>>(mesh.get());
+  auto [fes_u, fec_u] = generateParFiniteElementSpace<L2<p - 1>>(mesh.get());
+
+  mfem::VectorFunctionCoefficient sigma_coeff(dim, sigma_exact_3d_fn);
+  mfem::ParGridFunction sigma_gf(fes_sigma.get());
+  sigma_gf.ProjectCoefficient(sigma_coeff);
+
+  mfem::FunctionCoefficient u_coeff(u_exact_3d_fn);
+  mfem::ParGridFunction u_gf(fes_u.get());
+  u_gf.ProjectCoefficient(u_coeff);
+
+  mfem::Vector sigma_exact(fes_sigma->TrueVSize());
+  sigma_gf.GetTrueDofs(sigma_exact);
+  mfem::Vector u_exact(fes_u->TrueVSize());
+  u_gf.GetTrueDofs(u_exact);
+
+  mfem::Vector sigma_zero(fes_sigma->TrueVSize());
+  sigma_zero = 0.0;
+  mfem::Vector u_zero(fes_u->TrueVSize());
+  u_zero = 0.0;
+
+  Functional<Hdiv<p>(Hdiv<p>, L2<p - 1>)> res_sigma(fes_sigma.get(), {fes_sigma.get(), fes_u.get()});
+
+  Domain whole_domain = EntireDomain(*mesh);
+
+  res_sigma.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0, 1>{},
+      [](double, auto, auto sigma_arg, auto u_arg) {
+        auto [sigma_val, sigma_div] = sigma_arg;
+        auto [u_val, u_grad] = u_arg;
+        return smith::tuple{sigma_val, -u_val};
+      },
+      whole_domain);
+
+  constexpr double eps = 1.0e-10;
+  Functional<L2<p - 1>(Hdiv<p>, L2<p - 1>)> res_u(fes_u.get(), {fes_sigma.get(), fes_u.get()});
+
+  res_u.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0, 1>{},
+      [=](double, auto, auto sigma_arg, auto u_arg) {
+        auto [sigma_val, sigma_div] = sigma_arg;
+        auto [u_val, u_grad] = u_arg;
+        return smith::tuple{sigma_div + eps * u_val, tensor<double, dim>{}};
+      },
+      whole_domain);
+
+  double t = 0.0;
+
+  auto [r_sigma_0, dRsigma_dsigma] = res_sigma(t, differentiate_wrt(sigma_zero), u_zero);
+  auto [dummy0, dRsigma_du] = res_sigma(t, sigma_zero, differentiate_wrt(u_zero));
+  auto [r_u_0, dRu_dsigma] = res_u(t, differentiate_wrt(sigma_zero), u_zero);
+  auto [dummy1, dRu_du] = res_u(t, sigma_zero, differentiate_wrt(u_zero));
+
+  auto J_00 = assemble(dRsigma_dsigma);
+  auto J_01 = assemble(dRsigma_du);
+  auto J_10 = assemble(dRu_dsigma);
+  auto J_11 = assemble(dRu_du);
+
+  mfem::Array<int> ess_bdr(mesh->bdr_attributes.Max());
+  ess_bdr = 1;
+  mfem::Array<int> ess_tdofs_sigma;
+  fes_sigma->GetEssentialTrueDofs(ess_bdr, ess_tdofs_sigma);
+
+  mfem::Vector sigma_bc(fes_sigma->TrueVSize());
+  sigma_bc = 0.0;
+  for (int i = 0; i < ess_tdofs_sigma.Size(); i++) {
+    sigma_bc[ess_tdofs_sigma[i]] = sigma_exact[ess_tdofs_sigma[i]];
+  }
+
+  mfem::Vector rhs_sigma(fes_sigma->TrueVSize());
+  rhs_sigma = 0.0;
+  {
+    mfem::Vector tmp(rhs_sigma.Size());
+    J_00->Mult(sigma_bc, tmp);
+    rhs_sigma -= tmp;
+  }
+
+  mfem::Vector rhs_u(fes_u->TrueVSize());
+  rhs_u = 0.0;
+  {
+    mfem::Vector tmp(rhs_u.Size());
+    J_10->Mult(sigma_bc, tmp);
+    rhs_u -= tmp;
+  }
+
+  {
+    auto* elim = J_00->EliminateRowsCols(ess_tdofs_sigma);
+    delete elim;
+  }
+  J_01->EliminateRows(ess_tdofs_sigma);
+  J_10->EliminateCols(ess_tdofs_sigma);
+
+  for (int i = 0; i < ess_tdofs_sigma.Size(); i++) {
+    rhs_sigma[ess_tdofs_sigma[i]] = sigma_exact[ess_tdofs_sigma[i]];
+  }
+
+  mfem::Array<int> offsets;
+  offsets.SetSize(3);
+  offsets[0] = 0;
+  offsets[1] = fes_sigma->TrueVSize();
+  offsets[2] = fes_sigma->TrueVSize() + fes_u->TrueVSize();
+
+  mfem::BlockOperator block_op(offsets);
+  block_op.SetBlock(0, 0, J_00.get());
+  block_op.SetBlock(0, 1, J_01.get());
+  block_op.SetBlock(1, 0, J_10.get());
+  block_op.SetBlock(1, 1, J_11.get());
+
+  mfem::BlockVector rhs_block(offsets), sol_block(offsets);
+  rhs_block.GetBlock(0) = rhs_sigma;
+  rhs_block.GetBlock(1) = rhs_u;
+  sol_block = 0.0;
+
+  smith::SuperLUSolver superlu(0, mesh->GetComm());
+  superlu.SetOperator(block_op);
+  superlu.Mult(rhs_block, sol_block);
+
+  mfem::Vector sigma_err(sol_block.GetBlock(0));
+  sigma_err -= sigma_exact;
+  double err = sigma_err.Norml2();
+  double norm_ref = sigma_exact.Norml2();
+  return err / (norm_ref > 0.0 ? norm_ref : 1.0);
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+// 2D tests
+TEST(DarcyPatch, RT1_DG1_2D) { EXPECT_LT(darcy_solve<2>(), 1.0e-8); }
+TEST(DarcyPatch, RT2_DG2_2D) { EXPECT_LT(darcy_solve<3>(), 1.0e-8); }
+
+// 3D tests
+TEST(DarcyPatch, RT1_DG1_3D) { EXPECT_LT(darcy_solve_3d<2>(), 1.0e-8); }
+TEST(DarcyPatch, RT2_DG2_3D) { EXPECT_LT(darcy_solve_3d<3>(), 1.0e-8); }
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  smith::ApplicationManager applicationManager(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/smith/numerics/functional/tests/functional_basic_hdiv.cpp
+++ b/src/smith/numerics/functional/tests/functional_basic_hdiv.cpp
@@ -1,0 +1,99 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include <fstream>
+#include <iostream>
+
+#include "mfem.hpp"
+#include "gtest/gtest.h"
+
+#include "axom/slic/core/SimpleLogger.hpp"
+#include "smith/infrastructure/application_manager.hpp"
+#include "smith/smith_config.hpp"
+#include "smith/mesh_utils/mesh_utils.hpp"
+#include "smith/numerics/stdfunction_operator.hpp"
+#include "smith/numerics/functional/functional.hpp"
+#include "smith/numerics/functional/tensor.hpp"
+#include "smith/numerics/functional/domain.hpp"
+#include "smith/numerics/functional/tests/check_gradient.hpp"
+
+using namespace smith;
+
+template <int p, int dim>
+void hdiv_test_impl(std::unique_ptr<mfem::ParMesh>& mesh)
+{
+  using test_space = Hdiv<p>;
+  using trial_space = Hdiv<p>;
+
+  auto [fespace, fec] = smith::generateParFiniteElementSpace<Hdiv<p>>(mesh.get());
+
+  mfem::Vector U(fespace->TrueVSize());
+  U.Randomize(7);
+
+  Functional<test_space(trial_space)> residual(fespace.get(), {fespace.get()});
+
+  auto d00 = make_tensor<dim, dim>([](int i, int j) { return i + j * j - 1; });
+  auto d01 = make_tensor<dim>([](int i) { return i * i + 3; });
+  auto d10 = make_tensor<dim>([](int i) { return 3 * i - 2; });
+  auto d11 = 1.0;
+
+  Domain whole_domain = EntireDomain(*mesh);
+  residual.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0>{},
+      [=](double /*t*/, auto /*x*/, auto sigma) {
+        auto [val, div_val] = sigma;
+        auto source = dot(d00, val) + d01 * div_val;
+        auto flux = dot(d10, val) + d11 * div_val;
+        return smith::tuple{source, flux};
+      },
+      whole_domain);
+
+  double t = 0.0;
+  check_gradient(residual, t, U);
+}
+
+template <int p>
+void hdiv_test(std::string meshfile)
+{
+  auto mesh = mesh::refineAndDistribute(buildMeshFromFile(SMITH_REPO_DIR + meshfile), 1);
+
+  if (mesh->Dimension() == 2) {
+    hdiv_test_impl<p, 2>(mesh);
+  }
+
+  if (mesh->Dimension() == 3) {
+    hdiv_test_impl<p, 3>(mesh);
+  }
+}
+
+// 2D tests
+TEST(basic, hdiv_quads) { hdiv_test<1>("/data/meshes/patch2D_quads.mesh"); }
+TEST(basic, hdiv_tris) { hdiv_test<1>("/data/meshes/patch2D_tris.mesh"); }
+TEST(basic, hdiv_tris_and_quads) { hdiv_test<1>("/data/meshes/patch2D_tris_and_quads.mesh"); }
+
+// 3D tests
+TEST(basic, hdiv_hexes) { hdiv_test<1>("/data/meshes/patch3D_hexes.mesh"); }
+TEST(basic, hdiv_tets) { hdiv_test<1>("/data/meshes/patch3D_tets.mesh"); }
+TEST(basic, hdiv_tets_and_hexes) { hdiv_test<1>("/data/meshes/patch3D_tets_and_hexes.mesh"); }
+
+// Higher order
+TEST(basic, hdiv_quads_p2) { hdiv_test<2>("/data/meshes/patch2D_quads.mesh"); }
+TEST(basic, hdiv_hexes_p2) { hdiv_test<2>("/data/meshes/patch3D_hexes.mesh"); }
+TEST(basic, hdiv_tris_p2) { hdiv_test<2>("/data/meshes/patch2D_tris.mesh"); }
+TEST(basic, hdiv_tets_p2) { hdiv_test<2>("/data/meshes/patch3D_tets.mesh"); }
+
+// p=3 assembly / gradient checks
+TEST(basic, hdiv_quads_p3) { hdiv_test<3>("/data/meshes/patch2D_quads.mesh"); }
+TEST(basic, hdiv_tris_p3) { hdiv_test<3>("/data/meshes/patch2D_tris.mesh"); }
+TEST(basic, hdiv_hexes_p3) { hdiv_test<3>("/data/meshes/patch3D_hexes.mesh"); }
+TEST(basic, hdiv_tets_p3) { hdiv_test<3>("/data/meshes/patch3D_tets.mesh"); }
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  smith::ApplicationManager applicationManager(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/smith/numerics/functional/tests/hdiv_convergence_test.cpp
+++ b/src/smith/numerics/functional/tests/hdiv_convergence_test.cpp
@@ -1,0 +1,315 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+/**
+ * @file hdiv_convergence_test.cpp
+ *
+ * @brief H-refinement convergence rate test for Hdiv elements
+ *
+ * Solves a Darcy problem with a smooth manufactured solution on progressively
+ * refined meshes and verifies that the L2 error in sigma decays at the expected
+ * O(h^p) rate.  Also includes a normal continuity verification on shared faces.
+ */
+
+#include "gtest/gtest.h"
+#include "mfem.hpp"
+
+#include "smith/infrastructure/application_manager.hpp"
+#include "smith/smith_config.hpp"
+#include "smith/mesh_utils/mesh_utils.hpp"
+#include "smith/numerics/equation_solver.hpp"
+#include "smith/numerics/functional/differentiate_wrt.hpp"
+#include "smith/numerics/functional/domain.hpp"
+#include "smith/numerics/functional/functional.hpp"
+#include "smith/numerics/functional/tests/check_gradient.hpp"
+
+using namespace smith;
+
+// ─── Manufactured solution ──────────────────────────────────────────────────
+//
+// u_exact = sin(pi x) sin(pi y)
+// sigma_exact = -grad u = (-pi cos(pi x) sin(pi y),
+//                          -pi sin(pi x) cos(pi y))
+// f = -div(sigma) = -laplacian(u) = 2 pi^2 sin(pi x) sin(pi y)
+
+static constexpr double PI = 3.14159265358979323846;
+
+static void sigma_exact_fn(const mfem::Vector& x, mfem::Vector& v)
+{
+  v(0) = -PI * cos(PI * x(0)) * sin(PI * x(1));
+  v(1) = -PI * sin(PI * x(0)) * cos(PI * x(1));
+}
+
+template <int p>
+double darcy_convergence_solve(int n_elem)
+{
+  constexpr int dim = 2;
+
+  auto mesh = mesh::refineAndDistribute(
+      mfem::Mesh::MakeCartesian2D(n_elem, n_elem, mfem::Element::QUADRILATERAL, true, 1.0, 1.0), 0);
+
+  auto [fes_sigma, fec_sigma] = generateParFiniteElementSpace<Hdiv<p>>(mesh.get());
+  auto [fes_u, fec_u] = generateParFiniteElementSpace<L2<p - 1>>(mesh.get());
+
+  // Project exact solution for BCs and error measurement
+  mfem::VectorFunctionCoefficient sigma_coeff(dim, sigma_exact_fn);
+  mfem::ParGridFunction sigma_gf(fes_sigma.get());
+  sigma_gf.ProjectCoefficient(sigma_coeff);
+
+  mfem::Vector sigma_exact(fes_sigma->TrueVSize());
+  sigma_gf.GetTrueDofs(sigma_exact);
+
+  mfem::Vector sigma_zero(fes_sigma->TrueVSize());
+  sigma_zero = 0.0;
+  mfem::Vector u_zero(fes_u->TrueVSize());
+  u_zero = 0.0;
+
+  // Flux equation: (K^{-1} sigma, tau) - (u, div tau) = 0
+  Functional<Hdiv<p>(Hdiv<p>, L2<p - 1>)> res_sigma(fes_sigma.get(), {fes_sigma.get(), fes_u.get()});
+
+  Domain whole_domain = EntireDomain(*mesh);
+
+  res_sigma.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0, 1>{},
+      [](double, auto, auto sigma_arg, auto u_arg) {
+        auto [sigma_val, sigma_div] = sigma_arg;
+        auto [u_val, u_grad] = u_arg;
+        return smith::tuple{sigma_val, -u_val};
+      },
+      whole_domain);
+
+  // Continuity equation: (div sigma, v) + eps*(u,v) = (f, v)
+  constexpr double eps = 1.0e-10;
+  Functional<L2<p - 1>(Hdiv<p>, L2<p - 1>)> res_u(fes_u.get(), {fes_sigma.get(), fes_u.get()});
+
+  res_u.AddDomainIntegral(
+      Dimension<dim>{}, DependsOn<0, 1>{},
+      [=](double, auto position, auto sigma_arg, auto u_arg) {
+        auto [X, J] = position;
+        auto [sigma_val, sigma_div] = sigma_arg;
+        auto [u_val, u_grad] = u_arg;
+        double f = 2.0 * PI * PI * sin(PI * X[0]) * sin(PI * X[1]);
+        return smith::tuple{sigma_div + eps * u_val - f, tensor<double, dim>{}};
+      },
+      whole_domain);
+
+  double t = 0.0;
+
+  auto [r_sigma_0, dRsigma_dsigma] = res_sigma(t, differentiate_wrt(sigma_zero), u_zero);
+  auto [dummy0, dRsigma_du] = res_sigma(t, sigma_zero, differentiate_wrt(u_zero));
+  auto [r_u_0, dRu_dsigma] = res_u(t, differentiate_wrt(sigma_zero), u_zero);
+  auto [dummy1, dRu_du] = res_u(t, sigma_zero, differentiate_wrt(u_zero));
+
+  auto J_00 = assemble(dRsigma_dsigma);
+  auto J_01 = assemble(dRsigma_du);
+  auto J_10 = assemble(dRu_dsigma);
+  auto J_11 = assemble(dRu_du);
+
+  // Essential BCs on sigma dot n
+  mfem::Array<int> ess_bdr(mesh->bdr_attributes.Max());
+  ess_bdr = 1;
+  mfem::Array<int> ess_tdofs_sigma;
+  fes_sigma->GetEssentialTrueDofs(ess_bdr, ess_tdofs_sigma);
+
+  mfem::Vector sigma_bc(fes_sigma->TrueVSize());
+  sigma_bc = 0.0;
+  for (int i = 0; i < ess_tdofs_sigma.Size(); i++) {
+    sigma_bc[ess_tdofs_sigma[i]] = sigma_exact[ess_tdofs_sigma[i]];
+  }
+
+  // RHS = -residual(0,0) - J * sigma_bc  (for the nonzero source f)
+  mfem::Vector rhs_sigma(fes_sigma->TrueVSize());
+  {
+    mfem::Vector tmp(rhs_sigma.Size());
+    J_00->Mult(sigma_bc, tmp);
+    rhs_sigma = r_sigma_0;
+    rhs_sigma *= -1.0;
+    rhs_sigma -= tmp;
+  }
+
+  mfem::Vector rhs_u(fes_u->TrueVSize());
+  {
+    mfem::Vector tmp(rhs_u.Size());
+    J_10->Mult(sigma_bc, tmp);
+    rhs_u = r_u_0;
+    rhs_u *= -1.0;
+    rhs_u -= tmp;
+  }
+
+  {
+    auto* elim = J_00->EliminateRowsCols(ess_tdofs_sigma);
+    delete elim;
+  }
+  J_01->EliminateRows(ess_tdofs_sigma);
+  J_10->EliminateCols(ess_tdofs_sigma);
+
+  for (int i = 0; i < ess_tdofs_sigma.Size(); i++) {
+    rhs_sigma[ess_tdofs_sigma[i]] = sigma_exact[ess_tdofs_sigma[i]];
+  }
+
+  mfem::Array<int> offsets;
+  offsets.SetSize(3);
+  offsets[0] = 0;
+  offsets[1] = fes_sigma->TrueVSize();
+  offsets[2] = fes_sigma->TrueVSize() + fes_u->TrueVSize();
+
+  mfem::BlockOperator block_op(offsets);
+  block_op.SetBlock(0, 0, J_00.get());
+  block_op.SetBlock(0, 1, J_01.get());
+  block_op.SetBlock(1, 0, J_10.get());
+  block_op.SetBlock(1, 1, J_11.get());
+
+  mfem::BlockVector rhs_block(offsets), sol_block(offsets);
+  rhs_block.GetBlock(0) = rhs_sigma;
+  rhs_block.GetBlock(1) = rhs_u;
+  sol_block = 0.0;
+
+  smith::SuperLUSolver superlu(0, mesh->GetComm());
+  superlu.SetOperator(block_op);
+  superlu.Mult(rhs_block, sol_block);
+
+  // Compute L2 error in sigma via mfem GridFunction
+  mfem::ParGridFunction sigma_h(fes_sigma.get());
+  sigma_h.SetFromTrueDofs(sol_block.GetBlock(0));
+
+  double l2_err = sigma_h.ComputeL2Error(sigma_coeff);
+  return l2_err;
+}
+
+// ─── Convergence rate tests ─────────────────────────────────────────────────
+
+template <int p>
+void check_convergence_rate()
+{
+  // Solve on two mesh sizes, compute convergence rate
+  double err_coarse = darcy_convergence_solve<p>(4);
+  double err_fine = darcy_convergence_solve<p>(8);
+
+  // rate = log(err_coarse/err_fine) / log(h_coarse/h_fine) = log(err_coarse/err_fine) / log(2)
+  double rate = log(err_coarse / err_fine) / log(2.0);
+
+  // Expect at least O(h^p) convergence.  Allow 0.5 margin for pre-asymptotic effects.
+  EXPECT_GT(rate, double(p) - 0.5) << "Convergence rate " << rate << " is below expected O(h^" << p << ")";
+}
+
+TEST(HdivConvergence, RT1_quads) { check_convergence_rate<2>(); }
+TEST(HdivConvergence, RT2_quads) { check_convergence_rate<3>(); }
+
+// ─── Normal continuity verification ─────────────────────────────────────────
+//
+// Project a known vector field into the Hdiv space, then verify that the
+// normal component is continuous across internal faces by checking that
+// mfem's RT DOFs (which represent sigma dot n integrated against face basis
+// functions) are single-valued.
+
+template <int p>
+void check_normal_continuity()
+{
+  constexpr int dim = 2;
+
+  auto mesh =
+      mesh::refineAndDistribute(mfem::Mesh::MakeCartesian2D(4, 4, mfem::Element::QUADRILATERAL, true, 1.0, 1.0), 0);
+
+  auto [fes_sigma, fec_sigma] = generateParFiniteElementSpace<Hdiv<p>>(mesh.get());
+
+  mfem::VectorFunctionCoefficient sigma_coeff(dim, sigma_exact_fn);
+  mfem::ParGridFunction sigma_gf(fes_sigma.get());
+  sigma_gf.ProjectCoefficient(sigma_coeff);
+
+  // RT DOFs on shared faces should be single-valued (this is the definition of
+  // H(div) conformity).  GetTrueDofs reduces to unique DOFs; if we scatter back
+  // and compare, any discontinuity would show up as a difference.
+  mfem::Vector true_dofs(fes_sigma->TrueVSize());
+  sigma_gf.GetTrueDofs(true_dofs);
+
+  mfem::ParGridFunction sigma_check(fes_sigma.get());
+  sigma_check.SetFromTrueDofs(true_dofs);
+
+  // The round-trip should be lossless for a conforming space
+  mfem::Vector diff(sigma_gf.Size());
+  subtract(sigma_gf, sigma_check, diff);
+  double err = diff.Norml2();
+  EXPECT_NEAR(err, 0.0, 1.0e-12) << "Normal continuity violated: round-trip DOF error = " << err;
+}
+
+TEST(HdivNormalContinuity, RT1_quads) { check_normal_continuity<2>(); }
+TEST(HdivNormalContinuity, RT2_quads) { check_normal_continuity<3>(); }
+
+// ─── Boundary integral gradient check ───────────────────────────────────────
+//
+// Exercises AddBoundaryIntegral with Hdiv test/trial spaces.
+
+template <int p>
+void hdiv_boundary_test()
+{
+  constexpr int dim = 2;
+
+  auto mesh =
+      mesh::refineAndDistribute(mfem::Mesh::MakeCartesian2D(4, 4, mfem::Element::QUADRILATERAL, true, 1.0, 1.0), 1);
+
+  auto [fespace, fec] = smith::generateParFiniteElementSpace<Hdiv<p>>(mesh.get());
+
+  mfem::Vector U(fespace->TrueVSize());
+  U.Randomize(42);
+
+  Functional<Hdiv<p>(Hdiv<p>)> residual(fespace.get(), {fespace.get()});
+
+  Domain bdr = EntireBoundary(*mesh);
+
+  residual.AddBoundaryIntegral(
+      Dimension<dim - 1>{}, DependsOn<0>{},
+      [](double /*t*/, auto /*position*/, auto sigma) {
+        auto [sigma_n, d_sigma_n] = sigma;
+        // sigma_n is the scalar normal flux (sigma dot n) on the boundary
+        return sigma_n * sigma_n + 0.5 * d_sigma_n;
+      },
+      bdr);
+
+  double t = 0.0;
+  check_gradient(residual, t, U);
+}
+
+template <int p>
+void hdiv_boundary_test_3d()
+{
+  constexpr int dim = 3;
+
+  auto mesh =
+      mesh::refineAndDistribute(mfem::Mesh::MakeCartesian3D(2, 2, 2, mfem::Element::HEXAHEDRON, 1.0, 1.0, 1.0), 1);
+
+  auto [fespace, fec] = smith::generateParFiniteElementSpace<Hdiv<p>>(mesh.get());
+
+  mfem::Vector U(fespace->TrueVSize());
+  U.Randomize(42);
+
+  Functional<Hdiv<p>(Hdiv<p>)> residual(fespace.get(), {fespace.get()});
+
+  Domain bdr = EntireBoundary(*mesh);
+
+  residual.AddBoundaryIntegral(
+      Dimension<dim - 1>{}, DependsOn<0>{},
+      [](double /*t*/, auto /*position*/, auto sigma) {
+        auto [sigma_n, d_sigma_n] = sigma;
+        // sigma_n is the scalar normal flux (sigma dot n) on the boundary
+        return sigma_n * sigma_n + 0.5 * d_sigma_n[0] + 0.5 * d_sigma_n[1];
+      },
+      bdr);
+
+  double t = 0.0;
+  check_gradient(residual, t, U);
+}
+
+TEST(HdivBoundary, RT1_quads) { hdiv_boundary_test<1>(); }
+TEST(HdivBoundary, RT2_quads) { hdiv_boundary_test<2>(); }
+TEST(HdivBoundary, RT1_hexes) { hdiv_boundary_test_3d<1>(); }
+TEST(HdivBoundary, RT2_hexes) { hdiv_boundary_test_3d<2>(); }
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  smith::ApplicationManager applicationManager(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/smith/numerics/functional/tests/hdiv_unit_tests.cpp
+++ b/src/smith/numerics/functional/tests/hdiv_unit_tests.cpp
@@ -1,0 +1,174 @@
+// Copyright (c) Lawrence Livermore National Security, LLC and
+// other Smith Project Developers. See the top-level LICENSE file for
+// details.
+//
+// SPDX-License-Identifier: (BSD-3-Clause)
+
+#include "gtest/gtest.h"
+
+#include "smith/numerics/functional/tensor.hpp"
+#include "smith/numerics/functional/finite_element.hpp"
+#include "smith/infrastructure/application_manager.hpp"
+
+using namespace smith;
+
+static constexpr double kronecker_tolerance = 1.0e-13;
+static constexpr double div_tolerance = 1.0e-10;  // coarser, since comparing to a finite difference approximation
+static constexpr int num_points = 10;
+static constexpr tensor random_numbers = {
+    {-0.886787, -0.850126, 0.464212,  -0.0733101, -0.397738, 0.302355,   -0.570758, 0.977727,  0.282365,  -0.768947,
+     0.6216,    0.43598,   -0.696321, 0.92545,    0.183003,  0.121761,   -0.877239, 0.0347577, -0.818463, -0.216474,
+     -0.43894,  0.0178874, -0.869944, -0.733499,  0.255124,  -0.0561095, -0.34607,  -0.305958, 0.414472,  -0.744998}};
+
+/*
+iterate over the node/direction pairs in the element, and verify that
+contributions from other shape functions in the element are orthogonal
+*/
+template <typename element_type>
+void verify_kronecker_delta_property()
+{
+  static constexpr auto nodes = element_type::nodes;
+  static constexpr auto directions = element_type::directions;
+  static constexpr auto I = DenseIdentity<element_type::ndof>();
+
+  for (int i = 0; i < element_type::ndof; i++) {
+    double error = norm(I[i] - dot(element_type::shape_functions(nodes[i]), directions[i]));
+    EXPECT_NEAR(error, 0.0, kronecker_tolerance);
+  }
+}
+
+/*
+  compare the direct divergence evaluation to a finite difference approximation
+*/
+template <typename element_type>
+void verify_div_calculation()
+{
+  static constexpr double eps = 1.0e-6;
+  static constexpr int dim = element_type::dim;
+  static constexpr auto I = DenseIdentity<dim>();
+  static constexpr auto random_points =
+      make_tensor<num_points, dim>([](int i, int j) { return random_numbers[i * dim + j]; });
+
+  constexpr auto N = element_type::shape_functions;
+  constexpr auto divN = element_type::shape_function_div;
+
+  for (int i = 0; i < num_points; i++) {
+    auto x = random_points[i];
+    if constexpr (dim == 2) {
+      auto dN_dx = (N(x + eps * I[0]) - N(x - eps * I[0])) / (2.0 * eps);
+      auto dN_dy = (N(x + eps * I[1]) - N(x - eps * I[1])) / (2.0 * eps);
+
+      // divergence = d(Nx)/dx + d(Ny)/dy
+      auto fd_div = dot(dN_dx, I[0]) + dot(dN_dy, I[1]);
+      double relative_error = norm(divN(x) - fd_div) / norm(divN(x));
+      EXPECT_NEAR(relative_error, 0.0, div_tolerance);
+    }
+
+    if constexpr (dim == 3) {
+      auto dN_dx = (N(x + eps * I[0]) - N(x - eps * I[0])) / (2.0 * eps);
+      auto dN_dy = (N(x + eps * I[1]) - N(x - eps * I[1])) / (2.0 * eps);
+      auto dN_dz = (N(x + eps * I[2]) - N(x - eps * I[2])) / (2.0 * eps);
+
+      // divergence = d(Nx)/dx + d(Ny)/dy + d(Nz)/dz
+      auto fd_div = dot(dN_dx, I[0]) + dot(dN_dy, I[1]) + dot(dN_dz, I[2]);
+      double relative_error = norm(divN(x) - fd_div) / norm(divN(x));
+      EXPECT_NEAR(relative_error, 0.0, div_tolerance);
+    }
+  }
+}
+
+TEST(HdivKroneckerDelta, QuadrilateralLinear)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::SQUARE, Hdiv<1>>>();
+}
+
+TEST(HdivKroneckerDelta, QuadrilateralQuadratic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::SQUARE, Hdiv<2>>>();
+}
+
+TEST(HdivKroneckerDelta, QuadrilateralCubic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::SQUARE, Hdiv<3>>>();
+}
+
+TEST(HdivKroneckerDelta, HexahedronLinear)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::CUBE, Hdiv<1>>>();
+}
+
+TEST(HdivKroneckerDelta, HexahedronQuadratic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::CUBE, Hdiv<2>>>();
+}
+
+TEST(HdivKroneckerDelta, HexahedronCubic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::CUBE, Hdiv<3>>>();
+}
+
+TEST(HdivDiv, QuadrilateralLinear) { verify_div_calculation<finite_element<::mfem::Geometry::SQUARE, Hdiv<1>>>(); }
+
+TEST(HdivDiv, QuadrilateralQuadratic) { verify_div_calculation<finite_element<::mfem::Geometry::SQUARE, Hdiv<2>>>(); }
+
+TEST(HdivDiv, QuadrilateralCubic) { verify_div_calculation<finite_element<::mfem::Geometry::SQUARE, Hdiv<3>>>(); }
+
+TEST(HdivDiv, HexahedronLinear) { verify_div_calculation<finite_element<::mfem::Geometry::CUBE, Hdiv<1>>>(); }
+
+TEST(HdivDiv, HexahedronQuadratic) { verify_div_calculation<finite_element<::mfem::Geometry::CUBE, Hdiv<2>>>(); }
+
+TEST(HdivDiv, HexahedronCubic) { verify_div_calculation<finite_element<::mfem::Geometry::CUBE, Hdiv<3>>>(); }
+
+// Triangle
+TEST(HdivKroneckerDelta, TriangleLinear)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::TRIANGLE, Hdiv<1>>>();
+}
+
+TEST(HdivKroneckerDelta, TriangleQuadratic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::TRIANGLE, Hdiv<2>>>();
+}
+
+TEST(HdivKroneckerDelta, TriangleCubic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::TRIANGLE, Hdiv<3>>>();
+}
+
+TEST(HdivDiv, TriangleLinear) { verify_div_calculation<finite_element<::mfem::Geometry::TRIANGLE, Hdiv<1>>>(); }
+
+TEST(HdivDiv, TriangleQuadratic) { verify_div_calculation<finite_element<::mfem::Geometry::TRIANGLE, Hdiv<2>>>(); }
+
+TEST(HdivDiv, TriangleCubic) { verify_div_calculation<finite_element<::mfem::Geometry::TRIANGLE, Hdiv<3>>>(); }
+
+// Tetrahedron
+TEST(HdivKroneckerDelta, TetrahedronLinear)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::TETRAHEDRON, Hdiv<1>>>();
+}
+
+TEST(HdivKroneckerDelta, TetrahedronQuadratic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::TETRAHEDRON, Hdiv<2>>>();
+}
+
+TEST(HdivKroneckerDelta, TetrahedronCubic)
+{
+  verify_kronecker_delta_property<finite_element<::mfem::Geometry::TETRAHEDRON, Hdiv<3>>>();
+}
+
+TEST(HdivDiv, TetrahedronLinear) { verify_div_calculation<finite_element<::mfem::Geometry::TETRAHEDRON, Hdiv<1>>>(); }
+
+TEST(HdivDiv, TetrahedronQuadratic)
+{
+  verify_div_calculation<finite_element<::mfem::Geometry::TETRAHEDRON, Hdiv<2>>>();
+}
+
+TEST(HdivDiv, TetrahedronCubic) { verify_div_calculation<finite_element<::mfem::Geometry::TETRAHEDRON, Hdiv<3>>>(); }
+
+int main(int argc, char* argv[])
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  smith::ApplicationManager applicationManager(argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/smith/numerics/functional/tuple_tensor_dual_functions.hpp
+++ b/src/smith/numerics/functional/tuple_tensor_dual_functions.hpp
@@ -385,7 +385,7 @@ SMITH_HOST_DEVICE constexpr LuFactorization<T, n> factorize_lu(const tensor<T, n
   tensor<int, n> P(make_tensor<n>([](auto i) { return i; }));
 
   for (int i = 0; i < n; i++) {
-    // Search for maximum in this column
+    // Search for maximum in this column (partial pivoting on partially-eliminated U)
     double max_val = abs(get_value(U[i][i]));
 
     int max_row = i;
@@ -399,11 +399,12 @@ SMITH_HOST_DEVICE constexpr LuFactorization<T, n> factorize_lu(const tensor<T, n
 
     swap(P[max_row], P[i]);
     swap(U[max_row], U[i]);
-  }
+    // Swap already-computed L entries to keep L consistent with the row permutation
+    for (int k = 0; k < i; k++) {
+      swap(L[max_row][k], L[i][k]);
+    }
 
-  for (int i = 0; i < n; i++) {
-    // zero entries below in this column in U
-    // and fill in L entries
+    // zero entries below in this column in U and fill in L entries
     for (int j = i + 1; j < n; j++) {
       auto c = U[j][i] / U[i][i];
       L[j][i] = c;


### PR DESCRIPTION
 - [x]    Foundational HIV Support: Introduced the foundational abstractions for the Hdiv finite element family (mapping to mfem::RT_FECollection), allowing the code to represent and compute with normal-continuous vector fields.
- [x]     Comprehensive Element Bases: Implemented the detailed H(div) reference shape functions and curl/divergence evaluations for all primary geometries: Segment, Triangle, Quadrilateral, Tetrahedron, and Hexahedron (*_Hdiv.inl files).
- [x]     Contravariant Piola Pullbacks: Implemented correct physical-to-parent element mappings for H(div) spaces. Specifically, handling the Piola transformation ( J T s for sources and direct flux mappings canceling the determinant multipliers) in functional.hpp and qoi.inl.
- [x]     DoF Orientation & Sign Mapping: Updated the ElementRestriction class to correctly unpack negative degrees of freedom (dofs[k] < 0) into a sign representation, and ensure gather/scatter operations accurately multiply by this sign ( ± 1 ) for face orientations.
- [x]     Integral Kernels Expansion: Broadened interior_face_integral_kernels.hpp, boundary_integral_kernels.hpp, and domain_integral_kernels.hpp to incorporate H(div) trace components and their derivatives for face-based and domain-based integrations.
- [x]     LU Factorization Bug Fix: Corrected a logical error in the compile-time LU factorization (tuple_tensor_dual_functions.hpp) where the lower triangular elements (L) were not being correctly swapped during partial pivoting, ensuring algebraic correctness.
- [x]     Robust Validation & Testing: Added comprehensive functional tests (hdiv_unit_tests, hdiv_convergence_test) and a representative physics test (darcy_patch_test.cpp) to actively validate the H(div) functionality and ensure expected convergence rates. 