### PR TITLE
type alias mfem::future::tuple to smith::tuple

### DIFF
--- a/src/smith/numerics/functional/domain_integral_kernels.hpp
+++ b/src/smith/numerics/functional/domain_integral_kernels.hpp
@@ -100,8 +100,8 @@ template <int i, int dim, typename... trials, typename lambda, typename qpt_data
 auto get_derivative_type(const lambda& qf, qpt_data_type qpt_data)
 {
   using qf_arguments = smith::tuple<typename QFunctionArgument<trials, smith::Dimension<dim>>::type...>;
-  return get_gradient(apply_qf(qf, double{}, smith::tuple<tensor<double, dim>, tensor<double, dim, dim>>{}, qpt_data,
-                               make_dual_wrt<i>(qf_arguments{})));
+  return get_gradient(apply_qf(qf, double{}, smith::tuple<tensor<double, dim>, tensor<double, dim, dim>>{},
+                                      qpt_data, make_dual_wrt<i>(qf_arguments{})));
 };
 
 template <typename lambda, int dim, int n, typename... T>

--- a/src/smith/numerics/functional/domain_integral_kernels.hpp
+++ b/src/smith/numerics/functional/domain_integral_kernels.hpp
@@ -100,8 +100,8 @@ template <int i, int dim, typename... trials, typename lambda, typename qpt_data
 auto get_derivative_type(const lambda& qf, qpt_data_type qpt_data)
 {
   using qf_arguments = smith::tuple<typename QFunctionArgument<trials, smith::Dimension<dim>>::type...>;
-  return get_gradient(apply_qf(qf, double{}, smith::tuple<tensor<double, dim>, tensor<double, dim, dim>>{},
-                                      qpt_data, make_dual_wrt<i>(qf_arguments{})));
+  return get_gradient(apply_qf(qf, double{}, smith::tuple<tensor<double, dim>, tensor<double, dim, dim>>{}, qpt_data,
+                               make_dual_wrt<i>(qf_arguments{})));
 };
 
 template <typename lambda, int dim, int n, typename... T>

--- a/src/smith/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
+++ b/src/smith/numerics/functional/tests/tuple_arithmetic_unit_tests.cpp
@@ -28,6 +28,24 @@ TEST(TupleArithmeticUnitTests, StructuredBinding)
   EXPECT_NEAR(c, 2.0f, 1.0e-10);
 }
 
+TEST(TupleArithmeticUnitTests, TenElementTuple)
+{
+  smith::tuple x{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+  EXPECT_EQ(smith::get<9>(x), 9);
+  smith::get<9>(x) = 42;
+  EXPECT_EQ(smith::get<9>(x), 42);
+}
+
+TEST(TupleArithmeticUnitTests, ElevenElementTuple)
+{
+  smith::tuple x{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+
+  EXPECT_EQ(smith::get<10>(x), 10);
+  smith::get<10>(x) = 42;
+  EXPECT_EQ(smith::get<10>(x), 42);
+}
+
 TEST(TupleArithmeticUnitTests, Add)
 {
   smith::tuple a{0.0, make_tensor<3>([](int) { return 3.0; }),

--- a/src/smith/numerics/functional/tuple.hpp
+++ b/src/smith/numerics/functional/tuple.hpp
@@ -7,202 +7,21 @@
 /**
  * @file tuple.hpp
  *
- * @brief Implements a std::tuple-like object that works in CUDA kernels
+ * @brief Smith tuple compatibility layer over mfem::future::tuple
  */
 #pragma once
 
-#include <utility>
+#include "mfem/fem/dfem/tuple.hpp"
 
 #include "smith/infrastructure/accelerator.hpp"
 
-namespace smith {
+namespace mfem::future {
 
 /**
- * @tparam T the types stored in the tuple
- * @brief This is a class that mimics most of std::tuple's interface,
- * except that it is usable in CUDA kernels and admits some arithmetic operator overloads.
+ * @brief Smith compatibility extension for the MFEM tuple implementation.
  *
- * see https://en.cppreference.com/w/cpp/utility/tuple for more information about std::tuple
- */
-template <typename... T>
-struct tuple {};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- */
-template <typename T0>
-struct tuple<T0> {
-  T0 v0;  ///< The first member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- */
-template <typename T0, typename T1>
-struct tuple<T0, T1> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- */
-template <typename T0, typename T1, typename T2>
-struct tuple<T0, T1, T2> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-  T2 v2;  ///< The third member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- */
-template <typename T0, typename T1, typename T2, typename T3>
-struct tuple<T0, T1, T2, T3> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-  T2 v2;  ///< The third member of the tuple
-  T3 v3;  ///< The fourth member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- * @tparam T4 The fifth type stored in the tuple
- */
-template <typename T0, typename T1, typename T2, typename T3, typename T4>
-struct tuple<T0, T1, T2, T3, T4> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-  T2 v2;  ///< The third member of the tuple
-  T3 v3;  ///< The fourth member of the tuple
-  T4 v4;  ///< The fifth member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- * @tparam T4 The fifth type stored in the tuple
- * @tparam T5 The sixth type stored in the tuple
- */
-template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5>
-struct tuple<T0, T1, T2, T3, T4, T5> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-  T2 v2;  ///< The third member of the tuple
-  T3 v3;  ///< The fourth member of the tuple
-  T4 v4;  ///< The fifth member of the tuple
-  T5 v5;  ///< The sixth member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- * @tparam T4 The fifth type stored in the tuple
- * @tparam T5 The sixth type stored in the tuple
- * @tparam T6 The seventh type stored in the tuple
- */
-template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6>
-struct tuple<T0, T1, T2, T3, T4, T5, T6> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-  T2 v2;  ///< The third member of the tuple
-  T3 v3;  ///< The fourth member of the tuple
-  T4 v4;  ///< The fifth member of the tuple
-  T5 v5;  ///< The sixth member of the tuple
-  T6 v6;  ///< The seventh member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- * @tparam T4 The fifth type stored in the tuple
- * @tparam T5 The sixth type stored in the tuple
- * @tparam T6 The seventh type stored in the tuple
- * @tparam T7 The eighth type stored in the tuple
- */
-template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7>
-struct tuple<T0, T1, T2, T3, T4, T5, T6, T7> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-  T2 v2;  ///< The third member of the tuple
-  T3 v3;  ///< The fourth member of the tuple
-  T4 v4;  ///< The fifth member of the tuple
-  T5 v5;  ///< The sixth member of the tuple
-  T6 v6;  ///< The seventh member of the tuple
-  T7 v7;  ///< The eighth member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- * @tparam T4 The fifth type stored in the tuple
- * @tparam T5 The sixth type stored in the tuple
- * @tparam T6 The seventh type stored in the tuple
- * @tparam T7 The eighth type stored in the tuple
- * @tparam T8 The ninth type stored in the tuple
- */
-template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
-          typename T8>
-struct tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8> {
-  T0 v0;  ///< The first member of the tuple
-  T1 v1;  ///< The second member of the tuple
-  T2 v2;  ///< The third member of the tuple
-  T3 v3;  ///< The fourth member of the tuple
-  T4 v4;  ///< The fifth member of the tuple
-  T5 v5;  ///< The sixth member of the tuple
-  T6 v6;  ///< The seventh member of the tuple
-  T7 v7;  ///< The eighth member of the tuple
-  T8 v8;  ///< The ninth member of the tuple
-};
-
-/**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- * @tparam T4 The fifth type stored in the tuple
- * @tparam T5 The sixth type stored in the tuple
- * @tparam T6 The seventh type stored in the tuple
- * @tparam T7 The eighth type stored in the tuple
- * @tparam T8 The ninth type stored in the tuple
- * @tparam T9 The tenth type stored in the tuple
+ * MFEM's tuple copy currently stores up to nine elements, while Smith's
+ * historical tuple API supports ten and eleven elements.
  */
 template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
           typename T8, typename T9>
@@ -220,19 +39,7 @@ struct tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9> {
 };
 
 /**
- * @brief Type that mimics std::tuple
- *
- * @tparam T0 The first type stored in the tuple
- * @tparam T1 The second type stored in the tuple
- * @tparam T2 The third type stored in the tuple
- * @tparam T3 The fourth type stored in the tuple
- * @tparam T4 The fifth type stored in the tuple
- * @tparam T5 The sixth type stored in the tuple
- * @tparam T6 The seventh type stored in the tuple
- * @tparam T7 The eighth type stored in the tuple
- * @tparam T8 The ninth type stored in the tuple
- * @tparam T9 The tenth type stored in the tuple
- * @tparam T10 The eleventh type stored in the tuple
+ * @brief Smith compatibility extension for the MFEM tuple implementation.
  */
 template <typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
           typename T8, typename T9, typename T10>
@@ -250,39 +57,12 @@ struct tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10> {
   T10 v10;  ///< The eleventh member of the tuple
 };
 
-/**
- * @brief Class template argument deduction rule for tuples
- * @tparam T The variadic template parameter for tuple types
- */
-template <typename... T>
-tuple(T...) -> tuple<T...>;
+namespace detail {
 
-/**
- * @brief helper function for combining a list of values into a tuple
- * @tparam T types of the values to be tuple-d
- * @param args the actual values to be put into a tuple
- */
-template <typename... T>
-SMITH_HOST_DEVICE tuple<T...> make_tuple(const T&... args)
+/// @brief Return element @p i from a 10- or 11-element tuple.
+template <int i, typename Tuple>
+MFEM_HOST_DEVICE constexpr auto& tuple_get_extended(Tuple& values)
 {
-  return tuple<T...>{args...};
-}
-
-template <class... Types>
-struct tuple_size {};
-
-template <class... Types>
-struct tuple_size<smith::tuple<Types...>> : std::integral_constant<std::size_t, sizeof...(Types)> {};
-
-/**
- * @tparam i the tuple index to access
- * @tparam T the types stored in the tuple
- * @brief return a reference to the ith tuple entry
- */
-template <int i, typename... T>
-SMITH_HOST_DEVICE constexpr auto& get(tuple<T...>& values)
-{
-  static_assert(i < sizeof...(T), "");
   if constexpr (i == 0) {
     return values.v0;
   }
@@ -316,17 +96,13 @@ SMITH_HOST_DEVICE constexpr auto& get(tuple<T...>& values)
   if constexpr (i == 10) {
     return values.v10;
   }
+  MFEM_UNREACHABLE();
 }
 
-/**
- * @tparam i the tuple index to access
- * @tparam T the types stored in the tuple
- * @brief return a copy of the ith tuple entry
- */
-template <int i, typename... T>
-SMITH_HOST_DEVICE constexpr const auto& get(const tuple<T...>& values)
+/// @brief Return const element @p i from a 10- or 11-element tuple.
+template <int i, typename Tuple>
+MFEM_HOST_DEVICE constexpr const auto& tuple_get_extended(const Tuple& values)
 {
-  static_assert(i < sizeof...(T), "");
   if constexpr (i == 0) {
     return values.v0;
   }
@@ -360,6 +136,45 @@ SMITH_HOST_DEVICE constexpr const auto& get(const tuple<T...>& values)
   if constexpr (i == 10) {
     return values.v10;
   }
+  MFEM_UNREACHABLE();
+}
+
+}  // namespace detail
+
+/// @brief Return mutable element @p i from a 10-element tuple.
+template <int i, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
+          typename T8, typename T9>
+MFEM_HOST_DEVICE constexpr auto& get(tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>& values)
+{
+  static_assert(i < 10);
+  return detail::tuple_get_extended<i>(values);
+}
+
+/// @brief Return mutable element @p i from an 11-element tuple.
+template <int i, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
+          typename T8, typename T9, typename T10>
+MFEM_HOST_DEVICE constexpr auto& get(tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>& values)
+{
+  static_assert(i < 11);
+  return detail::tuple_get_extended<i>(values);
+}
+
+/// @brief Return const element @p i from a 10-element tuple.
+template <int i, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
+          typename T8, typename T9>
+MFEM_HOST_DEVICE constexpr const auto& get(const tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>& values)
+{
+  static_assert(i < 10);
+  return detail::tuple_get_extended<i>(values);
+}
+
+/// @brief Return const element @p i from an 11-element tuple.
+template <int i, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
+          typename T8, typename T9, typename T10>
+MFEM_HOST_DEVICE constexpr const auto& get(const tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>& values)
+{
+  static_assert(i < 11);
+  return detail::tuple_get_extended<i>(values);
 }
 
 /**
@@ -368,489 +183,87 @@ SMITH_HOST_DEVICE constexpr const auto& get(const tuple<T...>& values)
  * @note type<i>(my_tuple) returns a value, whereas get<i>(my_tuple) returns a reference
  *
  * @tparam i the index of the tuple to query
- * @tparam T the types stored in the tuple
+ * @tparam T0 The first type stored in the tuple
+ * @tparam T1 The second type stored in the tuple
+ * @tparam T2 The third type stored in the tuple
+ * @tparam T3 The fourth type stored in the tuple
+ * @tparam T4 The fifth type stored in the tuple
+ * @tparam T5 The sixth type stored in the tuple
+ * @tparam T6 The seventh type stored in the tuple
+ * @tparam T7 The eighth type stored in the tuple
+ * @tparam T8 The ninth type stored in the tuple
+ * @tparam T9 The tenth type stored in the tuple
  * @param values the tuple of values
  * @return a copy of the ith entry of the input
  */
-template <int i, typename... T>
-SMITH_HOST_DEVICE constexpr auto type(const tuple<T...>& values)
+template <int i, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
+          typename T8, typename T9>
+MFEM_HOST_DEVICE constexpr auto type(const tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>& values)
 {
-  static_assert(i < sizeof...(T), "");
-  if constexpr (i == 0) {
-    return values.v0;
-  }
-  if constexpr (i == 1) {
-    return values.v1;
-  }
-  if constexpr (i == 2) {
-    return values.v2;
-  }
-  if constexpr (i == 3) {
-    return values.v3;
-  }
-  if constexpr (i == 4) {
-    return values.v4;
-  }
-  if constexpr (i == 5) {
-    return values.v5;
-  }
-  if constexpr (i == 6) {
-    return values.v6;
-  }
-  if constexpr (i == 7) {
-    return values.v7;
-  }
-  if constexpr (i == 8) {
-    return values.v8;
-  }
-  if constexpr (i == 9) {
-    return values.v9;
-  }
-  if constexpr (i == 10) {
-    return values.v10;
-  }
+  static_assert(i < 10);
+  return detail::tuple_get_extended<i>(values);
 }
 
 /**
- * @brief A helper function for the + operator of tuples
+ * @brief a function intended to be used for extracting the ith type from a tuple.
  *
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param y tuple of values
- * @return the returned tuple sum
- */
-template <typename... S, typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto plus_helper(const tuple<S...>& x, const tuple<T...>& y,
-                                             std::integer_sequence<int, i...>)
-{
-  return tuple{get<i>(x) + get<i>(y)...};
-}
-
-/**
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @param x a tuple of values
- * @param y a tuple of values
- * @brief return a tuple of values defined by elementwise sum of x and y
- */
-template <typename... S, typename... T>
-SMITH_HOST_DEVICE constexpr auto operator+(const tuple<S...>& x, const tuple<T...>& y)
-{
-  static_assert(sizeof...(S) == sizeof...(T));
-  return plus_helper(x, y, std::make_integer_sequence<int, static_cast<int>(sizeof...(S))>());
-}
-
-/**
- * @brief A helper function for the += operator of tuples
+ * @note type<i>(my_tuple) returns a value, whereas get<i>(my_tuple) returns a reference
  *
- * @tparam T the types stored in the tuples x and y
- * @tparam i integer sequence used to index the tuples
- * @param x tuple of values to be incremented
- * @param y tuple of increment values
+ * @tparam i the index of the tuple to query
+ * @tparam T0 The first type stored in the tuple
+ * @tparam T1 The second type stored in the tuple
+ * @tparam T2 The third type stored in the tuple
+ * @tparam T3 The fourth type stored in the tuple
+ * @tparam T4 The fifth type stored in the tuple
+ * @tparam T5 The sixth type stored in the tuple
+ * @tparam T6 The seventh type stored in the tuple
+ * @tparam T7 The eighth type stored in the tuple
+ * @tparam T8 The ninth type stored in the tuple
+ * @tparam T9 The tenth type stored in the tuple
+ * @tparam T10 The eleventh type stored in the tuple
+ * @param values the tuple of values
+ * @return a copy of the ith entry of the input
  */
-template <typename... T, int... i>
-SMITH_HOST_DEVICE constexpr void plus_equals_helper(tuple<T...>& x, const tuple<T...>& y,
-                                                    std::integer_sequence<int, i...>)
+template <int i, typename T0, typename T1, typename T2, typename T3, typename T4, typename T5, typename T6, typename T7,
+          typename T8, typename T9, typename T10>
+MFEM_HOST_DEVICE constexpr auto type(const tuple<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>& values)
 {
-  ((get<i>(x) += get<i>(y)), ...);
+  static_assert(i < 11);
+  return detail::tuple_get_extended<i>(values);
 }
 
-/**
- * @tparam T the types stored in the tuples x and y
- * @param x a tuple of values
- * @param y a tuple of values
- * @brief add values contained in y, to the tuple x
- */
+}  // namespace mfem::future
+
+namespace smith {
+
+/// @brief Expose MFEM tuple in the Smith namespace.
 template <typename... T>
-SMITH_HOST_DEVICE constexpr auto operator+=(tuple<T...>& x, const tuple<T...>& y)
-{
-  return plus_equals_helper(x, y, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
+using tuple = mfem::future::tuple<T...>;
 
-/**
- * @brief A helper function for the -= operator of tuples
- *
- * @tparam T the types stored in the tuples x and y
- * @tparam i integer sequence used to index the tuples
- * @param x tuple of values to be subracted from
- * @param y tuple of values to subtract from x
- */
-template <typename... T, int... i>
-SMITH_HOST_DEVICE constexpr void minus_equals_helper(tuple<T...>& x, const tuple<T...>& y,
-                                                     std::integer_sequence<int, i...>)
-{
-  ((get<i>(x) -= get<i>(y)), ...);
-}
+/// @brief Expose MFEM tuple application in the Smith namespace.
+using mfem::future::apply;
+/// @brief Expose MFEM tuple element access in the Smith namespace.
+using mfem::future::get;
+/// @brief Expose MFEM tuple construction in the Smith namespace.
+using mfem::future::make_tuple;
+/// @brief Expose MFEM tuple type selection in the Smith namespace.
+using mfem::future::type;
 
-/**
- * @tparam T the types stored in the tuples x and y
- * @param x a tuple of values
- * @param y a tuple of values
- * @brief add values contained in y, to the tuple x
- */
-template <typename... T>
-SMITH_HOST_DEVICE constexpr auto operator-=(tuple<T...>& x, const tuple<T...>& y)
-{
-  return minus_equals_helper(x, y, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
+/// @brief Alias for the MFEM tuple size trait.
+template <class... Types>
+using tuple_size = mfem::future::tuple_size<Types...>;
 
-/**
- * @brief A helper function for the - operator of tuples
- *
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param y tuple of values
- * @return the returned tuple difference
- */
-template <typename... S, typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto minus_helper(const tuple<S...>& x, const tuple<T...>& y,
-                                              std::integer_sequence<int, i...>)
-{
-  return tuple{get<i>(x) - get<i>(y)...};
-}
-
-/**
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @param x a tuple of values
- * @param y a tuple of values
- * @brief return a tuple of values defined by elementwise difference of x and y
- */
-template <typename... S, typename... T>
-SMITH_HOST_DEVICE constexpr auto operator-(const tuple<S...>& x, const tuple<T...>& y)
-{
-  static_assert(sizeof...(S) == sizeof...(T));
-  return minus_helper(x, y, std::make_integer_sequence<int, static_cast<int>(sizeof...(S))>());
-}
-
-/**
- * @brief A helper function for the - operator of tuples
- *
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @return the returned tuple difference
- */
-template <typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto unary_minus_helper(const tuple<T...>& x, std::integer_sequence<int, i...>)
-{
-  return tuple{-get<i>(x)...};
-}
-
-/**
- * @tparam T the types stored in the tuple y
- * @param x a tuple of values
- * @brief return a tuple of values defined by applying the unary minus operator to each element of x
- */
-template <typename... T>
-SMITH_HOST_DEVICE constexpr auto operator-(const tuple<T...>& x)
-{
-  return unary_minus_helper(x, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
-
-/**
- * @brief A helper function for the / operator of tuples
- *
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param y tuple of values
- * @return the returned tuple ratio
- */
-template <typename... S, typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto div_helper(const tuple<S...>& x, const tuple<T...>& y,
-                                            std::integer_sequence<int, i...>)
-{
-  return tuple{get<i>(x) / get<i>(y)...};
-}
-
-/**
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @param x a tuple of values
- * @param y a tuple of values
- * @brief return a tuple of values defined by elementwise division of x by y
- */
-template <typename... S, typename... T>
-SMITH_HOST_DEVICE constexpr auto operator/(const tuple<S...>& x, const tuple<T...>& y)
-{
-  static_assert(sizeof...(S) == sizeof...(T));
-  return div_helper(x, y, std::make_integer_sequence<int, static_cast<int>(sizeof...(S))>());
-}
-
-/**
- * @brief A helper function for the / operator of tuples
- *
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param a the constant numerator
- * @return the returned tuple ratio
- */
-template <typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto div_helper(const double a, const tuple<T...>& x, std::integer_sequence<int, i...>)
-{
-  return tuple{a / get<i>(x)...};
-}
-
-/**
- * @brief A helper function for the / operator of tuples
- *
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param a the constant denomenator
- * @return the returned tuple ratio
- */
-template <typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto div_helper(const tuple<T...>& x, const double a, std::integer_sequence<int, i...>)
-{
-  return tuple{get<i>(x) / a...};
-}
-
-/**
- * @tparam T the types stored in the tuple x
- * @param a the numerator
- * @param x a tuple of denominator values
- * @brief return a tuple of values defined by division of a by the elements of x
- */
-template <typename... T>
-SMITH_HOST_DEVICE constexpr auto operator/(const double a, const tuple<T...>& x)
-{
-  return div_helper(a, x, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
-
-/**
- * @tparam T the types stored in the tuple y
- * @param x a tuple of numerator values
- * @param a a denominator
- * @brief return a tuple of values defined by elementwise division of x by a
- */
-template <typename... T>
-SMITH_HOST_DEVICE constexpr auto operator/(const tuple<T...>& x, const double a)
-{
-  return div_helper(x, a, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
-
-/**
- * @brief A helper function for the * operator of tuples
- *
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param y tuple of values
- * @return the returned tuple product
- */
-template <typename... S, typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto mult_helper(const tuple<S...>& x, const tuple<T...>& y,
-                                             std::integer_sequence<int, i...>)
-{
-  return tuple{get<i>(x) * get<i>(y)...};
-}
-
-/**
- * @tparam S the types stored in the tuple x
- * @tparam T the types stored in the tuple y
- * @param x a tuple of values
- * @param y a tuple of values
- * @brief return a tuple of values defined by elementwise multiplication of x and y
- */
-template <typename... S, typename... T>
-SMITH_HOST_DEVICE constexpr auto operator*(const tuple<S...>& x, const tuple<T...>& y)
-{
-  static_assert(sizeof...(S) == sizeof...(T));
-  return mult_helper(x, y, std::make_integer_sequence<int, static_cast<int>(sizeof...(S))>());
-}
-
-/**
- * @brief A helper function for the * operator of tuples
- *
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param a a constant multiplier
- * @return the returned tuple product
- */
-template <typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto mult_helper(const double a, const tuple<T...>& x, std::integer_sequence<int, i...>)
-{
-  return tuple{a * get<i>(x)...};
-}
-
-/**
- * @brief A helper function for the * operator of tuples
- *
- * @tparam T the types stored in the tuple y
- * @tparam i The integer sequence to i
- * @param x tuple of values
- * @param a a constant multiplier
- * @return the returned tuple product
- */
-template <typename... T, int... i>
-SMITH_HOST_DEVICE constexpr auto mult_helper(const tuple<T...>& x, const double a, std::integer_sequence<int, i...>)
-{
-  return tuple{get<i>(x) * a...};
-}
-
-/**
- * @tparam T the types stored in the tuple
- * @param a a scaling factor
- * @param x the tuple object
- * @brief multiply each component of x by the value a on the left
- */
-template <typename... T>
-SMITH_HOST_DEVICE constexpr auto operator*(const double a, const tuple<T...>& x)
-{
-  return mult_helper(a, x, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
-
-/**
- * @tparam T the types stored in the tuple
- * @param x the tuple object
- * @param a a scaling factor
- * @brief multiply each component of x by the value a on the right
- */
-template <typename... T>
-SMITH_HOST_DEVICE constexpr auto operator*(const tuple<T...>& x, const double a)
-{
-  return mult_helper(x, a, std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
-
-/**
- * @tparam T the types stored in the tuple
- * @tparam i a list of indices used to acces each element of the tuple
- * @param out the ostream to write the output to
- * @param A the tuple of values
- * @brief helper used to implement printing a tuple of values
- */
-template <typename... T, std::size_t... i>
-auto& print_helper(std::ostream& out, const smith::tuple<T...>& A, std::integer_sequence<size_t, i...>)
-{
-  out << "tuple{";
-  (..., (out << (i == 0 ? "" : ", ") << smith::get<i>(A)));
-  out << "}";
-  return out;
-}
-
-/**
- * @tparam T the types stored in the tuple
- * @param out the ostream to write the output to
- * @param A the tuple of values
- * @brief print a tuple of values
- */
-template <typename... T>
-auto& operator<<(std::ostream& out, const smith::tuple<T...>& A)
-{
-  return print_helper(out, A, std::make_integer_sequence<size_t, sizeof...(T)>());
-}
-
-/**
- * @brief A helper to apply a lambda to a tuple
- *
- * @tparam lambda The functor type
- * @tparam T The tuple types
- * @tparam i The integer sequence to i
- * @param f The functor to apply to the tuple
- * @param args The input tuple
- * @return The functor output
- */
-template <typename lambda, typename... T, int... i>
-SMITH_HOST_DEVICE auto apply_helper(lambda f, tuple<T...>& args, std::integer_sequence<int, i...>)
-{
-  return f(get<i>(args)...);
-}
-
-/**
- * @tparam lambda a callable type
- * @tparam T the types of arguments to be passed in to f
- * @param f the callable object
- * @param args a tuple of arguments
- * @brief a way of passing an n-tuple to a function that expects n separate arguments
- *
- *   e.g. foo(bar, baz) is equivalent to apply(foo, smith::tuple(bar,baz));
- */
-template <typename lambda, typename... T>
-SMITH_HOST_DEVICE auto apply(lambda f, tuple<T...>& args)
-{
-  return apply_helper(f, std::move(args), std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
-
-/**
- * @overload
- */
-template <typename lambda, typename... T, int... i>
-SMITH_HOST_DEVICE auto apply_helper(lambda f, const tuple<T...>& args, std::integer_sequence<int, i...>)
-{
-  return f(get<i>(args)...);
-}
-
-/**
- * @tparam lambda a callable type
- * @tparam T the types of arguments to be passed in to f
- * @param f the callable object
- * @param args a tuple of arguments
- * @brief a way of passing an n-tuple to a function that expects n separate arguments
- *
- *   e.g. foo(bar, baz) is equivalent to apply(foo, smith::tuple(bar,baz));
- */
-template <typename lambda, typename... T>
-SMITH_HOST_DEVICE auto apply(lambda f, const tuple<T...>& args)
-{
-  return apply_helper(f, std::move(args), std::make_integer_sequence<int, static_cast<int>(sizeof...(T))>());
-}
-
-/**
- * @brief a struct used to determine the type at index I of a tuple
- *
- * @note see: https://en.cppreference.com/w/cpp/utility/tuple/tuple_element
- *
- * @tparam I the index of the desired type
- * @tparam T a tuple of different types
- */
+/// @brief Alias for the MFEM tuple element trait.
 template <size_t I, class T>
-struct tuple_element;
+using tuple_element = mfem::future::tuple_element<I, T>;
 
-// recursive case
-/// @overload
-template <size_t I, class Head, class... Tail>
-struct tuple_element<I, tuple<Head, Tail...>> : tuple_element<I - 1, tuple<Tail...>> {};
-
-// base case
-/// @overload
-template <class Head, class... Tail>
-struct tuple_element<0, tuple<Head, Tail...>> {
-  using type = Head;  ///< the type at the specified index
-};
-
-/**
- * @brief Trait for checking if a type is a @p smith::tuple
- */
+/// @brief Alias for the MFEM tuple detection trait.
 template <typename T>
-struct is_tuple : std::false_type {};
+using is_tuple = mfem::future::is_tuple<T>;
 
-/// @overload
-template <typename... T>
-struct is_tuple<smith::tuple<T...>> : std::true_type {};
-
-/**
- * @brief Trait for checking if a type if a @p smith::tuple containing only @p smith::tuple
- */
+/// @brief Alias for the MFEM nested tuple detection trait.
 template <typename T>
-struct is_tuple_of_tuples : std::false_type {};
-
-/**
- * @brief Trait for checking if a type if a @p smith::tuple containing only @p smith::tuple
- */
-template <typename... T>
-struct is_tuple_of_tuples<smith::tuple<T...>> {
-  static constexpr bool value = (is_tuple<T>::value && ...);  ///< true/false result of type check
-};
+using is_tuple_of_tuples = mfem::future::is_tuple_of_tuples<T>;
 
 }  // namespace smith
 

--- a/src/smith/numerics/functional/tuple.hpp
+++ b/src/smith/numerics/functional/tuple.hpp
@@ -11,7 +11,7 @@
  */
 #pragma once
 
-#include "mfem/fem/dfem/tuple.hpp"
+#include "mfem.hpp"
 
 #include "smith/infrastructure/accelerator.hpp"
 

--- a/src/smith/numerics/functional/tuple_tensor_dual_functions.hpp
+++ b/src/smith/numerics/functional/tuple_tensor_dual_functions.hpp
@@ -332,8 +332,7 @@ SMITH_HOST_DEVICE auto get_gradient(const tensor<dual<smith::tuple<T...>>, n...>
 template <typename... T>
 SMITH_HOST_DEVICE auto get_gradient(smith::tuple<T...> tuple_of_values)
 {
-  return smith::apply([](auto... each_value) { return smith::tuple{get_gradient(each_value)...}; },
-                      tuple_of_values);
+  return smith::apply([](auto... each_value) { return smith::tuple{get_gradient(each_value)...}; }, tuple_of_values);
 }
 
 /**

--- a/src/smith/numerics/functional/tuple_tensor_dual_functions.hpp
+++ b/src/smith/numerics/functional/tuple_tensor_dual_functions.hpp
@@ -277,6 +277,18 @@ constexpr auto make_dual_wrt(const smith::tuple<T...>& args)
 }
 
 /**
+ * @brief Retrieves the value components of a set of (possibly dual) numbers
+ * @param[in] tuple_of_values The tuple of numbers to retrieve values from
+ * @pre The tuple must contain only scalars or tensors of @p dual numbers or doubles
+ */
+template <typename... T>
+SMITH_HOST_DEVICE auto get_value(const smith::tuple<T...>& tuple_of_values)
+{
+  return smith::apply([](const auto&... each_value) { return smith::tuple{get_value(each_value)...}; },
+                      tuple_of_values);
+}
+
+/**
  * @brief Extracts all of the values from a tensor of dual numbers
  *
  * @tparam T1 the first type of the tuple stored in the tensor
@@ -288,23 +300,11 @@ constexpr auto make_dual_wrt(const smith::tuple<T...>& args)
 template <typename T1, typename T2, int n>
 SMITH_HOST_DEVICE auto get_value(const tensor<tuple<T1, T2>, n>& input)
 {
-  tensor<decltype(get_value(tuple<T1, T2>{})), n> output{};
+  tensor<decltype(smith::get_value(smith::tuple<T1, T2>{})), n> output{};
   for (int i = 0; i < n; i++) {
     output[i] = get_value(input[i]);
   }
   return output;
-}
-
-/**
- * @brief Retrieves the value components of a set of (possibly dual) numbers
- * @param[in] tuple_of_values The tuple of numbers to retrieve values from
- * @pre The tuple must contain only scalars or tensors of @p dual numbers or doubles
- */
-template <typename... T>
-SMITH_HOST_DEVICE auto get_value(const smith::tuple<T...>& tuple_of_values)
-{
-  return smith::apply([](const auto&... each_value) { return smith::tuple{get_value(each_value)...}; },
-                      tuple_of_values);
 }
 
 /**
@@ -332,7 +332,8 @@ SMITH_HOST_DEVICE auto get_gradient(const tensor<dual<smith::tuple<T...>>, n...>
 template <typename... T>
 SMITH_HOST_DEVICE auto get_gradient(smith::tuple<T...> tuple_of_values)
 {
-  return smith::apply([](auto... each_value) { return smith::tuple{get_gradient(each_value)...}; }, tuple_of_values);
+  return smith::apply([](auto... each_value) { return smith::tuple{get_gradient(each_value)...}; },
+                      tuple_of_values);
 }
 
 /**


### PR DESCRIPTION
This removes a large portion of the implementation in Smith. Originally I was going to swap completely over to the `mfem::tuple` but it exists in a `future` namespace and it would have bled over all codebase. We might want to do that when it gets out of the `future` namespace and when we don't have large PRs up.