### PR TITLE
Make mfem::FiniteElementSpace a std::shared_ptr in FiniteElementVector

### DIFF
--- a/src/smith/physics/state/finite_element_dual.hpp
+++ b/src/smith/physics/state/finite_element_dual.hpp
@@ -58,13 +58,10 @@ class FiniteElementDual : public FiniteElementVector {
   /**
    * @brief Move assignment
    *
-   * @note Move assignment is deleted because replacing a registered dual's identity and FE space does not interact
-   * well with StateManager.
-   *
    * @param rhs The right hand side input Dual
    * @return The assigned FiniteElementDual
    */
-  FiniteElementDual& operator=(FiniteElementDual&& rhs) = delete;
+  FiniteElementDual& operator=(FiniteElementDual&& rhs) = default;
 
   /**
    * @brief Copy assignment

--- a/src/smith/physics/state/finite_element_state.hpp
+++ b/src/smith/physics/state/finite_element_state.hpp
@@ -147,13 +147,10 @@ class FiniteElementState : public FiniteElementVector {
   /**
    * @brief Move assignment
    *
-   * @note Move assignment is deleted because replacing a registered state's identity and FE space does not interact
-   * well with StateManager.
-   *
    * @param rhs The right hand side input State
    * @return The assigned FiniteElementState
    */
-  FiniteElementState& operator=(FiniteElementState&& rhs) = delete;
+  FiniteElementState& operator=(FiniteElementState&& rhs) = default;
 
   /**
    * @brief Copy assignment with HypreParVector

--- a/src/smith/physics/state/finite_element_vector.hpp
+++ b/src/smith/physics/state/finite_element_vector.hpp
@@ -194,13 +194,15 @@ class FiniteElementVector : public mfem::HypreParVector {
   std::reference_wrapper<mfem::ParMesh> mesh_;
 
   /**
-   * @brief Handle to the FiniteElementCollection. Shared to ensure it outlives any Sidre grid functions.
+   * @brief Handle to the FiniteElementCollection. Shared to allow safe memory management when multiple vectors or grid
+   * functions use the same collection.
    * @note Must be const as FESpaces store a const reference to their FEColls
    */
   std::shared_ptr<mfem::FiniteElementCollection> coll_;
 
   /**
-   * @brief Handle to the mfem::ParFiniteElementSpace. Shared to ensure it outlives any Sidre grid functions.
+   * @brief Handle to the mfem::ParFiniteElementSpace. Shared to allow safe memory management when multiple vectors or
+   * grid functions use the same space.
    */
   std::shared_ptr<mfem::ParFiniteElementSpace> space_;
 

--- a/src/smith/physics/state/finite_element_vector.hpp
+++ b/src/smith/physics/state/finite_element_vector.hpp
@@ -163,6 +163,16 @@ class FiniteElementVector : public mfem::HypreParVector {
   std::string name() const { return name_; }
 
   /**
+   * @brief Get a shared pointer to the internal ParFiniteElementSpace
+   */
+  std::shared_ptr<mfem::ParFiniteElementSpace> shared_space() const { return space_; }
+
+  /**
+   * @brief Get a shared pointer to the internal FiniteElementCollection
+   */
+  std::shared_ptr<mfem::FiniteElementCollection> shared_coll() const { return coll_; }
+
+  /**
    * @brief Set a finite element state to a constant value
    *
    * @param value The constant to set the finite element state to
@@ -184,15 +194,15 @@ class FiniteElementVector : public mfem::HypreParVector {
   std::reference_wrapper<mfem::ParMesh> mesh_;
 
   /**
-   * @brief Handle to the FiniteElementCollection, which is owned by MFEMSidreDataCollection
+   * @brief Handle to the FiniteElementCollection. Shared to ensure it outlives any Sidre grid functions.
    * @note Must be const as FESpaces store a const reference to their FEColls
    */
-  std::unique_ptr<mfem::FiniteElementCollection> coll_;
+  std::shared_ptr<mfem::FiniteElementCollection> coll_;
 
   /**
-   * @brief Handle to the mfem::ParFiniteElementSpace, which is owned by MFEMSidreDataCollection
+   * @brief Handle to the mfem::ParFiniteElementSpace. Shared to ensure it outlives any Sidre grid functions.
    */
-  std::unique_ptr<mfem::ParFiniteElementSpace> space_;
+  std::shared_ptr<mfem::ParFiniteElementSpace> space_;
 
   /**
    * @brief The name of the finite element vector

--- a/src/smith/physics/state/state_manager.cpp
+++ b/src/smith/physics/state/state_manager.cpp
@@ -30,6 +30,8 @@ std::unordered_map<std::string, mfem::ParGridFunction*> StateManager::named_stat
 std::unordered_map<std::string, mfem::ParGridFunction*> StateManager::named_duals_;
 std::vector<std::unique_ptr<mfem::ParGridFunction>> StateManager::owned_states_;
 std::vector<std::unique_ptr<mfem::ParGridFunction>> StateManager::owned_duals_;
+std::vector<std::shared_ptr<mfem::ParFiniteElementSpace>> StateManager::owned_spaces_;
+std::vector<std::shared_ptr<mfem::FiniteElementCollection>> StateManager::owned_colls_;
 
 double StateManager::newDataCollection(const std::string& mesh_tag, const std::optional<int> cycle_to_load)
 {
@@ -156,6 +158,10 @@ void StateManager::storeState(FiniteElementState& state)
     datacoll.RegisterField(name, grid_function);
     state.fillGridFunction(*grid_function);
     owned_states_.push_back(std::move(owned_grid_function));
+
+    // Keep a shared pointer to the space and collection so they outlive the user's FiniteElementState instance
+    owned_spaces_.push_back(state.shared_space());
+    owned_colls_.push_back(state.shared_coll());
   }
   named_states_[name] = grid_function;
 }
@@ -194,6 +200,10 @@ void StateManager::storeDual(FiniteElementDual& dual)
     datacoll.RegisterField(name, grid_function);
     grid_function->SetFromTrueDofs(dual);
     owned_duals_.push_back(std::move(owned_grid_function));
+
+    // Keep a shared pointer to the space and collection so they outlive the user's FiniteElementDual instance
+    owned_spaces_.push_back(dual.shared_space());
+    owned_colls_.push_back(dual.shared_coll());
   }
   named_duals_[name] = grid_function;
 }

--- a/src/smith/physics/state/state_manager.hpp
+++ b/src/smith/physics/state/state_manager.hpp
@@ -342,6 +342,8 @@ class StateManager {
     named_duals_.clear();
     owned_states_.clear();
     owned_duals_.clear();
+    owned_spaces_.clear();
+    owned_colls_.clear();
     shape_displacements_.clear();
     shape_displacement_duals_.clear();
     datacolls_.clear();
@@ -538,6 +540,13 @@ class StateManager {
   /// @brief Dual grid functions allocated by StateManager and registered as non-owning data in Sidre.
   /// Used for lifetime management only. May not contain all duals (for example, restarted duals).
   static std::vector<std::unique_ptr<mfem::ParGridFunction>> owned_duals_;
+
+  /// @brief Spaces allocated by StateManager and registered as non-owning data in Sidre.
+  /// Shared ownership ensures the space outlives any user-held FiniteElementVector copies.
+  static std::vector<std::shared_ptr<mfem::ParFiniteElementSpace>> owned_spaces_;
+  /// @brief Collections allocated by StateManager and registered as non-owning data in Sidre.
+  /// Shared ownership ensures the collection outlives any user-held FiniteElementVector copies.
+  static std::vector<std::shared_ptr<mfem::FiniteElementCollection>> owned_colls_;
 };
 
 /// @brief Check that a mesh satisfies our required properties

--- a/src/smith/physics/state/tests/test_state_manager.cpp
+++ b/src/smith/physics/state/tests/test_state_manager.cpp
@@ -253,6 +253,42 @@ TEST(StateManager, ResetDoesNotDeleteExternallySharedMesh)
   EXPECT_EQ(2, mesh->Dimension());
 }
 
+TEST(StateManager, MoveAssignmentLifetime)
+{
+  std::string name = "move_assignment_test";
+  axom::sidre::DataStore datastore;
+  const std::string output_dir = name + "_data";
+
+  if (axom::utilities::filesystem::pathExists(output_dir)) {
+    GTEST_SKIP() << "Output directory already exists from a prior run: " << output_dir;
+  }
+  if (axom::utilities::filesystem::makeDirsForPath(output_dir) != 0) {
+    GTEST_SKIP() << "Could not create output directory: " << output_dir;
+  }
+  StateManager::initialize(datastore, output_dir);
+
+  std::string filename = SMITH_REPO_DIR "/data/meshes/ball.mesh";
+  std::string mesh_tag = "ball_mesh";
+  auto mesh = mesh::refineAndDistribute(buildMeshFromFile(filename), 0, 0);
+  StateManager::setMesh(std::move(mesh), mesh_tag);
+
+  {
+    // Create an initial state via StateManager
+    smith::FiniteElementState state1 = smith::StateManager::newState(smith::H1<1>{}, "my_field", mesh_tag);
+    state1 = 1.0;
+
+    // Move-assign it into a brand new state
+    smith::FiniteElementState state2(smith::StateManager::mesh(mesh_tag), smith::H1<1>{}, "dummy");
+    state2 = std::move(state1);
+    state2 = 2.0;
+
+    // Both state1 and state2 go out of scope here and are destroyed
+  }
+
+  // Now, StateManager attempts to save. This should work since state1 and state2's space are saved as std::shared_ptr.
+  EXPECT_NO_THROW(smith::StateManager::save(0.0, 1, mesh_tag));
+}
+
 }  // namespace smith
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
- Allows StateManager's FESpace to remain valid even if a user-held FE Space or Dual's space is overwritten or goes out of scope
- Reinstates move assignment for FE Dual and FE Space, since they no longer break StateManager