### PR TITLE
macos: how to fix ld object warning `built for newer 'macOS' version (26.0) than being linked (16.0)`

### DIFF
--- a/src/docs/sphinx/build_guide/build_smith.rst
+++ b/src/docs/sphinx/build_guide/build_smith.rst
@@ -249,5 +249,18 @@ We provide the following useful build targets that can be run from the build dir
 * ``check``: Runs a set of code checks over source code (CppCheck and clang-format)
 * ``install``: Installs Smith into the previously given ``CMAKE_INSTALL_PREFIX`` directory
 
+MacOS Deployment Target Warning
+-------------------------------
 
+This section is for MacOS machines only.
 
+If you get the following warning(s) when building Smith...
+
+``ld: warning: object file (/Users/chapman39/dev/lido-2.0/lido_tpls/darwin/upstreams/2026_03_18_15_16_50/darwin-tahoe-aarch64/llvm-19.1.7/petsc-3.21.6-gg26icdjjmc5le6de6f5nviiqnhlanvj/lib/libpetsc.a[1377](slregis.o)) was built for newer 'macOS' version (26.0) than being linked (16.0)``
+
+...run the following command to add `MACOSX_DEPLOYMENT_TARGET` to your environment (the target version may be different
+for you):
+
+  .. code-block:: bash
+
+    echo "export MACOSX_DEPLOYMENT_TARGET=26.0" >> ~/.bash_profile

--- a/src/docs/sphinx/build_guide/build_smith.rst
+++ b/src/docs/sphinx/build_guide/build_smith.rst
@@ -256,7 +256,7 @@ This section is for MacOS machines only.
 
 If you get the following warning(s) when building Smith...
 
-``ld: warning: object file (/Users/chapman39/dev/lido-2.0/lido_tpls/darwin/upstreams/2026_03_18_15_16_50/darwin-tahoe-aarch64/llvm-19.1.7/petsc-3.21.6-gg26icdjjmc5le6de6f5nviiqnhlanvj/lib/libpetsc.a[1377](slregis.o)) was built for newer 'macOS' version (26.0) than being linked (16.0)``
+``ld: warning: object file (/spack_install_path/darwin-tahoe-aarch64/llvm-19.1.7/petsc-3.21.6-gg26icdjjmc5le6de6f5nviiqnhlanvj/lib/libpetsc.a[1377](slregis.o)) was built for newer 'macOS' version (26.0) than being linked (16.0)``
 
 ...run the following command to add `MACOSX_DEPLOYMENT_TARGET` to your environment (the target version may be different
 for you):


### PR DESCRIPTION
adds how to resolve a warning i noticed when building lido on mac.