### PR TITLE
Create script to help developers avoid exceeding disk quota on LC

### DIFF
--- a/scripts/setup_jacamar_ci.sh
+++ b/scripts/setup_jacamar_ci.sh
@@ -54,7 +54,7 @@ cron_script_contents() {
 0,20,40 * * * * crontab ${CRON_SCRIPT_PATH}
 
 # Remove contents of Jacamar CI that are older than 48 hours
-0 0 * * * srun -N1 find "${WORKSPACE_CI_DIR}" -mindepth 1 -maxdepth 1 -mtime +1 -exec rm -rf -- {} +
+0 0 * * * srun -N1 find "${WORKSPACE_CI_DIR}" -mindepth 1 -mtime +1 -exec rm -rf -- {} +
 EOF
 }
 

--- a/scripts/setup_jacamar_ci.sh
+++ b/scripts/setup_jacamar_ci.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Redirect Jacamar CI from your HOME directory to your LC workspace and periodically cleanup CI jobs to avoid exceeding
+# disk quota
+#
+# Some things to note:
+# - Running this script on oslic is recommended, because its best suited for file IO
+# - It's important to understand that Cron jobs are installed per node (not per machine!), so do not run this script
+#   more than once unless you know what you're doing.
+# - For more info on Cron, see https://myconfluence.llnl.gov/spaces/RAM/pages/417729120/Cron+-+how+it+can+be+useful+for+triggering+work+at+a+given+time
+
+set -euo pipefail
+
+USER_NAME="$(whoami)"
+HOST_NAME="$(hostname)"
+WORKSPACE_CI_DIR="/usr/workspace/${USER_NAME}/.jacamar-ci"
+HOME_CI_LINK="${HOME}/.jacamar-ci"
+CRON_DIR="${HOME}/crontabs"
+CRON_SCRIPT_PATH="${CRON_DIR}/${HOST_NAME}Cron"
+
+echo "Starting setup for user: ${USER_NAME}"
+echo "Host: ${HOST_NAME}"
+
+# Error checking. Guard against running this script more than once.
+if [ -e "${WORKSPACE_CI_DIR}" ]; then
+  echo "Workspace CI directory already exists at: ${WORKSPACE_CI_DIR}"
+  exit 1
+# fi
+if [ -e "${CRON_DIR}" ]; then
+  echo "Cron directory already exists at: ${CRON_DIR}."
+  echo "If you want to regenerate your Cron job, first log into the specific node that has the job, then delete"
+  echo "it with 'crontab -r'. After that you can safely remove the crontab directory in your HOME directory."
+  exit 1
+fi
+
+# Setup symlink
+echo "Creating symlink: ${HOME_CI_LINK} -> ${WORKSPACE_CI_DIR}"
+rm -rf "${HOME_CI_LINK}"
+mkdir "${WORKSPACE_CI_DIR}"
+ln -s "${WORKSPACE_CI_DIR}" "${HOME_CI_LINK}"
+
+# Setup Cron job
+cron_script_contents() {
+  cat <<EOF
+# For more information about using Cron on LC:
+# https://myconfluence.llnl.gov/spaces/RAM/pages/417729120/Cron+-+how+it+can+be+useful+for+triggering+work+at+a+given+time
+
+# Allows you to update your Cron job without having to go to the specific node
+0,20,40 * * * * crontab ${CRON_SCRIPT_PATH}
+
+# Remove contents of Jacamar CI
+0 0 * * * srun -N1 rm -rf ${WORKSPACE_CI_DIR}/*
+EOF
+}
+
+echo "Writing Cron file to: ${CRON_SCRIPT_PATH}"
+mkdir "${CRON_DIR}"
+cron_script_contents > "${CRON_SCRIPT_PATH}"
+crontab "${CRON_SCRIPT_PATH}"

--- a/scripts/setup_jacamar_ci.sh
+++ b/scripts/setup_jacamar_ci.sh
@@ -24,7 +24,11 @@ echo "Host: ${HOST_NAME}"
 if [ -e "${WORKSPACE_CI_DIR}" ]; then
   echo "Workspace CI directory already exists at: ${WORKSPACE_CI_DIR}"
   exit 1
-# fi
+fi
+if [ -n "$(crontab -l 2>/dev/null)" ] ; then
+  echo "A cron job has already installed on ${HOSTNAME}."
+  exit 1
+fi
 if [ -e "${CRON_DIR}" ]; then
   echo "Cron directory already exists at: ${CRON_DIR}."
   echo "If you want to regenerate your Cron job, first log into the specific node that has the job, then delete"
@@ -41,6 +45,8 @@ ln -s "${WORKSPACE_CI_DIR}" "${HOME_CI_LINK}"
 # Setup Cron job
 cron_script_contents() {
   cat <<EOF
+# This cron job has been installed on $HOST_NAME.
+
 # For more information about using Cron on LC:
 # https://myconfluence.llnl.gov/spaces/RAM/pages/417729120/Cron+-+how+it+can+be+useful+for+triggering+work+at+a+given+time
 
@@ -53,6 +59,6 @@ EOF
 }
 
 echo "Writing Cron file to: ${CRON_SCRIPT_PATH}"
-mkdir "${CRON_DIR}"
+mkdir -p "${CRON_DIR}"
 cron_script_contents > "${CRON_SCRIPT_PATH}"
 crontab "${CRON_SCRIPT_PATH}"

--- a/scripts/setup_jacamar_ci.sh
+++ b/scripts/setup_jacamar_ci.sh
@@ -53,8 +53,8 @@ cron_script_contents() {
 # Allows you to update your Cron job without having to go to the specific node
 0,20,40 * * * * crontab ${CRON_SCRIPT_PATH}
 
-# Remove contents of Jacamar CI
-0 0 * * * srun -N1 rm -rf ${WORKSPACE_CI_DIR}/*
+# Remove contents of Jacamar CI that are older than 48 hours
+0 0 * * * srun -N1 find "${WORKSPACE_CI_DIR}" -mindepth 1 -maxdepth 1 -mtime +1 -exec rm -rf -- {} +
 EOF
 }
 


### PR DESCRIPTION
Now that we are using Hubcast, CI will run as the developer who pushes the commit, merges the branch, etc. Because of this, each Smith developer is at risk of exceeding disk quota. This script helps prevent that by doing the following two things

1. setup symlink pointing the jacamar ci directory out of the HOME directory and to the workspace
2. create a cron job that will periodically (daily at midnight) remove the contents of the jacamar ci

I'm sort of worried that people will create conflicting cron jobs across multiple machine nodes so I created some checks to avoid it.