### PR TITLE
fix contact_finite_diff intermittent error

### DIFF
--- a/src/smith/physics/tests/contact_finite_diff.cpp
+++ b/src/smith/physics/tests/contact_finite_diff.cpp
@@ -80,7 +80,7 @@ TEST_P(ContactFiniteDiff, patch)
 #endif
 
   // Do a single iteration per timestep to check gradient for each iteration
-  NonlinearSolverOptions nonlinear_options{.nonlin_solver = NonlinearSolver::Newton,
+  NonlinearSolverOptions nonlinear_options{.nonlin_solver = NonlinearSolver::NewtonLineSearch,
                                            .relative_tol = 1.0e-15,
                                            .absolute_tol = 1.0e-15,
                                            .max_iterations = 1,


### PR DESCRIPTION
I hit this failure multiple times in a row:

```
  75: Assertion failed: (mfem::IsFinite(norm)) is false:
  75:  --> norm = nan
  75:  ... in function: virtual void smith::NewtonSolver::Mult(const mfem::Vector &,
  mfem::Vector &) const
  75:  ... in file: /gitlabbuilds/LFzxfHnsE/000/gitlab/smith/smith/src/smith/numerics/equation_solver.cpp:230
```

As much as it pains me to just copy/paste an AI explanation, this is out of my ability. @ebchin can you verify this? If it makes no sense I'll close the PR.

Changed src/smith/physics/tests/contact_finite_diff.cpp to use
NonlinearSolver::NewtonLineSearch instead of NonlinearSolver::Newton.

The test still limits each timestep solve to one nonlinear iteration with
max_iterations = 1. That preserves the intent of the regression test: check the
contact Jacobian against finite differences at each timestep rather than drive
the nonlinear solve to convergence.

The failing path was plain Newton accepting an undamped full step during
advanceTimestep(). For this small contact problem, that can leave the contact
state in a configuration where the next residual evaluation produces a NaN
norm, triggering the NewtonSolver::Mult finite-norm assertion. Using the
existing line-search Newton path allows the one allowed nonlinear iteration to
cut back an unstable step before it is accepted.