### PR TITLE
Pin github actions to prevent possible security issue

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -68,7 +68,7 @@ jobs:
       options: --user root
     steps:
       - name: Checkout Smith
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
       - name: Print Matrix Variables
@@ -89,7 +89,7 @@ jobs:
       - name: Upload Test Results
         # CUDA containers do not run tests, because runners don't have GPUs, so skip upload in that case
         if: ${{ matrix.config.compiler_image != needs.set_image_vars.outputs.cuda_docker_image }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: Test Results ${{ matrix.config.host_config }} ${{ matrix.build_type }} ${{ matrix.config.cmake_opts }}
           path: "**/Test.xml"
@@ -114,14 +114,14 @@ jobs:
         HOST_CONFIG: llvm@19.1.1.cmake
     steps:
     - name: Checkout Smith
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         submodules: recursive
     - name: Check ${{ matrix.check_type }}
       run: ./scripts/github-actions/linux-check.sh 
     - name: Upload coverage to Codecov
       if: ${{ matrix.check_type == 'coverage' }}
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
       with:
         fail_ci_if_error: true
         files: smith_coverage.info.cleaned

--- a/.github/workflows/docker_build_tpls.yml
+++ b/.github/workflows/docker_build_tpls.yml
@@ -45,20 +45,20 @@ jobs:
         sudo docker image prune --all --force
 
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
     - name: Login to DockerHub
-      uses: docker/login-action@v3
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
     - name: Build and push
       id: docker_build
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7
       with:
         push: true
         tags: ${{ steps.repo_name.outputs.repo_plus_tag }},${{ steps.repo_name.outputs.repo_plus_latest }}
@@ -77,7 +77,7 @@ jobs:
         docker rm extract_hc
     
     - name: Upload hostconfig
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
       with:
         name: ${{ matrix.dockerfile_suffix }}_hostconfigs
         path: ./extracted_hc/export_hostconfig/*


### PR DESCRIPTION
Tags can be changed to point to different commits while commits can not. This is recommended to avoid security vulnerabilities and also improves stability.