### PR TITLE
fix -Wdocumentation warnings

### DIFF
--- a/src/smith/numerics/functional/boundary_integral_kernels.hpp
+++ b/src/smith/numerics/functional/boundary_integral_kernels.hpp
@@ -243,7 +243,7 @@ SMITH_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, c
  * inherently just a linear transformation
  *
  * @param[in] dU The full set of per-element DOF values (primary input)
- * @param[inout] dR The full set of per-element residuals (primary output)
+ * @param[in,out] dR The full set of per-element residuals (primary output)
  * @param[in] derivatives_ptr The address at which derivatives of the q-function with
  * respect to its arguments are stored
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
@@ -291,7 +291,7 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
  * @tparam derivatives_type Type representing the derivative of the q-function w.r.t. its input arguments
  *
  *
- * @param[inout] dk 3-dimensional array storing the element gradient matrices
+ * @param[in,out] dk 3-dimensional array storing the element gradient matrices
  * @param[in] derivatives_ptr pointer to data describing the derivatives of the q-function with respect to its arguments
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
  * @see mfem::GeometricFactors

--- a/src/smith/numerics/functional/domain_integral_kernels.cuh
+++ b/src/smith/numerics/functional/domain_integral_kernels.cuh
@@ -83,7 +83,7 @@ SMITH_HOST_DEVICE constexpr derivatives_type& AccessDerivatives(derivatives_type
  * @tparam position_type quadrature point position
  *
  * @param[in] u The element DOF values (primary input)
- * @param[inout] r The element residuals (primary output)
+ * @param[in,out] r The element residuals (primary output)
  * @param[out] derivatives_ptr The address at which derivatives of @a lambda with
  * respect to its arguments will be stored
  * @param[in] J The Jacobians of the element transformation at all quadrature points
@@ -91,7 +91,7 @@ SMITH_HOST_DEVICE constexpr derivatives_type& AccessDerivatives(derivatives_type
  * @see mfem::GeometricFactors
  * @param[in] num_elements The number of elements in the mesh
  * @param[in] qf The actual quadrature function, see @p lambda
- * @param[inout] data The data for each quadrature point
+ * @param[in,out] data The data for each quadrature point
  */
 
 template <mfem::Geometry::Type g, typename test, typename trial, int Q, typename derivatives_type, typename lambda,
@@ -178,7 +178,7 @@ __global__ void eval_cuda_element(const solution_type u, residual_type r, deriva
  * @tparam position_type quadrature point position
  *
  * @param[in] u The element DOF values (primary input)
- * @param[inout] r The element residuals (primary output)
+ * @param[in,out] r The element residuals (primary output)
  * @param[out] derivatives_ptr The address at which derivatives of @a lambda with
  * respect to its arguments will be stored
  * @param[in] J The Jacobians of the element transformation at all quadrature points
@@ -186,7 +186,7 @@ __global__ void eval_cuda_element(const solution_type u, residual_type r, deriva
  * @see mfem::GeometricFactors
  * @param[in] num_elements The number of elements in the mesh
  * @param[in] qf The actual quadrature function, see @p lambda
- * @param[inout] data The data for each quadrature point
+ * @param[in,out] data The data for each quadrature point
  */
 template <mfem::Geometry::Type g, typename test, typename trial, int Q, typename derivatives_type, typename lambda,
           typename solution_type, typename residual_type, typename jacobian_type, typename position_type,
@@ -263,7 +263,7 @@ __global__ void eval_cuda_quadrature(const solution_type u, residual_type r,
  *
  * @param[in] config Execution configuration for the GPU kernel
  * @param[in] U The full set of per-element DOF values (primary input)
- * @param[inout] R The full set of per-element residuals (primary output)
+ * @param[in,out] R The full set of per-element residuals (primary output)
  * @param[out] derivatives_ptr The address at which derivatives of @a lambda with
  * respect to its arguments will be stored
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
@@ -271,7 +271,7 @@ __global__ void eval_cuda_quadrature(const solution_type u, residual_type r,
  * @see mfem::GeometricFactors
  * @param[in] num_elements The number of elements in the mesh
  * @param[in] qf The actual quadrature function, see @p lambda
- * @param[inout] data The data for each quadrature point
+ * @param[in,out] data The data for each quadrature point
  */
 
 template <mfem::Geometry::Type g, typename test, typename trial, int Q,
@@ -337,7 +337,7 @@ void evaluation_kernel_cuda(smith::detail::GPULaunchConfiguration config, const 
  * @tparam dresidual_type element residual
  *
  * @param[in] dU The element DOF values (primary input)
- * @param[inout] dR The element residuals (primary output)
+ * @param[in,out] dR The element residuals (primary output)
  * @param[in] derivatives_ptr The address at which derivatives of the q-function with
  * respect to its arguments are stored
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
@@ -414,7 +414,7 @@ __global__ void gradient_cuda_element(const dsolution_type du, dresidual_type dr
  * @tparam dresidual_type element residual
  *
  * @param[in] dU The element DOF values (primary input)
- * @param[inout] dR The element residuals (primary output)
+ * @param[in,out] dR The element residuals (primary output)
  * @param[in] derivatives_ptr The address at which derivatives of the q-function with
  * respect to its arguments are stored
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
@@ -490,7 +490,7 @@ __global__ void gradient_cuda_quadrature(const dsolution_type du, dresidual_type
  *
  * @param[in] config Execution configuration for the GPU kernel
  * @param[in] dU The full set of per-element DOF values (primary input)
- * @param[inout] dR The full set of per-element residuals (primary output)
+ * @param[in,out] dR The full set of per-element residuals (primary output)
  * @param[in] derivatives_ptr The address at which derivatives of the q-function with
  * respect to its arguments are stored
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points

--- a/src/smith/numerics/functional/domain_integral_kernels.hpp
+++ b/src/smith/numerics/functional/domain_integral_kernels.hpp
@@ -86,7 +86,7 @@ SMITH_HOST_DEVICE auto apply_qf_helper(const lambda& qf, double t, const coords_
  * @param[in] qf The quadrature function functor object
  * @param[in] x_q The physical coordinates of the quadrature point
  * @param[in] arg_tuple The values and derivatives at the quadrature point, as a dual
- * @param[inout] qpt_data The state information at the quadrature point
+ * @param[in,out] qpt_data The state information at the quadrature point
  */
 template <typename lambda, typename coords_type, typename... T, typename qpt_data_type>
 SMITH_HOST_DEVICE auto apply_qf(const lambda& qf, double t, const coords_type& x_q, qpt_data_type& qpt_data,
@@ -269,7 +269,7 @@ SMITH_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, c
  * inherently just a linear transformation
  *
  * @param[in] dU The full set of per-element DOF values (primary input)
- * @param[inout] dR The full set of per-element residuals (primary output)
+ * @param[in,out] dR The full set of per-element residuals (primary output)
  * @param[in] derivatives_ptr The address at which derivatives of the q-function with
  * respect to its arguments are stored
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
@@ -320,7 +320,7 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
  * @tparam derivatives_type Type representing the derivative of the q-function w.r.t. its input arguments
  *
  *
- * @param[inout] dk 3-dimensional array storing the element gradient matrices
+ * @param[in,out] dk 3-dimensional array storing the element gradient matrices
  * @param[in] derivatives_ptr pointer to data describing the derivatives of the q-function with respect to its arguments
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
  * @see mfem::GeometricFactors

--- a/src/smith/numerics/functional/functional.hpp
+++ b/src/smith/numerics/functional/functional.hpp
@@ -386,7 +386,7 @@ class Functional<test(trials...), exec> {
    * @param[in] domain The domain on which to evaluate the integral
    * @note The @p Dimension parameters are used to assist in the deduction of the @a geometry_dim
    * and @a spatial_dim template parameter
-   * @param[inout] qdata The data for each quadrature point
+   * @param[in,out] qdata The data for each quadrature point
    */
   template <int dim, int... args, typename lambda, typename qpt_data_type = Nothing>
   void AddDomainIntegral(Dimension<dim>, DependsOn<args...>, const lambda& integrand, Domain& domain,
@@ -465,7 +465,7 @@ class Functional<test(trials...), exec> {
    * @param[in] which_args a tag type used to indicate which trial spaces are required by this calculation
    * @param[in] integrand The quadrature function
    * @param[in] domain The mesh to evaluate the integral on
-   * @param[inout] data The data for each quadrature point
+   * @param[in,out] data The data for each quadrature point
    */
   template <int... args, typename lambda, typename qpt_data_type = Nothing>
   void AddAreaIntegral(DependsOn<args...> which_args, const lambda& integrand, Domain& domain,
@@ -481,7 +481,7 @@ class Functional<test(trials...), exec> {
    * @param[in] which_args a tag type used to indicate which trial spaces are required by this calculation
    * @param[in] integrand The quadrature function
    * @param[in] domain The mesh to evaluate the integral on
-   * @param[inout] data The data for each quadrature point
+   * @param[in,out] data The data for each quadrature point
    */
   template <int... args, typename lambda, typename qpt_data_type = Nothing>
   void AddVolumeIntegral(DependsOn<args...> which_args, const lambda& integrand, Domain& domain,

--- a/src/smith/numerics/functional/interior_face_integral_kernels.hpp
+++ b/src/smith/numerics/functional/interior_face_integral_kernels.hpp
@@ -240,7 +240,7 @@ SMITH_HOST_DEVICE auto batch_apply_chain_rule(derivative_type* qf_derivatives, c
  * inherently just a linear transformation
  *
  * @param[in] dU The full set of per-element DOF values (primary input)
- * @param[inout] dR The full set of per-element residuals (primary output)
+ * @param[in,out] dR The full set of per-element residuals (primary output)
  * @param[in] derivatives_ptr The address at which derivatives of the q-function with
  * respect to its arguments are stored
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
@@ -289,7 +289,7 @@ void action_of_gradient_kernel(const double* dU, double* dR, derivatives_type* q
  * @tparam derivatives_type Type representing the derivative of the q-function w.r.t. its input arguments
  *
  *
- * @param[inout] dk 3-dimensional array storing the element gradient matrices
+ * @param[in,out] dk 3-dimensional array storing the element gradient matrices
  * @param[in] derivatives_ptr pointer to data describing the derivatives of the q-function with respect to its arguments
  * @param[in] J_ The Jacobians of the element transformations at all quadrature points
  * @see mfem::GeometricFactors

--- a/src/smith/numerics/functional/shape_aware_functional.hpp
+++ b/src/smith/numerics/functional/shape_aware_functional.hpp
@@ -439,7 +439,7 @@ class ShapeAwareFunctional<shape, test(trials...), exec> {
    *
    * @param[in] integrand The user-provided quadrature function, see @p Integral
    * @param[in] domain The domain on which to evaluate the integral
-   * @param[inout] qdata The data for each quadrature point
+   * @param[in,out] qdata The data for each quadrature point
    *
    * @note The @p Dimension parameters are used to assist in the deduction of the @a geometry_dim
    * and @a spatial_dim template parameter

--- a/src/smith/numerics/odes.hpp
+++ b/src/smith/numerics/odes.hpp
@@ -151,10 +151,10 @@ class SecondOrderODE : public mfem::SecondOrderTimeDependentOperator {
   /**
    * @brief Performs a time step
    *
-   * @param[inout] x The predicted solution
-   * @param[inout] dxdt The predicted rate
-   * @param[inout] time The current time
-   * @param[inout] dt The desired time step
+   * @param[in,out] x The predicted solution
+   * @param[in,out] dxdt The predicted rate
+   * @param[in,out] time The current time
+   * @param[in,out] dt The desired time step
    *
    * @see mfem::SecondOrderODESolver::Step
    */
@@ -334,9 +334,9 @@ class FirstOrderODE : public mfem::TimeDependentOperator {
   /**
    * @brief Performs a time step
    *
-   * @param[inout] x The predicted solution
-   * @param[inout] time The current time
-   * @param[inout] dt The desired time step
+   * @param[in,out] x The predicted solution
+   * @param[in,out] time The current time
+   * @param[in,out] dt The desired time step
    *
    * @see mfem::ODESolver::Step
    */

--- a/src/smith/physics/boundary_conditions/boundary_condition.hpp
+++ b/src/smith/physics/boundary_conditions/boundary_condition.hpp
@@ -113,7 +113,7 @@ class BoundaryCondition {
   /**
    * @brief Projects the associated coefficient over a solution vector on the DOFs constrained by the boundary condition
    * @param[in] time The time at which to project the boundary condition
-   * @param[inout] state The field to project over
+   * @param[in,out] state The field to project over
    */
   void setDofs(mfem::Vector& state, const double time = 0.0) const;
 
@@ -134,9 +134,9 @@ class BoundaryCondition {
    * these equations only apply to the non-essential dofs. For the essential rows, \f$ A \f$ is modified to contain one
    * on the diagonal and the right hand side is modified to contain the essential value originally contained in \f$ x
    * \f$. If \f$ A \f$ is given as the input @a k_mat , \f$ A_e \f$ is returned in @a k_mat .
-   * @param[inout] k_mat A stiffness (system) matrix. The rows and cols of the essential dofs will be set to zero with a
+   * @param[in,out] k_mat A stiffness (system) matrix. The rows and cols of the essential dofs will be set to zero with a
    * one on the diagonal after the return of this method.
-   * @param[inout] rhs The RHS vector for the system. At return, this vector contains \f$ b - A_e x \f$.
+   * @param[in,out] rhs The RHS vector for the system. At return, this vector contains \f$ b - A_e x \f$.
    * @param[in] state The state from which the solution DOF values are extracted and used to modify @a k_mat
    * @pre The input state solution must contain the correct essential DOFs. This can be done by calling the @a
    * BoundaryCondition::setDofs method.

--- a/src/smith/physics/boundary_conditions/boundary_condition_manager.hpp
+++ b/src/smith/physics/boundary_conditions/boundary_condition_manager.hpp
@@ -92,7 +92,7 @@ class BoundaryConditionManager {
 
   /**
    * @brief Eliminates all essential BCs from a matrix
-   * @param[inout] matrix The matrix to eliminate from, will be modified
+   * @param[in,out] matrix The matrix to eliminate from, will be modified
    * @return The eliminated matrix entries
    * @note The sum of the eliminated matrix and the modified parameter is
    * equal to the initial state of the parameter


### PR DESCRIPTION
TODO

- [ ] add -Wdocumentation to build
- [ ] fix rest of errors

```
/home/epperly2/current/lido/lido-2.0/smith_cz/smith/src/smith/infrastructure/../../smith/numerics/functional/domain_integral_kernels.hpp:89:10: error: unrecognized parameter passing direction, valid directions are '[in]', '[out]' and '[in,out]' [-Werror,-Wdocumentation]
   89 |  * @param[inout] qpt_data The state information at the quadrature point
      |          ^~~~~~~
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```